### PR TITLE
import qzmq files and remove submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "qzmq"]
-	path = src/corelib/qzmq
-	url = https://github.com/jkarneges/qzmq.git

--- a/src/corelib/qzmq/.gitignore
+++ b/src/corelib/qzmq/.gitignore
@@ -1,0 +1,7 @@
+conf.pri
+Makefile
+*.o
+*.moc
+moc_*.cpp
+/examples/helloclient/helloclient
+/examples/helloserver/helloserver

--- a/src/corelib/qzmq/COPYING
+++ b/src/corelib/qzmq/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2012 Justin Karneges
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/corelib/qzmq/README
+++ b/src/corelib/qzmq/README
@@ -1,0 +1,24 @@
+QZmq
+----
+
+Author: Justin Karneges <justin@fanout.io>
+
+Yet another Qt binding for ZeroMQ. It wraps the C API of libzmq. It is
+compatible with libzmq versions 2.x, 3.x, and 4.x.
+
+Some features:
+  - Completely event-driven, with both read and write notifications.
+  - For convenience, it is not necessary to create a Context explicitly. If a
+    Socket is created without one, then a globally shared Context will be
+    created automatically.
+  - Some handy extra classes. For example, RepRouter makes it easy to write a
+    REP socket server that handles multiple requests simultaneously, and Valve
+    makes it easy to regulate reads.
+
+To build the examples:
+
+  echo "LIBS += -lzmq" > conf.pri
+  qmake && make
+
+To include the code in your project, just use the files in src. From a qmake
+project you can include src.pri. It's your responsibility to link to libzmq.

--- a/src/corelib/qzmq/examples/examples.pri
+++ b/src/corelib/qzmq/examples/examples.pri
@@ -1,0 +1,7 @@
+exists($$PWD/../conf.pri):include($$PWD/../conf.pri)
+
+QT -= gui
+QT += network
+
+INCLUDEPATH += $$PWD/../src
+include($$PWD/../src/src.pri)

--- a/src/corelib/qzmq/examples/examples.pro
+++ b/src/corelib/qzmq/examples/examples.pro
@@ -1,0 +1,3 @@
+TEMPLATE = subdirs
+
+SUBDIRS += helloclient helloserver

--- a/src/corelib/qzmq/examples/helloclient/helloclient.cpp
+++ b/src/corelib/qzmq/examples/helloclient/helloclient.cpp
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <QCoreApplication>
+#include <QTimer>
+#include "qzmqsocket.h"
+
+class App : public QObject
+{
+	Q_OBJECT
+
+private:
+	QZmq::Socket sock;
+
+public:
+	App() :
+		sock(QZmq::Socket::Req)
+	{
+	}
+
+public slots:
+	void start()
+	{
+		connect(&sock, SIGNAL(readyRead()), SLOT(sock_readyRead()));
+		connect(&sock, SIGNAL(messagesWritten(int)), SLOT(sock_messagesWritten(int)));
+		sock.connectToAddress("tcp://localhost:5555");
+		QByteArray out = "hello";
+		printf("writing: %s\n", out.data());
+		sock.write(QList<QByteArray>() << out);
+	}
+
+signals:
+	void quit();
+
+private slots:
+	void sock_readyRead()
+	{
+		QList<QByteArray> resp = sock.read();
+		printf("read: %s\n", resp[0].data());
+		emit quit();
+	}
+
+	void sock_messagesWritten(int count)
+	{
+		printf("messages written: %d\n", count);
+	}
+};
+
+int main(int argc, char **argv)
+{
+	QCoreApplication qapp(argc, argv);
+	App app;
+	QObject::connect(&app, SIGNAL(quit()), &qapp, SLOT(quit()));
+	QTimer::singleShot(0, &app, SLOT(start()));
+	return qapp.exec();
+}
+
+#include "helloclient.moc"

--- a/src/corelib/qzmq/examples/helloclient/helloclient.pro
+++ b/src/corelib/qzmq/examples/helloclient/helloclient.pro
@@ -1,0 +1,3 @@
+include(../examples.pri)
+
+SOURCES += helloclient.cpp

--- a/src/corelib/qzmq/examples/helloserver/helloserver.cpp
+++ b/src/corelib/qzmq/examples/helloserver/helloserver.cpp
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <QCoreApplication>
+#include <QTimer>
+#include "qzmqreqmessage.h"
+#include "qzmqreprouter.h"
+
+class App : public QObject
+{
+	Q_OBJECT
+
+private:
+	QZmq::RepRouter sock;
+
+public slots:
+	void start()
+	{
+		connect(&sock, SIGNAL(readyRead()), SLOT(sock_readyRead()));
+		connect(&sock, SIGNAL(messagesWritten(int)), SLOT(sock_messagesWritten(int)));
+		sock.bind("tcp://*:5555");
+	}
+
+signals:
+	void quit();
+
+private slots:
+	void sock_readyRead()
+	{
+		QZmq::ReqMessage msg = sock.read();
+		if(msg.content().isEmpty())
+		{
+			printf("error: received empty message\n");
+			return;
+		}
+
+		printf("read: %s\n", msg.content()[0].data());
+		QByteArray out = "world";
+		printf("writing: %s\n", out.data());
+		sock.write(msg.createReply(QList<QByteArray>() << out));
+	}
+
+	void sock_messagesWritten(int count)
+	{
+		printf("messages written: %d\n", count);
+	}
+};
+
+int main(int argc, char **argv)
+{
+	QCoreApplication qapp(argc, argv);
+	App app;
+	QObject::connect(&app, SIGNAL(quit()), &qapp, SLOT(quit()));
+	QTimer::singleShot(0, &app, SLOT(start()));
+	return qapp.exec();
+}
+
+#include "helloserver.moc"

--- a/src/corelib/qzmq/examples/helloserver/helloserver.pro
+++ b/src/corelib/qzmq/examples/helloserver/helloserver.pro
@@ -1,0 +1,3 @@
+include(../examples.pri)
+
+SOURCES += helloserver.cpp

--- a/src/corelib/qzmq/qzmq.pro
+++ b/src/corelib/qzmq/qzmq.pro
@@ -1,0 +1,3 @@
+TEMPLATE = subdirs
+
+SUBDIRS += examples

--- a/src/corelib/qzmq/src/qzmqcontext.cpp
+++ b/src/corelib/qzmq/src/qzmqcontext.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2012 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "qzmqcontext.h"
+
+#include <assert.h>
+#include <zmq.h>
+
+namespace QZmq {
+
+Context::Context(int ioThreads)
+{
+	context_ = zmq_init(ioThreads);
+	assert(context_);
+}
+
+Context::~Context()
+{
+	zmq_term(context_);
+}
+
+}

--- a/src/corelib/qzmq/src/qzmqcontext.h
+++ b/src/corelib/qzmq/src/qzmqcontext.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2012 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef QZMQCONTEXT_H
+#define QZMQCONTEXT_H
+
+namespace QZmq {
+
+class Context
+{
+public:
+	Context(int ioThreads = 1);
+	~Context();
+
+	// the zmq context
+	void *context() { return context_; }
+
+private:
+	void *context_;
+};
+
+}
+
+#endif

--- a/src/corelib/qzmq/src/qzmqreprouter.cpp
+++ b/src/corelib/qzmq/src/qzmqreprouter.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2012 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "qzmqreprouter.h"
+
+#include "qzmqsocket.h"
+#include "qzmqreqmessage.h"
+
+namespace QZmq {
+
+class RepRouter::Private : public QObject
+{
+	Q_OBJECT
+
+public:
+	RepRouter *q;
+	Socket *sock;
+
+	Private(RepRouter *_q) :
+		QObject(_q),
+		q(_q)
+	{
+		sock = new Socket(Socket::Router, this);
+		connect(sock, SIGNAL(readyRead()), SLOT(sock_readyRead()));
+		connect(sock, SIGNAL(messagesWritten(int)), SLOT(sock_messagesWritten(int)));
+	}
+
+public slots:
+	void sock_readyRead()
+	{
+		emit q->readyRead();
+	}
+
+	void sock_messagesWritten(int count)
+	{
+		emit q->messagesWritten(count);
+	}
+};
+
+RepRouter::RepRouter(QObject *parent) :
+	QObject(parent)
+{
+	d = new Private(this);
+}
+
+RepRouter::~RepRouter()
+{
+	delete d;
+}
+
+void RepRouter::setShutdownWaitTime(int msecs)
+{
+	d->sock->setShutdownWaitTime(msecs);
+}
+
+void RepRouter::connectToAddress(const QString &addr)
+{
+	d->sock->connectToAddress(addr);
+}
+
+bool RepRouter::bind(const QString &addr)
+{
+	return d->sock->bind(addr);
+}
+
+bool RepRouter::canRead() const
+{
+	return d->sock->canRead();
+}
+
+ReqMessage RepRouter::read()
+{
+	return ReqMessage(d->sock->read());
+}
+
+void RepRouter::write(const ReqMessage &message)
+{
+	d->sock->write(message.toRawMessage());
+}
+
+}
+
+#include "qzmqreprouter.moc"

--- a/src/corelib/qzmq/src/qzmqreprouter.h
+++ b/src/corelib/qzmq/src/qzmqreprouter.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef QZMQREPROUTER_H
+#define QZMQREPROUTER_H
+
+#include <QObject>
+
+namespace QZmq {
+
+class ReqMessage;
+
+class RepRouter : public QObject
+{
+	Q_OBJECT
+
+public:
+	RepRouter(QObject *parent = 0);
+	~RepRouter();
+
+	void setShutdownWaitTime(int msecs);
+
+	void connectToAddress(const QString &addr);
+	bool bind(const QString &addr);
+
+	bool canRead() const;
+
+	ReqMessage read();
+	void write(const ReqMessage &message);
+
+signals:
+	void readyRead();
+	void messagesWritten(int count);
+
+private:
+	Q_DISABLE_COPY(RepRouter)
+
+	class Private;
+	friend class Private;
+	Private *d;
+};
+
+}
+
+#endif

--- a/src/corelib/qzmq/src/qzmqreqmessage.h
+++ b/src/corelib/qzmq/src/qzmqreqmessage.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2012 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef QZMQREQMESSAGE_H
+#define QZMQREQMESSAGE_H
+
+namespace QZmq {
+
+class ReqMessage
+{
+public:
+	ReqMessage()
+	{
+	}
+
+	ReqMessage(const QList<QByteArray> &headers, const QList<QByteArray> &content) :
+		headers_(headers),
+		content_(content)
+	{
+	}
+
+	ReqMessage(const QList<QByteArray> &rawMessage)
+	{
+		bool collectHeaders = true;
+		foreach(const QByteArray &part, rawMessage)
+		{
+			if(part.isEmpty())
+			{
+				collectHeaders = false;
+				continue;
+			}
+
+			if(collectHeaders)
+				headers_ += part;
+			else
+				content_ += part;
+		}
+	}
+
+	bool isNull() const { return headers_.isEmpty() && content_.isEmpty(); }
+
+	QList<QByteArray> headers() const { return headers_; }
+	QList<QByteArray> content() const { return content_; }
+
+	ReqMessage createReply(const QList<QByteArray> &content)
+	{
+		return ReqMessage(headers_, content);
+	}
+
+	QList<QByteArray> toRawMessage() const
+	{
+		QList<QByteArray> out;
+		out += headers_;
+		out += QByteArray();
+		out += content_;
+		return out;
+	}
+
+private:
+	QList<QByteArray> headers_;
+	QList<QByteArray> content_;
+};
+
+}
+
+#endif

--- a/src/corelib/qzmq/src/qzmqsocket.cpp
+++ b/src/corelib/qzmq/src/qzmqsocket.cpp
@@ -1,0 +1,760 @@
+/*
+ * Copyright (C) 2012-2020 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "qzmqsocket.h"
+
+#include <stdio.h>
+#include <assert.h>
+#include <QStringList>
+#include <QPointer>
+#include <QTimer>
+#include <QSocketNotifier>
+#include <QMutex>
+#include <zmq.h>
+#include "qzmqcontext.h"
+
+namespace QZmq {
+
+static int get_fd(void *sock)
+{
+	int fd;
+	size_t opt_len = sizeof(fd);
+	int ret = zmq_getsockopt(sock, ZMQ_FD, &fd, &opt_len);
+	assert(ret == 0);
+	return fd;
+}
+
+static void set_subscribe(void *sock, const char *data, int size)
+{
+	size_t opt_len = size;
+	int ret = zmq_setsockopt(sock, ZMQ_SUBSCRIBE, data, opt_len);
+	assert(ret == 0);
+}
+
+static void set_unsubscribe(void *sock, const char *data, int size)
+{
+	size_t opt_len = size;
+	zmq_setsockopt(sock, ZMQ_UNSUBSCRIBE, data, opt_len);
+	// note: we ignore errors, such as unsubscribing a nonexisting filter
+}
+
+static void set_linger(void *sock, int value)
+{
+	size_t opt_len = sizeof(value);
+	int ret = zmq_setsockopt(sock, ZMQ_LINGER, &value, opt_len);
+	assert(ret == 0);
+}
+
+static int get_identity(void *sock, char *data, int size)
+{
+	size_t opt_len = size;
+	int ret = zmq_getsockopt(sock, ZMQ_IDENTITY, data, &opt_len);
+	assert(ret == 0);
+	return (int)opt_len;
+}
+
+static void set_identity(void *sock, const char *data, int size)
+{
+	size_t opt_len = size;
+	int ret = zmq_setsockopt(sock, ZMQ_IDENTITY, data, opt_len);
+	if(ret != 0)
+		printf("%d\n", errno);
+	assert(ret == 0);
+}
+
+#if ZMQ_VERSION_MAJOR >= 4
+
+static void set_immediate(void *sock, bool on)
+{
+	int v = on ? 1 : 0;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_IMMEDIATE, &v, opt_len);
+	assert(ret == 0);
+}
+
+#else
+
+static void set_immediate(void *sock, bool on)
+{
+	int v = on ? 1 : 0;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_DELAY_ATTACH_ON_CONNECT, &v, opt_len);
+	assert(ret == 0);
+}
+
+#endif
+
+#if (ZMQ_VERSION_MAJOR >= 4) || ((ZMQ_VERSION_MAJOR >= 3) && (ZMQ_VERSION_MINOR >= 2))
+
+#define USE_MSG_IO
+
+static bool get_rcvmore(void *sock)
+{
+	int more;
+	size_t opt_len = sizeof(more);
+	int ret = zmq_getsockopt(sock, ZMQ_RCVMORE, &more, &opt_len);
+	assert(ret == 0);
+	return more ? true : false;
+}
+
+static int get_events(void *sock)
+{
+	while(true)
+	{
+		int events;
+		size_t opt_len = sizeof(events);
+
+		int ret = zmq_getsockopt(sock, ZMQ_EVENTS, &events, &opt_len);
+		if(ret == 0)
+		{
+			return (int)events;
+		}
+
+		assert(errno == EINTR);
+	}
+}
+
+static int get_sndhwm(void *sock)
+{
+	int hwm;
+	size_t opt_len = sizeof(hwm);
+	int ret = zmq_getsockopt(sock, ZMQ_SNDHWM, &hwm, &opt_len);
+	assert(ret == 0);
+	return (int)hwm;
+}
+
+static void set_sndhwm(void *sock, int value)
+{
+	int v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_SNDHWM, &v, opt_len);
+	assert(ret == 0);
+}
+
+static int get_rcvhwm(void *sock)
+{
+	int hwm;
+	size_t opt_len = sizeof(hwm);
+	int ret = zmq_getsockopt(sock, ZMQ_RCVHWM, &hwm, &opt_len);
+	assert(ret == 0);
+	return (int)hwm;
+}
+
+static void set_rcvhwm(void *sock, int value)
+{
+	int v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_RCVHWM, &v, opt_len);
+	assert(ret == 0);
+}
+
+static int get_hwm(void *sock)
+{
+	return get_sndhwm(sock);
+}
+
+static void set_hwm(void *sock, int value)
+{
+	set_sndhwm(sock, value);
+	set_rcvhwm(sock, value);
+}
+
+static void set_tcp_keepalive(void *sock, int value)
+{
+	int v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE, &v, opt_len);
+	assert(ret == 0);
+}
+
+static void set_tcp_keepalive_idle(void *sock, int value)
+{
+	int v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE_IDLE, &v, opt_len);
+	assert(ret == 0);
+}
+
+static void set_tcp_keepalive_cnt(void *sock, int value)
+{
+	int v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE_CNT, &v, opt_len);
+	assert(ret == 0);
+}
+
+static void set_tcp_keepalive_intvl(void *sock, int value)
+{
+	int v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE_INTVL, &v, opt_len);
+	assert(ret == 0);
+}
+
+#else
+
+static bool get_rcvmore(void *sock)
+{
+	qint64 more;
+	size_t opt_len = sizeof(more);
+	int ret = zmq_getsockopt(sock, ZMQ_RCVMORE, &more, &opt_len);
+	assert(ret == 0);
+	return more ? true : false;
+}
+
+static int get_events(void *sock)
+{
+	while(true)
+	{
+		quint32 events;
+		size_t opt_len = sizeof(events);
+
+		int ret = zmq_getsockopt(sock, ZMQ_EVENTS, &events, &opt_len);
+		if(ret == 0)
+		{
+			return (int)events;
+		}
+
+		assert(errno == EINTR);
+	}
+}
+
+static int get_hwm(void *sock)
+{
+	quint64 hwm;
+	size_t opt_len = sizeof(hwm);
+	int ret = zmq_getsockopt(sock, ZMQ_HWM, &hwm, &opt_len);
+	assert(ret == 0);
+	return (int)hwm;
+}
+
+static void set_hwm(void *sock, int value)
+{
+	quint64 v = value;
+	size_t opt_len = sizeof(v);
+	int ret = zmq_setsockopt(sock, ZMQ_HWM, &v, opt_len);
+	assert(ret == 0);
+}
+
+static int get_sndhwm(void *sock)
+{
+	return get_hwm(sock);
+}
+
+static void set_sndhwm(void *sock, int value)
+{
+	set_hwm(sock, value);
+}
+
+static int get_rcvhwm(void *sock)
+{
+	return get_hwm(sock);
+}
+
+static void set_rcvhwm(void *sock, int value)
+{
+	set_hwm(sock, value);
+}
+
+static void set_tcp_keepalive(void *sock, int value)
+{
+	// not supported for this zmq version
+	Q_UNUSED(sock);
+	Q_UNUSED(on);
+}
+
+static void set_tcp_keepalive_idle(void *sock, int value)
+{
+	// not supported for this zmq version
+	Q_UNUSED(sock);
+	Q_UNUSED(on);
+}
+
+static void set_tcp_keepalive_cnt(void *sock, int value)
+{
+	// not supported for this zmq version
+	Q_UNUSED(sock);
+	Q_UNUSED(on);
+}
+
+static void set_tcp_keepalive_intvl(void *sock, int value)
+{
+	// not supported for this zmq version
+	Q_UNUSED(sock);
+	Q_UNUSED(on);
+}
+
+#endif
+
+Q_GLOBAL_STATIC(QMutex, g_mutex)
+
+class Global
+{
+public:
+	Context context;
+	int refs;
+
+	Global() :
+		refs(0)
+	{
+	}
+};
+
+static Global *global = 0;
+
+static Context *addGlobalContextRef()
+{
+	QMutexLocker locker(g_mutex());
+
+	if(!global)
+		global = new Global;
+
+	++(global->refs);
+	return &(global->context);
+}
+
+static void removeGlobalContextRef()
+{
+	QMutexLocker locker(g_mutex());
+
+	assert(global);
+	assert(global->refs > 0);
+
+	--(global->refs);
+	if(global->refs == 0)
+	{
+		delete global;
+		global = 0;
+	}
+}
+
+class Socket::Private : public QObject
+{
+	Q_OBJECT
+
+public:
+	Socket *q;
+	bool usingGlobalContext;
+	Context *context;
+	void *sock;
+	QSocketNotifier *sn_read;
+	bool canWrite, canRead;
+	QList< QList<QByteArray> > pendingWrites;
+	int pendingWritten;
+	QTimer *updateTimer;
+	bool pendingUpdate;
+	int shutdownWaitTime;
+	bool writeQueueEnabled;
+
+	Private(Socket *_q, Socket::Type type, Context *_context) :
+		QObject(_q),
+		q(_q),
+		canWrite(false),
+		canRead(false),
+		pendingWritten(0),
+		pendingUpdate(false),
+		shutdownWaitTime(-1),
+		writeQueueEnabled(true)
+	{
+		if(_context)
+		{
+			usingGlobalContext = false;
+			context = _context;
+		}
+		else
+		{
+			usingGlobalContext = true;
+			context = addGlobalContextRef();
+		}
+
+		int ztype = 0;
+		switch(type)
+		{
+			case Socket::Pair: ztype = ZMQ_PAIR; break;
+			case Socket::Dealer: ztype = ZMQ_DEALER; break;
+			case Socket::Router: ztype = ZMQ_ROUTER; break;
+			case Socket::Req: ztype = ZMQ_REQ; break;
+			case Socket::Rep: ztype = ZMQ_REP; break;
+			case Socket::Push: ztype = ZMQ_PUSH; break;
+			case Socket::Pull: ztype = ZMQ_PULL; break;
+			case Socket::Pub: ztype = ZMQ_PUB; break;
+			case Socket::Sub: ztype = ZMQ_SUB; break;
+			default:
+				assert(0);
+		}
+
+		sock = zmq_socket(context->context(), ztype);
+		assert(sock != NULL);
+
+		sn_read = new QSocketNotifier(get_fd(sock), QSocketNotifier::Read, this);
+		connect(sn_read, SIGNAL(activated(int)), SLOT(sn_read_activated()));
+		sn_read->setEnabled(true);
+
+		updateTimer = new QTimer(this);
+		connect(updateTimer, SIGNAL(timeout()), SLOT(update_timeout()));
+		updateTimer->setSingleShot(true);
+	}
+
+	~Private()
+	{
+		updateTimer->disconnect(this);
+		updateTimer->setParent(0);
+		updateTimer->deleteLater();
+
+		set_linger(sock, shutdownWaitTime);
+		zmq_close(sock);
+
+		if(usingGlobalContext)
+			removeGlobalContextRef();
+	}
+
+	void update()
+	{
+		if(!pendingUpdate)
+		{
+			pendingUpdate = true;
+			updateTimer->start();
+		}
+	}
+
+	QList<QByteArray> read()
+	{
+		if(canRead)
+		{
+			QList<QByteArray> out;
+
+			bool ok = true;
+
+			do
+			{
+				zmq_msg_t msg;
+
+				int ret = zmq_msg_init(&msg);
+				assert(ret == 0);
+
+#ifdef USE_MSG_IO
+				ret = zmq_msg_recv(&msg, sock, ZMQ_DONTWAIT);
+#else
+				ret = zmq_recv(sock, &msg, ZMQ_NOBLOCK);
+#endif
+
+				if(ret < 0)
+				{
+					ret = zmq_msg_close(&msg);
+					assert(ret == 0);
+
+					ok = false;
+					break;
+				}
+
+				QByteArray buf((const char *)zmq_msg_data(&msg), zmq_msg_size(&msg));
+
+				ret = zmq_msg_close(&msg);
+				assert(ret == 0);
+
+				out += buf;
+			} while(get_rcvmore(sock));
+
+			processEvents();
+
+			if((canWrite && !pendingWrites.isEmpty()) || canRead)
+				update();
+
+			if(ok)
+				return out;
+			else
+				return QList<QByteArray>();
+		}
+		else
+			return QList<QByteArray>();
+	}
+
+	void write(const QList<QByteArray> &message)
+	{
+		assert(!message.isEmpty());
+
+		if(writeQueueEnabled)
+		{
+			pendingWrites += message;
+
+			if(canWrite)
+				update();
+		}
+		else
+		{
+			if(zmqWrite(message))
+			{
+				++pendingWritten;
+			}
+
+			processEvents();
+
+			if(pendingWritten > 0 || canRead)
+				update();
+		}
+	}
+
+	// return true if flags changed
+	bool processEvents()
+	{
+		int flags = get_events(sock);
+
+		bool canWriteOld = canWrite;
+		bool canReadOld = canRead;
+
+		canWrite = (flags & ZMQ_POLLOUT);
+		canRead = (flags & ZMQ_POLLIN);
+
+		return (canWrite != canWriteOld || canRead != canReadOld);
+	}
+
+	bool zmqWrite(const QList<QByteArray> &message)
+	{
+		for(int n = 0; n < message.count(); ++n)
+		{
+			const QByteArray &buf = message[n];
+
+			zmq_msg_t msg;
+
+			int ret = zmq_msg_init_size(&msg, buf.size());
+			assert(ret == 0);
+
+			memcpy(zmq_msg_data(&msg), buf.data(), buf.size());
+
+#ifdef USE_MSG_IO
+			ret = zmq_msg_send(&msg, sock, ZMQ_DONTWAIT | (n + 1 < message.count() ? ZMQ_SNDMORE : 0));
+#else
+			ret = zmq_send(sock, &msg, ZMQ_NOBLOCK | (n + 1 < message.count() ? ZMQ_SNDMORE : 0));
+#endif
+
+			if(ret < 0)
+			{
+				ret = zmq_msg_close(&msg);
+				assert(ret == 0);
+
+				return false;
+			}
+
+			ret = zmq_msg_close(&msg);
+			assert(ret == 0);
+		}
+
+		return true;
+	}
+
+	void tryWrite()
+	{
+		while(canWrite && !pendingWrites.isEmpty())
+		{
+			// whether this write succeeds or not, we assume we
+			//   can't write afterwards
+			canWrite = false;
+
+			if(zmqWrite(pendingWrites.first()))
+			{
+				pendingWrites.removeFirst();
+				++pendingWritten;
+			}
+
+			processEvents();
+		}
+	}
+
+	void doUpdate()
+	{
+		tryWrite();
+
+		if(canRead)
+		{
+			QPointer<QObject> self = this;
+			emit q->readyRead();
+			if(!self)
+				return;
+		}
+
+		if(pendingWritten > 0)
+		{
+			int count = pendingWritten;
+			pendingWritten = 0;
+
+			emit q->messagesWritten(count);
+		}
+	}
+
+public slots:
+	void sn_read_activated()
+	{
+		if(!processEvents())
+			return;
+
+		if(pendingUpdate)
+		{
+			pendingUpdate = false;
+			updateTimer->stop();
+		}
+
+		doUpdate();
+	}
+
+	void update_timeout()
+	{
+		pendingUpdate = false;
+
+		doUpdate();
+	}
+};
+
+Socket::Socket(Type type, QObject *parent) :
+	QObject(parent)
+{
+	d = new Private(this, type, 0);
+}
+
+Socket::Socket(Type type, Context *context, QObject *parent) :
+	QObject(parent)
+{
+	d = new Private(this, type, context);
+}
+
+Socket::~Socket()
+{
+	delete d;
+}
+
+void Socket::setShutdownWaitTime(int msecs)
+{
+	d->shutdownWaitTime = msecs;
+}
+
+void Socket::setWriteQueueEnabled(bool enable)
+{
+	d->writeQueueEnabled = enable;
+}
+
+void Socket::subscribe(const QByteArray &filter)
+{
+	set_subscribe(d->sock, filter.data(), filter.size());
+}
+
+void Socket::unsubscribe(const QByteArray &filter)
+{
+	set_unsubscribe(d->sock, filter.data(), filter.size());
+}
+
+QByteArray Socket::identity() const
+{
+	QByteArray buf(255, 0);
+	buf.resize(get_identity(d->sock, buf.data(), buf.size()));
+	return buf;
+}
+
+void Socket::setIdentity(const QByteArray &id)
+{
+	set_identity(d->sock, id.data(), id.size());
+}
+
+int Socket::hwm() const
+{
+	return get_hwm(d->sock);
+}
+
+void Socket::setHwm(int hwm)
+{
+	set_hwm(d->sock, hwm);
+}
+
+int Socket::sendHwm() const
+{
+	return get_sndhwm(d->sock);
+}
+
+int Socket::receiveHwm() const
+{
+	return get_rcvhwm(d->sock);
+}
+
+void Socket::setSendHwm(int hwm)
+{
+	set_sndhwm(d->sock, hwm);
+}
+
+void Socket::setReceiveHwm(int hwm)
+{
+	set_rcvhwm(d->sock, hwm);
+}
+
+void Socket::setImmediateEnabled(bool on)
+{
+	set_immediate(d->sock, on);
+}
+
+void Socket::setTcpKeepAliveEnabled(bool on)
+{
+	set_tcp_keepalive(d->sock, on ? 1 : 0);
+}
+
+void Socket::setTcpKeepAliveParameters(int idle, int count, int interval)
+{
+	set_tcp_keepalive_idle(d->sock, idle);
+	set_tcp_keepalive_cnt(d->sock, count);
+	set_tcp_keepalive_intvl(d->sock, interval);
+}
+
+void Socket::connectToAddress(const QString &addr)
+{
+	int ret = zmq_connect(d->sock, addr.toUtf8().data());
+	assert(ret == 0);
+}
+
+bool Socket::bind(const QString &addr)
+{
+	int ret = zmq_bind(d->sock, addr.toUtf8().data());
+	if(ret != 0)
+		return false;
+
+	return true;
+}
+
+bool Socket::canRead() const
+{
+	return d->canRead;
+}
+
+bool Socket::canWriteImmediately() const
+{
+	return d->canWrite;
+}
+
+QList<QByteArray> Socket::read()
+{
+	return d->read();
+}
+
+void Socket::write(const QList<QByteArray> &message)
+{
+	d->write(message);
+}
+
+}
+
+#include "qzmqsocket.moc"

--- a/src/corelib/qzmq/src/qzmqsocket.h
+++ b/src/corelib/qzmq/src/qzmqsocket.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2012-2015 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef QZMQSOCKET_H
+#define QZMQSOCKET_H
+
+#include <QObject>
+
+namespace QZmq {
+
+class Context;
+
+class Socket : public QObject
+{
+	Q_OBJECT
+
+public:
+	enum Type
+	{
+		Pair,
+		Dealer,
+		Router,
+		Req,
+		Rep,
+		Push,
+		Pull,
+		Pub,
+		Sub
+	};
+
+	Socket(Type type, QObject *parent = 0);
+	Socket(Type type, Context *context, QObject *parent = 0);
+	~Socket();
+
+	// 0 means drop queue and don't block, -1 means infinite (default = -1)
+	void setShutdownWaitTime(int msecs);
+
+	// if enabled, messages are queued internally until the socket is able
+	//   to accept them. the messagesWritten signal is emitted once writes
+	//   have succeeded. otherwise, messages are passed directly to
+	//   zmq_send and dropped if they can't be written. default enabled.
+	// disabling the queue is good for socket types where the HWM has a
+	//   drop policy. enabling the queue is good when the HWM has a
+	//   blocking policy.
+	void setWriteQueueEnabled(bool enable);
+
+	void subscribe(const QByteArray &filter);
+	void unsubscribe(const QByteArray &filter);
+
+	QByteArray identity() const;
+	void setIdentity(const QByteArray &id);
+
+	// deprecated, zmq 2.x
+	int hwm() const;
+	void setHwm(int hwm);
+
+	int sendHwm() const;
+	int receiveHwm() const;
+	void setSendHwm(int hwm);
+	void setReceiveHwm(int hwm);
+
+	void setImmediateEnabled(bool on);
+
+	void setTcpKeepAliveEnabled(bool on);
+	void setTcpKeepAliveParameters(int idle = -1, int count = -1, int interval = -1);
+
+	void connectToAddress(const QString &addr);
+	bool bind(const QString &addr);
+
+	bool canRead() const;
+
+	// returns true if this object believes the next write to zmq will
+	//   succeed immediately. note that it starts out false until the
+	//   value is discovered. also note that the write could still end up
+	//   needing to be queued, if the conditions change in between.
+	bool canWriteImmediately() const;
+
+	QList<QByteArray> read();
+	void write(const QList<QByteArray> &message);
+
+signals:
+	void readyRead();
+	void messagesWritten(int count);
+
+private:
+	Q_DISABLE_COPY(Socket)
+
+	class Private;
+	friend class Private;
+	Private *d;
+};
+
+}
+
+#endif

--- a/src/corelib/qzmq/src/qzmqvalve.cpp
+++ b/src/corelib/qzmq/src/qzmqvalve.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2012-2020 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "qzmqvalve.h"
+
+#include <QPointer>
+#include "qzmqsocket.h"
+
+namespace QZmq {
+
+class Valve::Private : public QObject
+{
+	Q_OBJECT
+
+public:
+	Valve *q;
+	QZmq::Socket *sock;
+	bool isOpen;
+	bool pendingRead;
+	int maxReadsPerEvent;
+
+	Private(Valve *_q) :
+		QObject(_q),
+		q(_q),
+		sock(0),
+		isOpen(false),
+		pendingRead(false),
+		maxReadsPerEvent(100)
+	{
+	}
+
+	void setup(QZmq::Socket *_sock)
+	{
+		sock = _sock;
+		connect(sock, SIGNAL(readyRead()), SLOT(sock_readyRead()));
+	}
+
+	void queueRead()
+	{
+		if(pendingRead)
+			return;
+
+		pendingRead = true;
+		QMetaObject::invokeMethod(this, "queuedRead", Qt::QueuedConnection);
+	}
+
+	void tryRead()
+	{
+		QPointer<QObject> self = this;
+
+		int count = 0;
+		while(isOpen && sock->canRead())
+		{
+			if(count >= maxReadsPerEvent)
+			{
+				queueRead();
+				return;
+			}
+
+			QList<QByteArray> msg = sock->read();
+
+			if(!msg.isEmpty())
+			{
+				emit q->readyRead(msg);
+				if(!self)
+					return;
+			}
+
+			++count;
+		}
+	}
+
+private slots:
+	void sock_readyRead()
+	{
+		if(pendingRead)
+			return;
+
+		tryRead();
+	}
+
+	void queuedRead()
+	{
+		pendingRead = false;
+		tryRead();
+	}
+};
+
+Valve::Valve(QZmq::Socket *sock, QObject *parent) :
+	QObject(parent)
+{
+	d = new Private(this);
+	d->setup(sock);
+}
+
+Valve::~Valve()
+{
+	delete d;
+}
+
+bool Valve::isOpen() const
+{
+	return d->isOpen;
+}
+
+void Valve::setMaxReadsPerEvent(int max)
+{
+	d->maxReadsPerEvent = max;
+}
+
+void Valve::open()
+{
+	if(!d->isOpen)
+	{
+		d->isOpen = true;
+		if(!d->pendingRead && d->sock->canRead())
+			d->queueRead();
+	}
+}
+
+void Valve::close()
+{
+	d->isOpen = false;
+}
+
+}
+
+#include "qzmqvalve.moc"

--- a/src/corelib/qzmq/src/qzmqvalve.h
+++ b/src/corelib/qzmq/src/qzmqvalve.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2012 Justin Karneges
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef QZMQVALVE_H
+#define QZMQVALVE_H
+
+#include <QObject>
+
+namespace QZmq {
+
+class Socket;
+
+class Valve : public QObject
+{
+	Q_OBJECT
+
+public:
+	Valve(QZmq::Socket *sock, QObject *parent = 0);
+	~Valve();
+
+	bool isOpen() const;
+
+	void setMaxReadsPerEvent(int max);
+
+	void open();
+	void close();
+
+signals:
+	void readyRead(const QList<QByteArray> &message);
+
+private:
+	class Private;
+	friend class Private;
+	Private *d;
+};
+
+}
+
+#endif

--- a/src/corelib/qzmq/src/src.pri
+++ b/src/corelib/qzmq/src/src.pri
@@ -1,0 +1,12 @@
+HEADERS += \
+	$$PWD/qzmqcontext.h \
+	$$PWD/qzmqsocket.h \
+	$$PWD/qzmqvalve.h \
+	$$PWD/qzmqreqmessage.h \
+	$$PWD/qzmqreprouter.h
+
+SOURCES += \
+	$$PWD/qzmqcontext.cpp \
+	$$PWD/qzmqsocket.cpp \
+	$$PWD/qzmqvalve.cpp \
+	$$PWD/qzmqreprouter.cpp


### PR DESCRIPTION
Currently, we use zmq from both Rust and C++ code, but each language uses a different process for detecting and linking against zmq (C++ uses the configure script, and Rust uses the logic from the zmq crate), which is a) weird and could lead to inconsistent results, and b) problematic when mixing Rust & C++ code together. In order to fix this, I'm planning to have the C++ code access zmq through Rust rather than directly. This way, only the Rust code will contain direct zmq usage and we can keep the detecting/linking logic in one place (in Rust). Relatedly, this will require turning all of our C++ programs into Rust programs, even if the Rust versions are just tiny wrappers around C++, to get Rust's linking behavior in all of our programs.

For our C++ zmq code to go through Rust, we'll need to be able to modify the qzmq dependency which we currently pull in as a submodule. So, as a first step, this PR copies qzmq into in the repo so we can modify it. The rest of the above plan will be handled in subsequent PRs.