### PR TITLE
rename condure to pushpin-condure

### DIFF
--- a/examples/config/pushpin.conf
+++ b/examples/config/pushpin.conf
@@ -19,7 +19,7 @@ stats_connection_send=true
 
 [runner]
 # services to start
-services=condure,zurl,pushpin-proxy,pushpin-handler
+services=condure,pushpin-proxy,pushpin-handler
 
 # plain HTTP port to listen on for client connections
 http_port=7999

--- a/postbuild/postbuild.pro
+++ b/postbuild/postbuild.pro
@@ -15,9 +15,9 @@ RELEASE = $$(RELEASE)
 
 # copy bin files
 
-condure_bin.target = $$bin_dir/condure
-condure_bin.depends = $$target_dir/condure
-condure_bin.commands = mkdir -p $$bin_dir && cp -a $$target_dir/condure $$bin_dir/condure
+condure_bin.target = $$bin_dir/pushpin-condure
+condure_bin.depends = $$target_dir/pushpin-condure
+condure_bin.commands = mkdir -p $$bin_dir && cp -a $$target_dir/pushpin-condure $$bin_dir/pushpin-condure
 
 m2adapter_bin.target = $$bin_dir/m2adapter
 m2adapter_bin.depends = $$target_dir/m2adapter
@@ -53,7 +53,7 @@ QMAKE_EXTRA_TARGETS += \
 	publish_bin
 
 PRE_TARGETDEPS += \
-	$$bin_dir/condure \
+	$$bin_dir/pushpin-condure \
 	$$bin_dir/m2adapter \
 	$$bin_dir/pushpin-proxy \
 	$$bin_dir/pushpin-handler \
@@ -75,7 +75,7 @@ PRE_TARGETDEPS += pushpin.conf.inst
 unix:!isEmpty(BINDIR) {
 	binfiles.path = $$BINDIR
 	binfiles.files = \
-		$$bin_dir/condure \
+		$$bin_dir/pushpin-condure \
 		$$bin_dir/m2adapter \
 		$$bin_dir/pushpin-proxy \
 		$$bin_dir/pushpin-handler \

--- a/src/bin/pushpin-condure.rs
+++ b/src/bin/pushpin-condure.rs
@@ -199,7 +199,7 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
 }
 
 fn main() {
-    let matches = Command::new("condure")
+    let matches = Command::new("pushpin-condure")
         .version(version())
         .about("HTTP/WebSocket connection manager")
         .arg(

--- a/src/cpp/runner/runnerapp.cpp
+++ b/src/cpp/runner/runnerapp.cpp
@@ -454,8 +454,8 @@ public:
 		if(fi.isFile())
 			m2aBin = fi.canonicalFilePath();
 
-		QString condureBin = "condure";
-		fi = QFileInfo(QDir(exeDir).filePath("bin/condure"));
+		QString condureBin = "pushpin-condure";
+		fi = QFileInfo(QDir(exeDir).filePath("bin/pushpin-condure"));
 		if(fi.isFile())
 			condureBin = fi.canonicalFilePath();
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -392,7 +392,11 @@ impl Settings {
             config_file: config_file_path.to_path_buf(),
             run_dir,
             log_file: args_data.log_file,
-            condure_bin: get_service_dir(exec_dir.into(), "condure", "bin/condure")?,
+            condure_bin: get_service_dir(
+                exec_dir.into(),
+                "pushpin-condure",
+                "bin/pushpin-condure",
+            )?,
             proxy_bin: get_service_dir(exec_dir.into(), "pushpin-proxy", "bin/pushpin-proxy")?,
             handler_bin: get_service_dir(
                 exec_dir.into(),
@@ -824,10 +828,10 @@ mod tests {
                 run_dir: exec_dir.clone().join("run"),
                 log_file: None,
                 certs_dir: PathBuf::from("./examples/config/runner/certs"),
-                condure_bin: if exec_dir.clone().join("bin/condure").exists() {
-                    exec_dir.clone().join("bin/condure")
+                condure_bin: if exec_dir.clone().join("bin/pushpin-condure").exists() {
+                    exec_dir.clone().join("bin/pushpin-condure")
                 } else {
-                    PathBuf::from("condure")
+                    PathBuf::from("pushpin-condure")
                 },
                 proxy_bin: if exec_dir.clone().join("bin/pushpin-proxy").exists() {
                     exec_dir.clone().join("bin/pushpin-proxy")


### PR DESCRIPTION
To avoid conflicts with any separately-installed condure.

For v2 we'll probably rename it again to something like pushpin-connmgr, but either way we'll want this prefixing.