### PR TITLE
bug fix to correct default config path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -446,7 +446,7 @@ pub fn get_config_file(arg_config: &Path) -> Result<PathBuf, Box<dyn Error>> {
         config_files.push(PathBuf::from("./examples/config/pushpin.conf"));
         // default
         config_files.push(PathBuf::from(format!(
-            "{:?}/pushpin.conf",
+            "{}/pushpin.conf",
             env!("CONFIG_DIR")
         )));
     }


### PR DESCRIPTION
this is to correct the format of the default config from `"/usr/local/etc/pushpin"/pushpin.conf` to `/usr/local/etc/pushpin/pushpin.conf`