### PR TITLE
handler: separate retry-seq values per proxy

### DIFF
--- a/src/cpp/handler/handlerengine.cpp
+++ b/src/cpp/handler/handlerengine.cpp
@@ -1003,7 +1003,7 @@ private:
 
 					needRemoveFromStats.remove(cid);
 
-					int unreportedTime = stats->removeConnection(cid, true);
+					int unreportedTime = stats->removeConnection(cid, true, reqFrom);
 
 					RetryRequestPacket::Request rpreq;
 					rpreq.rid = rs.rid;
@@ -1052,7 +1052,7 @@ private:
 				}
 
 				rp.route = route.toUtf8();
-				rp.retrySeq = stats->lastRetrySeq();
+				rp.retrySeq = stats->lastRetrySeq(reqFrom);
 
 				retryPacketReady(reqFrom, rp);
 

--- a/src/cpp/handler/httpsession.cpp
+++ b/src/cpp/handler/httpsession.cpp
@@ -1081,7 +1081,7 @@ private:
 
 			needRemoveFromStats = false;
 
-			int unreportedTime = stats->removeConnection(cid, true);
+			int unreportedTime = stats->removeConnection(cid, true, adata.from);
 
 			ZhttpRequest::ServerState ss = req->serverState();
 
@@ -1137,7 +1137,7 @@ private:
 			}
 
 			rp.route = adata.route.toUtf8();
-			rp.retrySeq = stats->lastRetrySeq();
+			rp.retrySeq = stats->lastRetrySeq(adata.from);
 
 			retryToAddress = adata.from;
 			retryPacket = rp;

--- a/src/cpp/statsmanager.h
+++ b/src/cpp/statsmanager.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -73,7 +73,7 @@ public:
 	void addMessage(const QString &channel, const QString &itemId, const QString &transport, quint32 count = 1, int blocks = -1);
 
 	void addConnection(const QByteArray &id, const QByteArray &routeId, ConnectionType type, const QHostAddress &peerAddress, bool ssl, bool quiet, int reportOffset = -1);
-	int removeConnection(const QByteArray &id, bool linger); // return unreported time
+	int removeConnection(const QByteArray &id, bool linger, const QByteArray &source = QByteArray()); // return unreported time
 
 	// manager automatically refreshes, but it may be useful to force a
 	//   send before removing with linger
@@ -104,7 +104,7 @@ public:
 
 	void flushReport(const QByteArray &routeId);
 
-	qint64 lastRetrySeq() const;
+	qint64 lastRetrySeq(const QByteArray &source) const;
 
 	StatsPacket getConnMaxPacket(const QByteArray &routeId);
 	void setRetrySeq(const QByteArray &routeId, int value);


### PR DESCRIPTION
This is hopefully the last change needed for accept/retry to work right when used with multiple proxies.

Seq values are kept in a map, keyed by proxy ID. As new proxy instances are discovered, they are added to the map. We never remove values from this map, so this is a potential memory leak, but under normal conditions we expect the map to have very few entries and not grow out of control. I've left a FIXME comment in case we want to harden this somehow.

Logs showing different retry-seqs per proxy:
```
[DEBUG] 2024-01-31 11:41:16.367 [handler] OUT retry: to=pushpin-proxy_28738 { "requests": [ { "peer-address": "127.0.0.1", "in-seq": 3, "rid": { "id": "0-0-0", "sender": "condure" }, "out-seq": 4, "out-credits": 8192 } ], "inspect": { "no-proxy": false }, "route": "*,*,*,*", "request-data": { "method": "GET", "uri": "http://localhost:7999/longpoll.php?topic=a", "body": "", "headers": [ [ "Host", "localhost:7999" ], [ "User-Agent", "curl/8.4.0" ], [ "Accept", "*/*" ] ] }, "retry-seq": 0 }
...
[DEBUG] 2024-01-31 11:41:18.793 [handler] OUT retry: to=pushpin-proxy_28739 { "requests": [ { "peer-address": "127.0.0.1", "in-seq": 3, "rid": { "id": "1-0-0", "sender": "condure" }, "out-seq": 4, "out-credits": 8192 } ], "inspect": { "no-proxy": false }, "route": "*,*,*,*", "request-data": { "method": "GET", "uri": "http://localhost:7999/longpoll.php?topic=b", "body": "", "headers": [ [ "Host", "localhost:7999" ], [ "User-Agent", "curl/8.4.0" ], [ "Accept", "*/*" ] ] }, "retry-seq": 0 }
...
[DEBUG] 2024-01-31 11:41:21.794 [handler] OUT retry: to=pushpin-proxy_28738 { "requests": [ { "peer-address": "127.0.0.1", "in-seq": 3, "rid": { "id": "0-1-1", "sender": "condure" }, "out-seq": 4, "out-credits": 8192 } ], "inspect": { "no-proxy": false }, "route": "*,*,*,*", "request-data": { "method": "GET", "uri": "http://localhost:7999/longpoll.php?topic=c", "body": "", "headers": [ [ "Host", "localhost:7999" ], [ "User-Agent", "curl/8.4.0" ], [ "Accept", "*/*" ] ] }, "retry-seq": 1 }
```