### PR TITLE
X-Forwarded-Protocol should actually be X-Forwarded-Proto per RFC7239

### DIFF
--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -416,7 +416,7 @@ public:
 
 	bool isXForwardedProtocolTls(const HttpHeaders &headers)
 	{
-		QByteArray xfp = headers.get("X-Forwarded-Protocol");
+		QByteArray xfp = headers.get("X-Forwarded-Proto");
 		return (!xfp.isEmpty() && (xfp == "https" || xfp == "wss"));
 	}
 

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -180,13 +180,13 @@ bool manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
 	}
 
 	if(acceptXForwardedProtocol || useXForwardedProtocol)
-		requestData->headers.removeAll("X-Forwarded-Protocol");
+		requestData->headers.removeAll("X-Forwarded-Proto");
 
 	if(useXForwardedProtocol)
 	{
 		QString scheme = requestData->uri.scheme();
 		if(scheme == "https" || scheme == "wss")
-			requestData->headers += HttpHeader("X-Forwarded-Protocol", scheme.toUtf8());
+			requestData->headers += HttpHeader("X-Forwarded-Proto", scheme.toUtf8());
 	}
 
 	const XffRule *xr;


### PR DESCRIPTION
So I wasted a few hours debugging why none of my apps that do https redirects were respecting this header... turns out this is the culprit... Per [RFC7239](https://tools.ietf.org/html/rfc7239) and most common usage (nginx/flask/apache/etc), the header should be `X-Forwarded-Proto`.

We have worked around this in our app code for now but it is less than ideal.
