### PR TITLE
runner: fix qt linkage

### DIFF
--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-use pushpin::call_c_main;
+use pushpin::{call_c_main, import_cpp};
 use std::env;
 use std::process::ExitCode;
 
-#[cfg(target_os = "macos")]
-#[link(name = "pushpin-cpp")]
-#[link(name = "QtCore", kind = "framework")]
-#[link(name = "QtNetwork", kind = "framework")]
-#[link(name = "c++")]
-extern "C" {
-    fn runner_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-}
-
-#[cfg(not(target_os = "macos"))]
-#[link(name = "pushpin-cpp")]
-#[link(name = "Qt5Core")]
-#[link(name = "Qt5Network")]
-#[link(name = "stdc++")]
-extern "C" {
+import_cpp! {
     fn runner_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
 }
 


### PR DESCRIPTION
Runner on v1 branch (legacy runner) is not using updated Qt linking logic. This fixes it.

Legacy runner on main is already doing the right thing.