### PR TITLE
remove check for libzmq in configure script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       run: cargo install cargo-audit
       shell: bash
     - name: Install deps
-      run: sudo apt-get update && sudo apt-get install -y make g++ libssl-dev qtbase5-dev libzmq3-dev
+      run: sudo apt-get update && sudo apt-get install -y make g++ libssl-dev qtbase5-dev
     - name: fmt
       run: cargo fmt --check
       shell: bash

--- a/configure
+++ b/configure
@@ -576,9 +576,6 @@ cat >"$1/modules_new.cpp" <<EOT
     o = new qc_conf(conf);
     o->required = true;
     o->disabled = false;
-    o = new qc_internal_pkgconfig(conf, "libzmq", "libzmq >= 2.0", VersionMin, "2.0");
-    o->required = true;
-    o->disabled = false;
     o = new qc_internal_pkgconfig(conf, "libcrypto", "libcrypto >= 1.0", VersionMin, "1.0");
     o->required = true;
     o->disabled = false;

--- a/pushpin.qc
+++ b/pushpin.qc
@@ -8,9 +8,6 @@
  <dep type='conf'>
   <required/>
  </dep>
- <dep type='pkg' name='libzmq' pkgname='libzmq' version='>=2.0'>
-  <required/>
- </dep>
  <dep type='pkg' name='libcrypto' pkgname='libcrypto' version='>=1.0'>
   <required/>
  </dep>


### PR DESCRIPTION
the check is not needed since the zmq crate (as of 0.10) vendors libzmq and all zmq usage goes through the crate