### PR TITLE
handler: allow configuring multiple proxy accept/stats specs

### DIFF
--- a/src/cpp/handler/handlerapp.cpp
+++ b/src/cpp/handler/handlerapp.cpp
@@ -248,14 +248,22 @@ public:
 		QStringList intreq_in_specs = settings.value("handler/proxy_intreq_in_specs").toStringList();
 		trimlist(&intreq_in_specs);
 		QString proxy_inspect_spec = settings.value("handler/proxy_inspect_spec").toString();
+		QStringList proxy_accept_specs = settings.value("handler/proxy_accept_specs").toStringList();
+		trimlist(&proxy_accept_specs);
 		QString proxy_accept_spec = settings.value("handler/proxy_accept_spec").toString();
+		if(!proxy_accept_spec.isEmpty())
+			proxy_accept_specs += proxy_accept_spec;
 		QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
 		QString ws_control_in_spec = settings.value("handler/proxy_ws_control_in_spec").toString();
 		QString ws_control_out_spec = settings.value("handler/proxy_ws_control_out_spec").toString();
 		QString stats_spec = settings.value("handler/stats_spec").toString();
 		QString command_spec = settings.value("handler/command_spec").toString();
 		QString state_spec = settings.value("handler/state_spec").toString();
+		QStringList proxy_stats_specs = settings.value("handler/proxy_stats_specs").toStringList();
+		trimlist(&proxy_stats_specs);
 		QString proxy_stats_spec = settings.value("handler/proxy_stats_spec").toString();
+		if(!proxy_stats_spec.isEmpty())
+			proxy_stats_specs += proxy_stats_spec;
 		QString proxy_command_spec = settings.value("handler/proxy_command_spec").toString();
 		QString push_in_spec = settings.value("handler/push_in_spec").toString();
 		QStringList push_in_sub_specs = settings.value("handler/push_in_sub_specs").toStringList();
@@ -294,9 +302,9 @@ public:
 			return;
 		}
 
-		if(proxy_inspect_spec.isEmpty() || proxy_accept_spec.isEmpty() || proxy_retry_out_spec.isEmpty())
+		if(proxy_inspect_spec.isEmpty() || proxy_accept_specs.isEmpty() || proxy_retry_out_spec.isEmpty())
 		{
-			log_error("must set proxy_inspect_spec, proxy_accept_spec, and proxy_retry_out_spec");
+			log_error("must set proxy_inspect_spec, proxy_accept_specs, and proxy_retry_out_spec");
 			q->quit(0);
 			return;
 		}
@@ -318,14 +326,14 @@ public:
 		config.clientOutStreamSpecs = intreq_out_stream_specs;
 		config.clientInSpecs = intreq_in_specs;
 		config.inspectSpec = proxy_inspect_spec;
-		config.acceptSpec = proxy_accept_spec;
+		config.acceptSpecs = proxy_accept_specs;
 		config.retryOutSpec = proxy_retry_out_spec;
 		config.wsControlInSpec = ws_control_in_spec;
 		config.wsControlOutSpec = ws_control_out_spec;
 		config.statsSpec = stats_spec;
 		config.commandSpec = command_spec;
 		config.stateSpec = state_spec;
-		config.proxyStatsSpec = proxy_stats_spec;
+		config.proxyStatsSpecs = proxy_stats_specs;
 		config.proxyCommandSpec = proxy_command_spec;
 		config.pushInSpec = push_in_spec;
 		config.pushInSubSpecs = push_in_sub_specs;

--- a/src/cpp/handler/handlerengine.h
+++ b/src/cpp/handler/handlerengine.h
@@ -49,14 +49,14 @@ public:
 		QStringList clientOutStreamSpecs;
 		QStringList clientInSpecs;
 		QString inspectSpec;
-		QString acceptSpec;
+		QStringList acceptSpecs;
 		QString retryOutSpec;
 		QString wsControlInSpec;
 		QString wsControlOutSpec;
 		QString statsSpec;
 		QString commandSpec;
 		QString stateSpec;
-		QString proxyStatsSpec;
+		QStringList proxyStatsSpecs;
 		QString proxyCommandSpec;
 		QString pushInSpec;
 		QStringList pushInSubSpecs;

--- a/src/cpp/tests/handlerenginetest.cpp
+++ b/src/cpp/tests/handlerenginetest.cpp
@@ -286,7 +286,7 @@ private slots:
 		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("server-in"));
 		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("server-in-stream"));
 		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("server-out"));
-		config.acceptSpec = ("ipc://" + workDir.filePath("accept"));
+		config.acceptSpecs = QStringList() << ("ipc://" + workDir.filePath("accept"));
 		config.pushInSpec = ("ipc://" + workDir.filePath("publish-pull"));
 		config.connectionSubscriptionMax = 20;
 		config.connectionsMax = 20;

--- a/src/internal.conf
+++ b/src/internal.conf
@@ -70,8 +70,8 @@ intreq_out_specs=ipc://{rundir}/{ipc_prefix}intreq-out
 # connect REP for responding with inspection info (internal, used with proxy)
 proxy_inspect_spec=ipc://{rundir}/{ipc_prefix}inspect
 
-# connect REP for receiving HTTP requests (internal, used with proxy)
-proxy_accept_spec=ipc://{rundir}/{ipc_prefix}accept
+# list of connect REP for receiving HTTP requests (internal, used with proxy)
+proxy_accept_specs=ipc://{rundir}/{ipc_prefix}accept
 
 # connect PUSH for sending HTTP requests (internal, used with proxy)
 proxy_retry_out_spec=ipc://{rundir}/{ipc_prefix}retry
@@ -82,8 +82,8 @@ proxy_ws_control_in_spec=ipc://{rundir}/{ipc_prefix}ws-control-out
 # bind PUSH for writing proxy WS control messages
 proxy_ws_control_out_spec=ipc://{rundir}/{ipc_prefix}ws-control-in
 
-# connect SUB for receiving stats from proxy
-proxy_stats_spec=ipc://{rundir}/{ipc_prefix}proxy-stats
+# list of connect SUB for receiving stats from proxy
+proxy_stats_specs=ipc://{rundir}/{ipc_prefix}proxy-stats
 
 # connect DEALER for sending commands to proxy
 proxy_command_spec=ipc://{rundir}/{ipc_prefix}proxy-command


### PR DESCRIPTION
This allows one handler to receive stats from multiple proxies. Proxy instances send most stats types over the stats socket, but they also send conn-max over the accept socket, so the handler needs to be able to connect to multiple of both.

With this change, it is possible to then tell the handler to connect to multiple proxy instances like this:

```
[handler]
...
proxy_accept_specs=ipc://{rundir}/{ipc_prefix}accept-1,ipc://{rundir}/{ipc_prefix}accept-2
proxy_stats_specs=ipc://{rundir}/{ipc_prefix}proxy-stats-1,ipc://{rundir}/{ipc_prefix}proxy-stats-2
```

Notes:

* Running multiple handlers (e.g. N handlers and 1 proxy, or N handlers and M proxies) will result in incorrect stats. This change only enables stats to work with 1 handler and N proxies.
* Other things are broken when running multiple proxies, such as retry and websocket control sessions. This change is just a first step towards eventually getting multiple proxies to work.