### PR TITLE
Continue monitoring routes file when it gets overwritten.

### DIFF
--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -153,9 +153,10 @@ public:
 	QString fileName;
 	QHash< QString, QList<Rule> > map;
 	QTimer t;
+	QFileSystemWatcher watcher;
 
 	Worker() :
-		t(this)
+		t(this), watcher(this)
 	{
 		connect(&t, &QTimer::timeout, this, &Worker::doReload);
 		t.setSingleShot(true);
@@ -251,9 +252,8 @@ public slots:
 	{
 		if(!fileName.isEmpty())
 		{
-			QFileSystemWatcher *watcher = new QFileSystemWatcher(this);
-			connect(watcher, &QFileSystemWatcher::fileChanged, this, &Worker::fileChanged);
-			watcher->addPath(fileName);
+			connect(&watcher, &QFileSystemWatcher::fileChanged, this, &Worker::fileChanged);
+			watcher.addPath(fileName);
 
 			reload();
 		}
@@ -277,6 +277,11 @@ public slots:
 	void doReload()
 	{
 		reload();
+		// in case the file was not changed, but overwritten by a different
+		// file, re-arm watcher.
+		if(!fileName.isEmpty()) {
+			watcher.addPath(fileName);
+		}
 	}
 
 private:


### PR DESCRIPTION
Some editors don't change files in-place, but write to a new file and
then move the new file to the original location.

In that case, the file needs to be added to the watcher, again.
http://stackoverflow.com/questions/18300376/qt-qfilesystemwatcher-signal-filechanged-gets-emited-only-once