### PR TITLE
various fixes related to boost signals

### DIFF
--- a/src/cpp/handler/handlerapp.cpp
+++ b/src/cpp/handler/handlerapp.cpp
@@ -164,6 +164,12 @@ public:
 		hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&Private::reload, this));
 	}
 
+	~Private()
+	{
+		hupConnection.disconnect();
+		quitConnection.disconnect();
+	}
+
 	void start()
 	{
 		QCoreApplication::setApplicationName("pushpin-handler");
@@ -396,8 +402,6 @@ HandlerApp::HandlerApp(QObject *parent) :
 
 HandlerApp::~HandlerApp()
 {
-	d->hupConnection.disconnect();
-	d->quitConnection.disconnect();
 	delete d;
 }
 

--- a/src/cpp/handler/handlerapp.h
+++ b/src/cpp/handler/handlerapp.h
@@ -19,6 +19,7 @@
  *
  * $FANOUT_END_LICENSE$
  */
+
 #ifndef HANDLERAPP_H
 #define HANDLERAPP_H
 

--- a/src/cpp/handler/handlermain.cpp
+++ b/src/cpp/handler/handlermain.cpp
@@ -31,20 +31,15 @@ public:
 
 	void start()
 	{
-		app = new HandlerApp();
+		app = new HandlerApp;
 		app->quit.connect(boost::bind(&HandlerAppMain::app_quit, this, boost::placeholders::_1));
 		app->start();
 	}
 
 	void app_quit(int returnCode)
 	{
-		delete app;
-		QCoreApplication::exit(returnCode);
-	}
-	
-	~HandlerAppMain()
-	{
         	delete app;
+		QCoreApplication::exit(returnCode);
 	}
 };
 

--- a/src/cpp/m2adapter/m2adapterapp.cpp
+++ b/src/cpp/m2adapter/m2adapterapp.cpp
@@ -472,7 +472,7 @@ public:
 		zhttpCancelMeter(0)
 	{
 		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::doQuit, this));
-        hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&M2AdapterApp::Private::reload, this));
+		hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&M2AdapterApp::Private::reload, this));
 
 		statusTimer = new QTimer(this);
 		connect(statusTimer, &QTimer::timeout, this, &Private::status_timeout);
@@ -488,6 +488,9 @@ public:
 		qDeleteAll(sessionsByZhttpRid);
 		qDeleteAll(sessionsByZwsRid);
 		qDeleteAll(m2ConnectionsByRid);
+
+		hupConnection.disconnect();
+		quitConnection.disconnect();
 	}
 
 	void start()

--- a/src/cpp/m2adapter/m2adaptermain.cpp
+++ b/src/cpp/m2adapter/m2adaptermain.cpp
@@ -31,7 +31,7 @@ public:
 
 	void start()
 	{
-		app = new M2AdapterApp();
+		app = new M2AdapterApp;
 		app->quit.connect(boost::bind(&M2AdapterAppMain::app_quit, this, boost::placeholders::_1));
 		app->start();
 	}

--- a/src/cpp/proxy/app.cpp
+++ b/src/cpp/proxy/app.cpp
@@ -179,7 +179,13 @@ public:
 		engine(0)
 	{
 		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::doQuit, this));
-        hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&App::Private::reload, this));
+		hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&App::Private::reload, this));
+	}
+
+	~Private()
+	{
+		hupConnection.disconnect();
+		quitConnection.disconnect();
 	}
 
 	void start()

--- a/src/cpp/proxy/main.cpp
+++ b/src/cpp/proxy/main.cpp
@@ -31,7 +31,7 @@ public:
 
 	void start()
 	{
-		app = new App();
+		app = new App;
 		app->quit.connect(boost::bind(&AppMain::app_quit, this, boost::placeholders::_1));
 		app->start();
 	}

--- a/src/cpp/runner/runnerapp.cpp
+++ b/src/cpp/runner/runnerapp.cpp
@@ -265,8 +265,14 @@ public:
 		stopping(false),
 		errored(false)
 	{
-		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::doQuit, this));
-        hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&Private::reload, this));
+		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::processQuit, this));
+		hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&Private::reload, this));
+	}
+
+	~Private()
+	{
+		hupConnection.disconnect();
+		quitConnection.disconnect();
 	}
 
 	void start()
@@ -698,9 +704,6 @@ private:
 
 	void doQuit()
 	{
-		hupConnection.disconnect();
-		quitConnection.disconnect();
-		
 		emit q->quit(errored ? 1 : 0);
 	}
 
@@ -790,6 +793,10 @@ private:
 		else
 		{
 			qDeleteAll(services);
+
+			hupConnection.disconnect();
+			quitConnection.disconnect();
+
 			ProcessQuit::cleanup();
 
 			// if we were already stopping, then exit immediately

--- a/src/cpp/runner/runnermain.cpp
+++ b/src/cpp/runner/runnermain.cpp
@@ -31,7 +31,7 @@ public:
 
 	void start()
 	{
-		app = new RunnerApp();
+		app = new RunnerApp;
 		app->quit.connect(boost::bind(&RunnerAppMain::app_quit, this, boost::placeholders::_1));
 		app->start();
 	}


### PR DESCRIPTION
* don't double-delete handlerapp
* call correct quit signal in legacy runner
* disconnect signals in the right places in all apps

Tested both runners locally.