### PR TITLE
runner: allow `:0` as a valid listen port

### DIFF
--- a/src/runner/app.cpp
+++ b/src/runner/app.cpp
@@ -485,7 +485,7 @@ public:
 			foreach(const QString &httpPortStr, httpPortStrs)
 			{
 				QPair<QHostAddress, int> p = parsePort(httpPortStr);
-				if(p.second < 1)
+				if(p.second < 0)
 				{
 					log_error("invalid http port: %s", qPrintable(httpPortStr));
 					emit q->quit(1);


### PR DESCRIPTION
This will let the kernel pick a port, and condure works as expected when
asked to bind port 0. It will make writing integration tests easier.