### PR TITLE
mark various globals as thread local, to enable thread-safe use

### DIFF
--- a/src/cpp/config.cpp
+++ b/src/cpp/config.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -26,7 +26,7 @@
 
 namespace Config {
 
-static Config *g_config = 0;
+static thread_local Config *g_config = 0;
 
 Config & get()
 {

--- a/src/cpp/config.h
+++ b/src/cpp/config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -35,6 +35,7 @@ public:
 	QString libDir;
 };
 
+// value is thread local
 Config & get();
 
 }

--- a/src/cpp/proxy/websocketoverhttp.cpp
+++ b/src/cpp/proxy/websocketoverhttp.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -124,8 +124,8 @@ private:
 	}
 };
 
-WebSocketOverHttp::DisconnectManager *WebSocketOverHttp::g_disconnectManager = 0;
-int WebSocketOverHttp::g_maxManagedDisconnects = -1;
+thread_local WebSocketOverHttp::DisconnectManager *WebSocketOverHttp::g_disconnectManager = 0;
+thread_local int WebSocketOverHttp::g_maxManagedDisconnects = -1;
 
 static QList<WsEvent> decodeEvents(const QByteArray &in, bool *ok = 0)
 {

--- a/src/cpp/proxy/websocketoverhttp.h
+++ b/src/cpp/proxy/websocketoverhttp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2020 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -46,6 +46,7 @@ public:
 	void setMaxEventsPerRequest(int max);
 	void refresh();
 
+	// disconnection management is thread local
 	static void setMaxManagedDisconnects(int max);
 	static void clearDisconnectManager();
 
@@ -97,8 +98,8 @@ private:
 	friend class Private;
 	Private *d;
 
-	static DisconnectManager *g_disconnectManager;
-	static int g_maxManagedDisconnects;
+	static thread_local DisconnectManager *g_disconnectManager;
+	static thread_local int g_maxManagedDisconnects;
 };
 
 #endif

--- a/src/cpp/rtimer.cpp
+++ b/src/cpp/rtimer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -170,7 +171,7 @@ void TimerManager::updateTimeout(qint64 currentTime)
 	}
 }
 
-static TimerManager *g_manager = 0;
+static thread_local TimerManager *g_manager = 0;
 
 RTimer::RTimer(QObject *parent) :
 	QObject(parent),

--- a/src/cpp/rtimer.h
+++ b/src/cpp/rtimer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -45,6 +46,7 @@ public:
 	void start();
 	void stop();
 
+	// initialization is thread local
 	static void init(int capacity);
 
 	// only call if there are no active RTimers


### PR DESCRIPTION
We currently don't use these APIs from multiple threads but after this change we will be able to.