### PR TITLE
updated log_dir to an optional pathbuf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,7 @@ fn try_with_increasing_buffer<T, U>(starting_size: usize, f: T) -> Result<U, io:
 where
     T: Fn(&mut [u8]) -> Result<U, io::Error>,
 {
-    let mut buf = Vec::new();
-    buf.resize(starting_size, 0);
+    let mut buf = vec![0; starting_size];
 
     loop {
         match f(&mut buf) {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -85,7 +85,7 @@ impl ArgsData {
         Ok(Self {
             id: Self::get_id(cli_args.id)?,
             config_file: Self::get_config_file(cli_args.config.as_deref()),
-            log_file: cli_args.logfile.as_deref().map(|x| x.to_path_buf()),
+            log_file: cli_args.logfile,
             route_lines: Self::get_route_lines(cli_args.route.as_deref()),
             log_levels: Self::get_log_levels(cli_args.loglevel.as_deref(), cli_args.verbose)?,
             socket: Self::get_socket(cli_args.port.as_deref())?,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -85,7 +85,7 @@ impl ArgsData {
         Ok(Self {
             id: Self::get_id(cli_args.id)?,
             config_file: Self::get_config_file(cli_args.config.as_deref()),
-            log_file: Self::get_log_file(cli_args.logfile.as_deref()),
+            log_file: cli_args.logfile.as_deref().map(|x| x.to_path_buf()),
             route_lines: Self::get_route_lines(cli_args.route.as_deref()),
             log_levels: Self::get_log_levels(cli_args.loglevel.as_deref(), cli_args.verbose)?,
             socket: Self::get_socket(cli_args.port.as_deref())?,
@@ -109,13 +109,6 @@ impl ArgsData {
         match config_file {
             Some(x) => x.to_path_buf(),
             _ => PathBuf::new(),
-        }
-    }
-
-    fn get_log_file(log_file: Option<&Path>) -> Option<PathBuf> {
-        match log_file {
-            Some(x) => Some(x.to_path_buf()),
-            _ => None,
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -217,7 +217,7 @@ pub struct Settings {
     pub service_names: Vec<String>,
     pub config_file: PathBuf,
     pub run_dir: PathBuf,
-    pub log_dir: PathBuf,
+    pub log_dir: Option<PathBuf>,
     pub certs_dir: PathBuf,
     pub condure_bin: PathBuf,
     pub proxy_bin: PathBuf,
@@ -274,7 +274,11 @@ impl Settings {
         run_dir = exec_dir.join(run_dir);
         ensure_dir(run_dir.as_ref())?;
 
-        let log_dir = exec_dir.join(config.runner.logdir);
+        let log_dir = if config.runner.logdir.is_empty() {
+            None
+        } else {
+            Some(exec_dir.join(config.runner.logdir))
+        };
 
         let mut port_offset = 0;
         let mut ipc_prefix = if !config.global.ipc_prefix.is_empty() {
@@ -835,7 +839,7 @@ mod tests {
                 ],
                 config_file: PathBuf::from("mock/cfg"),
                 run_dir: exec_dir.clone().join("run"),
-                log_dir: exec_dir.clone().join("log"),
+                log_dir: Some(exec_dir.clone().join("log")),
                 certs_dir: PathBuf::from("mock/runner/certs"),
                 condure_bin: if exec_dir.clone().join("bin/condure").exists() {
                     exec_dir.clone().join("bin/condure")


### PR DESCRIPTION
This is the 8th PR in a series of PRs to rewrite Pushpin's Runner in Rust.
here we are :
-removing log_dir as in the new implementation there will be only one log_file to log to
-updating log_file var to make it an optional param to support the case of logging to stdout, and adding it to the settings obj
-addressing cargo clippy recommendations

This has been manually tested.