### PR TITLE
fix tests on qt 5.12

### DIFF
--- a/src/cpp/tests/handlerenginetest.cpp
+++ b/src/cpp/tests/handlerenginetest.cpp
@@ -827,11 +827,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(HandlerEngineTest)
+}
+}
+
 extern "C" {
 
 int handlerengine_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(HandlerEngineTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/httpheaderstest.cpp
+++ b/src/cpp/tests/httpheaderstest.cpp
@@ -86,11 +86,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(HttpHeadersTest)
+}
+}
+
 extern "C" {
 
 int httpheaders_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(HttpHeadersTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/idformattest.cpp
+++ b/src/cpp/tests/idformattest.cpp
@@ -85,11 +85,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(IdFormatTest)
+}
+}
+
 extern "C" {
 
 int idformat_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(IdFormatTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/instructtest.cpp
+++ b/src/cpp/tests/instructtest.cpp
@@ -298,11 +298,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(InstructTest)
+}
+}
+
 extern "C" {
 
 int instruct_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(InstructTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/jsonpatchtest.cpp
+++ b/src/cpp/tests/jsonpatchtest.cpp
@@ -96,11 +96,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(JsonPatchTest)
+}
+}
+
 extern "C" {
 
 int jsonpatch_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(JsonPatchTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/jwttest.cpp
+++ b/src/cpp/tests/jwttest.cpp
@@ -174,11 +174,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(JwtTest)
+}
+}
+
 extern "C" {
 
 int jwt_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(JwtTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/proxyenginetest.cpp
+++ b/src/cpp/tests/proxyenginetest.cpp
@@ -1395,11 +1395,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(ProxyEngineTest)
+}
+}
+
 extern "C" {
 
 int proxyengine_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(ProxyEngineTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/publishformattest.cpp
+++ b/src/cpp/tests/publishformattest.cpp
@@ -128,11 +128,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(PublishFormatTest)
+}
+}
+
 extern "C" {
 
 int publishformat_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(PublishFormatTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/publishitemtest.cpp
+++ b/src/cpp/tests/publishitemtest.cpp
@@ -94,11 +94,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(PublishItemTest)
+}
+}
+
 extern "C" {
 
 int publishitem_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(PublishItemTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/routesfiletest.cpp
+++ b/src/cpp/tests/routesfiletest.cpp
@@ -117,11 +117,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(RoutesFileTest)
+}
+}
+
 extern "C" {
 
 int routesfile_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(RoutesFileTest)
+	return Main::main(argc, argv);
 }
 
 }

--- a/src/cpp/tests/templatetest.cpp
+++ b/src/cpp/tests/templatetest.cpp
@@ -60,11 +60,17 @@ private slots:
 	}
 };
 
+namespace {
+namespace Main {
+QTEST_MAIN(TemplateTest)
+}
+}
+
 extern "C" {
 
 int template_test(int argc, char **argv)
 {
-	QTEST_MAIN_IMPL(TemplateTest)
+	return Main::main(argc, argv);
 }
 
 }


### PR DESCRIPTION
Qt 5.12 does not have `QTEST_MAIN_IMPL`, only `QTEST_MAIN`, the latter of which declares a function literally named `main`. In order to get the impl under a different name for each test, `QTEST_MAIN` is wrapped in namespaces (one named `Main` to avoid ambiguity, and one with no name for file-locality) and then called from differently-named functions.