### PR TITLE
cleaning up unused logic in rust runner condure service

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -156,15 +156,13 @@ impl CondureService {
         if settings.allow_compression {
             args.push("--compression".to_string());
         }
-        if Self::has_client_mode(settings.condure_bin.display().to_string()) {
-            // client mode
-            args.push(format!(
-                "--zserver-stream=ipc://{}/{}condure-client",
-                settings.run_dir.display(),
-                settings.ipc_prefix
-            ));
-            args.push("--deny-out-internal".to_string());
-        }
+        args.push(format!(
+            "--zserver-stream=ipc://{}/{}condure-client",
+            settings.run_dir.display(),
+            settings.ipc_prefix
+        ));
+        args.push("--deny-out-internal".to_string());
+    
         if !settings.ports.is_empty() {
             //server mode
             let mut using_ssl = false;
@@ -213,26 +211,6 @@ impl CondureService {
         Self {
             service: Service::new(String::from(service_name)),
             args,
-        }
-    }
-
-    fn has_client_mode(condure_bin: String) -> bool {
-        let result: Result<std::process::Output, std::io::Error> =
-            Command::new(condure_bin).arg("--help").output();
-
-        match result {
-            Ok(output) => {
-                if !output.status.success() {
-                    error!("Condure returned non-zero status: {}", output.status);
-                    return false;
-                }
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                stdout.contains("--zserver-stream")
-            }
-            Err(e) => {
-                error!("Failed to run condure: process error: {}", e);
-                false
-            }
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -162,7 +162,7 @@ impl CondureService {
             settings.ipc_prefix
         ));
         args.push("--deny-out-internal".to_string());
-    
+
         if !settings.ports.is_empty() {
             //server mode
             let mut using_ssl = false;


### PR DESCRIPTION
Since Zurl service is being removed, the enable client flag logic is not needed.

Manual testing was done.
<img width="672" alt="Screenshot 2023-09-27 at 8 40 28 AM" src="https://github.com/fastly/pushpin/assets/64804941/dfc1688d-8117-4562-aa43-1dbd21784d74">
