### PR TITLE
handler: make http publish maximum body and headers size configurable

### DIFF
--- a/examples/config/pushpin.conf
+++ b/examples/config/pushpin.conf
@@ -115,6 +115,10 @@ push_in_sub_connect=false
 push_in_http_addr=127.0.0.1
 push_in_http_port=5561
 
+# maximum headers and body size in bytes when receiving publish commands via HTTP
+push_in_http_max_headers_size=10000
+push_in_http_max_body_size=1000000
+
 # bind PUB for sending stats (metrics, subscription info, etc)
 stats_spec=ipc://{rundir}/{ipc_prefix}stats
 

--- a/src/handler/app.cpp
+++ b/src/handler/app.cpp
@@ -40,6 +40,9 @@
 #include "engine.h"
 #include "config.h"
 
+#define DEFAULT_HTTP_MAX_HEADERS_SIZE 10000
+#define DEFAULT_HTTP_MAX_BODY_SIZE 1000000
+
 static void trimlist(QStringList *list)
 {
 	for(int n = 0; n < list->count(); ++n)
@@ -261,6 +264,8 @@ public:
 		bool push_in_sub_connect = settings.value("handler/push_in_sub_connect").toBool();
 		QString push_in_http_addr = settings.value("handler/push_in_http_addr").toString();
 		int push_in_http_port = settings.adjustedPort("handler/push_in_http_port");
+		int push_in_http_max_headers_size = settings.value("handler/push_in_max_headers_size", DEFAULT_HTTP_MAX_HEADERS_SIZE).toInt();
+		int push_in_http_max_body_size = settings.value("handler/push_in_max_body_size", DEFAULT_HTTP_MAX_BODY_SIZE).toInt();
 		bool ok;
 		int ipcFileMode = settings.value("handler/ipc_file_mode", -1).toString().toInt(&ok, 8);
 		bool shareAll = settings.value("handler/share_all").toBool();
@@ -312,6 +317,8 @@ public:
 		config.pushInSubConnect = push_in_sub_connect;
 		config.pushInHttpAddr = QHostAddress(push_in_http_addr);
 		config.pushInHttpPort = push_in_http_port;
+		config.pushInHttpMaxHeadersSize = push_in_http_max_headers_size;
+		config.pushInHttpMaxBodySize = push_in_http_max_body_size;
 		config.ipcFileMode = ipcFileMode;
 		config.shareAll = shareAll;
 		config.messageRate = messageRate;

--- a/src/handler/engine.cpp
+++ b/src/handler/engine.cpp
@@ -1646,7 +1646,7 @@ public:
 
 		if(config.pushInHttpPort != -1)
 		{
-			controlHttpServer = new SimpleHttpServer(this);
+			controlHttpServer = new SimpleHttpServer(config.pushInHttpMaxHeadersSize, config.pushInHttpMaxBodySize, this);
 			connect(controlHttpServer, &SimpleHttpServer::requestReady, this, &Private::controlHttpServer_requestReady);
 			controlHttpServer->listen(config.pushInHttpAddr, config.pushInHttpPort);
 

--- a/src/handler/engine.h
+++ b/src/handler/engine.h
@@ -63,6 +63,8 @@ public:
 		bool pushInSubConnect;
 		QHostAddress pushInHttpAddr;
 		int pushInHttpPort;
+		int pushInHttpMaxHeadersSize;
+		int pushInHttpMaxBodySize;
 		int ipcFileMode;
 		bool shareAll;
 		int messageRate;
@@ -79,6 +81,8 @@ public:
 		Configuration() :
 			pushInSubConnect(false),
 			pushInHttpPort(-1),
+			pushInHttpMaxHeadersSize(-1),
+			pushInHttpMaxBodySize(-1),
 			ipcFileMode(-1),
 			shareAll(false),
 			messageRate(-1),

--- a/src/handler/simplehttpserver.h
+++ b/src/handler/simplehttpserver.h
@@ -40,6 +40,7 @@ class SimpleHttpRequest : public QObject
 	Q_OBJECT
 
 public:
+	SimpleHttpRequest(int maxHeadersSize, int maxBodySize, QObject* parent = 0);
 	~SimpleHttpRequest();
 
 	QString requestMethod() const;
@@ -67,7 +68,7 @@ class SimpleHttpServer : public QObject
 	Q_OBJECT
 
 public:
-	SimpleHttpServer(QObject *parent = 0);
+	SimpleHttpServer(int maxHeadersSize, int maxBodySize, QObject *parent = 0);
 	~SimpleHttpServer();
 
 	bool listen(const QHostAddress &addr, int port);


### PR DESCRIPTION
This Pull Request allows to configure the max headers and body size when publishing over HTTP.

Linked issue: #47690