### PR TITLE
treat some buffer writes as infallible

### DIFF
--- a/src/core/http1/client.rs
+++ b/src/core/http1/client.rs
@@ -154,7 +154,11 @@ impl<'a, R: AsyncRead, W: AsyncWrite> RequestBody<'a, R, W> {
                 return Err(Error::FurtherInputNotAllowed);
             }
 
-            let size = w.buf.write(src)?;
+            let size = match w.buf.write(src) {
+                Ok(size) => size,
+                Err(e) if e.kind() == io::ErrorKind::WriteZero => 0,
+                Err(e) => panic!("infallible buffer write failed: {}", e),
+            };
 
             assert!(size <= src.len());
 


### PR DESCRIPTION
These writes are made against memory buffers which never return an error, except for `WriteZero` which is not a real error in these cases, so we can treat the calls as infallible. Notably, this implies that `server::ResponsePrepareBody::prepare` is infallible when called with valid input.