### PR TITLE
use correct route and retry-seq for conn-max packets

### DIFF
--- a/src/cpp/proxy/engine.cpp
+++ b/src/cpp/proxy/engine.cpp
@@ -867,9 +867,6 @@ private:
 
 		log_debug("IN (retry) %s %s", qPrintable(p.requestData.method), p.requestData.uri.toEncoded().data());
 
-		if(p.retrySeq >= 0)
-			stats->setRetrySeq(p.route, p.retrySeq);
-
 		InspectData idata;
 		if(p.haveInspectInfo)
 		{
@@ -911,7 +908,7 @@ private:
 			// note: if the routing table was changed, there's a chance the request
 			//   might get a different route id this time around. this could confuse
 			//   stats processors tracking route+connection mappings.
-			rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin, req.jsonpCallback, req.jsonpExtendedResponse, req.unreportedTime);
+			rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin, req.jsonpCallback, req.jsonpExtendedResponse, req.unreportedTime, p.retrySeq);
 
 			doProxy(rs, p.haveInspectInfo ? &idata : 0);
 		}

--- a/src/cpp/proxy/proxysession.cpp
+++ b/src/cpp/proxy/proxysession.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -1321,10 +1321,10 @@ public slots:
 			if(!statsManager->connectionSendEnabled())
 			{
 				// flush max. the count will include the connections we just unregistered
-				adata.connMaxPackets += statsManager->getConnMaxPacket(route.id).toVariant();
+				adata.connMaxPackets += statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
 
 				// flush max again to get the count without the connections
-				adata.connMaxPackets += statsManager->getConnMaxPacket(route.id).toVariant();
+				adata.connMaxPackets += statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
 			}
 
 			acceptRequest = new AcceptRequest(acceptManager, this);

--- a/src/cpp/proxy/requestsession.cpp
+++ b/src/cpp/proxy/requestsession.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -383,7 +384,7 @@ public:
 		processIncomingRequest();
 	}
 
-	void startRetry(int unreportedTime)
+	void startRetry(int unreportedTime, int retrySeq)
 	{
 		trusted = ProxyUtil::checkTrustedClient("requestsession", q, requestData, defaultUpstreamKey);
 
@@ -417,6 +418,9 @@ public:
 
 		if(stats)
 		{
+			if(retrySeq >= 0)
+				stats->setRetrySeq(route.statsRoute(), retrySeq);
+
 			connectionRegistered = true;
 
 			int reportOffset = stats->connectionSendEnabled() ? -1 : qMax(unreportedTime, 0);
@@ -1323,7 +1327,7 @@ void RequestSession::start(ZhttpRequest *req)
 	d->start(req);
 }
 
-void RequestSession::startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin, const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime)
+void RequestSession::startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin, const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime, int retrySeq)
 {
 	d->isRetry = true;
 	d->zhttpRequest = req;
@@ -1337,7 +1341,7 @@ void RequestSession::startRetry(ZhttpRequest *req, bool debug, bool autoCrossOri
 	d->requestData.headers = req->requestHeaders();
 	d->requestData.body = req->readBody();
 
-	d->startRetry(unreportedTime);
+	d->startRetry(unreportedTime, retrySeq);
 }
 
 void RequestSession::pause()

--- a/src/cpp/proxy/requestsession.h
+++ b/src/cpp/proxy/requestsession.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -87,7 +88,7 @@ public:
 
 	// takes ownership
 	void start(ZhttpRequest *req);
-	void startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin, const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime);
+	void startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin, const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime, int retrySeq);
 
 	void pause();
 	void resume();


### PR DESCRIPTION
Route IDs in stats packets should use the value from the `statsRoute()` method rather than the route's `id` field directly. These are often the same value, but not always. Also, retry-seq values should be tracked by `statsRoute()` as well.