### PR TITLE
build the c++ code in the correct mode

### DIFF
--- a/src/cpp/cpp.pro
+++ b/src/cpp/cpp.pro
@@ -4,7 +4,6 @@ CONFIG += staticlib c++11
 QT -= gui
 QT += network
 TARGET = pushpin-cpp
-DESTDIR = ../../target/cpp
 
 cpp_build_dir = $$OUT_PWD
 

--- a/src/cpp/tests/handlerenginetest.cpp
+++ b/src/cpp/tests/handlerenginetest.cpp
@@ -32,6 +32,7 @@
 #include "packet/httpresponsedata.h"
 #include "rtimer.h"
 #include "handlerengine.h"
+#include "test_config.h"
 
 namespace {
 
@@ -270,8 +271,7 @@ private slots:
 		log_setOutputLevel(LOG_LEVEL_WARNING);
 		//log_setOutputLevel(LOG_LEVEL_DEBUG);
 
-		QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
-		QDir workDir(rootDir.filePath("target/cpp/test-work"));
+		QDir workDir(QDir::current().relativeFilePath(TESTDIR));
 
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();

--- a/src/cpp/tests/proxyenginetest.cpp
+++ b/src/cpp/tests/proxyenginetest.cpp
@@ -40,6 +40,7 @@
 #include "zhttpmanager.h"
 #include "statsmanager.h"
 #include "engine.h"
+#include "test_config.h"
 
 Q_DECLARE_METATYPE(QList<StatsPacket>);
 
@@ -572,7 +573,7 @@ private slots:
 
 		QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
 		QDir configDir(rootDir.filePath("src/cpp/tests"));
-		QDir workDir(rootDir.filePath("target/cpp/test-work"));
+		QDir workDir(QDir::current().relativeFilePath(TESTDIR));
 
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();

--- a/src/cpp/tests/tests.pro
+++ b/src/cpp/tests/tests.pro
@@ -4,7 +4,6 @@ CONFIG += staticlib c++11
 QT -= gui
 QT *= network testlib
 TARGET = pushpin-cpptest
-DESTDIR = ../../../target/cpp
 
 cpp_build_dir = $$OUT_PWD
 


### PR DESCRIPTION
Notably this places the build files within mode-specific dirs (e.g. `target/debug`).