### PR TITLE
when retrying, send to the same proxy that sent the accept

### DIFF
--- a/src/cpp/handler/handlerapp.cpp
+++ b/src/cpp/handler/handlerapp.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2022 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -257,7 +258,11 @@ public:
 		QString proxy_accept_spec = settings.value("handler/proxy_accept_spec").toString();
 		if(!proxy_accept_spec.isEmpty())
 			proxy_accept_specs += proxy_accept_spec;
+		QStringList proxy_retry_out_specs = settings.value("handler/proxy_retry_out_specs").toStringList();
+		trimlist(&proxy_retry_out_specs);
 		QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
+		if(!proxy_retry_out_spec.isEmpty())
+			proxy_retry_out_specs += proxy_retry_out_spec;
 		QString ws_control_in_spec = settings.value("handler/proxy_ws_control_in_spec").toString();
 		QString ws_control_out_spec = settings.value("handler/proxy_ws_control_out_spec").toString();
 		QString stats_spec = settings.value("handler/stats_spec").toString();
@@ -306,9 +311,9 @@ public:
 			return;
 		}
 
-		if(proxy_inspect_specs.isEmpty() || proxy_accept_specs.isEmpty() || proxy_retry_out_spec.isEmpty())
+		if(proxy_inspect_specs.isEmpty() || proxy_accept_specs.isEmpty() || proxy_retry_out_specs.isEmpty())
 		{
-			log_error("must set proxy_inspect_specs, proxy_accept_specs, and proxy_retry_out_spec");
+			log_error("must set proxy_inspect_specs, proxy_accept_specs, and proxy_retry_out_specs");
 			q->quit(0);
 			return;
 		}
@@ -331,7 +336,7 @@ public:
 		config.clientInSpecs = intreq_in_specs;
 		config.inspectSpecs = proxy_inspect_specs;
 		config.acceptSpecs = proxy_accept_specs;
-		config.retryOutSpec = proxy_retry_out_spec;
+		config.retryOutSpecs = proxy_retry_out_specs;
 		config.wsControlInSpec = ws_control_in_spec;
 		config.wsControlOutSpec = ws_control_out_spec;
 		config.statsSpec = stats_spec;

--- a/src/cpp/handler/handlerengine.h
+++ b/src/cpp/handler/handlerengine.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -50,7 +51,7 @@ public:
 		QStringList clientInSpecs;
 		QStringList inspectSpecs;
 		QStringList acceptSpecs;
-		QString retryOutSpec;
+		QStringList retryOutSpecs;
 		QString wsControlInSpec;
 		QString wsControlOutSpec;
 		QString statsSpec;

--- a/src/cpp/handler/httpsession.cpp
+++ b/src/cpp/handler/httpsession.cpp
@@ -167,6 +167,7 @@ public:
 	Priority needUpdatePriority;
 	UpdateAction *pendingAction;
 	QList<PublishItem> publishQueue;
+	QByteArray retryToAddress;
 	RetryRequestPacket retryPacket;
 	LogUtil::Config logConfig;
 	FilterStack *responseFilters;
@@ -1138,6 +1139,7 @@ private:
 			rp.route = adata.route.toUtf8();
 			rp.retrySeq = stats->lastRetrySeq();
 
+			retryToAddress = adata.from;
 			retryPacket = rp;
 		}
 		else
@@ -1597,6 +1599,11 @@ QHash<QString, Instruct::Channel> HttpSession::channels() const
 QHash<QString, QString> HttpSession::meta() const
 {
 	return d->instruct.meta;
+}
+
+QByteArray HttpSession::retryToAddress() const
+{
+	return d->retryToAddress;
 }
 
 RetryRequestPacket HttpSession::retryPacket() const

--- a/src/cpp/handler/httpsession.h
+++ b/src/cpp/handler/httpsession.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2023 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -53,6 +54,7 @@ public:
 	class AcceptData
 	{
 	public:
+		QByteArray from;
 		QHostAddress logicalPeerAddress;
 		bool debug;
 		bool isRetry;
@@ -95,6 +97,7 @@ public:
 	QString sid() const;
 	QHash<QString, Instruct::Channel> channels() const;
 	QHash<QString, QString> meta() const;
+	QByteArray retryToAddress() const;
 	RetryRequestPacket retryPacket() const;
 
 	void start();

--- a/src/cpp/qzmq/src/qzmqsocket.cpp
+++ b/src/cpp/qzmq/src/qzmqsocket.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2020 Justin Karneges
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
@@ -89,6 +90,14 @@ static void set_immediate(void *sock, bool on)
 	int v = on ? 1 : 0;
 	size_t opt_len = sizeof(v);
 	int ret = wzmq_setsockopt(sock, WZMQ_IMMEDIATE, &v, opt_len);
+	assert(ret == 0);
+}
+
+static void set_router_mandatory(void *sock, bool on)
+{
+	int v = on ? 1 : 0;
+	size_t opt_len = sizeof(v);
+	int ret = wzmq_setsockopt(sock, WZMQ_ROUTER_MANDATORY, &v, opt_len);
 	assert(ret == 0);
 }
 
@@ -706,6 +715,11 @@ void Socket::setReceiveHwm(int hwm)
 void Socket::setImmediateEnabled(bool on)
 {
 	set_immediate(d->sock, on);
+}
+
+void Socket::setRouterMandatoryEnabled(bool on)
+{
+	set_router_mandatory(d->sock, on);
 }
 
 void Socket::setTcpKeepAliveEnabled(bool on)

--- a/src/cpp/qzmq/src/qzmqsocket.h
+++ b/src/cpp/qzmq/src/qzmqsocket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2015 Justin Karneges
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
@@ -85,6 +86,7 @@ public:
 	void setReceiveHwm(int hwm);
 
 	void setImmediateEnabled(bool on);
+	void setRouterMandatoryEnabled(bool on);
 
 	void setTcpKeepAliveEnabled(bool on);
 	void setTcpKeepAliveParameters(int idle = -1, int count = -1, int interval = -1);

--- a/src/cpp/tests/proxyenginetest.cpp
+++ b/src/cpp/tests/proxyenginetest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2022 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -135,7 +136,7 @@ public:
 		handlerInspectValve = new QZmq::Valve(handlerInspectSock, this);
 		handlerInspectValveConnection = handlerInspectValve->readyRead.connect(boost::bind(&Wrapper::handlerInspect_readyRead, this, boost::placeholders::_1));
 
-		handlerRetryOutSock = new QZmq::Socket(QZmq::Socket::Push, this);
+		handlerRetryOutSock = new QZmq::Socket(QZmq::Socket::Router, this);
 	}
 
 	void startHttp()
@@ -540,7 +541,12 @@ private:
 				vretry["request-data"] = vaccept["request-data"];
 				QByteArray buf = TnetString::fromVariant(vretry);
 				log_debug("retrying: %s", qPrintable(TnetString::variantToString(vretry, -1)));
-				handlerRetryOutSock->write(QList<QByteArray>() << buf);
+
+				QList<QByteArray> msg;
+				msg.append("proxy");
+				msg.append(QByteArray());
+				msg.append(buf);
+				handlerRetryOutSock->write(msg);
 				return;
 			}
 		}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021-2022 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -383,6 +383,7 @@ const WZMQ_TCP_KEEPALIVE: libc::c_int = 10;
 const WZMQ_TCP_KEEPALIVE_IDLE: libc::c_int = 11;
 const WZMQ_TCP_KEEPALIVE_CNT: libc::c_int = 12;
 const WZMQ_TCP_KEEPALIVE_INTVL: libc::c_int = 13;
+const WZMQ_ROUTER_MANDATORY: libc::c_int = 14;
 
 // NOTE: must match values in wzmq.h
 const WZMQ_DONTWAIT: libc::c_int = 0x01;
@@ -721,6 +722,21 @@ pub unsafe extern "C" fn wzmq_setsockopt(
             };
 
             if let Err(e) = sock.set_immediate(*x != 0) {
+                set_errno(e.to_raw());
+                return -1;
+            }
+        }
+        WZMQ_ROUTER_MANDATORY => {
+            if option_len as u32 != libc::c_int::BITS / 8 {
+                return -1;
+            }
+
+            let x = match (option_value as *mut libc::c_int).as_ref() {
+                Some(x) => x,
+                None => return -1,
+            };
+
+            if let Err(e) = sock.set_router_mandatory(*x != 0) {
                 set_errno(e.to_raw());
                 return -1;
             }

--- a/src/internal.conf
+++ b/src/internal.conf
@@ -41,7 +41,7 @@ handler_inspect_spec=ipc://{rundir}/{ipc_prefix}inspect
 # bind DEALER for passing off requests (internal, used with handler)
 handler_accept_spec=ipc://{rundir}/{ipc_prefix}accept
 
-# bind PULL for receiving retry requests (internal, used with handler)
+# bind ROUTER for receiving retry requests (internal, used with handler)
 handler_retry_in_spec=ipc://{rundir}/{ipc_prefix}retry
 
 # bind PULL for reading handler WS control messages
@@ -73,8 +73,8 @@ proxy_inspect_specs=ipc://{rundir}/{ipc_prefix}inspect
 # list of connect REP for receiving HTTP requests (internal, used with proxy)
 proxy_accept_specs=ipc://{rundir}/{ipc_prefix}accept
 
-# connect PUSH for sending HTTP requests (internal, used with proxy)
-proxy_retry_out_spec=ipc://{rundir}/{ipc_prefix}retry
+# list of connect ROUTER for sending HTTP requests (internal, used with proxy)
+proxy_retry_out_specs=ipc://{rundir}/{ipc_prefix}retry
 
 # bind PULL for reading proxy WS control messages
 proxy_ws_control_in_spec=ipc://{rundir}/{ipc_prefix}ws-control-out

--- a/src/rust/wzmq.h
+++ b/src/rust/wzmq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -58,6 +58,7 @@
 #define WZMQ_TCP_KEEPALIVE_IDLE 11
 #define WZMQ_TCP_KEEPALIVE_CNT 12
 #define WZMQ_TCP_KEEPALIVE_INTVL 13
+#define WZMQ_ROUTER_MANDATORY 14
 
 // NOTE: must match values in ffi.rs
 #define WZMQ_DONTWAIT 0x01


### PR DESCRIPTION
Previously, retries would round robin between multiple proxies. Note that stats will still be incorrect when multiple proxies are used since the handler shares a single retry-seq value among all proxies. To complete multiple proxy support for accept/retry interactions, the handler will need to be updated to keep a retry-seq value per proxy.

```
[DEBUG] 2024-01-26 14:08:35.403 [handler] accepting 1 requests from pushpin-proxy_43696
[DEBUG] 2024-01-26 14:08:36.555 [handler] OUT retry: to=pushpin-proxy_43696 { "request-data": { "headers": [ [ "Host", "localhost:7999" ], [ "User-Agent", "curl/8.4.0" ], [ "Accept", "*/*" ] ], "method": "GET", "uri": "http://localhost:7999/longpoll.php", "body": "" }, "retry-seq": 0, "inspect": { "no-proxy": false }, "requests": [ { "rid": { "sender": "condure", "id": "0-0-0" }, "peer-address": "127.0.0.1", "in-seq": 3, "out-seq": 4, "out-credits": 8192 } ] }
[DEBUG] 2024-01-26 14:08:36.556 [proxy] retry: IN { "inspect": { "no-proxy": false }, "request-data": { "body": "", "headers": [ [ "Host", "localhost:7999" ], [ "User-Agent", "curl/8.4.0" ], [ "Accept", "*/*" ] ], "method": "GET", "uri": "http://localhost:7999/longpoll.php" }, "requests": [ { "in-seq": 3, "rid": { "id": "0-0-0", "sender": "condure" }, "out-seq": 4, "out-credits": 8192, "peer-address": "127.0.0.1" } ], "retry-seq": 0 }
```