### PR TITLE
settings object from cli args & config data

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,12 +3,13 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let (app_version, config_dir) = {
+    let (app_version, config_dir, lib_dir) = {
         let f = fs::File::open("conf.pri")?;
         let reader = BufReader::new(f);
 
         let mut av = String::new();
         let mut cd = String::new();
+        let mut ld = String::new();
 
         for line in reader.lines() {
             let line = line?;
@@ -21,14 +22,19 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let pos = line.find('=').unwrap();
 
                 cd = line[(pos + 1)..].trim().into();
+            } else if line.starts_with("LIBDIR =") {
+                let pos = line.find('=').unwrap();
+
+                ld = line[(pos + 1)..].trim().into();
             }
         }
 
-        (av, cd)
+        (av, cd, ld)
     };
 
     println!("cargo:rustc-env=APP_VERSION={}", app_version);
     println!("cargo:rustc-env=CONFIG_DIR={}", config_dir);
+    println!("cargo:rustc-env=LIB_DIR={}", lib_dir);
 
     Ok(())
 }

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -15,6 +15,7 @@
  */
 
 use clap::Parser;
+use log::info;
 use pushpin::config::get_config_file;
 use pushpin::runner::{ArgsData, CliArgs, Settings};
 use std::error::Error;
@@ -33,7 +34,7 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
 
 fn main() {
     let args = CliArgs::parse();
-    println!("starting...");
+    info!("starting...");
 
     if let Err(e) = process_args_and_run(args) {
         eprintln!("Error: {}", e);

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -16,14 +16,16 @@
 
 use clap::Parser;
 use pushpin::config::get_config_file;
-use pushpin::runner::{ArgsData, CliArgs};
+use pushpin::runner::{ArgsData, CliArgs, Settings};
 use std::error::Error;
 use std::process;
 
 fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let args_data = ArgsData::new(args)?;
     let config_file = get_config_file(args_data.config_file.as_ref())?;
-    println!("Processed config file: {:?}", config_file);
+    println!("using config: {:?}", config_file.as_os_str());
+    let settings = Settings::new(args_data, &config_file)?;
+    println!("settings: {:?}", settings);
     //To be implemented in the next PR
 
     Ok(())
@@ -31,7 +33,8 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
 
 fn main() {
     let args = CliArgs::parse();
-
+    println!("starting...");
+    
     if let Err(e) = process_args_and_run(args) {
         eprintln!("Error: {}", e);
         process::exit(1);

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -34,7 +34,7 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
 fn main() {
     let args = CliArgs::parse();
     println!("starting...");
-    
+
     if let Err(e) = process_args_and_run(args) {
         eprintln!("Error: {}", e);
         process::exit(1);


### PR DESCRIPTION
This is the 3rd PR in a series of PRs to rewrite Pushpin's Runner in Rust.

In this PR we are adding logic to build a settings object from cli args & config data.

Unit tests added.


