### PR TITLE
proxy req session zhttpReq readyread disconnect fix

### DIFF
--- a/src/cpp/proxy/requestsession.h
+++ b/src/cpp/proxy/requestsession.h
@@ -27,7 +27,9 @@
 #include "zhttprequest.h"
 #include "domainmap.h"
 #include <boost/signals2.hpp>
+#include <map>
 
+using std::map;
 using Connection = boost::signals2::scoped_connection;
 
 class QHostAddress;


### PR DESCRIPTION
proxy req session zhttpReq readyread disconnect fix
the disconnect needs to happen per request 

tested locally