### PR TITLE
put c++ build output in target/ and fix cargo rerun-if-changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vendor
 .vscode
 
 /pushpin
+/pushpin-legacy
 /bin/*
 /conf.log
 /conf.pri
@@ -23,26 +24,14 @@ vendor
 /src/config.h
 /src/Makefile
 /src/cpp/Makefile
+/src/cpp/makedirs/Makefile
 /src/cpp/cpp/Makefile
-/src/cpp/libpushpin-cpp.a
-/src/cpp/libpushpin-cpptest.a
 /src/cpp/tests/Makefile
-/src/cpp/tests/*test/Makefile
-/src/cpp/tests/*test/*test
-/src/m2adapter/Makefile
-/src/proxy/Makefile
-/src/handler/Makefile
 /src/rust/Makefile
-/src/runner/Makefile
-/src/runner/tests/Makefile
-/src/runner/tests/*test/Makefile
-/src/runner/tests/*test/*test
 /src/runner/certs/*.crt
 /src/runner/certs/*.key
 /src/pushpin/Makefile
 /src/pushpin/*.inst
-/tools/Makefile
-/tools/publish/Makefile
 /config
 /run
 /log

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use std::env;
 use std::error::Error;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let conf = {
@@ -35,7 +36,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let lib_dir = conf.get("LIBDIR").unwrap();
     let qt_install_libs = conf.get("QT_INSTALL_LIBS").unwrap();
 
-    let cpp_lib_dir = fs::canonicalize(Path::new("src/cpp")).unwrap();
+    let cpp_lib_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join(Path::new("target/cpp"));
 
     println!("cargo:rustc-env=APP_VERSION={}", app_version);
     println!("cargo:rustc-env=CONFIG_DIR={}", config_dir);
@@ -50,6 +52,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-search={}", qt_install_libs);
 
     println!("cargo:rerun-if-changed=conf.pri");
+    println!("cargo:rerun-if-changed=src");
+    println!(
+        "cargo:rerun-if-changed={}/libpushpin-cpp.a",
+        cpp_lib_dir.display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}/libpushpin-cpptest.a",
+        cpp_lib_dir.display()
+    );
 
     Ok(())
 }

--- a/pushpin.pro
+++ b/pushpin.pro
@@ -2,8 +2,4 @@ TEMPLATE = subdirs
 
 src.subdir = src
 
-tools.subdir = tools
-tools.depends = src
-
 SUBDIRS += src
-#SUBDIRS += src tools

--- a/src/cpp/cpp.pro
+++ b/src/cpp/cpp.pro
@@ -1,10 +1,14 @@
 TEMPLATE = subdirs
 
+makedirs.subdir = makedirs
+
 cpp.subdir = cpp
+cpp.depends = makedirs
 
 tests.subdir = tests
-tests.depends = cpp
+tests.depends = cpp makedirs
 
 SUBDIRS += \
+	makedirs \
 	cpp \
 	tests

--- a/src/cpp/cpp/cpp.pro
+++ b/src/cpp/cpp/cpp.pro
@@ -4,10 +4,12 @@ CONFIG += staticlib
 QT -= gui
 QT += network
 TARGET = pushpin-cpp
-DESTDIR = ..
+DESTDIR = ../../../target/cpp
 
-MOC_DIR = $$OUT_PWD/_moc
-OBJECTS_DIR = $$OUT_PWD/_obj
+cpp_build_dir = $$OUT_PWD/../../../target/cpp
+
+MOC_DIR = $$cpp_build_dir/moc
+OBJECTS_DIR = $$cpp_build_dir/obj
 
 include($$OUT_PWD/../../../conf.pri)
 include(cpp.pri)

--- a/src/cpp/makedirs/makedirs.pro
+++ b/src/cpp/makedirs/makedirs.pro
@@ -1,0 +1,10 @@
+TEMPLATE = aux
+
+cpp_build_dir = $$PWD/../../../target/cpp
+
+makedirs.target = $$cpp_build_dir
+makedirs.commands = mkdir -p $$cpp_build_dir/moc $$cpp_build_dir/obj $$cpp_build_dir/test-moc $$cpp_build_dir/test-obj $$cpp_build_dir/test-work
+
+QMAKE_EXTRA_TARGETS += makedirs
+
+PRE_TARGETDEPS += $$cpp_build_dir

--- a/src/cpp/tests/handlerenginetest/handlerenginetest.cpp
+++ b/src/cpp/tests/handlerenginetest/handlerenginetest.cpp
@@ -271,7 +271,7 @@ private slots:
 		//log_setOutputLevel(LOG_LEVEL_DEBUG);
 
 		QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
-		QDir workDir(rootDir.filePath("src/cpp/tests/handlerenginetest"));
+		QDir workDir(rootDir.filePath("target/cpp/test-work"));
 
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();

--- a/src/cpp/tests/proxyenginetest/proxyenginetest.cpp
+++ b/src/cpp/tests/proxyenginetest/proxyenginetest.cpp
@@ -571,7 +571,8 @@ private slots:
 		//log_setOutputLevel(LOG_LEVEL_DEBUG);
 
 		QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
-		QDir workDir(rootDir.filePath("src/cpp/tests/proxyenginetest"));
+		QDir configDir(rootDir.filePath("src/cpp/tests/proxyenginetest"));
+		QDir workDir(rootDir.filePath("target/cpp/test-work"));
 
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();
@@ -592,7 +593,7 @@ private slots:
 		config.statsSpec = ("ipc://" + workDir.filePath("stats"));
 		config.inspectTimeout = 500;
 		config.inspectPrefetch = 5;
-		config.routesFile = workDir.filePath("routes");
+		config.routesFile = configDir.filePath("routes");
 		config.sigIss = "pushpin";
 		config.sigKey = Jwt::EncodingKey::fromSecret("changeme");
 		config.connectionsMax = 20;

--- a/src/cpp/tests/tests.pro
+++ b/src/cpp/tests/tests.pro
@@ -4,16 +4,18 @@ CONFIG += staticlib
 QT -= gui
 QT *= network testlib
 TARGET = pushpin-cpptest
-DESTDIR = ..
+DESTDIR = ../../../target/cpp
 
-MOC_DIR = $$OUT_PWD/_moc
-OBJECTS_DIR = $$OUT_PWD/_obj
+cpp_build_dir = $$OUT_PWD/../../../target/cpp
+
+MOC_DIR = $$cpp_build_dir/test-moc
+OBJECTS_DIR = $$cpp_build_dir/test-obj
 
 SRC_DIR = $$PWD/..
 QZMQ_DIR = $$SRC_DIR/qzmq
 RUST_DIR = $$SRC_DIR/../rust
 
-PRE_TARGETDEPS += $$PWD/../libpushpin-cpp.a
+PRE_TARGETDEPS += $$cpp_build_dir/libpushpin-cpp.a
 
 include($$PWD/../../../conf.pri)
 

--- a/tools/tools.pro
+++ b/tools/tools.pro
@@ -1,5 +1,0 @@
-TEMPLATE = subdirs
-
-publish.subdir = publish
-
-SUBDIRS += publish


### PR DESCRIPTION
This helps `cargo build` avoid rebuilding things unnecessarily.