### PR TITLE
proxy: don't use qapp as parent for objects not in main thread

### DIFF
--- a/src/cpp/proxy/websocketoverhttp.cpp
+++ b/src/cpp/proxy/websocketoverhttp.cpp
@@ -26,7 +26,6 @@
 #include <assert.h>
 #include <QTimer>
 #include <QPointer>
-#include <QCoreApplication>
 #include <QRandomGenerator>
 #include "log.h"
 #include "bufferlist.h"
@@ -268,7 +267,7 @@ public:
 		maxEvents(0)
 	{
 		if(!g_disconnectManager)
-			g_disconnectManager = new DisconnectManager(QCoreApplication::instance());
+			g_disconnectManager = new DisconnectManager;
 
 		keepAliveTimer = new QTimer(this);
 		connect(keepAliveTimer, &QTimer::timeout, this, &Private::keepAliveTimer_timeout);


### PR DESCRIPTION
This was probably done to ensure automatic cleanup on shutdown, but it's not needed since we explicitly call `clearDisconnectManager()`.