### PR TITLE
use test-work dir in config & runner tests

### DIFF
--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -19,12 +19,13 @@ use log::{error, info, LevelFilter};
 use pushpin::log::{ensure_init_simple_logger, get_simple_logger, local_offset_check};
 use pushpin::runner::{open_log_file, ArgsData, CliArgs, Settings};
 use pushpin::service::start_services;
+use std::env;
 use std::error::Error;
 use std::process;
 
 fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let args_data = ArgsData::new(args)?;
-    let settings = Settings::new(args_data)?;
+    let settings = Settings::new(&env::current_dir()?, args_data)?;
 
     let log_file = match settings.log_file.clone() {
         Some(x) => match open_log_file(x) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,31 @@ where
 }
 
 #[cfg(test)]
+pub fn test_dir() -> PathBuf {
+    // "cargo test" ensures this is present
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    out_dir.join("test-work")
+}
+
+#[cfg(test)]
+pub fn ensure_example_config(dest: &Path) {
+    use std::fs;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        let src_dir = Path::new("examples").join("config");
+        let dest_dir = dest.join("examples").join("config");
+
+        fs::create_dir_all(&dest_dir).unwrap();
+        fs::copy(src_dir.join("pushpin.conf"), dest_dir.join("pushpin.conf")).unwrap();
+        fs::copy(src_dir.join("routes"), dest_dir.join("routes")).unwrap();
+    });
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::OsString;
@@ -447,10 +472,7 @@ mod tests {
         let output_file = if output_direct {
             None
         } else {
-            // "cargo test" ensures this is present
-            let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-            Some(out_dir.join("test-work").join("output"))
+            Some(test_dir().join("output"))
         };
 
         let output_file = output_file.as_deref();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -18,7 +18,6 @@ use clap::{ArgAction, Parser};
 use log::{error, warn};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::env;
 use std::error::Error;
 use std::fs::{self, File, OpenOptions};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -222,14 +221,14 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn new(args_data: ArgsData) -> Result<Self, Box<dyn Error>> {
-        let config_file_path = get_config_file(args_data.config_file)?;
+    pub fn new(work_dir: &Path, args_data: ArgsData) -> Result<Self, Box<dyn Error>> {
+        let config_file_path = get_config_file(work_dir, args_data.config_file)?;
         let config = match CustomConfig::new(config_file_path.to_str().unwrap()) {
             Ok(x) => x,
             Err(e) => return Err(format!("error: parsing config. {:?}", e).into()),
         };
 
-        let exec_dir = &env::current_dir()?;
+        let exec_dir = work_dir;
 
         let config_dir = config_file_path.parent().unwrap().join("runner");
         let certs_dir = config_dir.join("certs");
@@ -544,8 +543,8 @@ fn parse_log_levels(log_levels: Vec<String>) -> Result<HashMap<String, u8>, Box<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{ensure_example_config, test_dir};
     use std::collections::HashMap;
-    use std::env;
     use std::error::Error;
     use std::net::SocketAddr;
     use std::net::{IpAddr, Ipv4Addr};
@@ -804,7 +803,10 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let exec_dir = &env::current_dir().unwrap();
+        let test_dir = test_dir();
+        ensure_example_config(&test_dir);
+
+        let exec_dir = &test_dir;
         let mut log_map = HashMap::new();
         log_map.insert("".to_string(), 2);
         log_map.insert("default".to_string(), 2);
@@ -824,10 +826,17 @@ mod tests {
                     "pushpin-proxy".to_string(),
                     "pushpin-handler".to_string(),
                 ],
-                config_file: PathBuf::from("./examples/config/pushpin.conf"),
+                config_file: test_dir
+                    .join("examples")
+                    .join("config")
+                    .join("pushpin.conf"),
                 run_dir: exec_dir.clone().join("run"),
                 log_file: None,
-                certs_dir: PathBuf::from("./examples/config/runner/certs"),
+                certs_dir: test_dir
+                    .join("examples")
+                    .join("config")
+                    .join("runner")
+                    .join("certs"),
                 condure_bin: if exec_dir.clone().join("bin/pushpin-condure").exists() {
                     exec_dir.clone().join("bin/pushpin-condure")
                 } else {
@@ -885,7 +894,7 @@ mod tests {
 
         for test_arg in test_args.iter() {
             assert_eq!(
-                Settings::new(test_arg.input.clone()).unwrap(),
+                Settings::new(&test_dir, test_arg.input.clone()).unwrap(),
                 test_arg.output.as_ref().unwrap().clone(),
                 "{}",
                 test_arg.name


### PR DESCRIPTION
Notably this ensures the tests pass when `./config/pushpin.conf` happens to exist.