### PR TITLE
removed qobj parent from deferred

### DIFF
--- a/src/cpp/handler/conncheckworker.cpp
+++ b/src/cpp/handler/conncheckworker.cpp
@@ -28,8 +28,8 @@
 #include "controlrequest.h"
 #include "statsmanager.h"
 
-ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats, QObject *parent) :
-	Deferred(parent),
+ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats) :
+	Deferred(),
 	req_(req)
 {
 	req_->setParent(this);
@@ -64,7 +64,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 	if(!missing_.isEmpty())
 	{
 		// ask the proxy about any cids we don't know about
-		Deferred *d = ControlRequest::connCheck(proxyControlClient, missing_, this);
+		Deferred *d = ControlRequest::connCheck(proxyControlClient, missing_);
 		finishedConnection_ = d->finished.connect(boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
 		return;
 	}

--- a/src/cpp/handler/conncheckworker.cpp
+++ b/src/cpp/handler/conncheckworker.cpp
@@ -64,7 +64,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 	if(!missing_.isEmpty())
 	{
 		// ask the proxy about any cids we don't know about
-		Deferred *d = ControlRequest::connCheck(proxyControlClient, missing_);
+		auto d = ControlRequest::connCheck(proxyControlClient, missing_);
 		finishedConnection_ = d->finished.connect(boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
 		return;
 	}

--- a/src/cpp/handler/conncheckworker.cpp
+++ b/src/cpp/handler/conncheckworker.cpp
@@ -64,7 +64,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 	if(!missing_.isEmpty())
 	{
 		// ask the proxy about any cids we don't know about
-		auto d = ControlRequest::connCheck(proxyControlClient, missing_);
+		auto d = std::unique_ptr<Deferred>(ControlRequest::connCheck(proxyControlClient, missing_));
 		finishedConnection_ = d->finished.connect(boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
 		return;
 	}

--- a/src/cpp/handler/conncheckworker.h
+++ b/src/cpp/handler/conncheckworker.h
@@ -39,7 +39,7 @@ class ConnCheckWorker : public Deferred
 	Q_OBJECT
 
 public:
-	ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats, QObject *parent = 0);
+	ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats);
 
 private:
 	ZrpcRequest *req_;

--- a/src/cpp/handler/controlrequest.cpp
+++ b/src/cpp/handler/controlrequest.cpp
@@ -34,7 +34,6 @@ class ConnCheck : public Deferred
 {
 	Q_OBJECT
 	
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
@@ -54,6 +53,8 @@ public:
 	}
 
 private:
+	std::unique_ptr<ZrpcRequest> req;
+
 	void req_finished(ZrpcRequest *req)
 	{
 		if(req->success())
@@ -92,7 +93,6 @@ class Refresh : public Deferred
 {
 	Q_OBJECT
 	
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
@@ -114,13 +114,15 @@ public:
 		else
 			setFinished(false, req->errorConditionString());
 	}
+
+private:
+	std::unique_ptr<ZrpcRequest> req;
 };
 
 class Report : public Deferred
 {
 	Q_OBJECT
 
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
@@ -142,21 +144,24 @@ public:
 		else
 			setFinished(false, req->errorCondition());
 	}
+
+private:
+	std::unique_ptr<ZrpcRequest> req;
 };
 
-std::unique_ptr<Deferred> connCheck(ZrpcManager *controlClient, const CidSet &cids)
+Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids)
 {
-	return std::make_unique<ConnCheck>(controlClient, cids);
+	return new ConnCheck(controlClient, cids);
 }
 
-std::unique_ptr<Deferred> refresh(ZrpcManager *controlClient, const QByteArray &cid)
+Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid)
 {
-	return std::make_unique<Refresh>(controlClient, cid);
+	return new Refresh(controlClient, cid);
 }
 
-std::unique_ptr<Deferred> report(ZrpcManager *controlClient, const StatsPacket &packet)
+Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet)
 {
-	return std::make_unique<Report>(controlClient, packet);
+	return new Report(controlClient, packet);
 }
 
 }

--- a/src/cpp/handler/controlrequest.cpp
+++ b/src/cpp/handler/controlrequest.cpp
@@ -40,8 +40,8 @@ public:
 	ConnCheck(ZrpcManager *controlClient, const CidSet &cids) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(controlClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(controlClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this, req.get()));
 
 		QVariantList vcids;
 		foreach(const QString &cid, cids)
@@ -97,8 +97,8 @@ public:
 	Refresh(ZrpcManager *controlClient, const QByteArray &cid) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(controlClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(controlClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this, req.get()));
 
 		QVariantHash args;
 		args["cid"] = cid;
@@ -124,8 +124,8 @@ public:
 	Report(ZrpcManager *controlClient, const StatsPacket &packet) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(controlClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&Report::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(controlClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&Report::req_finished, this, req.get()));
 
 		QVariantHash args;
 		args["stats"] = packet.toVariant();

--- a/src/cpp/handler/controlrequest.cpp
+++ b/src/cpp/handler/controlrequest.cpp
@@ -37,8 +37,8 @@ class ConnCheck : public Deferred
 	Connection finishedConnection;
 
 public:
-	ConnCheck(ZrpcManager *controlClient, const CidSet &cids, QObject *parent = 0) :
-		Deferred(parent)
+	ConnCheck(ZrpcManager *controlClient, const CidSet &cids) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(controlClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this, req));
@@ -94,8 +94,8 @@ class Refresh : public Deferred
 	Connection finishedConnection;
 
 public:
-	Refresh(ZrpcManager *controlClient, const QByteArray &cid, QObject *parent) :
-		Deferred(parent)
+	Refresh(ZrpcManager *controlClient, const QByteArray &cid) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(controlClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this, req));
@@ -121,8 +121,8 @@ class Report : public Deferred
 	Connection finishedConnection;
 
 public:
-	Report(ZrpcManager *controlClient, const StatsPacket &packet, QObject *parent) :
-		Deferred(parent)
+	Report(ZrpcManager *controlClient, const StatsPacket &packet) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(controlClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&Report::req_finished, this, req));
@@ -141,19 +141,19 @@ public:
 	}
 };
 
-Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids, QObject *parent)
+Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids)
 {
-	return new ConnCheck(controlClient, cids, parent);
+	return new ConnCheck(controlClient, cids);
 }
 
-Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid, QObject *parent)
+Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid)
 {
-	return new Refresh(controlClient, cid, parent);
+	return new Refresh(controlClient, cid);
 }
 
-Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet, QObject *parent)
+Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet)
 {
-	return new Report(controlClient, packet, parent);
+	return new Report(controlClient, packet);
 }
 
 }

--- a/src/cpp/handler/controlrequest.cpp
+++ b/src/cpp/handler/controlrequest.cpp
@@ -33,14 +33,15 @@ namespace ControlRequest {
 class ConnCheck : public Deferred
 {
 	Q_OBJECT
-
+	
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
 	ConnCheck(ZrpcManager *controlClient, const CidSet &cids) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(controlClient, this);
+		req = std::make_unique<ZrpcRequest>(controlClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this, req.get()));
 
 		QVariantList vcids;
@@ -90,14 +91,15 @@ private:
 class Refresh : public Deferred
 {
 	Q_OBJECT
-
+	
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
 	Refresh(ZrpcManager *controlClient, const QByteArray &cid) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(controlClient, this);
+		req = std::make_unique<ZrpcRequest>(controlClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this, req.get()));
 
 		QVariantHash args;
@@ -118,13 +120,14 @@ class Report : public Deferred
 {
 	Q_OBJECT
 
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
 	Report(ZrpcManager *controlClient, const StatsPacket &packet) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(controlClient, this);
+		req = std::make_unique<ZrpcRequest>(controlClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&Report::req_finished, this, req.get()));
 
 		QVariantHash args;
@@ -141,19 +144,19 @@ public:
 	}
 };
 
-Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids)
+std::unique_ptr<Deferred> connCheck(ZrpcManager *controlClient, const CidSet &cids)
 {
-	return new ConnCheck(controlClient, cids);
+	return std::make_unique<ConnCheck>(controlClient, cids);
 }
 
-Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid)
+std::unique_ptr<Deferred> refresh(ZrpcManager *controlClient, const QByteArray &cid)
 {
-	return new Refresh(controlClient, cid);
+	return std::make_unique<Refresh>(controlClient, cid);
 }
 
-Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet)
+std::unique_ptr<Deferred> report(ZrpcManager *controlClient, const StatsPacket &packet)
 {
-	return new Report(controlClient, packet);
+	return std::make_unique<Report>(controlClient, packet);
 }
 
 }

--- a/src/cpp/handler/controlrequest.h
+++ b/src/cpp/handler/controlrequest.h
@@ -36,9 +36,9 @@ class Deferred;
 
 namespace ControlRequest {
 
-Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids, QObject *parent = 0);
-Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid, QObject *parent = 0);
-Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet, QObject *parent = 0);
+Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids);
+Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid);
+Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet);
 
 }
 

--- a/src/cpp/handler/controlrequest.h
+++ b/src/cpp/handler/controlrequest.h
@@ -36,9 +36,9 @@ class Deferred;
 
 namespace ControlRequest {
 
-Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids);
-Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid);
-Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet);
+std::unique_ptr<Deferred> connCheck(ZrpcManager *controlClient, const CidSet &cids);
+std::unique_ptr<Deferred> refresh(ZrpcManager *controlClient, const QByteArray &cid);
+std::unique_ptr<Deferred> report(ZrpcManager *controlClient, const StatsPacket &packet);
 
 }
 

--- a/src/cpp/handler/controlrequest.h
+++ b/src/cpp/handler/controlrequest.h
@@ -36,9 +36,9 @@ class Deferred;
 
 namespace ControlRequest {
 
-std::unique_ptr<Deferred> connCheck(ZrpcManager *controlClient, const CidSet &cids);
-std::unique_ptr<Deferred> refresh(ZrpcManager *controlClient, const QByteArray &cid);
-std::unique_ptr<Deferred> report(ZrpcManager *controlClient, const StatsPacket &packet);
+Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids);
+Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid);
+Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet);
 
 }
 

--- a/src/cpp/handler/deferred.cpp
+++ b/src/cpp/handler/deferred.cpp
@@ -22,8 +22,7 @@
 
 #include "deferred.h"
 
-Deferred::Deferred(QObject *parent) :
-	QObject(parent)
+Deferred::Deferred() 
 {
 	qRegisterMetaType<DeferredResult>();
 }

--- a/src/cpp/handler/deferred.h
+++ b/src/cpp/handler/deferred.h
@@ -24,7 +24,6 @@
 #define DEFERRED_H
 
 #include <QVariant>
-#include <QObject>
 #include <boost/signals2.hpp>
 
 class DeferredResult
@@ -59,7 +58,7 @@ public:
 	boost::signals2::signal<void(const DeferredResult&)> finished;
 
 protected:
-	Deferred(QObject *parent = 0);
+	Deferred();
 
 	void setFinished(bool ok, const QVariant &value = QVariant());
 

--- a/src/cpp/handler/handlerengine.cpp
+++ b/src/cpp/handler/handlerengine.cpp
@@ -232,7 +232,7 @@ public:
 			if(getSession && stateClient)
 			{
 				// determine session info
-				auto d = SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(QUrl::FullyEncoded).toUtf8());
+				auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(QUrl::FullyEncoded).toUtf8()));
 				finishedConnection[d.get()] = d->finished.connect(boost::bind(&InspectWorker::sessionDetectRulesGet_finished, this, boost::placeholders::_1));
 				return;
 			}
@@ -351,7 +351,7 @@ private:
 
 			if(!sid.isEmpty())
 			{
-				auto d = SessionRequest::getLastIds(stateClient, sid);
+				auto d = std::unique_ptr<Deferred>(SessionRequest::getLastIds(stateClient, sid));
 				finishedConnection[d.get()] = d->finished.connect(boost::bind(&InspectWorker::sessionGetLastIds_finished, this, boost::placeholders::_1));
 				return;
 			}
@@ -795,7 +795,7 @@ public:
 		{
 			if(!rules.isEmpty())
 			{
-				auto d = SessionRequest::detectRulesSet(stateClient, rules);
+				auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesSet(stateClient, rules));
 				finishedConnection[d.get()] = d->finished.connect(boost::bind(&AcceptWorker::sessionDetectRulesSet_finished, this, boost::placeholders::_1));
 			}
 			else
@@ -877,7 +877,7 @@ private:
 	{
 		if(!sid.isEmpty())
 		{
-			auto d = SessionRequest::createOrUpdate(stateClient, sid, lastIds);
+			auto d = std::unique_ptr<Deferred>(SessionRequest::createOrUpdate(stateClient, sid, lastIds));
 			finishedConnection[d.get()] = d->finished.connect(boost::bind(&AcceptWorker::sessionCreateOrUpdate_finished, this, boost::placeholders::_1));
 		}
 		else
@@ -2320,7 +2320,7 @@ private:
 				sidLastIds[sid] = lastIds;
 			}
 
-			auto d = SessionRequest::updateMany(stateClient, sidLastIds);
+			auto d = std::unique_ptr<Deferred>(SessionRequest::updateMany(stateClient, sidLastIds));
 			finishedConnection[d.get()] = d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, boost::placeholders::_1, d.get()));
 			deferreds[d.get()] = std::move(d);
 		}
@@ -2433,7 +2433,7 @@ private:
 
 			if(!sidLastIds.isEmpty())
 			{
-				auto d = SessionRequest::updateMany(stateClient, sidLastIds);
+				auto d = std::unique_ptr<Deferred>(SessionRequest::updateMany(stateClient, sidLastIds));
 				finishedConnection[d.get()] = d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, boost::placeholders::_1, d.get()));
 				deferreds[d.get()] = std::move(d);
 			}
@@ -2474,7 +2474,7 @@ private:
 			all.httpResponseMessagesSent += qMax(p.httpResponseMessagesSent, 0);
 		}
 
-		report = ControlRequest::report(proxyControlClient.get(), all);
+		report = std::unique_ptr<Deferred>(ControlRequest::report(proxyControlClient.get(), all));
 		finishedConnection[report.get()] = report->finished.connect(boost::bind(&Private::report_finished, this, boost::placeholders::_1));
 		deferreds[report.get()] = std::move(report);
 	}
@@ -2893,14 +2893,14 @@ private:
 		{
 			foreach(const QString &sid, createOrUpdateSids)
 			{
-				auto d = SessionRequest::createOrUpdate(stateClient, sid, LastIds());
+				auto d = std::unique_ptr<Deferred>(SessionRequest::createOrUpdate(stateClient, sid, LastIds()));
 				finishedConnection[d.get()] = d->finished.connect(boost::bind(&Private::sessionCreateOrUpdate_finished, this, boost::placeholders::_1, d.get()));
 				deferreds[d.get()] = std::move(d);
 			}
 
 			if(!updateSids.isEmpty())
 			{
-				auto d = SessionRequest::updateMany(stateClient, updateSids);
+				auto d = std::unique_ptr<Deferred>(SessionRequest::updateMany(stateClient, updateSids));
 				finishedConnection[d.get()] = d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, boost::placeholders::_1, d.get()));
 				deferreds[d.get()] = std::move(d);
 			}

--- a/src/cpp/handler/handlerengine.cpp
+++ b/src/cpp/handler/handlerengine.cpp
@@ -126,8 +126,8 @@ public:
 	LastIds lastIds;
 	map<Deferred*, Connection> finishedConnection;
 
-	InspectWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, bool _shareAll, QObject *parent = 0) :
-		Deferred(parent),
+	InspectWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, bool _shareAll) :
+		Deferred(),
 		req(_req),
 		stateClient(_stateClient),
 		shareAll(_shareAll),
@@ -232,7 +232,7 @@ public:
 			if(getSession && stateClient)
 			{
 				// determine session info
-				Deferred *d = SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(QUrl::FullyEncoded).toUtf8(), this);
+				Deferred *d = SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(QUrl::FullyEncoded).toUtf8());
 				finishedConnection[d] = d->finished.connect(boost::bind(&InspectWorker::sessionDetectRulesGet_finished, this, boost::placeholders::_1));
 				return;
 			}
@@ -351,7 +351,7 @@ private:
 
 			if(!sid.isEmpty())
 			{
-				Deferred *d = SessionRequest::getLastIds(stateClient, sid, this);
+				Deferred *d = SessionRequest::getLastIds(stateClient, sid);
 				finishedConnection[d] = d->finished.connect(boost::bind(&InspectWorker::sessionGetLastIds_finished, this, boost::placeholders::_1));
 				return;
 			}
@@ -438,8 +438,8 @@ public:
 	QSet<QByteArray> needRemoveFromStats;
 	map<Deferred*, Connection> finishedConnection;
 
-	AcceptWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, CommonState *_cs, ZhttpManager *_zhttpIn, ZhttpManager *_zhttpOut, StatsManager *_stats, RateLimiter *_updateLimiter, HttpSessionUpdateManager *_httpSessionUpdateManager, int _connectionSubscriptionMax, QObject *parent = 0) :
-		Deferred(parent),
+	AcceptWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, CommonState *_cs, ZhttpManager *_zhttpIn, ZhttpManager *_zhttpOut, StatsManager *_stats, RateLimiter *_updateLimiter, HttpSessionUpdateManager *_httpSessionUpdateManager, int _connectionSubscriptionMax) :
+		Deferred(),
 		req(_req),
 		stateClient(_stateClient),
 		cs(_cs),
@@ -795,7 +795,7 @@ public:
 		{
 			if(!rules.isEmpty())
 			{
-				Deferred *d = SessionRequest::detectRulesSet(stateClient, rules, this);
+				Deferred *d = SessionRequest::detectRulesSet(stateClient, rules);
 				finishedConnection[d] = d->finished.connect(boost::bind(&AcceptWorker::sessionDetectRulesSet_finished, this, boost::placeholders::_1));
 			}
 			else
@@ -877,7 +877,7 @@ private:
 	{
 		if(!sid.isEmpty())
 		{
-			Deferred *d = SessionRequest::createOrUpdate(stateClient, sid, lastIds, this);
+			Deferred *d = SessionRequest::createOrUpdate(stateClient, sid, lastIds);
 			finishedConnection[d] = d->finished.connect(boost::bind(&AcceptWorker::sessionCreateOrUpdate_finished, this, boost::placeholders::_1));
 		}
 		else
@@ -1974,7 +1974,7 @@ private:
 		if(!req)
 			return;
 
-		InspectWorker *w = new InspectWorker(req, stateClient, config.shareAll, this);
+		InspectWorker *w = new InspectWorker(req, stateClient, config.shareAll);
 		finishedConnection[w] = w->finished.connect(boost::bind(&Private::inspectWorker_finished, this, boost::placeholders::_1, w));
 		inspectWorkers += w;
 	}
@@ -1995,7 +1995,7 @@ private:
 			// accept request immediately before returning to the event loop.
 			// the start() call will do this
 
-			AcceptWorker *w = new AcceptWorker(req, stateClient, &cs, zhttpIn, zhttpOut, stats, updateLimiter, httpSessionUpdateManager, config.connectionSubscriptionMax, this);
+			AcceptWorker *w = new AcceptWorker(req, stateClient, &cs, zhttpIn, zhttpOut, stats, updateLimiter, httpSessionUpdateManager, config.connectionSubscriptionMax);
 			finishedConnection[w] = w->finished.connect(boost::bind(&Private::acceptWorker_finished, this, boost::placeholders::_1, w));
 			sessionsReadyConnection[w] = w->sessionsReady.connect(boost::bind(&Private::acceptWorker_sessionsReady, this, w));
 			retryPacketReadyConnection[w] =  w->retryPacketReady.connect(boost::bind(&Private::acceptWorker_retryPacketReady, this, boost::placeholders::_1, boost::placeholders::_2));
@@ -2044,7 +2044,7 @@ private:
 
 		if(req->method() == "conncheck")
 		{
-			ConnCheckWorker *w = new ConnCheckWorker(req, proxyControlClient, stats, this);
+			ConnCheckWorker *w = new ConnCheckWorker(req, proxyControlClient, stats);
 			finishedConnection[w] = w->finished.connect(boost::bind(&Private::deferred_finished, this, boost::placeholders::_1, w));
 			deferreds += w;
 		}
@@ -2068,7 +2068,7 @@ private:
 		}
 		else if(req->method() == "refresh")
 		{
-			RefreshWorker *w = new RefreshWorker(req, proxyControlClient, &cs.wsSessionsByChannel, this);
+			RefreshWorker *w = new RefreshWorker(req, proxyControlClient, &cs.wsSessionsByChannel);
 			finishedConnection[w] = w->finished.connect(boost::bind(&Private::deferred_finished, this, boost::placeholders::_1, w));
 			deferreds += w;
 		}
@@ -2320,7 +2320,7 @@ private:
 				sidLastIds[sid] = lastIds;
 			}
 
-			Deferred *d = SessionRequest::updateMany(stateClient, sidLastIds, this);
+			Deferred *d = SessionRequest::updateMany(stateClient, sidLastIds);
 			finishedConnection[d] = d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, boost::placeholders::_1, d));
 			deferreds += d;
 		}
@@ -2433,7 +2433,7 @@ private:
 
 			if(!sidLastIds.isEmpty())
 			{
-				Deferred *d = SessionRequest::updateMany(stateClient, sidLastIds, this);
+				Deferred *d = SessionRequest::updateMany(stateClient, sidLastIds);
 				finishedConnection[d] = d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, boost::placeholders::_1, d));
 				deferreds += d;
 			}
@@ -2474,7 +2474,7 @@ private:
 			all.httpResponseMessagesSent += qMax(p.httpResponseMessagesSent, 0);
 		}
 
-		report = ControlRequest::report(proxyControlClient, all, this);
+		report = ControlRequest::report(proxyControlClient, all);
 		finishedConnection[report] = report->finished.connect(boost::bind(&Private::report_finished, this, boost::placeholders::_1));
 		deferreds += report;
 	}
@@ -2893,14 +2893,14 @@ private:
 		{
 			foreach(const QString &sid, createOrUpdateSids)
 			{
-				Deferred *d = SessionRequest::createOrUpdate(stateClient, sid, LastIds(), this);
+				Deferred *d = SessionRequest::createOrUpdate(stateClient, sid, LastIds());
 				finishedConnection[d] = d->finished.connect(boost::bind(&Private::sessionCreateOrUpdate_finished, this, boost::placeholders::_1, d));
 				deferreds += d;
 			}
 
 			if(!updateSids.isEmpty())
 			{
-				Deferred *d = SessionRequest::updateMany(stateClient, updateSids, this);
+				Deferred *d = SessionRequest::updateMany(stateClient, updateSids);
 				finishedConnection[d] = d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, boost::placeholders::_1, d));
 				deferreds += d;
 			}

--- a/src/cpp/handler/refreshworker.cpp
+++ b/src/cpp/handler/refreshworker.cpp
@@ -29,8 +29,8 @@
 #include "statsmanager.h"
 #include "wssession.h"
 
-RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel, QObject *parent) :
-	Deferred(parent),
+RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel) :
+	Deferred(),
 	ignoreErrors_(false),
 	proxyControlClient_(proxyControlClient),
 	req_(req)
@@ -93,7 +93,7 @@ void RefreshWorker::refreshNextCid()
 		return;
 	}
 
-	Deferred *d = ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8(), this);
+	Deferred *d = ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8());
 	finishedConnection_ = d->finished.connect(boost::bind(&RefreshWorker::proxyRefresh_finished, this, boost::placeholders::_1));
 }
 

--- a/src/cpp/handler/refreshworker.cpp
+++ b/src/cpp/handler/refreshworker.cpp
@@ -93,7 +93,7 @@ void RefreshWorker::refreshNextCid()
 		return;
 	}
 
-	Deferred *d = ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8());
+	auto d = ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8());
 	finishedConnection_ = d->finished.connect(boost::bind(&RefreshWorker::proxyRefresh_finished, this, boost::placeholders::_1));
 }
 

--- a/src/cpp/handler/refreshworker.h
+++ b/src/cpp/handler/refreshworker.h
@@ -41,7 +41,7 @@ class RefreshWorker : public Deferred
 	Q_OBJECT
 
 public:
-	RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel, QObject *parent = 0);
+	RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel);
 
 private:
 	QStringList cids_;

--- a/src/cpp/handler/sessionrequest.cpp
+++ b/src/cpp/handler/sessionrequest.cpp
@@ -37,13 +37,14 @@ class DetectRulesSet : public Deferred
 {
 	Q_OBJECT
 
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
 	DetectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		req = std::make_unique<ZrpcRequest>(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this, req.get()));
 
 		QVariantList rlist;
@@ -81,13 +82,14 @@ class DetectRulesGet : public Deferred
 {
 	Q_OBJECT
 
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
 	DetectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		req = std::make_unique<ZrpcRequest>(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this, req.get()));
 
 		QVariantHash args;
@@ -174,13 +176,14 @@ class CreateOrUpdate : public Deferred
 {
 	Q_OBJECT
 
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 	
 public:
 	CreateOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		req = std::make_unique<ZrpcRequest>(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this, req.get()));
 
 		QVariantHash args;
@@ -217,13 +220,14 @@ class UpdateMany : public Deferred
 {
 	Q_OBJECT
 
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 	
 public:
 	UpdateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		req = std::make_unique<ZrpcRequest>(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this, req.get()));
 
 		QVariantHash vsidLastIds;
@@ -270,13 +274,14 @@ class GetLastIds : public Deferred
 {
 	Q_OBJECT
 
+	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 	
 public:
 	GetLastIds(ZrpcManager *stateClient, const QString &sid) :
 		Deferred()
 	{
-		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		req = std::make_unique<ZrpcRequest>(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this, req.get()));
 
 		QVariantHash args;
@@ -322,29 +327,29 @@ private:
 	}
 };
 
-Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
+std::unique_ptr<Deferred> detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
 {
-	return new DetectRulesSet(stateClient, rules);
+	return std::make_unique<DetectRulesSet>(stateClient, rules);
 }
 
-Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
+std::unique_ptr<Deferred> detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
 {
-	return new DetectRulesGet(stateClient, domain, path);
+	return std::make_unique<DetectRulesGet>(stateClient, domain, path);
 }
 
-Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
+std::unique_ptr<Deferred> createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
 {
-	return new CreateOrUpdate(stateClient, sid, lastIds);
+	return std::make_unique<CreateOrUpdate>(stateClient, sid, lastIds);
 }
 
-Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
+std::unique_ptr<Deferred> updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
 {
-	return new UpdateMany(stateClient, sidLastIds);
+	return std::make_unique<UpdateMany>(stateClient, sidLastIds);
 }
 
-Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid)
+std::unique_ptr<Deferred> getLastIds(ZrpcManager *stateClient, const QString &sid)
 {
-	return new GetLastIds(stateClient, sid);
+	return std::make_unique<GetLastIds>(stateClient, sid);
 }
 
 }

--- a/src/cpp/handler/sessionrequest.cpp
+++ b/src/cpp/handler/sessionrequest.cpp
@@ -37,7 +37,6 @@ class DetectRulesSet : public Deferred
 {
 	Q_OBJECT
 
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
@@ -65,6 +64,8 @@ public:
 	}
 
 private:
+	std::unique_ptr<ZrpcRequest> req;
+
 	void req_finished(ZrpcRequest *req)
 	{
 		if(req->success())
@@ -82,7 +83,6 @@ class DetectRulesGet : public Deferred
 {
 	Q_OBJECT
 
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 
 public:
@@ -99,6 +99,8 @@ public:
 	}
 
 private:
+	std::unique_ptr<ZrpcRequest> req;
+
 	void req_finished(ZrpcRequest *req)
 	{
 		if(req->success())
@@ -176,7 +178,6 @@ class CreateOrUpdate : public Deferred
 {
 	Q_OBJECT
 
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 	
 public:
@@ -203,6 +204,8 @@ public:
 	}
 
 private:
+	std::unique_ptr<ZrpcRequest> req;
+
 	void req_finished(ZrpcRequest *req)
 	{
 		if(req->success())
@@ -220,7 +223,6 @@ class UpdateMany : public Deferred
 {
 	Q_OBJECT
 
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 	
 public:
@@ -257,6 +259,8 @@ public:
 	}
 
 private:
+	std::unique_ptr<ZrpcRequest> req;
+
 	void req_finished(ZrpcRequest *req)
 	{
 		if(req->success())
@@ -274,7 +278,6 @@ class GetLastIds : public Deferred
 {
 	Q_OBJECT
 
-	std::unique_ptr<ZrpcRequest> req;
 	Connection finishedConnection;
 	
 public:
@@ -290,6 +293,8 @@ public:
 	}
 
 private:
+	std::unique_ptr<ZrpcRequest> req;
+
 	void req_finished(ZrpcRequest *req)
 	{
 		if(req->success())
@@ -327,29 +332,29 @@ private:
 	}
 };
 
-std::unique_ptr<Deferred> detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
+Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
 {
-	return std::make_unique<DetectRulesSet>(stateClient, rules);
+	return new DetectRulesSet(stateClient, rules);
 }
 
-std::unique_ptr<Deferred> detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
+Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
 {
-	return std::make_unique<DetectRulesGet>(stateClient, domain, path);
+	return new DetectRulesGet(stateClient, domain, path);
 }
 
-std::unique_ptr<Deferred> createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
+Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
 {
-	return std::make_unique<CreateOrUpdate>(stateClient, sid, lastIds);
+	return new CreateOrUpdate(stateClient, sid, lastIds);
 }
 
-std::unique_ptr<Deferred> updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
+Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
 {
-	return std::make_unique<UpdateMany>(stateClient, sidLastIds);
+	return new UpdateMany(stateClient, sidLastIds);
 }
 
-std::unique_ptr<Deferred> getLastIds(ZrpcManager *stateClient, const QString &sid)
+Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid)
 {
-	return std::make_unique<GetLastIds>(stateClient, sid);
+	return new GetLastIds(stateClient, sid);
 }
 
 }

--- a/src/cpp/handler/sessionrequest.cpp
+++ b/src/cpp/handler/sessionrequest.cpp
@@ -40,8 +40,8 @@ class DetectRulesSet : public Deferred
 	Connection finishedConnection;
 
 public:
-	DetectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules, QObject *parent = 0) :
-		Deferred(parent)
+	DetectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this, req));
@@ -84,8 +84,8 @@ class DetectRulesGet : public Deferred
 	Connection finishedConnection;
 
 public:
-	DetectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path, QObject *parent = 0) :
-		Deferred(parent)
+	DetectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this, req));
@@ -177,8 +177,8 @@ class CreateOrUpdate : public Deferred
 	Connection finishedConnection;
 	
 public:
-	CreateOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds, QObject *parent = 0) :
-		Deferred(parent)
+	CreateOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this, req));
@@ -220,8 +220,8 @@ class UpdateMany : public Deferred
 	Connection finishedConnection;
 	
 public:
-	UpdateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds, QObject *parent = 0) :
-		Deferred(parent)
+	UpdateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this, req));
@@ -273,8 +273,8 @@ class GetLastIds : public Deferred
 	Connection finishedConnection;
 	
 public:
-	GetLastIds(ZrpcManager *stateClient, const QString &sid, QObject *parent = 0) :
-		Deferred(parent)
+	GetLastIds(ZrpcManager *stateClient, const QString &sid) :
+		Deferred()
 	{
 		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
 		finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this, req));
@@ -322,29 +322,29 @@ private:
 	}
 };
 
-Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules, QObject *parent)
+Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
 {
-	return new DetectRulesSet(stateClient, rules, parent);
+	return new DetectRulesSet(stateClient, rules);
 }
 
-Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path, QObject *parent)
+Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
 {
-	return new DetectRulesGet(stateClient, domain, path, parent);
+	return new DetectRulesGet(stateClient, domain, path);
 }
 
-Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds, QObject *parent)
+Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
 {
-	return new CreateOrUpdate(stateClient, sid, lastIds, parent);
+	return new CreateOrUpdate(stateClient, sid, lastIds);
 }
 
-Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds, QObject *parent)
+Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
 {
-	return new UpdateMany(stateClient, sidLastIds, parent);
+	return new UpdateMany(stateClient, sidLastIds);
 }
 
-Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid, QObject *parent)
+Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid)
 {
-	return new GetLastIds(stateClient, sid, parent);
+	return new GetLastIds(stateClient, sid);
 }
 
 }

--- a/src/cpp/handler/sessionrequest.cpp
+++ b/src/cpp/handler/sessionrequest.cpp
@@ -43,8 +43,8 @@ public:
 	DetectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this, req.get()));
 
 		QVariantList rlist;
 		foreach(const DetectRule &rule, rules)
@@ -87,8 +87,8 @@ public:
 	DetectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this, req.get()));
 
 		QVariantHash args;
 		args["domain"] = domain.toUtf8();
@@ -180,8 +180,8 @@ public:
 	CreateOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this, req.get()));
 
 		QVariantHash args;
 
@@ -223,8 +223,8 @@ public:
 	UpdateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this, req.get()));
 
 		QVariantHash vsidLastIds;
 
@@ -276,8 +276,8 @@ public:
 	GetLastIds(ZrpcManager *stateClient, const QString &sid) :
 		Deferred()
 	{
-		ZrpcRequest *req = new ZrpcRequest(stateClient, this);
-		finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this, req));
+		auto req = std::make_unique<ZrpcRequest>(stateClient, this);
+		finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this, req.get()));
 
 		QVariantHash args;
 		args["sid"] = sid.toUtf8();

--- a/src/cpp/handler/sessionrequest.h
+++ b/src/cpp/handler/sessionrequest.h
@@ -39,11 +39,11 @@ class DetectRule;
 
 namespace SessionRequest {
 
-Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules);
-Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path);
-Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds);
-Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds);
-Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid);
+std::unique_ptr<Deferred> detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules);
+std::unique_ptr<Deferred> detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path);
+std::unique_ptr<Deferred> createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds);
+std::unique_ptr<Deferred> updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds);
+std::unique_ptr<Deferred> getLastIds(ZrpcManager *stateClient, const QString &sid);
 
 }
 

--- a/src/cpp/handler/sessionrequest.h
+++ b/src/cpp/handler/sessionrequest.h
@@ -39,11 +39,11 @@ class DetectRule;
 
 namespace SessionRequest {
 
-Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules, QObject *parent = 0);
-Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path, QObject *parent = 0);
-Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds, QObject *parent = 0);
-Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds, QObject *parent = 0);
-Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid, QObject *parent = 0);
+Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules);
+Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path);
+Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds);
+Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds);
+Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid);
 
 }
 

--- a/src/cpp/handler/sessionrequest.h
+++ b/src/cpp/handler/sessionrequest.h
@@ -39,11 +39,11 @@ class DetectRule;
 
 namespace SessionRequest {
 
-std::unique_ptr<Deferred> detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules);
-std::unique_ptr<Deferred> detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path);
-std::unique_ptr<Deferred> createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds);
-std::unique_ptr<Deferred> updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds);
-std::unique_ptr<Deferred> getLastIds(ZrpcManager *stateClient, const QString &sid);
+Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules);
+Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path);
+Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds);
+Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds);
+Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid);
 
 }
 


### PR DESCRIPTION
This PR intends to remove QObject parent param from Deferred class.
We are not removing Q_Object altogether from Deferred yet as `QMetaObject::invokeMethod` is being used in Deferred which we will tackle at a later time.
All new obj creations are done using unique pointers now so we can manage their lifetime properly
We have also removed QObject parent param from other class constructors to remove any errors or warnings.