### PR TITLE
proxy: fix sharing with external routing

### DIFF
--- a/src/cpp/proxy/engine.cpp
+++ b/src/cpp/proxy/engine.cpp
@@ -553,7 +553,8 @@ public:
 				routeId = QString::fromUtf8(req->requestHeaders().get("Pushpin-Route"));
 		}
 
-		RequestSession *rs;
+		RequestSession *rs = new RequestSession(config.id, domainMap, sockJsManager, inspect, inspectChecker, accept, stats);
+
 		if(passthroughData.isValid() && !preferInternal)
 		{
 			// passthrough request with preferInternal=false. in this case,
@@ -585,7 +586,6 @@ public:
 
 			route.targets += target;
 
-			rs = new RequestSession(config.id, stats);
 			rs->setRoute(route);
 		}
 		else
@@ -594,13 +594,18 @@ public:
 			// request with preferInternal=true. in that case, use domainmap
 			// for lookup, with route ID if available
 
-			rs = new RequestSession(config.id, domainMap, sockJsManager, inspect, inspectChecker, accept, stats);
+			rs->setRouteId(routeId);
+		}
+
+		if(!passthroughData.isValid())
+		{
+			// these only make sense on regular requests
+
 			rs->setDebugEnabled(config.debug);
 			rs->setAutoCrossOrigin(config.autoCrossOrigin);
 			rs->setPrefetchSize(config.inspectPrefetch);
 			rs->setDefaultUpstreamKey(config.upstreamKey);
 			rs->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
-			rs->setRouteId(routeId);
 		}
 
 		rs->setAutoShare(autoShare);

--- a/src/cpp/proxy/requestsession.cpp
+++ b/src/cpp/proxy/requestsession.cpp
@@ -1190,12 +1190,6 @@ public slots:
 	}
 };
 
-RequestSession::RequestSession(int workerId, StatsManager *stats, QObject *parent) :
-	QObject(parent)
-{
-	d = new Private(this, workerId, 0, 0, 0, 0, 0, stats);
-}
-
 RequestSession::RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *acceptManager, StatsManager *stats, QObject *parent) :
 	QObject(parent)
 {

--- a/src/cpp/proxy/requestsession.h
+++ b/src/cpp/proxy/requestsession.h
@@ -54,7 +54,6 @@ class RequestSession : public QObject
 	Q_OBJECT
 
 public:
-	RequestSession(int workerId, StatsManager *stats, QObject *parent = 0);
 	RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats, QObject *parent = 0);
 	~RequestSession();
 


### PR DESCRIPTION
Next links are fetched by the handler through the proxy, and the proxy can route these requests either internally (by looking up the target in the routes table) or externally (by making a fake route that points to anywhere). For some reason, external routing skips the inspect step, and this breaks sharing (collapsing) since inspects are necessary for sharing.

This PR fixes sharing with external routing by making sure inspects are always used.