### PR TITLE
wrap zmq crate with libzmq-like C API and use from qzmq

### DIFF
--- a/src/corelib/qzmq/src/qzmqcontext.cpp
+++ b/src/corelib/qzmq/src/qzmqcontext.cpp
@@ -24,19 +24,19 @@
 #include "qzmqcontext.h"
 
 #include <assert.h>
-#include <zmq.h>
+#include "rust/wzmq.h"
 
 namespace QZmq {
 
 Context::Context(int ioThreads)
 {
-	context_ = zmq_init(ioThreads);
+	context_ = wzmq_init(ioThreads);
 	assert(context_);
 }
 
 Context::~Context()
 {
-	zmq_term(context_);
+	wzmq_term(context_);
 }
 
 }

--- a/src/corelib/qzmq/src/qzmqsocket.cpp
+++ b/src/corelib/qzmq/src/qzmqsocket.cpp
@@ -30,7 +30,7 @@
 #include <QTimer>
 #include <QSocketNotifier>
 #include <QMutex>
-#include <zmq.h>
+#include "rust/wzmq.h"
 #include "qzmqcontext.h"
 
 namespace QZmq {
@@ -39,7 +39,7 @@ static int get_fd(void *sock)
 {
 	int fd;
 	size_t opt_len = sizeof(fd);
-	int ret = zmq_getsockopt(sock, ZMQ_FD, &fd, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_FD, &fd, &opt_len);
 	assert(ret == 0);
 	return fd;
 }
@@ -47,28 +47,28 @@ static int get_fd(void *sock)
 static void set_subscribe(void *sock, const char *data, int size)
 {
 	size_t opt_len = size;
-	int ret = zmq_setsockopt(sock, ZMQ_SUBSCRIBE, data, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_SUBSCRIBE, data, opt_len);
 	assert(ret == 0);
 }
 
 static void set_unsubscribe(void *sock, const char *data, int size)
 {
 	size_t opt_len = size;
-	zmq_setsockopt(sock, ZMQ_UNSUBSCRIBE, data, opt_len);
+	wzmq_setsockopt(sock, WZMQ_UNSUBSCRIBE, data, opt_len);
 	// note: we ignore errors, such as unsubscribing a nonexisting filter
 }
 
 static void set_linger(void *sock, int value)
 {
 	size_t opt_len = sizeof(value);
-	int ret = zmq_setsockopt(sock, ZMQ_LINGER, &value, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_LINGER, &value, opt_len);
 	assert(ret == 0);
 }
 
 static int get_identity(void *sock, char *data, int size)
 {
 	size_t opt_len = size;
-	int ret = zmq_getsockopt(sock, ZMQ_IDENTITY, data, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_IDENTITY, data, &opt_len);
 	assert(ret == 0);
 	return (int)opt_len;
 }
@@ -76,19 +76,19 @@ static int get_identity(void *sock, char *data, int size)
 static void set_identity(void *sock, const char *data, int size)
 {
 	size_t opt_len = size;
-	int ret = zmq_setsockopt(sock, ZMQ_IDENTITY, data, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_IDENTITY, data, opt_len);
 	if(ret != 0)
 		printf("%d\n", errno);
 	assert(ret == 0);
 }
 
-#if ZMQ_VERSION_MAJOR >= 4
+#if WZMQ_VERSION_MAJOR >= 4
 
 static void set_immediate(void *sock, bool on)
 {
 	int v = on ? 1 : 0;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_IMMEDIATE, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_IMMEDIATE, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -98,13 +98,13 @@ static void set_immediate(void *sock, bool on)
 {
 	int v = on ? 1 : 0;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_DELAY_ATTACH_ON_CONNECT, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_DELAY_ATTACH_ON_CONNECT, &v, opt_len);
 	assert(ret == 0);
 }
 
 #endif
 
-#if (ZMQ_VERSION_MAJOR >= 4) || ((ZMQ_VERSION_MAJOR >= 3) && (ZMQ_VERSION_MINOR >= 2))
+#if (WZMQ_VERSION_MAJOR >= 4) || ((WZMQ_VERSION_MAJOR >= 3) && (WZMQ_VERSION_MINOR >= 2))
 
 #define USE_MSG_IO
 
@@ -112,7 +112,7 @@ static bool get_rcvmore(void *sock)
 {
 	int more;
 	size_t opt_len = sizeof(more);
-	int ret = zmq_getsockopt(sock, ZMQ_RCVMORE, &more, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_RCVMORE, &more, &opt_len);
 	assert(ret == 0);
 	return more ? true : false;
 }
@@ -124,7 +124,7 @@ static int get_events(void *sock)
 		int events;
 		size_t opt_len = sizeof(events);
 
-		int ret = zmq_getsockopt(sock, ZMQ_EVENTS, &events, &opt_len);
+		int ret = wzmq_getsockopt(sock, WZMQ_EVENTS, &events, &opt_len);
 		if(ret == 0)
 		{
 			return (int)events;
@@ -138,7 +138,7 @@ static int get_sndhwm(void *sock)
 {
 	int hwm;
 	size_t opt_len = sizeof(hwm);
-	int ret = zmq_getsockopt(sock, ZMQ_SNDHWM, &hwm, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_SNDHWM, &hwm, &opt_len);
 	assert(ret == 0);
 	return (int)hwm;
 }
@@ -147,7 +147,7 @@ static void set_sndhwm(void *sock, int value)
 {
 	int v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_SNDHWM, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_SNDHWM, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -155,7 +155,7 @@ static int get_rcvhwm(void *sock)
 {
 	int hwm;
 	size_t opt_len = sizeof(hwm);
-	int ret = zmq_getsockopt(sock, ZMQ_RCVHWM, &hwm, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_RCVHWM, &hwm, &opt_len);
 	assert(ret == 0);
 	return (int)hwm;
 }
@@ -164,7 +164,7 @@ static void set_rcvhwm(void *sock, int value)
 {
 	int v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_RCVHWM, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_RCVHWM, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -183,7 +183,7 @@ static void set_tcp_keepalive(void *sock, int value)
 {
 	int v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_TCP_KEEPALIVE, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -191,7 +191,7 @@ static void set_tcp_keepalive_idle(void *sock, int value)
 {
 	int v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE_IDLE, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_TCP_KEEPALIVE_IDLE, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -199,7 +199,7 @@ static void set_tcp_keepalive_cnt(void *sock, int value)
 {
 	int v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE_CNT, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_TCP_KEEPALIVE_CNT, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -207,7 +207,7 @@ static void set_tcp_keepalive_intvl(void *sock, int value)
 {
 	int v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_TCP_KEEPALIVE_INTVL, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_TCP_KEEPALIVE_INTVL, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -217,7 +217,7 @@ static bool get_rcvmore(void *sock)
 {
 	qint64 more;
 	size_t opt_len = sizeof(more);
-	int ret = zmq_getsockopt(sock, ZMQ_RCVMORE, &more, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_RCVMORE, &more, &opt_len);
 	assert(ret == 0);
 	return more ? true : false;
 }
@@ -229,7 +229,7 @@ static int get_events(void *sock)
 		quint32 events;
 		size_t opt_len = sizeof(events);
 
-		int ret = zmq_getsockopt(sock, ZMQ_EVENTS, &events, &opt_len);
+		int ret = wzmq_getsockopt(sock, WZMQ_EVENTS, &events, &opt_len);
 		if(ret == 0)
 		{
 			return (int)events;
@@ -243,7 +243,7 @@ static int get_hwm(void *sock)
 {
 	quint64 hwm;
 	size_t opt_len = sizeof(hwm);
-	int ret = zmq_getsockopt(sock, ZMQ_HWM, &hwm, &opt_len);
+	int ret = wzmq_getsockopt(sock, WZMQ_HWM, &hwm, &opt_len);
 	assert(ret == 0);
 	return (int)hwm;
 }
@@ -252,7 +252,7 @@ static void set_hwm(void *sock, int value)
 {
 	quint64 v = value;
 	size_t opt_len = sizeof(v);
-	int ret = zmq_setsockopt(sock, ZMQ_HWM, &v, opt_len);
+	int ret = wzmq_setsockopt(sock, WZMQ_HWM, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -390,20 +390,20 @@ public:
 		int ztype = 0;
 		switch(type)
 		{
-			case Socket::Pair: ztype = ZMQ_PAIR; break;
-			case Socket::Dealer: ztype = ZMQ_DEALER; break;
-			case Socket::Router: ztype = ZMQ_ROUTER; break;
-			case Socket::Req: ztype = ZMQ_REQ; break;
-			case Socket::Rep: ztype = ZMQ_REP; break;
-			case Socket::Push: ztype = ZMQ_PUSH; break;
-			case Socket::Pull: ztype = ZMQ_PULL; break;
-			case Socket::Pub: ztype = ZMQ_PUB; break;
-			case Socket::Sub: ztype = ZMQ_SUB; break;
+			case Socket::Pair: ztype = WZMQ_PAIR; break;
+			case Socket::Dealer: ztype = WZMQ_DEALER; break;
+			case Socket::Router: ztype = WZMQ_ROUTER; break;
+			case Socket::Req: ztype = WZMQ_REQ; break;
+			case Socket::Rep: ztype = WZMQ_REP; break;
+			case Socket::Push: ztype = WZMQ_PUSH; break;
+			case Socket::Pull: ztype = WZMQ_PULL; break;
+			case Socket::Pub: ztype = WZMQ_PUB; break;
+			case Socket::Sub: ztype = WZMQ_SUB; break;
 			default:
 				assert(0);
 		}
 
-		sock = zmq_socket(context->context(), ztype);
+		sock = wzmq_socket(context->context(), ztype);
 		assert(sock != NULL);
 
 		sn_read = new QSocketNotifier(get_fd(sock), QSocketNotifier::Read, this);
@@ -422,7 +422,7 @@ public:
 		updateTimer->deleteLater();
 
 		set_linger(sock, shutdownWaitTime);
-		zmq_close(sock);
+		wzmq_close(sock);
 
 		if(usingGlobalContext)
 			removeGlobalContextRef();
@@ -447,29 +447,29 @@ public:
 
 			do
 			{
-				zmq_msg_t msg;
+				wzmq_msg_t msg;
 
-				int ret = zmq_msg_init(&msg);
+				int ret = wzmq_msg_init(&msg);
 				assert(ret == 0);
 
 #ifdef USE_MSG_IO
-				ret = zmq_msg_recv(&msg, sock, ZMQ_DONTWAIT);
+				ret = wzmq_msg_recv(&msg, sock, WZMQ_DONTWAIT);
 #else
-				ret = zmq_recv(sock, &msg, ZMQ_NOBLOCK);
+				ret = wzmq_recv(sock, &msg, WZMQ_NOBLOCK);
 #endif
 
 				if(ret < 0)
 				{
-					ret = zmq_msg_close(&msg);
+					ret = wzmq_msg_close(&msg);
 					assert(ret == 0);
 
 					ok = false;
 					break;
 				}
 
-				QByteArray buf((const char *)zmq_msg_data(&msg), zmq_msg_size(&msg));
+				QByteArray buf((const char *)wzmq_msg_data(&msg), wzmq_msg_size(&msg));
 
-				ret = zmq_msg_close(&msg);
+				ret = wzmq_msg_close(&msg);
 				assert(ret == 0);
 
 				out += buf;
@@ -522,8 +522,8 @@ public:
 		bool canWriteOld = canWrite;
 		bool canReadOld = canRead;
 
-		canWrite = (flags & ZMQ_POLLOUT);
-		canRead = (flags & ZMQ_POLLIN);
+		canWrite = (flags & WZMQ_POLLOUT);
+		canRead = (flags & WZMQ_POLLIN);
 
 		return (canWrite != canWriteOld || canRead != canReadOld);
 	}
@@ -534,28 +534,28 @@ public:
 		{
 			const QByteArray &buf = message[n];
 
-			zmq_msg_t msg;
+			wzmq_msg_t msg;
 
-			int ret = zmq_msg_init_size(&msg, buf.size());
+			int ret = wzmq_msg_init_size(&msg, buf.size());
 			assert(ret == 0);
 
-			memcpy(zmq_msg_data(&msg), buf.data(), buf.size());
+			memcpy(wzmq_msg_data(&msg), buf.data(), buf.size());
 
 #ifdef USE_MSG_IO
-			ret = zmq_msg_send(&msg, sock, ZMQ_DONTWAIT | (n + 1 < message.count() ? ZMQ_SNDMORE : 0));
+			ret = wzmq_msg_send(&msg, sock, WZMQ_DONTWAIT | (n + 1 < message.count() ? WZMQ_SNDMORE : 0));
 #else
-			ret = zmq_send(sock, &msg, ZMQ_NOBLOCK | (n + 1 < message.count() ? ZMQ_SNDMORE : 0));
+			ret = wzmq_send(sock, &msg, WZMQ_NOBLOCK | (n + 1 < message.count() ? WZMQ_SNDMORE : 0));
 #endif
 
 			if(ret < 0)
 			{
-				ret = zmq_msg_close(&msg);
+				ret = wzmq_msg_close(&msg);
 				assert(ret == 0);
 
 				return false;
 			}
 
-			ret = zmq_msg_close(&msg);
+			ret = wzmq_msg_close(&msg);
 			assert(ret == 0);
 		}
 
@@ -722,13 +722,13 @@ void Socket::setTcpKeepAliveParameters(int idle, int count, int interval)
 
 void Socket::connectToAddress(const QString &addr)
 {
-	int ret = zmq_connect(d->sock, addr.toUtf8().data());
+	int ret = wzmq_connect(d->sock, addr.toUtf8().data());
 	assert(ret == 0);
 }
 
 bool Socket::bind(const QString &addr)
 {
-	int ret = zmq_bind(d->sock, addr.toUtf8().data());
+	int ret = wzmq_bind(d->sock, addr.toUtf8().data());
 	if(ret != 0)
 		return false;
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2022 Fanout, Inc.
+ * Copyright (C) 2023 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -346,4 +347,712 @@ pub unsafe extern "C" fn jwt_decode(
     *out_claim = claim.into_raw();
 
     0
+}
+
+// NOTE: must match values in wzmq.h
+const WZMQ_PAIR: libc::c_int = 0;
+const WZMQ_PUB: libc::c_int = 1;
+const WZMQ_SUB: libc::c_int = 2;
+const WZMQ_REQ: libc::c_int = 3;
+const WZMQ_REP: libc::c_int = 4;
+const WZMQ_DEALER: libc::c_int = 5;
+const WZMQ_ROUTER: libc::c_int = 6;
+const WZMQ_PULL: libc::c_int = 7;
+const WZMQ_PUSH: libc::c_int = 8;
+const WZMQ_XPUB: libc::c_int = 9;
+const WZMQ_XSUB: libc::c_int = 10;
+const WZMQ_STREAM: libc::c_int = 11;
+
+// NOTE: must match values in wzmq.h
+const WZMQ_FD: libc::c_int = 0;
+const WZMQ_SUBSCRIBE: libc::c_int = 1;
+const WZMQ_UNSUBSCRIBE: libc::c_int = 2;
+const WZMQ_LINGER: libc::c_int = 3;
+const WZMQ_IDENTITY: libc::c_int = 4;
+const WZMQ_IMMEDIATE: libc::c_int = 5;
+const WZMQ_RCVMORE: libc::c_int = 6;
+const WZMQ_EVENTS: libc::c_int = 7;
+const WZMQ_SNDHWM: libc::c_int = 8;
+const WZMQ_RCVHWM: libc::c_int = 9;
+const WZMQ_TCP_KEEPALIVE: libc::c_int = 10;
+const WZMQ_TCP_KEEPALIVE_IDLE: libc::c_int = 11;
+const WZMQ_TCP_KEEPALIVE_CNT: libc::c_int = 12;
+const WZMQ_TCP_KEEPALIVE_INTVL: libc::c_int = 13;
+
+// NOTE: must match values in wzmq.h
+const WZMQ_DONTWAIT: libc::c_int = 0x01;
+const WZMQ_SNDMORE: libc::c_int = 0x02;
+
+// NOTE: must match values in wzmq.h
+const WZMQ_POLLIN: libc::c_int = 0x01;
+const WZMQ_POLLOUT: libc::c_int = 0x02;
+
+#[repr(C)]
+pub struct WZmqMessage {
+    data: *mut zmq::Message,
+}
+
+fn convert_io_flags(flags: libc::c_int) -> i32 {
+    let mut out = 0;
+
+    if flags & WZMQ_DONTWAIT != 0 {
+        out |= zmq::DONTWAIT;
+    }
+
+    if flags & WZMQ_SNDMORE != 0 {
+        out |= zmq::SNDMORE;
+    }
+
+    out
+}
+
+fn convert_events(events: zmq::PollEvents) -> libc::c_int {
+    let mut out = 0;
+
+    if events.contains(zmq::POLLIN) {
+        out |= WZMQ_POLLIN;
+    }
+
+    if events.contains(zmq::POLLOUT) {
+        out |= WZMQ_POLLOUT;
+    }
+
+    out
+}
+
+#[cfg(target_os = "macos")]
+fn set_errno(value: libc::c_int) {
+    unsafe {
+        *libc::__error() = value;
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_errno(value: libc::c_int) {
+    unsafe {
+        *libc::__errno_location() = value;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn wzmq_init(io_threads: libc::c_int) -> *mut zmq::Context {
+    let ctx = zmq::Context::new();
+
+    if ctx.set_io_threads(io_threads).is_err() {
+        return ptr::null_mut();
+    }
+
+    Box::into_raw(Box::new(ctx))
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_term(context: *mut zmq::Context) -> libc::c_int {
+    if !context.is_null() {
+        drop(Box::from_raw(context));
+    }
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_socket(
+    context: *mut zmq::Context,
+    stype: libc::c_int,
+) -> *mut zmq::Socket {
+    let ctx = match context.as_ref() {
+        Some(ctx) => ctx,
+        None => return ptr::null_mut(),
+    };
+
+    let stype = match stype {
+        WZMQ_PAIR => zmq::PAIR,
+        WZMQ_PUB => zmq::PUB,
+        WZMQ_SUB => zmq::SUB,
+        WZMQ_REQ => zmq::REQ,
+        WZMQ_REP => zmq::REP,
+        WZMQ_DEALER => zmq::DEALER,
+        WZMQ_ROUTER => zmq::ROUTER,
+        WZMQ_PULL => zmq::PULL,
+        WZMQ_PUSH => zmq::PUSH,
+        WZMQ_XPUB => zmq::XPUB,
+        WZMQ_XSUB => zmq::XSUB,
+        WZMQ_STREAM => zmq::STREAM,
+        _ => return ptr::null_mut(),
+    };
+
+    let sock = match ctx.socket(stype) {
+        Ok(sock) => sock,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    Box::into_raw(Box::new(sock))
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_close(socket: *mut zmq::Socket) -> libc::c_int {
+    if socket.is_null() {
+        return -1;
+    }
+
+    drop(Box::from_raw(socket));
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_getsockopt(
+    socket: *mut zmq::Socket,
+    option_name: libc::c_int,
+    option_value: *mut libc::c_void,
+    option_len: *mut libc::size_t,
+) -> libc::c_int {
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if option_value.is_null() {
+        return -1;
+    }
+
+    let option_len = match option_len.as_mut() {
+        Some(x) => x,
+        None => return -1,
+    };
+
+    match option_name {
+        WZMQ_FD => {
+            if *option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_mut() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            let v = match sock.get_fd() {
+                Ok(v) => v,
+                Err(e) => {
+                    println!("get_fd failed: {:?}", e);
+                    set_errno(e.to_raw());
+                    return -1;
+                }
+            };
+
+            *x = v;
+        }
+        WZMQ_IDENTITY => {
+            let identity = match sock.get_identity() {
+                Ok(v) => v,
+                Err(_) => return -1,
+            };
+
+            let s = slice::from_raw_parts_mut(option_value as *mut u8, *option_len);
+
+            if s.len() < identity.len() {
+                return -1;
+            }
+
+            s[..identity.len()].copy_from_slice(&identity);
+        }
+        WZMQ_RCVMORE => {
+            if *option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_mut() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            let v = match sock.get_rcvmore() {
+                Ok(v) => v,
+                Err(e) => {
+                    set_errno(e.to_raw());
+                    return -1;
+                }
+            };
+
+            if v {
+                *x = 1;
+            } else {
+                *x = 0;
+            }
+        }
+        WZMQ_EVENTS => {
+            if *option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_mut() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            let v = match sock.get_events() {
+                Ok(v) => v,
+                Err(e) => {
+                    set_errno(e.to_raw());
+                    return -1;
+                }
+            };
+
+            *x = convert_events(v);
+        }
+        WZMQ_SNDHWM => {
+            if *option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_mut() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            let v = match sock.get_sndhwm() {
+                Ok(v) => v,
+                Err(e) => {
+                    set_errno(e.to_raw());
+                    return -1;
+                }
+            };
+
+            *x = v;
+        }
+        WZMQ_RCVHWM => {
+            if *option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_mut() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            let v = match sock.get_rcvhwm() {
+                Ok(v) => v,
+                Err(e) => {
+                    set_errno(e.to_raw());
+                    return -1;
+                }
+            };
+
+            *x = v;
+        }
+        _ => return -1,
+    }
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_setsockopt(
+    socket: *mut zmq::Socket,
+    option_name: libc::c_int,
+    option_value: *mut libc::c_void,
+    option_len: libc::size_t,
+) -> libc::c_int {
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if option_value.is_null() {
+        return -1;
+    }
+
+    match option_name {
+        WZMQ_SUBSCRIBE => {
+            let s = slice::from_raw_parts(option_value as *mut u8, option_len);
+
+            if let Err(e) = sock.set_subscribe(s) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_UNSUBSCRIBE => {
+            let s = slice::from_raw_parts(option_value as *mut u8, option_len);
+
+            if let Err(e) = sock.set_unsubscribe(s) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_LINGER => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_linger(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_IDENTITY => {
+            let s = slice::from_raw_parts(option_value as *mut u8, option_len);
+
+            if let Err(e) = sock.set_identity(s) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_IMMEDIATE => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_immediate(*x != 0) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_SNDHWM => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_sndhwm(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_RCVHWM => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_rcvhwm(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_TCP_KEEPALIVE => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_tcp_keepalive(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_TCP_KEEPALIVE_IDLE => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_tcp_keepalive_idle(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_TCP_KEEPALIVE_CNT => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_tcp_keepalive_cnt(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_TCP_KEEPALIVE_INTVL => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_tcp_keepalive_intvl(*x) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        _ => return -1,
+    }
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_connect(
+    socket: *mut zmq::Socket,
+    endpoint: *const libc::c_char,
+) -> libc::c_int {
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if endpoint.is_null() {
+        return -1;
+    }
+
+    let endpoint = match CStr::from_ptr(endpoint).to_str() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+
+    if let Err(e) = sock.connect(endpoint) {
+        set_errno(e.to_raw());
+        return -1;
+    }
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_bind(
+    socket: *mut zmq::Socket,
+    endpoint: *const libc::c_char,
+) -> libc::c_int {
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if endpoint.is_null() {
+        return -1;
+    }
+
+    let endpoint = match CStr::from_ptr(endpoint).to_str() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+
+    if let Err(e) = sock.bind(endpoint) {
+        set_errno(e.to_raw());
+        return -1;
+    }
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_send(
+    socket: *mut zmq::Socket,
+    buf: *const u8,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::c_int {
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if buf.is_null() {
+        return -1;
+    }
+
+    let buf = slice::from_raw_parts(buf, len);
+
+    if let Err(e) = sock.send(buf, convert_io_flags(flags)) {
+        set_errno(e.to_raw());
+        return -1;
+    }
+
+    buf.len() as libc::c_int
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_recv(
+    socket: *mut zmq::Socket,
+    buf: *mut u8,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::c_int {
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if buf.is_null() {
+        return -1;
+    }
+
+    let buf = slice::from_raw_parts_mut(buf, len);
+
+    let size = match sock.recv_into(buf, convert_io_flags(flags)) {
+        Ok(size) => size,
+        Err(e) => {
+            set_errno(e.to_raw());
+            return -1;
+        }
+    };
+
+    size as libc::c_int
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_init(msg: *mut WZmqMessage) -> libc::c_int {
+    let msg = msg.as_mut().unwrap();
+    msg.data = Box::into_raw(Box::new(zmq::Message::new()));
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_init_size(
+    msg: *mut WZmqMessage,
+    size: libc::size_t,
+) -> libc::c_int {
+    let msg = msg.as_mut().unwrap();
+    msg.data = Box::into_raw(Box::new(zmq::Message::with_size(size)));
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_data(msg: *mut WZmqMessage) -> *mut libc::c_void {
+    let msg = msg.as_mut().unwrap();
+    let data = msg.data.as_mut().unwrap();
+
+    data.as_mut_ptr() as *mut libc::c_void
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_size(msg: *const WZmqMessage) -> libc::size_t {
+    let msg = msg.as_ref().unwrap();
+    let data = msg.data.as_ref().unwrap();
+
+    data.len()
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_close(msg: *mut WZmqMessage) -> libc::c_int {
+    let msg = match msg.as_mut() {
+        Some(msg) => msg,
+        None => return -1,
+    };
+
+    if !msg.data.is_null() {
+        drop(Box::from_raw(msg.data));
+        msg.data = ptr::null_mut();
+    }
+
+    0
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_send(
+    msg: *mut WZmqMessage,
+    socket: *mut zmq::Socket,
+    flags: libc::c_int,
+) -> libc::c_int {
+    let msg = match msg.as_mut() {
+        Some(msg) => msg,
+        None => return -1,
+    };
+
+    if msg.data.is_null() {
+        return -1;
+    }
+
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    let data = Box::from_raw(msg.data);
+    msg.data = ptr::null_mut();
+
+    let size = data.len();
+
+    if let Err(e) = sock.send(*data, convert_io_flags(flags)) {
+        set_errno(e.to_raw());
+        return -1;
+    }
+
+    size as libc::c_int
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn wzmq_msg_recv(
+    msg: *mut WZmqMessage,
+    socket: *mut zmq::Socket,
+    flags: libc::c_int,
+) -> libc::c_int {
+    let msg = match msg.as_mut() {
+        Some(msg) => msg,
+        None => return -1,
+    };
+
+    let sock = match socket.as_ref() {
+        Some(sock) => sock,
+        None => return -1,
+    };
+
+    if !msg.data.is_null() {
+        drop(Box::from_raw(msg.data));
+        msg.data = ptr::null_mut();
+    }
+
+    let data = match sock.recv_msg(convert_io_flags(flags)) {
+        Ok(msg) => msg,
+        Err(e) => {
+            set_errno(e.to_raw());
+            return -1;
+        }
+    };
+
+    let size = data.len();
+
+    msg.data = Box::into_raw(Box::new(data));
+
+    size as libc::c_int
 }

--- a/src/m2adapter/m2adapter.pro
+++ b/src/m2adapter/m2adapter.pro
@@ -11,6 +11,7 @@ OBJECTS_DIR = $$OUT_PWD/_obj
 LIBS += -L$$PWD/../corelib -lpushpin-core
 PRE_TARGETDEPS += $$PWD/../corelib/libpushpin-core.a
 
+include($$OUT_PWD/../rust/lib.pri)
 include($$OUT_PWD/../../conf.pri)
 include(m2adapter.pri)
 

--- a/src/rust/include/rust/wzmq.h
+++ b/src/rust/include/rust/wzmq.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#ifndef RUST_WZMQ_H
+#define RUST_WZMQ_H
+
+#include <stddef.h>
+
+// zmq crate version 0.10 bundles zeromq 4.3
+#define WZMQ_VERSION_MAJOR 4
+#define WZMQ_VERSION_MINOR 3
+
+// NOTE: must match values in ffi.rs
+#define WZMQ_PAIR 0
+#define WZMQ_PUB 1
+#define WZMQ_SUB 2
+#define WZMQ_REQ 3
+#define WZMQ_REP 4
+#define WZMQ_DEALER 5
+#define WZMQ_ROUTER 6
+#define WZMQ_PULL 7
+#define WZMQ_PUSH 8
+#define WZMQ_XPUB 9
+#define WZMQ_XSUB 10
+#define WZMQ_STREAM 11
+
+// NOTE: must match values in ffi.rs
+#define WZMQ_FD 0
+#define WZMQ_SUBSCRIBE 1
+#define WZMQ_UNSUBSCRIBE 2
+#define WZMQ_LINGER 3
+#define WZMQ_IDENTITY 4
+#define WZMQ_IMMEDIATE 5
+#define WZMQ_RCVMORE 6
+#define WZMQ_EVENTS 7
+#define WZMQ_SNDHWM 8
+#define WZMQ_RCVHWM 9
+#define WZMQ_TCP_KEEPALIVE 10
+#define WZMQ_TCP_KEEPALIVE_IDLE 11
+#define WZMQ_TCP_KEEPALIVE_CNT 12
+#define WZMQ_TCP_KEEPALIVE_INTVL 13
+
+// NOTE: must match values in ffi.rs
+#define WZMQ_DONTWAIT 0x01
+#define WZMQ_SNDMORE 0x02
+
+// NOTE: must match values in ffi.rs
+#define WZMQ_POLLIN 0x01
+#define WZMQ_POLLOUT 0x02
+
+extern "C" {
+	typedef struct wzmq_msg {
+		void *data;
+	} wzmq_msg_t;
+
+	void *wzmq_init(int io_threads);
+	int wzmq_term(void *context);
+	void *wzmq_socket(void *context, int type);
+	int wzmq_close(void *socket);
+	int wzmq_getsockopt(void *socket, int option_name, void *option_value, size_t *option_len);
+	int wzmq_setsockopt(void *socket, int option_name, const void *option_value, size_t option_len);
+	int wzmq_connect(void *socket, const char *endpoint);
+	int wzmq_bind(void *socket, const char *endpoint);
+	int wzmq_send(void *socket, void *buf, size_t len, int flags);
+	int wzmq_recv(void *socket, void *buf, size_t len, int flags);
+	int wzmq_msg_init(wzmq_msg_t *msg);
+	int wzmq_msg_init_size(wzmq_msg_t *msg, size_t size);
+	void *wzmq_msg_data(wzmq_msg_t *msg);
+	size_t wzmq_msg_size(wzmq_msg_t *msg);
+	int wzmq_msg_close(wzmq_msg_t *msg);
+	int wzmq_msg_send(wzmq_msg_t *msg, void *socket, int flags);
+	int wzmq_msg_recv(wzmq_msg_t *msg, void *socket, int flags);
+}
+
+#endif


### PR DESCRIPTION
This change makes the C++ and Rust code share the same libzmq (the one used by the zmq crate), to avoid depending on two different versions of libzmq at the same time.

To simplify the way we handle dependencies, the C++ code does not interface directly with the libzmq used by the zmq crate. Instead, we wrap the zmq crate with a libzmq-like C API that the C++ code can use.

Testing: the tests pass (there's a lot of zmq in there) and also tested locally.