### PR TITLE
fix build on arm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ fn get_user_uid(name: &str) -> Result<libc::gid_t, io::Error> {
         if libc::getpwnam_r(
             name.as_ptr(),
             pwd.as_mut_ptr(),
-            buf.as_mut_ptr() as *mut i8,
+            buf.as_mut_ptr() as *mut libc::c_char,
             buf.len(),
             &mut passwd,
         ) != 0
@@ -197,7 +197,7 @@ fn get_group_gid(name: &str) -> Result<libc::gid_t, io::Error> {
         if libc::getgrnam_r(
             name.as_ptr(),
             grp.as_mut_ptr(),
-            buf.as_mut_ptr() as *mut i8,
+            buf.as_mut_ptr() as *mut libc::c_char,
             buf.len(),
             &mut group,
         ) != 0


### PR DESCRIPTION
Apparently [c_char is unsigned](https://docs.rs/libc/latest/arm-unknown-linux-musleabi/libc/type.c_char.html) on arm unlike on x86.