### PR TITLE
Log level handling

### DIFF
--- a/src/runner/app.cpp
+++ b/src/runner/app.cpp
@@ -464,7 +464,7 @@ public:
 				m2shBin = settings.value("runner/m2sh_bin").toString();
 
 			QString certsDir = QDir(configDir).filePath("certs");
-			if(!Mongrel2Service::generateConfigFile(m2shBin, QDir(libDir).filePath("mongrel2.conf.template"), runDir, logDir, ipcPrefix, filePrefix, certsDir, clientBufferSize, interfaces))
+			if(!Mongrel2Service::generateConfigFile(m2shBin, QDir(libDir).filePath("mongrel2.conf.template"), runDir, logDir, ipcPrefix, filePrefix, certsDir, clientBufferSize, interfaces, logLevel))
 			{
 				emit q->quit(1);
 				return;

--- a/src/runner/app.cpp
+++ b/src/runner/app.cpp
@@ -480,7 +480,7 @@ public:
 			foreach(const Mongrel2Service::Interface &i, interfaces)
 				ports += i.port;
 
-			services += new M2AdapterService(m2aBin, QDir(libDir).filePath("m2adapter.conf.template"), runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevel >= 3, ports, this);
+			services += new M2AdapterService(m2aBin, QDir(libDir).filePath("m2adapter.conf.template"), runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevel, ports, this);
 		}
 
 		bool quietCheck = false;
@@ -498,10 +498,10 @@ public:
 		}
 
 		if(serviceNames.contains("pushpin-proxy"))
-			services += new PushpinProxyService(proxyBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevel >= 3, args.routeLines, quietCheck, this);
+			services += new PushpinProxyService(proxyBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevel, args.routeLines, quietCheck, this);
 
 		if(serviceNames.contains("pushpin-handler"))
-			services += new PushpinHandlerService(handlerBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, portOffset, logLevel >= 3, this);
+			services += new PushpinHandlerService(handlerBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, portOffset, logLevel, this);
 
 		foreach(Service *s, services)
 		{

--- a/src/runner/m2adapterservice.cpp
+++ b/src/runner/m2adapterservice.cpp
@@ -41,7 +41,7 @@ M2AdapterService::M2AdapterService(
 	const QString &logDir,
 	const QString &ipcPrefix,
 	const QString &filePrefix,
-	bool verbose,
+	int logLevel,
 	const QList<int> &ports,
 	QObject *parent) :
 	Service(parent)
@@ -55,8 +55,8 @@ M2AdapterService::M2AdapterService(
 		setStandardOutputFile(QProcess::nullDevice());
 	}
 
-	if(verbose)
-		args_ += "--verbose";
+	if(logLevel >= 0)
+		args_ += "--loglevel=" + QString::number(logLevel);
 
 	configTemplateFile_ = configTemplateFile;
 	runDir_ = runDir;

--- a/src/runner/m2adapterservice.h
+++ b/src/runner/m2adapterservice.h
@@ -43,7 +43,7 @@ public:
 		const QString &logDir,
 		const QString &ipcPrefix,
 		const QString &filePrefix,
-		bool verbose,
+		int logLevel,
 		const QList<int> &ports,
 		QObject *parent = 0);
 

--- a/src/runner/mongrel2.conf.template
+++ b/src/runner/mongrel2.conf.template
@@ -30,7 +30,8 @@
 	"request.relaxed": 1,
 	"download.flow_control": 1,
 	"net.tcp_keepalive": 1,
-	"limits.buffer_size": {{ limits_buffer_size }}
+	"limits.buffer_size": {{ limits_buffer_size }},
+	"disable.access_logging": {{ disable_access_logging}}
 }
 
 servers = [{% for i in interfaces %}server_{{ i.port }}{% if not loop.last %}, {% endif %}{% endfor %}]

--- a/src/runner/mongrel2service.cpp
+++ b/src/runner/mongrel2service.cpp
@@ -59,7 +59,7 @@ Mongrel2Service::Mongrel2Service(
 	setStandardOutputFile(QDir(logDir).filePath(filePrefix + "mongrel2_" + QString::number(port) + ".log"));
 }
 
-bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, const QList<Interface> &interfaces)
+bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, const QList<Interface> &interfaces, int logLevel)
 {
 	QVariantList vinterfaces;
 
@@ -80,6 +80,7 @@ bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile, const QStri
 	context["ipc_prefix"] = ipcPrefix;
 	context["file_prefix"] = filePrefix;
 	context["limits_buffer_size"] = clientBufferSize;
+	context["disable_access_logging"] = (logLevel >= LOG_LEVEL_INFO) ? 0 : 1;
 
 	QString error;
 	if(!Template::renderFile(configTemplateFile, QDir(runDir).filePath(filePrefix + "mongrel2.conf"), context, &error))

--- a/src/runner/mongrel2service.h
+++ b/src/runner/mongrel2service.h
@@ -69,7 +69,7 @@ public:
 		bool ssl,
 		QObject *parent = 0);
 
-	static bool generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, const QList<Interface> &interfaces);
+	static bool generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, const QList<Interface> &interfaces, int logLevel);
 
 	// reimplemented
 

--- a/src/runner/pushpinhandlerservice.cpp
+++ b/src/runner/pushpinhandlerservice.cpp
@@ -39,7 +39,7 @@ PushpinHandlerService::PushpinHandlerService(
 	const QString &ipcPrefix,
 	const QString &filePrefix,
 	int portOffset,
-	bool verbose,
+	int logLevel,
 	QObject *parent) :
 	Service(parent)
 {
@@ -58,8 +58,8 @@ PushpinHandlerService::PushpinHandlerService(
 		setStandardOutputFile(QProcess::nullDevice());
 	}
 
-	if(verbose)
-		args_ += "--verbose";
+	if(logLevel >= 0)
+		args_ += "--loglevel=" + QString::number(logLevel);
 
 	setName("handler");
 	setPidFile(QDir(runDir).filePath(filePrefix + "pushpin-handler.pid"));

--- a/src/runner/pushpinhandlerservice.h
+++ b/src/runner/pushpinhandlerservice.h
@@ -44,7 +44,7 @@ public:
 		const QString &ipcPrefix,
 		const QString &filePrefix,
 		int portOffset,
-		bool verbose,
+		int logLevel,
 		QObject *parent = 0);
 
 	// reimplemented

--- a/src/runner/pushpinproxyservice.cpp
+++ b/src/runner/pushpinproxyservice.cpp
@@ -38,7 +38,7 @@ PushpinProxyService::PushpinProxyService(
 	const QString &logDir,
 	const QString &ipcPrefix,
 	const QString &filePrefix,
-	bool verbose,
+	int logLevel,
 	const QStringList &routeLines,
 	bool quietCheck,
 	QObject *parent) :
@@ -56,8 +56,8 @@ PushpinProxyService::PushpinProxyService(
 		setStandardOutputFile(QProcess::nullDevice());
 	}
 
-	if(verbose)
-		args_ += "--verbose";
+	if(logLevel >= 0)
+		args_ += "--loglevel=" + QString::number(logLevel);
 
 	foreach(const QString &route, routeLines)
 		args_ += "--route=" + route;

--- a/src/runner/pushpinproxyservice.h
+++ b/src/runner/pushpinproxyservice.h
@@ -43,7 +43,7 @@ public:
 		const QString &logDir,
 		const QString &ipcPrefix,
 		const QString &filePrefix,
-		bool verbose,
+		int logLevel,
 		const QStringList &routeLines,
 		bool quietCheck,
 		QObject *parent = 0);


### PR DESCRIPTION
Disable mongrel2 access logging for log levels < 2, and forward numeric log level to handler, m2adapter and proxy service.
This should take care of #47658