### PR TITLE
proxy: add option to run multiple worker threads

### DIFF
--- a/src/cpp/proxy/engine.cpp
+++ b/src/cpp/proxy/engine.cpp
@@ -583,7 +583,7 @@ public:
 
 			route.targets += target;
 
-			rs = new RequestSession(stats);
+			rs = new RequestSession(config.id, stats);
 			rs->setRoute(route);
 		}
 		else
@@ -592,7 +592,7 @@ public:
 			// request with preferInternal=true. in that case, use domainmap
 			// for lookup, with route ID if available
 
-			rs = new RequestSession(domainMap, sockJsManager, inspect, inspectChecker, accept, stats);
+			rs = new RequestSession(config.id, domainMap, sockJsManager, inspect, inspectChecker, accept, stats);
 			rs->setDebugEnabled(config.debug);
 			rs->setAutoCrossOrigin(config.autoCrossOrigin);
 			rs->setPrefetchSize(config.inspectPrefetch);
@@ -630,7 +630,7 @@ public:
 
 		QUrl requestUri = sock->requestUri();
 
-		log_debug("IN ws id=%s, %s", sock->rid().second.data(), requestUri.toEncoded().data());
+		log_debug("worker %d: IN ws id=%s, %s", config.id, sock->rid().second.data(), requestUri.toEncoded().data());
 
 		bool isSecure = (requestUri.scheme() == "wss");
 		QString host = requestUri.host();
@@ -898,7 +898,7 @@ private:
 
 			ZhttpRequest *zhttpRequest = zhttpIn->createRequestFromState(ss);
 
-			RequestSession *rs = new RequestSession(domainMap, sockJsManager, inspect, inspectChecker, accept, stats);
+			RequestSession *rs = new RequestSession(config.id, domainMap, sockJsManager, inspect, inspectChecker, accept, stats);
 
 			requestSessions += rs;
 

--- a/src/cpp/proxy/engine.h
+++ b/src/cpp/proxy/engine.h
@@ -46,6 +46,7 @@ public:
 	class Configuration
 	{
 	public:
+		int id;
 		QString appVersion;
 		QByteArray clientId;
 		QStringList serverInSpecs;
@@ -95,6 +96,7 @@ public:
 		QString prometheusPrefix;
 
 		Configuration() :
+			id(0),
 			ipcFileMode(-1),
 			sessionsMax(-1),
 			inspectTimeout(8000),

--- a/src/cpp/proxy/requestsession.h
+++ b/src/cpp/proxy/requestsession.h
@@ -54,8 +54,8 @@ class RequestSession : public QObject
 	Q_OBJECT
 
 public:
-	RequestSession(StatsManager *stats, QObject *parent = 0);
-	RequestSession(DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats, QObject *parent = 0);
+	RequestSession(int workerId, StatsManager *stats, QObject *parent = 0);
+	RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats, QObject *parent = 0);
 	~RequestSession();
 
 	bool isRetry() const;


### PR DESCRIPTION
This PR introduces a `workers=N` configuration option under `[proxy]`, for specifying the number of engine instances the proxy should run (default 1).

If `workers` is set to a value greater than 1, the internal ipc paths of each instance will be automatically suffixed with the instance number, starting from 0. For example, with 1 worker, a configured spec of `ipc://accept` will be used as-is with the one engine instance, but with 2 workers, the first instance will use `ipc://accept-0` and the second will use `ipc://accept-1` (and none will use `ipc://accept`).

The handler adapts its configuration to match. If the proxy is configured to run 2 workers, and the handler has a list of specs containing one entry, `ipc://accept`, the handler will turn this into a list of two entries, `ipc://accept-0` and `ipc://accept-1`, such that it communicates using both ipc paths.