### PR TITLE
Use dtolnay/rust-toolchain instead of actions-rs/toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         submodules: recursive
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust-toolchain }}
     - name: Cache cargo registry


### PR DESCRIPTION
Reason: actions-rs/toolchain is no longer supported.