### PR TITLE
proxy: run engine in separate thread

### DIFF
--- a/src/cpp/proxy/engine.h
+++ b/src/cpp/proxy/engine.h
@@ -36,6 +36,7 @@ using std::map;
 using Connection = boost::signals2::scoped_connection;
 
 class StatsManager;
+class DomainMap;
 
 class Engine : public QObject
 {
@@ -67,8 +68,6 @@ public:
 		int sessionsMax;
 		int inspectTimeout;
 		int inspectPrefetch;
-		QString routesFile;
-		QStringList routeLines;
 		bool debug;
 		bool autoCrossOrigin;
 		bool acceptXForwardedProto;
@@ -118,13 +117,13 @@ public:
 		}
 	};
 
-	Engine(QObject *parent = 0);
+	Engine(DomainMap *domainMap, QObject *parent = 0);
 	~Engine();
 
 	StatsManager *statsManager() const;
 
 	bool start(const Configuration &config);
-	void reload();
+	void routesChanged();
 
 private:
 	class Private;

--- a/src/cpp/tests/proxyenginetest.cpp
+++ b/src/cpp/tests/proxyenginetest.cpp
@@ -40,6 +40,7 @@
 #include "rtimer.h"
 #include "zhttpmanager.h"
 #include "statsmanager.h"
+#include "domainmap.h"
 #include "engine.h"
 
 Q_DECLARE_METATYPE(QList<StatsPacket>);
@@ -563,6 +564,7 @@ class ProxyEngineTest : public QObject
 	Q_OBJECT
 
 private:
+	DomainMap *domainMap;
 	Engine *engine;
 	Wrapper *wrapper;
 	QList<StatsPacket> trackedPackets;
@@ -596,7 +598,9 @@ private slots:
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();
 
-		engine = new Engine(this);
+		domainMap = new DomainMap(configDir.filePath("routes"), this);
+
+		engine = new Engine(domainMap, this);
 
 		Engine::Configuration config;
 		config.clientId = "proxy";
@@ -613,7 +617,6 @@ private slots:
 		config.sessionsMax = 20;
 		config.inspectTimeout = 500;
 		config.inspectPrefetch = 5;
-		config.routesFile = configDir.filePath("routes");
 		config.sigIss = "pushpin";
 		config.sigKey = Jwt::EncodingKey::fromSecret("changeme");
 		config.statsConnectionTtl = 120;
@@ -628,6 +631,7 @@ private slots:
 	void cleanupTestCase()
 	{
 		delete engine;
+		delete domainMap;
 		delete wrapper;
 
 		RTimer::deinit();


### PR DESCRIPTION
This runs the engine in a separate thread instead of the main thread, to prepare for supporting multiple threads. It also moves ownership of DomainMap out of the engine, to make it possible for multiple engines to share it.