### PR TITLE
don't write config.h and instead expose the values via ffi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ vendor
 /conf.log
 /conf.pri
 /Makefile
-/src/config.h
 /src/Makefile
 /src/cpp/Makefile
 /src/cpp/cpp/Makefile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ test-log = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
+time = { version = "=0.3.18", features = ["formatting", "local-offset", "macros"] }
 
 [[bench]]
 name = "server"

--- a/configure
+++ b/configure
@@ -421,24 +421,6 @@ arg: logdir=[path],Directory for log files.  Default: /var/log
 #define ENDL endl
 #endif
 
-static QString getVersion()
-{
-	QSettings settings("Cargo.toml", QSettings::IniFormat);
-
-	QString version = settings.value("package/version").toString();
-
-	if(version.isEmpty())
-		return QString();
-
-	if(version.endsWith("-dev"))
-	{
-		QString nowstr = QDateTime::currentDateTime().toString("yyyyMMdd");
-		version += QString("-") + nowstr;
-	}
-
-	return version;
-}
-
 class qc_conf : public ConfObj
 {
 public:
@@ -448,12 +430,6 @@ public:
 	QString checkString() const { return QString(); }
 	bool exec()
 	{
-		QString version = getVersion();
-		if(version.isEmpty())
-			return false;
-
-		conf->addExtra(QString("APP_VERSION = %1").arg(version));
-
 		QString prefix = conf->getenv("PREFIX");
 		QString varprefix = "/var";
 
@@ -477,20 +453,7 @@ public:
 			logdir = varprefix + "/log";
 		conf->addExtra(QString("LOGDIR = %1/pushpin").arg(logdir));
 
-		conf->addIncludePath("\$\$PWD/src");
-
 		conf->addExtra(QString("MAKETOOL = %1").arg(conf->maketool));
-
-		QFile file("src/config.h");
-		if(file.open(QIODevice::WriteOnly | QIODevice::Text))
-		{
-			QTextStream stream( &file );
-			stream << "#define VERSION \\"" << version << "\\"" << ENDL;
-			stream << "#define LIBDIR \\"" << libdir << "/pushpin\\"" << ENDL;
-			stream << "#define CONFIGDIR \\"" << configdir << "/pushpin\\"" << ENDL;
-		}
-
-		conf->addDefine("HAVE_CONFIG");
 
 		return true;
 	}

--- a/qcm/conf.qcm
+++ b/qcm/conf.qcm
@@ -18,24 +18,6 @@ arg: logdir=[path],Directory for log files.  Default: /var/log
 #define ENDL endl
 #endif
 
-static QString getVersion()
-{
-	QSettings settings("Cargo.toml", QSettings::IniFormat);
-
-	QString version = settings.value("package/version").toString();
-
-	if(version.isEmpty())
-		return QString();
-
-	if(version.endsWith("-dev"))
-	{
-		QString nowstr = QDateTime::currentDateTime().toString("yyyyMMdd");
-		version += QString("-") + nowstr;
-	}
-
-	return version;
-}
-
 class qc_conf : public ConfObj
 {
 public:
@@ -45,12 +27,6 @@ public:
 	QString checkString() const { return QString(); }
 	bool exec()
 	{
-		QString version = getVersion();
-		if(version.isEmpty())
-			return false;
-
-		conf->addExtra(QString("APP_VERSION = %1").arg(version));
-
 		QString prefix = conf->getenv("PREFIX");
 		QString varprefix = "/var";
 
@@ -74,20 +50,7 @@ public:
 			logdir = varprefix + "/log";
 		conf->addExtra(QString("LOGDIR = %1/pushpin").arg(logdir));
 
-		conf->addIncludePath("$$PWD/src");
-
 		conf->addExtra(QString("MAKETOOL = %1").arg(conf->maketool));
-
-		QFile file("src/config.h");
-		if(file.open(QIODevice::WriteOnly | QIODevice::Text))
-		{
-			QTextStream stream( &file );
-			stream << "#define VERSION \"" << version << "\"" << ENDL;
-			stream << "#define LIBDIR \"" << libdir << "/pushpin\"" << ENDL;
-			stream << "#define CONFIGDIR \"" << configdir << "/pushpin\"" << ENDL;
-		}
-
-		conf->addDefine("HAVE_CONFIG");
 
 		return true;
 	}

--- a/src/bin/condure.rs
+++ b/src/bin/condure.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use clap::{crate_version, Arg, ArgAction, Command};
+use clap::{Arg, ArgAction, Command};
 use log::{error, LevelFilter};
 use pushpin::condure::{run, App, Config};
 use pushpin::log::get_simple_logger;
+use pushpin::version;
 use pushpin::{ListenConfig, ListenSpec};
 use std::error::Error;
 use std::path::PathBuf;
@@ -199,7 +200,7 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
 
 fn main() {
     let matches = Command::new("condure")
-        .version(crate_version!())
+        .version(version())
         .about("HTTP/WebSocket connection manager")
         .arg(
             Arg::new("log-level")

--- a/src/bin/pushpin-publish.rs
+++ b/src/bin/pushpin-publish.rs
@@ -22,6 +22,7 @@
 
 use clap::{Arg, ArgAction, Command};
 use pushpin::publish_cli::{run, Action, Config, Content, Message};
+use pushpin::version;
 use std::env;
 use std::error::Error;
 use std::process;
@@ -133,7 +134,7 @@ fn main() {
     };
 
     let matches = Command::new(PROGRAM_NAME)
-        .version(env!("APP_VERSION"))
+        .version(version())
         .about("Publish messages to Pushpin")
         .arg(
             Arg::new("channel")

--- a/src/cpp/config.cpp
+++ b/src/cpp/config.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#include "config.h"
+
+#include "rust/build_config.h"
+
+namespace Config {
+
+static Config *g_config = 0;
+
+Config & get()
+{
+	if(!g_config)
+	{
+		Config *c = new Config;
+
+		BuildConfig *bc = build_config_new();
+		c->version = QString(bc->version);
+		c->configDir = QString(bc->config_dir);
+		c->libDir = QString(bc->lib_dir);
+		build_config_destroy(bc);
+
+		g_config = c;
+	}
+
+	return *g_config;
+}
+
+}

--- a/src/cpp/config.h
+++ b/src/cpp/config.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <QString>
+
+namespace Config {
+
+class Config
+{
+public:
+	QString version;
+	QString configDir;
+	QString libDir;
+};
+
+Config & get();
+
+}
+
+#endif

--- a/src/cpp/cpp/cpp.pri
+++ b/src/cpp/cpp/cpp.pri
@@ -52,6 +52,7 @@ SOURCES += \
 
 HEADERS += \
 	$$SRC_DIR/callback.h \
+	$$SRC_DIR/config.h \
 	$$SRC_DIR/timerwheel.h \
 	$$SRC_DIR/jwt.h \
 	$$SRC_DIR/rtimer.h \
@@ -74,6 +75,7 @@ HEADERS += \
 	$$SRC_DIR/settings.h
 
 SOURCES += \
+	$$SRC_DIR/config.cpp \
 	$$SRC_DIR/timerwheel.cpp \
 	$$SRC_DIR/jwt.cpp \
 	$$SRC_DIR/rtimer.cpp \

--- a/src/cpp/handler/handlerapp.cpp
+++ b/src/cpp/handler/handlerapp.cpp
@@ -165,7 +165,7 @@ public:
 	void start()
 	{
 		QCoreApplication::setApplicationName("pushpin-handler");
-		QCoreApplication::setApplicationVersion(VERSION);
+		QCoreApplication::setApplicationVersion(Config::get().version);
 
 		QCommandLineParser parser;
 		parser.setApplicationDescription("Pushpin handler component.");
@@ -208,7 +208,7 @@ public:
 
 		QString configFile = args.configFile;
 		if(configFile.isEmpty())
-			configFile = QDir(CONFIGDIR).filePath("pushpin.conf");
+			configFile = QDir(Config::get().configDir).filePath("pushpin.conf");
 
 		// QSettings doesn't inform us if the config file doesn't exist, so do that ourselves
 		{
@@ -300,7 +300,7 @@ public:
 		}
 
 		HandlerEngine::Configuration config;
-		config.appVersion = VERSION;
+		config.appVersion = Config::get().version;
 		config.instanceId = "pushpin-handler_" + QByteArray::number(QCoreApplication::applicationPid());
 		if(!services.contains("mongrel2") && (!condure_in_stream_specs.isEmpty() || !condure_out_specs.isEmpty()))
 		{

--- a/src/cpp/m2adapter/m2adapterapp.cpp
+++ b/src/cpp/m2adapter/m2adapterapp.cpp
@@ -491,7 +491,7 @@ public:
 	void start()
 	{
 		QCoreApplication::setApplicationName("m2adapter");
-		QCoreApplication::setApplicationVersion(VERSION);
+		QCoreApplication::setApplicationVersion(Config::get().version);
 
 		QCommandLineParser parser;
 		parser.setApplicationDescription("Mongrel2 <-> ZHTTP adapter.");
@@ -556,7 +556,7 @@ public:
 
 		QString configFile = args.configFile;
 		if(configFile.isEmpty())
-			configFile = QDir(CONFIGDIR).filePath("m2adapter.conf");
+			configFile = QDir(Config::get().configDir).filePath("m2adapter.conf");
 
 		// QSettings doesn't inform us if the config file doesn't exist, so do that ourselves
 		{

--- a/src/cpp/proxy/app.cpp
+++ b/src/cpp/proxy/app.cpp
@@ -183,7 +183,7 @@ public:
 	void start()
 	{
 		QCoreApplication::setApplicationName("pushpin-proxy");
-		QCoreApplication::setApplicationVersion(VERSION);
+		QCoreApplication::setApplicationVersion(Config::get().version);
 
 		QCommandLineParser parser;
 		parser.setApplicationDescription("Pushpin proxy component.");
@@ -226,7 +226,7 @@ public:
 
 		QString configFile = args.configFile;
 		if(configFile.isEmpty())
-			configFile = QDir(CONFIGDIR).filePath("pushpin.conf");
+			configFile = QDir(Config::get().configDir).filePath("pushpin.conf");
 
 		// QSettings doesn't inform us if the config file doesn't exist, so do that ourselves
 		{
@@ -344,7 +344,7 @@ public:
 			updatesCheck = "check";
 
 		Engine::Configuration config;
-		config.appVersion = VERSION;
+		config.appVersion = Config::get().version;
 		config.clientId = "pushpin-proxy_" + QByteArray::number(QCoreApplication::applicationPid());
 		if(!services.contains("mongrel2") && (!condure_in_specs.isEmpty() || !condure_in_stream_specs.isEmpty() || !condure_out_specs.isEmpty()))
 		{

--- a/src/cpp/runner/runnerapp.cpp
+++ b/src/cpp/runner/runnerapp.cpp
@@ -270,7 +270,7 @@ public:
 	void start()
 	{
 		QCoreApplication::setApplicationName("pushpin");
-		QCoreApplication::setApplicationVersion(VERSION);
+		QCoreApplication::setApplicationVersion(Config::get().version);
 
 		QCommandLineParser parser;
 		parser.setApplicationDescription("Reverse proxy for realtime web services.");
@@ -324,7 +324,7 @@ public:
 			configFileList += QDir("examples/config").absoluteFilePath("pushpin.conf");
 
 			// default
-			configFileList += QDir(CONFIGDIR).filePath("pushpin.conf");
+			configFileList += QDir(Config::get().configDir).filePath("pushpin.conf");
 		}
 
 		QString configFile;
@@ -381,7 +381,7 @@ public:
 			else
 			{
 				// use compiled value
-				libDir = QDir(LIBDIR).absoluteFilePath("runner");
+				libDir = QDir(Config::get().libDir).absoluteFilePath("runner");
 			}
 		}
 

--- a/src/cpp/settings.cpp
+++ b/src/cpp/settings.cpp
@@ -45,7 +45,7 @@ Settings::Settings(const QString &fileName) :
 		else
 		{
 			// use compiled value
-			libdir_ = LIBDIR;
+			libdir_ = Config::get().libDir;
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,10 @@ pub struct ListenConfig {
     pub stream: bool,
 }
 
+pub fn version() -> &'static str {
+    env!("APP_VERSION")
+}
+
 /// # Safety
 ///
 /// * `main_fn` must be safe to call.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -32,11 +32,12 @@ use std::sync::{Mutex, Once};
 use url::Url;
 
 use crate::config::{get_config_file, CustomConfig};
+use crate::version;
 
 #[derive(Parser, Clone)]
 #[command(
-    name = "Pushpin",
-    version,
+    name = "pushpin",
+    version = version(),
     about = "Reverse proxy for realtime web services."
 )]
 pub struct CliArgs {

--- a/src/rust/include/rust/build_config.h
+++ b/src/rust/include/rust/build_config.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#ifndef RUST_BUILD_CONFIG_H
+#define RUST_BUILD_CONFIG_H
+
+extern "C"
+{
+	struct BuildConfig
+	{
+		const char *version;
+		const char *config_dir;
+		const char *lib_dir;
+	};
+
+	BuildConfig *build_config_new();
+	void build_config_destroy(BuildConfig *c);
+}
+
+#endif


### PR DESCRIPTION
This continues the quest of reducing the responsibility of the configure script. It also moves the version date-suffixing into `build.rs` and ensures all the binaries use it.