### PR TITLE
improve dependency detection

### DIFF
--- a/src/bin/m2adapter.rs
+++ b/src/bin/m2adapter.rs
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-use pushpin::call_c_main;
+use pushpin::{call_c_main, import_cpp};
 use std::env;
 use std::process::ExitCode;
 
-#[cfg(target_os = "macos")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "QtCore", kind = "framework")]
-#[link(name = "QtNetwork", kind = "framework")]
-#[link(name = "c++")]
-extern "C" {
-    fn m2adapter_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-}
-
-#[cfg(not(target_os = "macos"))]
-#[link(name = "pushpin-cpp")]
-#[link(name = "Qt5Core")]
-#[link(name = "Qt5Network")]
-#[link(name = "stdc++")]
-extern "C" {
+import_cpp! {
     fn m2adapter_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
 }
 

--- a/src/bin/pushpin-handler.rs
+++ b/src/bin/pushpin-handler.rs
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-use pushpin::call_c_main;
+use pushpin::{call_c_main, import_cpp};
 use std::env;
 use std::process::ExitCode;
 
-#[cfg(target_os = "macos")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "QtCore", kind = "framework")]
-#[link(name = "QtNetwork", kind = "framework")]
-#[link(name = "c++")]
-extern "C" {
-    fn handler_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-}
-
-#[cfg(not(target_os = "macos"))]
-#[link(name = "pushpin-cpp")]
-#[link(name = "Qt5Core")]
-#[link(name = "Qt5Network")]
-#[link(name = "stdc++")]
-extern "C" {
+import_cpp! {
     fn handler_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
 }
 

--- a/src/bin/pushpin-legacy.rs
+++ b/src/bin/pushpin-legacy.rs
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-use pushpin::call_c_main;
+use pushpin::{call_c_main, import_cpp};
 use std::env;
 use std::process::ExitCode;
 
-#[cfg(target_os = "macos")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "QtCore", kind = "framework")]
-#[link(name = "QtNetwork", kind = "framework")]
-#[link(name = "c++")]
-extern "C" {
-    fn runner_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-}
-
-#[cfg(not(target_os = "macos"))]
-#[link(name = "pushpin-cpp")]
-#[link(name = "Qt5Core")]
-#[link(name = "Qt5Network")]
-#[link(name = "stdc++")]
-extern "C" {
+import_cpp! {
     fn runner_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
 }
 

--- a/src/bin/pushpin-proxy.rs
+++ b/src/bin/pushpin-proxy.rs
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-use pushpin::call_c_main;
+use pushpin::{call_c_main, import_cpp};
 use std::env;
 use std::process::ExitCode;
 
-#[cfg(target_os = "macos")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "QtCore", kind = "framework")]
-#[link(name = "QtNetwork", kind = "framework")]
-#[link(name = "c++")]
-extern "C" {
-    fn proxy_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-}
-
-#[cfg(not(target_os = "macos"))]
-#[link(name = "pushpin-cpp")]
-#[link(name = "Qt5Core")]
-#[link(name = "Qt5Network")]
-#[link(name = "stdc++")]
-extern "C" {
+import_cpp! {
     fn proxy_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -32,6 +32,9 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
+#[cfg(test)]
+use crate::import_cpptest;
+
 #[repr(C)]
 pub struct ExpiredTimer {
     key: libc::c_int,
@@ -1091,35 +1094,8 @@ pub unsafe fn build_config_destroy(c: *mut BuildConfig) {
     drop(CString::from_raw(c.lib_dir));
 }
 
-#[cfg(all(test, target_os = "macos"))]
-#[link(name = "pushpin-cpptest")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "QtCore", kind = "framework")]
-#[link(name = "QtNetwork", kind = "framework")]
-#[link(name = "QtTest", kind = "framework")]
-#[link(name = "c++")]
-extern "C" {
-    pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn jsonpatch_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn instruct_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn idformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn publishformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn publishitem_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn handlerengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn template_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-}
-
-#[cfg(all(test, not(target_os = "macos")))]
-#[link(name = "pushpin-cpptest")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "Qt5Core")]
-#[link(name = "Qt5Network")]
-#[link(name = "Qt5Test")]
-#[link(name = "stdc++")]
-extern "C" {
+#[cfg(test)]
+import_cpptest! {
     pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
     pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
     pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,97 @@ pub fn version() -> &'static str {
     env!("APP_VERSION")
 }
 
+#[macro_export]
+macro_rules! import_cpp {
+    ($($tt:tt)*) => {
+        #[link(name = "pushpin-cpp")]
+        #[cfg_attr(
+            all(target_os = "macos", qt_lib_prefix = "Qt"),
+            link(name = "QtCore", kind = "framework"),
+            link(name = "QtNetwork", kind = "framework")
+        )]
+        #[cfg_attr(
+            all(target_os = "macos", qt_lib_prefix = "Qt6"),
+            link(name = "Qt6Core", kind = "framework"),
+            link(name = "Qt6Network", kind = "framework")
+        )]
+        #[cfg_attr(
+            all(target_os = "macos", qt_lib_prefix = "Qt5"),
+            link(name = "Qt5Core", kind = "framework"),
+            link(name = "Qt5Network", kind = "framework")
+        )]
+        #[cfg_attr(
+            all(not(target_os = "macos"), qt_lib_prefix = "Qt"),
+            link(name = "QtCore", kind = "dylib"),
+            link(name = "QtNetwork", kind = "dylib")
+        )]
+        #[cfg_attr(
+            all(not(target_os = "macos"), qt_lib_prefix = "Qt6"),
+            link(name = "Qt6Core", kind = "dylib"),
+            link(name = "Qt6Network", kind = "dylib")
+        )]
+        #[cfg_attr(
+            all(not(target_os = "macos"), qt_lib_prefix = "Qt5"),
+            link(name = "Qt5Core", kind = "dylib"),
+            link(name = "Qt5Network", kind = "dylib")
+        )]
+        #[cfg_attr(target_os = "macos", link(name = "c++"))]
+        #[cfg_attr(not(target_os = "macos"), link(name = "stdc++"))]
+        extern "C" {
+            $($tt)*
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! import_cpptest {
+    ($($tt:tt)*) => {
+        #[link(name = "pushpin-cpptest")]
+        #[link(name = "pushpin-cpp")]
+        #[cfg_attr(
+            all(target_os = "macos", qt_lib_prefix = "Qt"),
+            link(name = "QtCore", kind = "framework"),
+            link(name = "QtNetwork", kind = "framework"),
+            link(name = "QtTest", kind = "framework")
+        )]
+        #[cfg_attr(
+            all(target_os = "macos", qt_lib_prefix = "Qt6"),
+            link(name = "Qt6Core", kind = "framework"),
+            link(name = "Qt6Network", kind = "framework"),
+            link(name = "Qt6Test", kind = "framework")
+        )]
+        #[cfg_attr(
+            all(target_os = "macos", qt_lib_prefix = "Qt5"),
+            link(name = "Qt5Core", kind = "framework"),
+            link(name = "Qt5Network", kind = "framework"),
+            link(name = "Qt5Test", kind = "framework")
+        )]
+        #[cfg_attr(
+            all(not(target_os = "macos"), qt_lib_prefix = "Qt"),
+            link(name = "QtCore", kind = "dylib"),
+            link(name = "QtNetwork", kind = "dylib"),
+            link(name = "QtTest", kind = "dylib")
+        )]
+        #[cfg_attr(
+            all(not(target_os = "macos"), qt_lib_prefix = "Qt6"),
+            link(name = "Qt6Core", kind = "dylib"),
+            link(name = "Qt6Network", kind = "dylib"),
+            link(name = "Qt6Test", kind = "dylib")
+        )]
+        #[cfg_attr(
+            all(not(target_os = "macos"), qt_lib_prefix = "Qt5"),
+            link(name = "Qt5Core", kind = "dylib"),
+            link(name = "Qt5Network", kind = "dylib"),
+            link(name = "Qt5Test", kind = "dylib")
+        )]
+        #[cfg_attr(target_os = "macos", link(name = "c++"))]
+        #[cfg_attr(not(target_os = "macos"), link(name = "stdc++"))]
+        extern "C" {
+            $($tt)*
+        }
+    };
+}
+
 /// # Safety
 ///
 /// * `main_fn` must be safe to call.


### PR DESCRIPTION
Support more Qt lib variations, and fix a case where the boost version wasn't checked.

Tested on mac and linux, including linuxbrew, with Qt 5 & 6.