### PR TITLE
multipartheader is too big, move its content to the heap

### DIFF
--- a/src/zhttpsocket.rs
+++ b/src/zhttpsocket.rs
@@ -1599,9 +1599,7 @@ impl ClientSocketManager {
                         trace!("OUT req {}", packet_to_string(&msg));
                     }
 
-                    let h = MultipartHeader::new();
-
-                    req_send = Some(client_req.sock.send_to(h, msg));
+                    req_send = Some(client_req.sock.send_to(MultipartHeader::new(), msg));
                 }
                 // req_send
                 Select9::R3(result) => {
@@ -1640,8 +1638,7 @@ impl ClientSocketManager {
                 }
                 // stream_handles_recv_addr
                 Select9::R7((addr, msg)) => {
-                    let mut h = MultipartHeader::new();
-                    h.push(zmq::Message::from(addr.as_ref()));
+                    let h = vec![zmq::Message::from(addr.as_ref())];
 
                     if log_enabled!(log::Level::Trace) {
                         trace!("OUT stream to {}", packet_to_string(&msg));


### PR DESCRIPTION
Apparently [zmq::Message](https://docs.rs/zmq/0.9.2/src/zmq/message.rs.html#21) has an overhead of [64 bytes](https://github.com/zeromq/libzmq/blob/dbb7e3dc017997f5c52f59be23d425eca5d9ce23/include/zmq.h#L218-L232), which causes `MultipartHeader` to be 520 bytes (64 * 8, plus 8-byte length). In general, Rust types should not be so large, especially if they are passed around a lot. Moving from `ArrayVec` to `Vec` reduces the size of the type to 24 bytes, at the cost of requiring a heap allocation whenever a `MultipartHeader` is populated. This change is motivated by a clippy warning about large types.

There's a chance this approach may turn out to be less efficient than what we had before. However, I expect any difference to not be significant, since:
* `MultipartHeader` is passed around more often than it is populated, so while there will be a new cost, some other cost will be saved too.
* `MultipartHeader` is only ever populated at the same time zmq messages are created/produced, and that involves other heap allocations with likely higher relative cost.
* Running `cargo bench` before and after doesn't show a meaningful difference. The benchmarks that involve `MultipartHeader` are pretty high level though, so I wouldn't expect any inefficiency from this change to register in them anyway. It's more of a smoke test.

Further, if this approach turns out to be less efficient and we want to do something about that, we would not revert it and go back to a large type, but rather we would seek an optimized solution based on a small type (e.g. small types + arenas). So I think it is acceptable to take the risk of a small efficiency hit for the sake of being idiomatic today, when the most efficient solution would likely be an evolution of this new approach anyway.