### PR TITLE
Remove date parsing from mongrel2 log parsing code

### DIFF
--- a/src/runner/mongrel2service.h
+++ b/src/runner/mongrel2service.h
@@ -83,7 +83,7 @@ private:
 	QString prefix_;
 	int logLevel_;
 
-	QString filterLogLine(int, const QDateTime&, const QString&) const;
+	QString filterLogLine(int, const QString&) const;
 };
 
 #endif


### PR DESCRIPTION
The parser failed for some locale settings. Instead of trying
to write a robust date parser, just use the current time, which
should be at most a few milliseconds later than the time mongrel2
wrote into the log message.