### PR TITLE
make wscontrol sessions work with multiple proxies/handlers

### DIFF
--- a/src/cpp/handler/handlerapp.cpp
+++ b/src/cpp/handler/handlerapp.cpp
@@ -263,8 +263,10 @@ public:
 		QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
 		if(!proxy_retry_out_spec.isEmpty())
 			proxy_retry_out_specs += proxy_retry_out_spec;
-		QString ws_control_in_spec = settings.value("handler/proxy_ws_control_in_spec").toString();
-		QString ws_control_out_spec = settings.value("handler/proxy_ws_control_out_spec").toString();
+		QStringList ws_control_init_specs = settings.value("handler/proxy_ws_control_init_specs").toStringList();
+		trimlist(&ws_control_init_specs);
+		QStringList ws_control_stream_specs = settings.value("handler/proxy_ws_control_stream_specs").toStringList();
+		trimlist(&ws_control_stream_specs);
 		QString stats_spec = settings.value("handler/stats_spec").toString();
 		QString command_spec = settings.value("handler/command_spec").toString();
 		QString state_spec = settings.value("handler/state_spec").toString();
@@ -337,8 +339,8 @@ public:
 		config.inspectSpecs = proxy_inspect_specs;
 		config.acceptSpecs = proxy_accept_specs;
 		config.retryOutSpecs = proxy_retry_out_specs;
-		config.wsControlInSpec = ws_control_in_spec;
-		config.wsControlOutSpec = ws_control_out_spec;
+		config.wsControlInitSpecs = ws_control_init_specs;
+		config.wsControlStreamSpecs = ws_control_stream_specs;
 		config.statsSpec = stats_spec;
 		config.commandSpec = command_spec;
 		config.stateSpec = state_spec;

--- a/src/cpp/handler/handlerengine.h
+++ b/src/cpp/handler/handlerengine.h
@@ -52,8 +52,8 @@ public:
 		QStringList inspectSpecs;
 		QStringList acceptSpecs;
 		QStringList retryOutSpecs;
-		QString wsControlInSpec;
-		QString wsControlOutSpec;
+		QStringList wsControlInitSpecs;
+		QStringList wsControlStreamSpecs;
 		QString statsSpec;
 		QString commandSpec;
 		QString stateSpec;

--- a/src/cpp/handler/wssession.h
+++ b/src/cpp/handler/wssession.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -39,6 +40,7 @@ class WsSession : public QObject
 	Q_OBJECT
 
 public:
+	QByteArray peer;
 	QString cid;
 	int nextReqId;
 	QString channelPrefix;

--- a/src/cpp/packet/wscontrolpacket.cpp
+++ b/src/cpp/packet/wscontrolpacket.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -153,6 +154,8 @@ QVariant WsControlPacket::toVariant() const
 {
 	QVariantHash obj;
 
+	obj["from"] = from;
+
 	QVariantList vitems;
 	foreach(const Item &item, items)
 	{
@@ -236,8 +239,14 @@ bool WsControlPacket::fromVariant(const QVariant &in)
 
 	QVariantHash obj = in.toHash();
 
+	if(!obj.contains("from") || obj["from"].type() != QVariant::ByteArray)
+		return false;
+
+	from = obj["from"].toByteArray();
+
 	if(!obj.contains("items") || obj["items"].type() != QVariant::List)
 		return false;
+
 	QVariantList vitems = obj["items"].toList();
 
 	items.clear();

--- a/src/cpp/packet/wscontrolpacket.h
+++ b/src/cpp/packet/wscontrolpacket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -78,6 +79,7 @@ public:
 		}
 	};
 
+	QByteArray from;
 	QList<Item> items;
 
 	QVariant toVariant() const;

--- a/src/cpp/proxy/app.cpp
+++ b/src/cpp/proxy/app.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2022 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -277,8 +277,10 @@ public:
 		QString handler_inspect_spec = settings.value("proxy/handler_inspect_spec").toString();
 		QString handler_accept_spec = settings.value("proxy/handler_accept_spec").toString();
 		QString handler_retry_in_spec = settings.value("proxy/handler_retry_in_spec").toString();
-		QString handler_ws_control_in_spec = settings.value("proxy/handler_ws_control_in_spec").toString();
-		QString handler_ws_control_out_spec = settings.value("proxy/handler_ws_control_out_spec").toString();
+		QStringList handler_ws_control_init_specs = settings.value("proxy/handler_ws_control_init_specs").toStringList();
+		trimlist(&handler_ws_control_init_specs);
+		QStringList handler_ws_control_stream_specs = settings.value("proxy/handler_ws_control_stream_specs").toStringList();
+		trimlist(&handler_ws_control_stream_specs);
 		QString stats_spec = settings.value("proxy/stats_spec").toString();
 		QString command_spec = settings.value("proxy/command_spec").toString();
 		QStringList intreq_in_specs = settings.value("proxy/intreq_in_specs").toStringList();
@@ -375,8 +377,8 @@ public:
 		config.inspectSpec = handler_inspect_spec;
 		config.acceptSpec = handler_accept_spec;
 		config.retryInSpec = handler_retry_in_spec;
-		config.wsControlInSpec = handler_ws_control_in_spec;
-		config.wsControlOutSpec = handler_ws_control_out_spec;
+		config.wsControlInitSpecs = handler_ws_control_init_specs;
+		config.wsControlStreamSpecs = handler_ws_control_stream_specs;
 		config.statsSpec = stats_spec;
 		config.commandSpec = command_spec;
 		config.intServerInSpecs = intreq_in_specs;

--- a/src/cpp/proxy/engine.cpp
+++ b/src/cpp/proxy/engine.cpp
@@ -298,21 +298,22 @@ public:
 		if(handler_retry_in_valve)
 			handler_retry_in_valve->open();
 
-		if(!config.wsControlInSpec.isEmpty() && !config.wsControlOutSpec.isEmpty())
+		if(!config.wsControlInitSpecs.isEmpty() && !config.wsControlStreamSpecs.isEmpty())
 		{
 			wsControl = new WsControlManager(this);
 
+			wsControl->setIdentity(config.clientId);
 			wsControl->setIpcFileMode(config.ipcFileMode);
 
-			if(!wsControl->setInSpec(config.wsControlInSpec))
+			if(!wsControl->setInitSpecs(config.wsControlInitSpecs))
 			{
-				log_error("unable to bind to handler_ws_control_in_spec: %s", qPrintable(config.wsControlInSpec));
+				log_error("unable to bind to handler_ws_control_init_specs: %s", qPrintable(config.wsControlInitSpecs.join(", ")));
 				return false;
 			}
 
-			if(!wsControl->setOutSpec(config.wsControlOutSpec))
+			if(!wsControl->setStreamSpecs(config.wsControlStreamSpecs))
 			{
-				log_error("unable to bind to handler_ws_control_out_spec: %s", qPrintable(config.wsControlOutSpec));
+				log_error("unable to bind to handler_ws_control_stream_specs: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
 				return false;
 			}
 		}

--- a/src/cpp/proxy/engine.h
+++ b/src/cpp/proxy/engine.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -56,8 +56,8 @@ public:
 		QString inspectSpec;
 		QString acceptSpec;
 		QString retryInSpec;
-		QString wsControlInSpec;
-		QString wsControlOutSpec;
+		QStringList wsControlInitSpecs;
+		QStringList wsControlStreamSpecs;
 		QString statsSpec;
 		QString commandSpec;
 		QStringList intServerInSpecs;

--- a/src/cpp/proxy/wscontrolmanager.h
+++ b/src/cpp/proxy/wscontrolmanager.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -36,10 +37,11 @@ public:
 	WsControlManager(QObject *parent = 0);
 	~WsControlManager();
 
+	void setIdentity(const QByteArray &id);
 	void setIpcFileMode(int mode);
 
-	bool setInSpec(const QString &spec);
-	bool setOutSpec(const QString &spec);
+	bool setInitSpecs(const QStringList &specs);
+	bool setStreamSpecs(const QStringList &specs);
 
 	WsControlSession *createSession(const QByteArray &cid);
 
@@ -50,8 +52,8 @@ private:
 	friend class WsControlSession;
 	void link(WsControlSession *s, const QByteArray &cid);
 	void unlink(const QByteArray &cid);
-	bool canWriteImmediately() const;
-	void write(const WsControlPacket::Item &item);
+	void writeInit(const WsControlPacket::Item &item);
+	void writeStream(const WsControlPacket::Item &item, const QByteArray &instanceAddress);
 	void registerKeepAlive(WsControlSession *s);
 	void unregisterKeepAlive(WsControlSession *s);
 };

--- a/src/cpp/proxy/wscontrolsession.h
+++ b/src/cpp/proxy/wscontrolsession.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -41,6 +42,7 @@ class WsControlSession : public QObject
 public:
 	~WsControlSession();
 
+	QByteArray peer() const;
 	QByteArray cid() const;
 
 	void start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, const QUrl &uri);
@@ -66,7 +68,7 @@ private:
 	friend class WsControlManager;
 	WsControlSession(QObject *parent = 0);
 	void setup(WsControlManager *manager, const QByteArray &cid);
-	void handle(const WsControlPacket::Item &item);
+	void handle(const QByteArray &from, const WsControlPacket::Item &item);
 };
 
 #endif

--- a/src/internal.conf
+++ b/src/internal.conf
@@ -44,11 +44,11 @@ handler_accept_spec=ipc://{rundir}/{ipc_prefix}accept
 # bind ROUTER for receiving retry requests (internal, used with handler)
 handler_retry_in_spec=ipc://{rundir}/{ipc_prefix}retry
 
-# bind PULL for reading handler WS control messages
-handler_ws_control_in_spec=ipc://{rundir}/{ipc_prefix}ws-control-in
+# list of bind PUSH for sending initial handler WS control messages
+handler_ws_control_init_specs=ipc://{rundir}/{ipc_prefix}ws-control-init
 
-# bind PUSH for writing handler WS control messages
-handler_ws_control_out_spec=ipc://{rundir}/{ipc_prefix}ws-control-out
+# list of bind ROUTER for sending/receiving subsequent handler WS control messages
+handler_ws_control_stream_specs=ipc://{rundir}/{ipc_prefix}ws-control-stream
 
 # bind PUB for sending stats
 stats_spec=ipc://{rundir}/{ipc_prefix}proxy-stats
@@ -56,13 +56,13 @@ stats_spec=ipc://{rundir}/{ipc_prefix}proxy-stats
 # bind REP for responding to commands
 command_spec=ipc://{rundir}/{ipc_prefix}proxy-command
 
-# bind PULL for receiving HTTP requests
+# list of bind PULL for receiving HTTP requests
 intreq_in_specs=ipc://{rundir}/{ipc_prefix}intreq-in
 
-# bind ROUTER for continuing HTTP requests
+# list of bind ROUTER for continuing HTTP requests
 intreq_in_stream_specs=ipc://{rundir}/{ipc_prefix}intreq-in-stream
 
-# bind PUB for sending HTTP responses
+# list of bind PUB for sending HTTP responses
 intreq_out_specs=ipc://{rundir}/{ipc_prefix}intreq-out
 
 
@@ -76,11 +76,11 @@ proxy_accept_specs=ipc://{rundir}/{ipc_prefix}accept
 # list of connect ROUTER for sending HTTP requests (internal, used with proxy)
 proxy_retry_out_specs=ipc://{rundir}/{ipc_prefix}retry
 
-# bind PULL for reading proxy WS control messages
-proxy_ws_control_in_spec=ipc://{rundir}/{ipc_prefix}ws-control-out
+# list of connect PULL for receiving initial proxy WS control messages
+proxy_ws_control_init_specs=ipc://{rundir}/{ipc_prefix}ws-control-init
 
-# bind PUSH for writing proxy WS control messages
-proxy_ws_control_out_spec=ipc://{rundir}/{ipc_prefix}ws-control-in
+# list of connect ROUTER for sending/receiving subsequent proxy WS control messages
+proxy_ws_control_stream_specs=ipc://{rundir}/{ipc_prefix}ws-control-stream
 
 # list of connect SUB for receiving stats from proxy
 proxy_stats_specs=ipc://{rundir}/{ipc_prefix}proxy-stats


### PR DESCRIPTION
This changes the wscontrol zmq communications to use ROUTER after a session has been initialized, so messages from the handler can be directed to specific proxy instances.

Log of publishing to two connections managed by different proxies:
```
[INFO] 2024-02-01 18:19:11.022 [handler] control: POST /publish/ code=200 10 items=1
[DEBUG] 2024-02-01 18:19:11.022 [handler] relaying to 2 ws-message subscribers
[DEBUG] 2024-02-01 18:19:11.022 [handler] stats: OUT message { "channel": "test", "count": 2, "from": "pushpin-handler_77794", "transport": "ws-message" }
[INFO] 2024-02-01 18:19:11.022 [handler] publish channel=test receivers=2
[DEBUG] 2024-02-01 18:19:11.023 [handler] OUT wscontrol: to=pushpin-proxy_77790 { "items": [ { "type": "send", "cid": "dbd70c23-e7bf-49b8-ae98-ee5dba3f57f2", "content-type": "text", "message": "hello" } ], "from": "pushpin-handler_77794" }
[DEBUG] 2024-02-01 18:19:11.023 [handler] OUT wscontrol: to=pushpin-proxy_77789 { "items": [ { "type": "send", "cid": "912e7334-83ff-4099-8fa2-28d23c6ddf9a", "content-type": "text", "message": "hello" } ], "from": "pushpin-handler_77794" }
```