### PR TITLE
base writeBytesAvailable on credits and emit signal when changed

### DIFF
--- a/src/corelib/httprequest.h
+++ b/src/corelib/httprequest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2016 Fanout, Inc.
+ * Copyright (C) 2023 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -88,6 +89,7 @@ signals:
 	void readyRead();
 	// indicates output data written and/or output finished
 	void bytesWritten(int count);
+	void writeBytesChanged();
 	void paused();
 	void error();
 };

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -200,6 +200,7 @@ public:
 
 		req->setParent(this);
 		connect(req, &ZhttpRequest::bytesWritten, this, &Private::req_bytesWritten);
+		connect(req, &ZhttpRequest::writeBytesChanged, this, &Private::req_writeBytesChanged);
 		connect(req, &ZhttpRequest::error, this, &Private::req_error);
 
 		timer = new RTimer(this);
@@ -1420,7 +1421,10 @@ private slots:
 			doFinish();
 			return;
 		}
+	}
 
+	void req_writeBytesChanged()
+	{
 		if(state == SendingFirstInstructResponse)
 		{
 			tryWriteFirstInstructResponse();


### PR DESCRIPTION
Currently, `writeBytesAvailable()` returns an amount of bytes the request is able to accept based on a constant. This PR changes it to be based on the credits provided by the peer, allowing the available amount to grow if the peer provides more credits. A signal is also added for indicating when the amount may have changed.