### PR TITLE
Missing IPv6 support -> Improve port parsing in pushpin config + Listen address building for condure

### DIFF
--- a/src/runner/app.cpp
+++ b/src/runner/app.cpp
@@ -34,6 +34,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
+#include <QUrl>
 #include "processquit.h"
 #include "log.h"
 #include "settings.h"
@@ -69,11 +70,9 @@ static bool ensureDir(const QString &path)
 
 static QPair<QHostAddress, int> parsePort(const QString &s)
 {
-	int at = s.indexOf(':');
-	if(at != -1)
-		return QPair<QHostAddress, int>(QHostAddress(s.mid(0, at)), s.mid(at + 1).toInt());
-	else
-		return QPair<QHostAddress, int>(QHostAddress(), s.toInt());
+	QUrl url{QUrl::fromUserInput(s)};
+
+	return QPair<QHostAddress, int>(QHostAddress(url.host()), url.port());
 }
 
 QMap<QString, int> parseLogLevel(const QStringList &parts, QString *errorMessage)

--- a/src/runner/condureservice.cpp
+++ b/src/runner/condureservice.cpp
@@ -31,6 +31,7 @@
 #include <QDir>
 #include <QVariantList>
 #include <QProcess>
+#include <QUrl>
 #include "log.h"
 #include "template.h"
 
@@ -70,9 +71,11 @@ CondureService::CondureService(
 		}
 		else
 		{
-			QString addr = !p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0");
+			QUrl url;
+			url.setHost(!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
+			url.setPort(p.port);
 
-			QString arg = "--listen=" + addr + ":" + QString::number(p.port) + ",stream";
+			QString arg = "--listen=" + url.authority() + ",stream";
 
 			if(p.ssl)
 			{


### PR DESCRIPTION
Leverage QUrl for parsing and building host and port combinations. This PR also retains the original parsing approach, i.e. invalid host addresses are still treated as a 0.0.0.0 listen address for Condure and invalid ports are also rejected by QUrl identically. 

Primarily, this directly adds support for IPv6 addresses without adding further custom parsing. 

Otherwise, IPv6 listen addresses are not understood by Pushpin - which is quite frustrating, because Condure and all other components seem to support IPv6 perfectly, one just can't specify IPv6 listen addresses in Pushpin's config file. 