### PR TITLE
connection: ability to dynamically resize write buffers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Fanout, Inc.
+ * Copyright (C) 2023 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1540,6 +1541,8 @@ impl Worker {
             &cid,
             arena::Rc::clone(&zreq),
             opts.buffer_size,
+            2,
+            None,
             stream_opts.messages_max,
             &opts.rb_tmp,
             opts.packet_buf,

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug)]
+pub struct CounterError;
+
+/// An unsigned integer that can be shared between threads. Counter is backed by an AtomicUsize
+/// and performs operations with Relaxed memory ordering, so its value cannot be reliably assumed
+/// to be in sync with other atomic values, including other Counter values.
+pub struct Counter(AtomicUsize);
+
+impl Counter {
+    pub fn new(value: usize) -> Self {
+        Self(AtomicUsize::new(value))
+    }
+
+    pub fn inc(&self, amount: usize) -> Result<(), CounterError> {
+        if amount == 0 {
+            return Ok(());
+        }
+
+        loop {
+            let value = self.0.load(Ordering::Relaxed);
+
+            if amount > usize::MAX - value {
+                return Err(CounterError);
+            }
+
+            if self
+                .0
+                .compare_exchange(value, value + amount, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn dec(&self, amount: usize) -> Result<(), CounterError> {
+        if amount == 0 {
+            return Ok(());
+        }
+
+        loop {
+            let value = self.0.load(Ordering::Relaxed);
+
+            if amount > value {
+                return Err(CounterError);
+            }
+
+            if self
+                .0
+                .compare_exchange(value, value - amount, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter() {
+        let c = Counter::new(2);
+
+        assert!(c.dec(1).is_ok());
+        assert!(c.dec(1).is_ok());
+        assert!(c.dec(1).is_err());
+
+        assert!(c.inc(1).is_ok());
+        assert!(c.dec(2).is_err());
+        assert!(c.dec(1).is_ok());
+
+        assert!(c.inc(usize::MAX).is_ok());
+        assert!(c.inc(1).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2022 Fanout, Inc.
+ * Copyright (C) 2023 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -27,6 +28,7 @@ pub mod client;
 pub mod condure;
 pub mod config;
 pub mod connection;
+pub mod counter;
 pub mod event;
 pub mod executor;
 pub mod ffi;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Fanout, Inc.
+ * Copyright (C) 2023 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1828,6 +1829,8 @@ impl Worker {
                         Some(&peer_addr),
                         false,
                         opts.buffer_size,
+                        2,
+                        None,
                         stream_opts.messages_max,
                         &opts.rb_tmp,
                         opts.packet_buf,
@@ -1851,6 +1854,8 @@ impl Worker {
                         Some(&peer_addr),
                         false,
                         opts.buffer_size,
+                        2,
+                        None,
                         stream_opts.messages_max,
                         &opts.rb_tmp,
                         opts.packet_buf,
@@ -1877,6 +1882,8 @@ impl Worker {
                     Some(&peer_addr),
                     true,
                     opts.buffer_size,
+                    2,
+                    None,
                     stream_opts.messages_max,
                     &opts.rb_tmp,
                     opts.packet_buf,


### PR DESCRIPTION
This change enables connections to support higher throughput by dynamically expanding the capacity of their write buffers. Capacity expands by a multiple of the configured buffer size ("blocks"). For example, if the buffer size is 1024, then when a write buffer is full it can expand to 2048 bytes, then 3072 bytes, and so on.

Size limits can be set for each connection as well as shared across connections. From the perspective of an individual connection, we refer to these limits as "blocks max" and "blocks available". Connections must have a minimum of 2 blocks (1 for the read buffer and 1 for the write buffer), and any additional blocks can go towards expanding the write buffer.