### PR TITLE
use immediate mode for router sockets that connect and send

### DIFF
--- a/src/cpp/handler/handlerengine.cpp
+++ b/src/cpp/handler/handlerengine.cpp
@@ -1464,6 +1464,7 @@ public:
 		if(!config.retryOutSpecs.isEmpty())
 		{
 			retrySock = new QZmq::Socket(QZmq::Socket::Router, this);
+			retrySock->setImmediateEnabled(true);
 			retrySock->setHwm(DEFAULT_HWM);
 			retrySock->setShutdownWaitTime(RETRY_WAIT_TIME);
 			retrySock->setRouterMandatoryEnabled(true);
@@ -1503,6 +1504,7 @@ public:
 
 			wsControlStreamSock = new QZmq::Socket(QZmq::Socket::Router, this);
 			wsControlStreamSock->setIdentity(config.instanceId);
+			wsControlStreamSock->setImmediateEnabled(true);
 			wsControlStreamSock->setHwm(DEFAULT_HWM);
 			wsControlStreamSock->setShutdownWaitTime(WSCONTROL_WAIT_TIME);
 

--- a/src/cpp/proxy/wscontrolmanager.cpp
+++ b/src/cpp/proxy/wscontrolmanager.cpp
@@ -337,6 +337,8 @@ private slots:
 			sessionsByLastRefresh.insert(QPair<qint64, KeepAliveRegistration*>(r->lastRefresh, r), r);
 
 			QByteArray peer = r->s->peer();
+			if(peer.isEmpty())
+				continue;
 
 			if(!packets.contains(peer))
 			{
@@ -377,6 +379,8 @@ private slots:
 			sessionsByLastRefresh.insert(QPair<qint64, KeepAliveRegistration*>(r->lastRefresh, r), r);
 
 			QByteArray peer = r->s->peer();
+			if(peer.isEmpty())
+				continue;
 
 			if(!packets.contains(peer))
 			{


### PR DESCRIPTION
Immediate mode is needed anytime we use zmq ROUTER sockets that connect and also send (if they bind, or if they connect and never send, this mode is not needed). This mode ensures that peer addresses can be renegotiated correctly anytime a binding peer restarts. Most of our ROUTER sockets already have this set, but I'd forgotten to set it on the ones added recently for multithreading.

Also, don't attempt to send keep alives before peer addr known.

Tested locally.