### PR TITLE
starting up pushpin runner proxy service

### DIFF
--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -27,7 +27,6 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let config_file = get_config_file(args_data.config_file.as_ref())?;
     println!("using config: {:?}", config_file.as_os_str());
     let settings = Settings::new(args_data, &config_file)?;
-    println!("settings: {:?}", settings);
     start_services(settings);
     //To be implemented in the next PR
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -44,7 +44,7 @@ pub fn start_services(settings: Settings) {
     {
         services.push(Box::new(PushpinProxyService::new(&settings)));
     }
-    
+
     let (sender, receiver) = channel();
     let mut threads: Vec<Option<JoinHandle<()>>> = vec![];
     for mut service in services {
@@ -249,13 +249,12 @@ pub struct PushpinProxyService {
 }
 
 impl PushpinProxyService {
-
     pub fn new(settings: &Settings) -> Self {
         let mut args: Vec<String> = vec![];
         let service_name = "proxy";
 
         args.push(settings.proxy_bin.display().to_string());
-        args.push(format!("--config={}", settings.config_file.display().to_string()));
+        args.push(format!("--config={}", settings.config_file.display()));
 
         if !settings.ipc_prefix.is_empty() {
             args.push(format!("--ipc-prefix={}", settings.ipc_prefix));
@@ -274,7 +273,7 @@ impl PushpinProxyService {
 
         Self {
             service: Service::new(String::from(service_name)),
-            args: args,
+            args,
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -38,7 +38,13 @@ pub fn start_services(settings: Settings) {
     if settings.service_names.contains(&String::from("condure")) {
         services.push(Box::new(CondureService::new(&settings)));
     }
-
+    if settings
+        .service_names
+        .contains(&String::from("pushpin-proxy"))
+    {
+        services.push(Box::new(PushpinProxyService::new(&settings)));
+    }
+    
     let (sender, receiver) = channel();
     let mut threads: Vec<Option<JoinHandle<()>>> = vec![];
     for mut service in services {
@@ -232,6 +238,48 @@ impl CondureService {
 }
 
 impl RunnerService for CondureService {
+    fn start(&mut self, sender: Sender<Result<(), ServiceError>>) -> Option<JoinHandle<()>> {
+        self.service.start(self.args.clone(), sender)
+    }
+}
+
+pub struct PushpinProxyService {
+    args: Vec<String>,
+    pub service: Service,
+}
+
+impl PushpinProxyService {
+
+    pub fn new(settings: &Settings) -> Self {
+        let mut args: Vec<String> = vec![];
+        let service_name = "proxy";
+
+        args.push(settings.proxy_bin.display().to_string());
+        args.push(format!("--config={}", settings.config_file.display().to_string()));
+
+        if !settings.ipc_prefix.is_empty() {
+            args.push(format!("--ipc-prefix={}", settings.ipc_prefix));
+        }
+        let log_level = match settings.log_levels.get("pushpin-proxy") {
+            Some(&x) => x as i8,
+            None => -1,
+        };
+        if log_level >= 0 {
+            args.push(format!("--loglevel={}", log_level));
+        }
+
+        for route in settings.route_lines.clone() {
+            args.push(format!("--route={}", route));
+        }
+
+        Self {
+            service: Service::new(String::from(service_name)),
+            args: args,
+        }
+    }
+}
+
+impl RunnerService for PushpinProxyService {
     fn start(&mut self, sender: Sender<Result<(), ServiceError>>) -> Option<JoinHandle<()>> {
         self.service.start(self.args.clone(), sender)
     }


### PR DESCRIPTION
This is the 5th PR in a series of PRs to rewrite Pushpin's Runner in Rust.

In this PR we are adding logic for the runner to start pushpin proxy service and term signals would stop condure and proxy services

Manually tested: started runner & stopped using Ctrl+c
<img width="533" alt="Screenshot 2023-09-21 at 10 25 45 AM" src="https://github.com/fastly/pushpin/assets/64804941/434279e6-ce67-4e85-b94c-29491a4e7077">

