### PR TITLE
Runner file logging

### DIFF
--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -16,7 +16,7 @@
 
 use clap::Parser;
 use log::{info, LevelFilter};
-use pushpin::runner::{get_runner_logger, ArgsData, CliArgs, Settings};
+use pushpin::runner::{get_log_file, get_runner_logger, ArgsData, CliArgs, Settings};
 use pushpin::service::start_services;
 use std::error::Error;
 use std::process;
@@ -25,7 +25,7 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let args_data = ArgsData::new(args)?;
     let settings = Settings::new(args_data)?;
 
-    log::set_logger(get_runner_logger(settings.log_file.clone())).unwrap();
+    log::set_logger(get_runner_logger(get_log_file(settings.log_file.clone()))).unwrap();
     let ll = settings
         .log_levels
         .get("")

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -15,7 +15,7 @@
  */
 
 use clap::Parser;
-use log::{info, LevelFilter};
+use log::{error, info, LevelFilter};
 use pushpin::runner::{get_runner_logger, open_log_file, ArgsData, CliArgs, Settings};
 use pushpin::service::start_services;
 use std::error::Error;
@@ -26,7 +26,16 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let settings = Settings::new(args_data)?;
 
     let logger = match settings.log_file.clone() {
-        Some(x) => get_runner_logger(open_log_file(x)),
+        Some(x) => {
+            let log_file = match open_log_file(x) {
+                Ok(x) => Some(x),
+                Err(_) => {
+                    error!("unable to open log file. logging to standard out.");
+                    None
+                }
+            };
+            get_runner_logger(log_file)
+        }
         None => get_runner_logger(None),
     };
     log::set_logger(logger).unwrap();

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -16,7 +16,7 @@
 
 use clap::Parser;
 use log::{info, LevelFilter};
-use pushpin::runner::{get_log_file, get_runner_logger, ArgsData, CliArgs, Settings};
+use pushpin::runner::{get_runner_logger, open_log_file, ArgsData, CliArgs, Settings};
 use pushpin::service::start_services;
 use std::error::Error;
 use std::process;
@@ -25,7 +25,11 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let args_data = ArgsData::new(args)?;
     let settings = Settings::new(args_data)?;
 
-    log::set_logger(get_runner_logger(get_log_file(settings.log_file.clone()))).unwrap();
+    let logger = match settings.log_file.clone() {
+        Some(x) => get_runner_logger(open_log_file(x)),
+        None => get_runner_logger(None),
+    };
+    log::set_logger(logger).unwrap();
     let ll = settings
         .log_levels
         .get("")

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -25,7 +25,7 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let args_data = ArgsData::new(args)?;
     let settings = Settings::new(args_data)?;
 
-    log::set_logger(get_runner_logger()).unwrap();
+    log::set_logger(get_runner_logger(settings.log_file.clone())).unwrap();
     let ll = settings
         .log_levels
         .get("")

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -931,23 +931,18 @@ pub fn get_runner_logger(log_file: Option<Mutex<File>>) -> &'static RunnerLogger
     }
 }
 
-pub fn get_log_file(log_file_path: Option<PathBuf>) -> Option<Mutex<File>> {
-    match log_file_path {
-        Some(x) => {
-            match ensure_dir(x.parent().unwrap()) {
-                Ok(_) => (),
-                Err(_) => return None,
-            }
-            match OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(x)
-            {
-                Ok(x) => return Some(Mutex::new(x)),
-                Err(_) => None,
-            }
-        }
-        None => None,
+pub fn open_log_file(log_file_path: PathBuf) -> Option<Mutex<File>> {
+    match ensure_dir(log_file_path.parent().unwrap()) {
+        Ok(_) => (),
+        Err(_) => return None,
+    }
+    match OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(log_file_path)
+    {
+        Ok(x) => Some(Mutex::new(x)),
+        Err(_) => None,
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -929,10 +929,8 @@ impl Log for RunnerLogger {
         }
 
         if let Some(log_file) = &self.log_file {
-            let mut log_file_guard: MutexGuard<'_, File> = log_file.lock().unwrap();
-            log_file_guard
-                .write_all(format!("{}\n", record.args()).as_bytes())
-                .expect("failed to write to log file");
+            let mut log_file: MutexGuard<'_, File> = log_file.lock().unwrap();
+            writeln!(log_file, "{}", record.args()).expect("failed to write to log file");
         } else {
             println!("{}", record.args());
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -21,16 +21,14 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
 use std::error::Error;
-use std::fs;
-use std::io;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::mem;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str;
 use std::string::String;
-use std::sync::Once;
-use time::macros::format_description;
-use time::{OffsetDateTime, UtcOffset};
+use std::sync::{Arc, Once, RwLock};
 use url::Url;
 
 use crate::config::{get_config_file, CustomConfig};
@@ -896,7 +894,28 @@ mod tests {
 }
 
 struct RunnerLogger {
-    local_offset: UtcOffset,
+    log_file: Option<Arc<RwLock<File>>>,
+}
+
+impl RunnerLogger {
+    fn new(log_file_path: Option<PathBuf>) -> Result<Self, Box<dyn Error>> {
+        let log_file = match log_file_path {
+            Some(x) => {
+                ensure_dir(x.parent().unwrap())?;
+                match OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(x)
+                {
+                    Ok(x) => Some(Arc::new(RwLock::new(x))),
+                    Err(_) => None,
+                }
+            }
+            None => None,
+        };
+        Ok(RunnerLogger { log_file })
+    }
 }
 
 impl Log for RunnerLogger {
@@ -909,47 +928,12 @@ impl Log for RunnerLogger {
             return;
         }
 
-        let binding = record.args().to_string();
-        let msg_parts: Vec<&str> = binding.split_whitespace().collect();
-
-        if msg_parts.len() >= 4 {
-            println!(
-                "{} {} {} [{}] {}",
-                msg_parts[0],
-                msg_parts[1],
-                msg_parts[2],
-                record.target(),
-                msg_parts[3..].join(" ")
-            );
+        if let Some(log_file) = &self.log_file {
+            if let Ok(mut file) = log_file.write() {
+                writeln!(file, "{}", record.args()).expect("Failed to write to log file");
+            }
         } else {
-            let now = OffsetDateTime::now_utc().to_offset(self.local_offset);
-
-            let format = format_description!(
-                "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]"
-            );
-
-            let mut ts = [0u8; 64];
-
-            let size = {
-                let mut ts = io::Cursor::new(&mut ts[..]);
-
-                now.format_into(&mut ts, &format)
-                    .expect("failed to write timestamp");
-
-                ts.position() as usize
-            };
-
-            let ts = str::from_utf8(&ts[..size]).expect("timestamp is not utf-8");
-
-            let lname = match record.level() {
-                log::Level::Error => "ERR",
-                log::Level::Warn => "WARN",
-                log::Level::Info => "INFO",
-                log::Level::Debug => "DEBUG",
-                log::Level::Trace => "TRACE",
-            };
-
-            println!("[{}] {} [{}] {}", lname, ts, record.target(), record.args());
+            println!("{}", record.args());
         }
     }
 
@@ -958,15 +942,12 @@ impl Log for RunnerLogger {
 
 static mut LOGGER: mem::MaybeUninit<RunnerLogger> = mem::MaybeUninit::uninit();
 
-pub fn get_runner_logger() -> &'static impl Log {
+pub fn get_runner_logger(log_file_path: Option<PathBuf>) -> &'static impl Log {
     static INIT: Once = Once::new();
 
     unsafe {
         INIT.call_once(|| {
-            let local_offset =
-                UtcOffset::current_local_offset().expect("failed to get local time offset");
-
-            LOGGER.write(RunnerLogger { local_offset });
+            LOGGER.write(RunnerLogger::new(log_file_path).expect("failed to set logger"));
         });
 
         LOGGER.as_ptr().as_ref().unwrap()

--- a/src/service.rs
+++ b/src/service.rs
@@ -383,11 +383,24 @@ fn start_log_handler(
 }
 
 fn log_message(name: &str, level: log::Level, msg: &str) {
+    // Find the position of the 3rd space (' ') in the string
+    let index = msg
+        .char_indices()
+        .filter(|&(_, c)| c == ' ')
+        .nth(2)
+        .map(|(i, _)| i)
+        .unwrap_or_else(|| 0);
+
     log::logger().log(
         &log::Record::builder()
             .level(level)
             .target(name)
-            .args(format_args!("{}", msg))
+            .args(format_args!(
+                "{} [{}]{}",
+                &msg[..index],
+                name,
+                &msg[index..]
+            ))
             .build(),
     );
 }


### PR DESCRIPTION
This is the 10th PR in a series of PRs to rewrite Pushpin's Runner in Rust.
here we are :
-Simplifying runner logger logic 
-Adding the option to log to file if --logfile cli param is set
-Ensuring log dir & file is created and available for writing

This was tested manually
<img width="688" alt="Screenshot 2023-10-19 at 5 32 03 AM" src="https://github.com/fastly/pushpin/assets/64804941/4cbb8526-675b-44ff-bb7e-8811858b0144">
