### PR TITLE
invoke refresh actions via wscontrol instead of rpc

### DIFF
--- a/src/cpp/handler/handlerengine.cpp
+++ b/src/cpp/handler/handlerengine.cpp
@@ -1831,10 +1831,7 @@ private:
 			}
 			else if(f.action == PublishFormat::Refresh)
 			{
-				Deferred *d = ControlRequest::refresh(proxyControlClient, i.cid, this);
-				finishedConnection[d] = d->finished.connect(boost::bind(&Private::deferred_finished, this, boost::placeholders::_1, d));
-				deferreds += d;
-				return;
+				i.type = WsControlPacket::Item::Refresh;
 			}
 
 			writeWsControlItems(s->peer, QList<WsControlPacket::Item>() << i);

--- a/src/cpp/packet/wscontrolpacket.cpp
+++ b/src/cpp/packet/wscontrolpacket.cpp
@@ -175,6 +175,7 @@ QVariant WsControlPacket::toVariant() const
 			case Item::Send:           typeStr = "send"; break;
 			case Item::NeedKeepAlive:  typeStr = "need-keep-alive"; break;
 			case Item::Subscribe:      typeStr = "subscribe"; break;
+			case Item::Refresh:        typeStr = "refresh"; break;
 			case Item::Close:          typeStr = "close"; break;
 			case Item::Detach:         typeStr = "detach"; break;
 			case Item::Ack:            typeStr = "ack"; break;
@@ -285,6 +286,8 @@ bool WsControlPacket::fromVariant(const QVariant &in)
 			item.type = Item::NeedKeepAlive;
 		else if(typeStr == "subscribe")
 			item.type = Item::Subscribe;
+		else if(typeStr == "refresh")
+			item.type = Item::Refresh;
 		else if(typeStr == "close")
 			item.type = Item::Close;
 		else if(typeStr == "detach")

--- a/src/cpp/packet/wscontrolpacket.h
+++ b/src/cpp/packet/wscontrolpacket.h
@@ -46,6 +46,7 @@ public:
 			Cancel,
 			Send,
 			KeepAliveSetup,
+			Refresh,
 			Close,
 			Detach,
 			Ack

--- a/src/cpp/proxy/wscontrolsession.cpp
+++ b/src/cpp/proxy/wscontrolsession.cpp
@@ -254,6 +254,10 @@ public:
 			else
 				q->keepAliveSetupEventReceived(WsControl::NoKeepAlive, -1);
 		}
+		else if(item.type == WsControlPacket::Item::Refresh)
+		{
+			q->refreshEventReceived();
+		}
 		else if(item.type == WsControlPacket::Item::Close)
 		{
 			q->closeEventReceived(item.code, item.reason);

--- a/src/cpp/proxy/wscontrolsession.h
+++ b/src/cpp/proxy/wscontrolsession.h
@@ -55,6 +55,7 @@ public:
 
 	boost::signals2::signal<void(WebSocket::Frame::Type, const QByteArray&, bool)> sendEventReceived;
 	boost::signals2::signal<void(WsControl::KeepAliveMode, int)> keepAliveSetupEventReceived;
+	Signal refreshEventReceived;
 	boost::signals2::signal<void(int, const QByteArray&)> closeEventReceived; // Use -1 for no code
 	Signal detachEventReceived;
 	Signal cancelEventReceived;

--- a/src/cpp/proxy/wsproxysession.cpp
+++ b/src/cpp/proxy/wsproxysession.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2023 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -253,6 +254,7 @@ public:
 	struct WSProxyConnections {
 		Connection sendEventReceivedConnection;
 		Connection keepAliveSetupEventReceivedConnection;
+		Connection refreshEventReceivedConnection;
 		Connection closeEventReceivedConnection;
 		Connection detachEventReceivedConnection;
 		Connection cancelEventReceivedConnection;
@@ -941,6 +943,7 @@ private slots:
 				wsProxyConnectionMap[wsControl] = {
 					wsControl->sendEventReceived.connect(boost::bind(&Private::wsControl_sendEventReceived, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3)),
 					wsControl->keepAliveSetupEventReceived.connect(boost::bind(&Private::wsControl_keepAliveSetupEventReceived, this, boost::placeholders::_1, boost::placeholders::_2)),
+					wsControl->refreshEventReceived.connect(boost::bind(&Private::wsControl_refreshEventReceived, this)),
 					wsControl->closeEventReceived.connect(boost::bind(&Private::wsControl_closeEventReceived, this, boost::placeholders::_1, boost::placeholders::_2)),
 					wsControl->detachEventReceived.connect(boost::bind(&Private::wsControl_detachEventReceived, this)),
 					wsControl->cancelEventReceived.connect(boost::bind(&Private::wsControl_cancelEventReceived, this)),
@@ -1117,6 +1120,13 @@ private:
 		{
 			cleanupKeepAliveTimer();
 		}
+	}
+
+	void wsControl_refreshEventReceived()
+	{
+		WebSocketOverHttp *woh = qobject_cast<WebSocketOverHttp*>(outSock);
+		if(woh)
+			woh->refresh();
 	}
 
 	void wsControl_closeEventReceived(int code, const QByteArray &reason)


### PR DESCRIPTION
Currently, refresh actions are relayed to the proxy via "command" RPC calls, however the handler->proxy RPC interface doesn't work correctly when there are multiple proxies. This PR changes refresh actions to relay via wscontrol messages instead, which does work with multiple proxies.

Note that refresh RPC calls made to the handler are still relayed to the proxy via RPC. It is only the refresh "publish action" that goes over wscontrol. Also, this PR does nothing to make other RPC calls work with multiple proxies by some other means. It only makes refresh actions work with multiple proxies.

Logs of refresh messages getting sent to multiple proxies:
```
[INFO] 2024-02-05 17:25:00.874 [handler] control: POST /publish/ code=200 10 items=1
[DEBUG] 2024-02-05 17:25:00.874 [handler] relaying to 2 ws-message subscribers
[DEBUG] 2024-02-05 17:25:00.874 [handler] stats: OUT message { "channel": "test", "count": 2, "from": "pushpin-handler_25050", "transport": "ws-message" }
[INFO] 2024-02-05 17:25:00.874 [handler] publish channel=test receivers=2
[DEBUG] 2024-02-05 17:25:00.874 [handler] OUT wscontrol: to=pushpin-proxy_25029 { "items": [ { "type": "refresh", "cid": "07276246-d68b-4e75-b2c7-63d0784f02d5" } ], "from": "pushpin-handler_25050" }
[DEBUG] 2024-02-05 17:25:00.874 [handler] OUT wscontrol: to=pushpin-proxy_25026 { "items": [ { "type": "refresh", "cid": "9967abaf-5219-417d-8816-ba46bfbc15de" } ], "from": "pushpin-handler_25050" }
```