### PR TITLE
proxy: rename workers to sessions, and cap sessions to maxconn

### DIFF
--- a/src/cpp/proxy/app.cpp
+++ b/src/cpp/proxy/app.cpp
@@ -291,7 +291,7 @@ public:
 		trimlist(&intreq_out_specs);
 		bool ok;
 		int ipcFileMode = settings.value("proxy/ipc_file_mode", -1).toString().toInt(&ok, 8);
-		int maxWorkers = settings.value("proxy/max_open_requests", -1).toInt();
+		int sessionsMax = settings.value("proxy/max_open_requests", -1).toInt();
 		QString routesFile = settings.value("proxy/routesfile").toString();
 		bool debug = settings.value("proxy/debug").toBool();
 		bool autoCrossOrigin = settings.value("proxy/auto_cross_origin").toBool();
@@ -347,6 +347,12 @@ public:
 		if(updatesCheck == "true")
 			updatesCheck = "check";
 
+		// sessionsMax should not exceed clientMaxconn
+		if(sessionsMax >= 0)
+			sessionsMax = qMin(sessionsMax, clientMaxconn);
+		else
+			sessionsMax = clientMaxconn;
+
 		Engine::Configuration config;
 		config.appVersion = Config::get().version;
 		config.clientId = "pushpin-proxy_" + QByteArray::number(QCoreApplication::applicationPid());
@@ -385,7 +391,7 @@ public:
 		config.intServerInStreamSpecs = intreq_in_stream_specs;
 		config.intServerOutSpecs = intreq_out_specs;
 		config.ipcFileMode = ipcFileMode;
-		config.maxWorkers = maxWorkers;
+		config.sessionsMax = sessionsMax;
 		if(!args.routeLines.isEmpty())
 			config.routeLines = args.routeLines;
 		else
@@ -409,7 +415,6 @@ public:
 		config.updatesCheck = updatesCheck;
 		config.organizationName = organizationName;
 		config.quietCheck = args.quietCheck;
-		config.connectionsMax = clientMaxconn;
 		config.statsConnectionSend = statsConnectionSend;
 		config.statsConnectionTtl = statsConnectionTtl;
 		config.statsConnectionsMaxTtl = statsConnectionsMaxTtl;

--- a/src/cpp/proxy/engine.cpp
+++ b/src/cpp/proxy/engine.cpp
@@ -203,13 +203,13 @@ public:
 	{
 		config = _config;
 
-		// up to 10 timers per connection
-		RTimer::init(config.connectionsMax * 10);
+		// up to 10 timers per session
+		RTimer::init(config.sessionsMax * 10);
 
 		logConfig.fromAddress = config.logFrom;
 		logConfig.userAgent = config.logUserAgent;
 
-		WebSocketOverHttp::setMaxManagedDisconnects(config.maxWorkers);
+		WebSocketOverHttp::setMaxManagedDisconnects(config.sessionsMax);
 
 		if(!config.routeLines.isEmpty())
 		{
@@ -328,7 +328,7 @@ public:
 
 		if(!config.statsSpec.isEmpty() || !config.prometheusPort.isEmpty())
 		{
-			stats = new StatsManager(config.connectionsMax, 0, this);
+			stats = new StatsManager(config.sessionsMax, 0, this);
 
 			connMaxConnection = stats->connMax.connect(boost::bind(&Private::stats_connMax, this, boost::placeholders::_1));
 
@@ -492,13 +492,13 @@ public:
 
 	bool canTake()
 	{
-		// don't accept new connections during shutdown
+		// don't accept new sessions during shutdown
 		if(destroying)
 			return false;
 
-		// don't accept new connections if we're servicing maximum
-		int curWorkers = requestSessions.count() + wsProxyItemsBySession.count();
-		if(config.maxWorkers != -1 && curWorkers >= config.maxWorkers)
+		// don't accept new sessions if we're servicing maximum
+		int curSessions = requestSessions.count() + wsProxyItemsBySession.count();
+		if(curSessions >= config.sessionsMax)
 			return false;
 
 		return true;

--- a/src/cpp/proxy/engine.h
+++ b/src/cpp/proxy/engine.h
@@ -64,7 +64,7 @@ public:
 		QStringList intServerInStreamSpecs;
 		QStringList intServerOutSpecs;
 		int ipcFileMode;
-		int maxWorkers;
+		int sessionsMax;
 		int inspectTimeout;
 		int inspectPrefetch;
 		QString routesFile;
@@ -88,7 +88,6 @@ public:
 		QString updatesCheck;
 		QString organizationName;
 		bool quietCheck;
-		int connectionsMax;
 		bool statsConnectionSend;
 		int statsConnectionTtl;
 		int statsConnectionsMaxTtl;
@@ -98,7 +97,7 @@ public:
 
 		Configuration() :
 			ipcFileMode(-1),
-			maxWorkers(-1),
+			sessionsMax(-1),
 			inspectTimeout(8000),
 			inspectPrefetch(10000),
 			debug(false),
@@ -111,7 +110,6 @@ public:
 			logUserAgent(false),
 			updatesCheck("check"),
 			quietCheck(false),
-			connectionsMax(-1),
 			statsConnectionSend(false),
 			statsConnectionTtl(-1),
 			statsConnectionsMaxTtl(-1),

--- a/src/cpp/tests/proxyenginetest.cpp
+++ b/src/cpp/tests/proxyenginetest.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <unistd.h>
+#include <boost/signals2.hpp>
 #include <QtTest/QtTest>
 #include <QDir>
 #include <QJsonDocument>
@@ -40,7 +41,6 @@
 #include "zhttpmanager.h"
 #include "statsmanager.h"
 #include "engine.h"
-#include <boost/signals2.hpp>
 
 Q_DECLARE_METATYPE(QList<StatsPacket>);
 
@@ -610,12 +610,12 @@ private slots:
 		config.acceptSpec = ("ipc://" + workDir.filePath("accept"));
 		config.retryInSpec = ("ipc://" + workDir.filePath("retry-out"));
 		config.statsSpec = ("ipc://" + workDir.filePath("stats"));
+		config.sessionsMax = 20;
 		config.inspectTimeout = 500;
 		config.inspectPrefetch = 5;
 		config.routesFile = configDir.filePath("routes");
 		config.sigIss = "pushpin";
 		config.sigKey = Jwt::EncodingKey::fromSecret("changeme");
-		config.connectionsMax = 20;
 		config.statsConnectionTtl = 120;
 		config.statsReportInterval = 1000; // set a large interval so there's only one working report
 		QVERIFY(engine->start(config));


### PR DESCRIPTION
Currently, the proxy uses the term "workers" to refer to connection/session handlers (for example if maxWorkers is 1000 then up to 1000 concurrent sessions can be supported). This PR changes the term from "workers" to "sessions", to free up the term "workers" so that we can use it for worker threads.