### PR TITLE
invoke qmake+make from build.rs to build c++ code

### DIFF
--- a/configure
+++ b/configure
@@ -505,6 +505,9 @@ public:
 		QString qtlibdir = QString::fromUtf8(out).trimmed();
 		conf->addExtra(QString("QT_INSTALL_LIBS = %1").arg(qtlibdir));
 
+		conf->addExtra(QString("QMAKE_PATH = %1").arg(conf->qmake_path));
+		conf->addExtra(QString("MAKETOOL = %1").arg(conf->maketool));
+
 		QFile file("src/config.h");
 		if(file.open(QIODevice::WriteOnly | QIODevice::Text))
 		{

--- a/qcm/conf.qcm
+++ b/qcm/conf.qcm
@@ -85,6 +85,9 @@ public:
 		QString qtlibdir = QString::fromUtf8(out).trimmed();
 		conf->addExtra(QString("QT_INSTALL_LIBS = %1").arg(qtlibdir));
 
+		conf->addExtra(QString("QMAKE_PATH = %1").arg(conf->qmake_path));
+		conf->addExtra(QString("MAKETOOL = %1").arg(conf->maketool));
+
 		QFile file("src/config.h");
 		if(file.open(QIODevice::WriteOnly | QIODevice::Text))
 		{

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,15 +1,9 @@
 TEMPLATE = subdirs
 
-include($$OUT_PWD/../conf.pri)
-
-cpp.subdir = cpp
-
 rust.subdir = rust
-rust.depends = cpp
 
 pushpin.subdir = pushpin
 
 SUBDIRS += \
-	cpp \
 	rust \
 	pushpin


### PR DESCRIPTION
Further cargo-ification of the build. Instead of `make` recursively running `make` in src/cpp to build the C++ code prior to `cargo build`, `make` simply runs `cargo build` which handles everything (`build.rs` runs `make` in src/cpp). This means `cargo build` will build all the code, both C++ and Rust.

Notably, this decouples the inner and outer make processes, and also removes cargo's dependency on the outer make process. All cargo depends on now is the `conf.pri` file generated by the configure script.

From here, we could consider:

* using the `cc` crate to build the C++ code instead of make
* replacing the configure script with something not qt-based, or moving the configuration logic into `build.rs` and not having a configure script at all