### PR TITLE
include from id on accept requests

### DIFF
--- a/src/cpp/handler/handlerengine.cpp
+++ b/src/cpp/handler/handlerengine.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -963,11 +963,13 @@ private:
 			return;
 		}
 
+		QByteArray reqFrom = req->from();
+
 		QVariantHash result;
 		result["accepted"] = true;
 		req->respond(result);
 
-		log_debug("accepting %d requests", requestStates.count());
+		log_debug("accepting %d requests from %s", requestStates.count(), reqFrom.data());
 
 		if(instruct.holdMode == Instruct::ResponseHold)
 		{

--- a/src/cpp/packet/zrpcrequestpacket.cpp
+++ b/src/cpp/packet/zrpcrequestpacket.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -26,6 +27,9 @@ QVariant ZrpcRequestPacket::toVariant() const
 {
 	QVariantHash obj;
 
+	if(!from.isEmpty())
+		obj["from"] = from;
+
 	if(!id.isEmpty())
 		obj["id"] = id;
 
@@ -43,6 +47,14 @@ bool ZrpcRequestPacket::fromVariant(const QVariant &in)
 		return false;
 
 	QVariantHash obj = in.toHash();
+
+	if(obj.contains("from"))
+	{
+		if(obj["from"].type() != QVariant::ByteArray)
+			return false;
+
+		from = obj["from"].toByteArray();
+	}
 
 	if(obj.contains("id"))
 	{

--- a/src/cpp/packet/zrpcrequestpacket.h
+++ b/src/cpp/packet/zrpcrequestpacket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -29,6 +30,7 @@
 class ZrpcRequestPacket
 {
 public:
+	QByteArray from;
 	QByteArray id;
 	QString method;
 	QVariantHash args;

--- a/src/cpp/proxy/engine.cpp
+++ b/src/cpp/proxy/engine.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -257,6 +257,7 @@ public:
 		if(!config.acceptSpec.isEmpty())
 		{
 			accept = new ZrpcManager(this);
+			accept->setInstanceId(config.clientId);
 			accept->setBind(true);
 			accept->setIpcFileMode(config.ipcFileMode);
 			if(!accept->setClientSpecs(QStringList() << config.acceptSpec))

--- a/src/cpp/zrpcmanager.cpp
+++ b/src/cpp/zrpcmanager.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2016 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -56,6 +57,7 @@ public:
 	};
 
 	ZrpcManager *q;
+	QByteArray instanceId;
 	int ipcFileMode;
 	bool doBind;
 	int timeout;
@@ -142,7 +144,10 @@ public:
 	{
 		assert(clientSock);
 
-		QVariant vpacket = packet.toVariant();
+		ZrpcRequestPacket p = packet;
+		p.from = instanceId;
+
+		QVariant vpacket = p.toVariant();
 		QByteArray buf = TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -262,6 +267,11 @@ ZrpcManager::~ZrpcManager()
 int ZrpcManager::timeout() const
 {
 	return d->timeout;
+}
+
+void ZrpcManager::setInstanceId(const QByteArray &instanceId)
+{
+	d->instanceId = instanceId;
 }
 
 void ZrpcManager::setIpcFileMode(int mode)

--- a/src/cpp/zrpcmanager.h
+++ b/src/cpp/zrpcmanager.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -43,6 +43,7 @@ public:
 
 	int timeout() const;
 
+	void setInstanceId(const QByteArray &instanceId);
 	void setIpcFileMode(int mode);
 	void setBind(bool enable);
 	void setTimeout(int ms);

--- a/src/cpp/zrpcrequest.cpp
+++ b/src/cpp/zrpcrequest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2015 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -38,6 +39,7 @@ public:
 	ZrpcRequest *q;
 	ZrpcManager *manager;
 	QList<QByteArray> reqHeaders;
+	QByteArray from;
 	QByteArray id;
 	QString method;
 	QVariantHash args;
@@ -101,6 +103,7 @@ public:
 	void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet)
 	{
 		reqHeaders = headers;
+		from = packet.from;
 		id = packet.id;
 		method = packet.method;
 		args = packet.args;
@@ -187,6 +190,11 @@ ZrpcRequest::ZrpcRequest(ZrpcManager *manager, QObject *parent) :
 ZrpcRequest::~ZrpcRequest()
 {
 	delete d;
+}
+
+QByteArray ZrpcRequest::from() const
+{
+	return d->from;
 }
 
 QByteArray ZrpcRequest::id() const

--- a/src/cpp/zrpcrequest.h
+++ b/src/cpp/zrpcrequest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2015 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -49,6 +50,7 @@ public:
 	ZrpcRequest(ZrpcManager *manager, QObject *parent = 0);
 	~ZrpcRequest();
 
+	QByteArray from() const;
 	QByteArray id() const;
 	QString method() const;
 	QVariantHash args() const;


### PR DESCRIPTION
This lets handler know which proxy sent an accept request. We need this in order to implement multiple retry-seq values, which will be needed to make stats work correctly when retries are used with multiple proxies.

```
[DEBUG] 2024-01-26 09:56:14.923 [handler] accepting 1 requests from pushpin-proxy_32027
```