### PR TITLE
fix yet more clippy warnings

### DIFF
--- a/src/bin/pushpin-condure.rs
+++ b/src/bin/pushpin-condure.rs
@@ -560,7 +560,7 @@ fn main() {
     let ipc_file_mode = matches
         .get_one::<String>("ipc-file-mode")
         .cloned()
-        .unwrap_or(String::from("0"));
+        .unwrap_or_else(|| String::from("0"));
 
     let ipc_file_mode = match u32::from_str_radix(&ipc_file_mode, 8) {
         Ok(x) => x,

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -42,7 +42,7 @@ fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
     let ll = settings
         .log_levels
         .get("")
-        .unwrap_or(settings.log_levels.get("default").unwrap());
+        .unwrap_or_else(|| settings.log_levels.get("default").unwrap());
     let level = match ll {
         0 => LevelFilter::Error,
         1 => LevelFilter::Warn,


### PR DESCRIPTION
```
% rustc --version
rustc 1.66.1 (90743e729 2023-01-10)
% cargo clippy
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
```
