### PR TITLE
write configuration .pri files from build.rs and use them

### DIFF
--- a/postbuild/postbuild.pro
+++ b/postbuild/postbuild.pro
@@ -1,7 +1,7 @@
 TEMPLATE = aux
 CONFIG -= debug_and_release debug
 
-include($$OUT_PWD/../conf.pri)
+include($$OUT_PWD/../target/postbuild_conf.pri)
 
 root_dir = $$PWD/..
 bin_dir = $$root_dir/bin

--- a/src/cpp/cpp/cpp.pro
+++ b/src/cpp/cpp/cpp.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 CONFIG -= app_bundle
-CONFIG += staticlib
+CONFIG += staticlib c++11
 QT -= gui
 QT += network
 TARGET = pushpin-cpp
@@ -11,5 +11,5 @@ cpp_build_dir = $$OUT_PWD/../../../target/cpp
 MOC_DIR = $$cpp_build_dir/moc
 OBJECTS_DIR = $$cpp_build_dir/obj
 
-include($$OUT_PWD/../../../conf.pri)
+include($$OUT_PWD/../../../target/cpp/conf.pri)
 include(cpp.pri)

--- a/src/cpp/tests/tests.pro
+++ b/src/cpp/tests/tests.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 CONFIG -= app_bundle
-CONFIG += staticlib
+CONFIG += staticlib c++11
 QT -= gui
 QT *= network testlib
 TARGET = pushpin-cpptest
@@ -15,7 +15,7 @@ SRC_DIR = $$PWD/..
 QZMQ_DIR = $$SRC_DIR/qzmq
 RUST_DIR = $$SRC_DIR/../rust
 
-include($$PWD/../../../conf.pri)
+include($$PWD/../../../target/cpp/conf.pri)
 
 INCLUDEPATH += $$SRC_DIR
 INCLUDEPATH += $$SRC_DIR/proxy

--- a/src/rust/rust.pro
+++ b/src/rust/rust.pro
@@ -1,8 +1,6 @@
 TEMPLATE = aux
 CONFIG -= debug_and_release debug
 
-include($$OUT_PWD/../../conf.pri)
-
 root_dir = $$PWD/../..
 
 CONFIG(debug, debug|release) {


### PR DESCRIPTION
This changes the qmake projects to not depend on conf.pri in the root. Now, the only user of that file will be `build.rs` which will write out other .pri files for the qmake projects to use instead. Two separate .pri files are written, one for building the C++ code (currently empty) and one for postbuild (containing the various install paths).