### PR TITLE
fix config_dir/lib_dir ordering in struct

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1060,8 +1060,8 @@ pub unsafe extern "C" fn wzmq_msg_recv(
 #[repr(C)]
 pub struct BuildConfig {
     version: *mut libc::c_char,
-    lib_dir: *mut libc::c_char,
     config_dir: *mut libc::c_char,
+    lib_dir: *mut libc::c_char,
 }
 
 #[no_mangle]
@@ -1071,8 +1071,8 @@ pub fn build_config_new() -> *mut BuildConfig {
 
     let c = BuildConfig {
         version: CString::new(version()).unwrap().into_raw(),
-        lib_dir: CString::new(lib_dir).unwrap().into_raw(),
         config_dir: CString::new(config_dir).unwrap().into_raw(),
+        lib_dir: CString::new(lib_dir).unwrap().into_raw(),
     };
 
     Box::into_raw(Box::new(c))
@@ -1087,6 +1087,6 @@ pub unsafe fn build_config_destroy(c: *mut BuildConfig) {
     };
 
     drop(CString::from_raw(c.version));
-    drop(CString::from_raw(c.lib_dir));
     drop(CString::from_raw(c.config_dir));
+    drop(CString::from_raw(c.lib_dir));
 }


### PR DESCRIPTION
The order wasn't matching the C struct definition.