### PR TITLE
Fix configuration in enginetest

### DIFF
--- a/src/handler/tests/enginetest/enginetest.cpp
+++ b/src/handler/tests/enginetest/enginetest.cpp
@@ -284,6 +284,7 @@ private slots:
 		config.acceptSpec = "ipc://accept";
 		config.pushInSpec = "ipc://publish-pull";
 		config.connectionSubscriptionMax = 20;
+		config.connectionsMax = 20;
 		QVERIFY(engine->start(config));
 
 		wrapper->startPublish();

--- a/src/proxy/tests/enginetest/enginetest.cpp
+++ b/src/proxy/tests/enginetest/enginetest.cpp
@@ -504,6 +504,7 @@ private slots:
 		config.routesFile = "routes";
 		config.sigIss = "pushpin";
 		config.sigKey = "changeme";
+		config.connectionsMax = 20;
 		QVERIFY(engine->start(config));
 
 		wrapper->startHandler();


### PR DESCRIPTION
Without this, enginetest fails with "memory allocation of 343597382880
bytes failed" (may be undeterministic because the config is not
initialized)