### PR TITLE
handler: only log route id for requests if explicitly set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["rlib", "staticlib"]
 arrayvec = "0.7"
 base64 = "0.13"
 clap = { version = "=4.2.1", features = ["cargo", "string", "wrap_help", "derive"] }
+config = "0.13.3"
 httparse = "1.7"
 ipnet = "2"
 jsonwebtoken = "8"
@@ -43,7 +44,6 @@ thiserror = "1.0"
 time = { version = "=0.3.18", features = ["formatting", "local-offset", "macros"] }
 url = "2.3"
 zmq = "0.9"
-config = "0.13.3"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/src/cpp/handler/httpsession.cpp
+++ b/src/cpp/handler/httpsession.cpp
@@ -1353,7 +1353,8 @@ private:
 	{
 		LogUtil::RequestData rd;
 
-		if(!adata.route.isEmpty())
+		// only log route id if explicitly set
+		if(!adata.statsRoute.isEmpty())
 			rd.routeId = adata.route;
 
 		rd.status = LogUtil::Response;
@@ -1372,7 +1373,8 @@ private:
 	{
 		LogUtil::RequestData rd;
 
-		if(!adata.route.isEmpty())
+		// only log route id if explicitly set
+		if(!adata.statsRoute.isEmpty())
 			rd.routeId = adata.route;
 
 		rd.status = LogUtil::Error;


### PR DESCRIPTION
This makes the logging consistent with the way the proxy logs requests.

Implicit ID (no `id` specified in route condition):

```
[INFO] 2024-03-04 13:08:01.390 [handler] subscribe http://localhost:7999/next.php channel=test
[INFO] 2024-03-04 13:08:01.391 [proxy] GET http://localhost:7999/next.php -> localhost:8080 accept
[INFO] 2024-03-04 13:08:02.547 [handler] GET http://localhost:8080/next.php?next=1 code=200 14
```

Explicit ID (`id=foo` in route condition):

```
[INFO] 2024-03-04 13:08:04.805 [handler] subscribe http://localhost:7999/next.php channel=test
[INFO] 2024-03-04 13:08:04.805 [proxy] GET http://localhost:7999/foo/next.php -> localhost:8080 route=foo accept
[INFO] 2024-03-04 13:08:05.872 [handler] GET http://localhost:8080/next.php?next=1 route=foo code=200 14
```