### PR TITLE
fix qt 5.12 & 5.13 compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -432,6 +432,12 @@ arg: logdir=[path],Directory for log files.  Default: /var/log
 #include <QDateTime>
 #include <QSettings>
 
+#if QT_VERSION >= 0x050e00
+#define ENDL Qt::endl
+#else
+#define ENDL endl
+#endif
+
 static QString getVersion()
 {
 	QSettings settings("Cargo.toml", QSettings::IniFormat);
@@ -494,9 +500,9 @@ public:
 		if(file.open(QIODevice::WriteOnly | QIODevice::Text))
 		{
 			QTextStream stream( &file );
-			stream << "#define VERSION \\"" << version << "\\"" << Qt::endl;
-			stream << "#define LIBDIR \\"" << libdir << "/pushpin\\"" << Qt::endl;
-			stream << "#define CONFIGDIR \\"" << configdir << "/pushpin\\"" << Qt::endl;
+			stream << "#define VERSION \\"" << version << "\\"" << ENDL;
+			stream << "#define LIBDIR \\"" << libdir << "/pushpin\\"" << ENDL;
+			stream << "#define CONFIGDIR \\"" << configdir << "/pushpin\\"" << ENDL;
 		}
 
 		conf->addDefine("HAVE_CONFIG");

--- a/qcm/conf.qcm
+++ b/qcm/conf.qcm
@@ -12,6 +12,12 @@ arg: logdir=[path],Directory for log files.  Default: /var/log
 #include <QDateTime>
 #include <QSettings>
 
+#if QT_VERSION >= 0x050e00
+#define ENDL Qt::endl
+#else
+#define ENDL endl
+#endif
+
 static QString getVersion()
 {
 	QSettings settings("Cargo.toml", QSettings::IniFormat);
@@ -74,9 +80,9 @@ public:
 		if(file.open(QIODevice::WriteOnly | QIODevice::Text))
 		{
 			QTextStream stream( &file );
-			stream << "#define VERSION \"" << version << "\"" << Qt::endl;
-			stream << "#define LIBDIR \"" << libdir << "/pushpin\"" << Qt::endl;
-			stream << "#define CONFIGDIR \"" << configdir << "/pushpin\"" << Qt::endl;
+			stream << "#define VERSION \"" << version << "\"" << ENDL;
+			stream << "#define LIBDIR \"" << libdir << "/pushpin\"" << ENDL;
+			stream << "#define CONFIGDIR \"" << configdir << "/pushpin\"" << ENDL;
 		}
 
 		conf->addDefine("HAVE_CONFIG");


### PR DESCRIPTION
The qt 6 compatibility changes accidentally broke older 5.x compat, notably 5.12 which is used by Ubuntu 20.04.