### PR TITLE
runner services log levels corrected

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::runner::Settings;
-use log::{error, info};
+use log::error;
 use mpsc::{channel, Sender};
 use signal_hook::consts::{SIGINT, SIGTERM, TERM_SIGNALS};
 use signal_hook::iterator::Signals;

--- a/src/service.rs
+++ b/src/service.rs
@@ -110,8 +110,6 @@ impl Service {
         args: Vec<String>,
         sender: Sender<Result<(), ServiceError>>,
     ) -> Option<thread::JoinHandle<()>> {
-        info!("starting {}", self.name);
-
         let name = self.name.clone();
 
         Some(thread::spawn(move || {
@@ -148,12 +146,14 @@ impl CondureService {
 
         args.push(settings.condure_bin.display().to_string());
 
-        let ll = settings
-            .log_levels
-            .get(service_name)
-            .unwrap_or(settings.log_levels.get("default").unwrap());
+        let log_level = match settings.log_levels.get(service_name) {
+            Some(&x) => x as i8,
+            None => settings.log_levels.get("default").unwrap().to_owned() as i8,
+        };
+        if log_level >= 0 {
+            args.push(format!("--log-level={}", log_level));
+        }
 
-        args.push(format!("--log-level={}", ll.to_owned()));
         args.push(format!("--buffer-size={}", settings.client_buffer_size));
         args.push(format!(
             "--stream-maxconn={}",
@@ -245,7 +245,7 @@ impl PushpinProxyService {
         }
         let log_level = match settings.log_levels.get("pushpin-proxy") {
             Some(&x) => x as i8,
-            None => -1,
+            None => settings.log_levels.get("default").unwrap().to_owned() as i8,
         };
         if log_level >= 0 {
             args.push(format!("--loglevel={}", log_level));
@@ -289,7 +289,7 @@ impl PushpinHandlerService {
         }
         let log_level = match settings.log_levels.get("pushpin-handler") {
             Some(&x) => x as i8,
-            None => -1,
+            None => settings.log_levels.get("default").unwrap().to_owned() as i8,
         };
         if log_level >= 0 {
             args.push(format!("--loglevel={}", log_level));


### PR DESCRIPTION
This is the 7th PR in a series of PRs to rewrite Pushpin's Runner in Rust.
here we are : 
-adding default log levels to runner services
-removing redundant logs

This has been manually tested: 
<img width="589" alt="Screenshot 2023-10-04 at 3 37 29 AM" src="https://github.com/fastly/pushpin/assets/64804941/999dc02e-d45a-429e-8b88-c0f16082c5b6">

<img width="821" alt="Screenshot 2023-10-04 at 3 39 56 AM" src="https://github.com/fastly/pushpin/assets/64804941/e2e9fbb2-c049-4175-9d01-8a0c90fca44f">

