### PR TITLE
move http1.rs to core/http1/protocol.rs

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use crate::future::{AsyncWrite, AsyncWriteExt};
 use std::cell::RefCell;
 use std::cmp;
 use std::io;
@@ -188,46 +187,6 @@ pub fn write_vectored_offset<W: Write>(
     }
 
     writer.write_vectored(&arr[..arr_len])
-}
-
-pub async fn write_vectored_offset_async<W: AsyncWrite>(
-    writer: &mut W,
-    bufs: &[&[u8]],
-    offset: usize,
-) -> Result<usize, io::Error> {
-    if bufs.is_empty() {
-        return Ok(0);
-    }
-
-    let mut offset = offset;
-    let mut start = 0;
-
-    while offset >= bufs[start].len() {
-        // on the last buf?
-        if start + 1 >= bufs.len() {
-            // exceeding the last buf is an error
-            if offset > bufs[start].len() {
-                return Err(io::Error::from(io::ErrorKind::InvalidInput));
-            }
-
-            return Ok(0);
-        }
-
-        offset -= bufs[start].len();
-        start += 1;
-    }
-
-    let mut arr = [io::IoSlice::new(&b""[..]); VECTORED_MAX];
-    let mut arr_len = 0;
-
-    for (index, &buf) in bufs.iter().enumerate().skip(start) {
-        let buf = if index == start { &buf[offset..] } else { buf };
-
-        arr[arr_len] = io::IoSlice::new(buf);
-        arr_len += 1;
-    }
-
-    writer.write_vectored(&arr[..arr_len]).await
 }
 
 struct LimitBufsRestore<T> {

--- a/src/core/http1/error.rs
+++ b/src/core/http1/error.rs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-use crate::http1;
+use crate::core::http1::protocol;
 use std::io;
 
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
-    Http(http1::Error),
+    Protocol(protocol::Error),
     RequestTooLarge(usize),
     ResponseTooLarge(usize),
     ResponseDuringContinue,
@@ -35,8 +35,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<http1::Error> for Error {
-    fn from(e: http1::Error) -> Self {
-        Self::Http(e)
+impl From<protocol::Error> for Error {
+    fn from(e: protocol::Error) -> Self {
+        Self::Protocol(e)
     }
 }

--- a/src/core/http1/mod.rs
+++ b/src/core/http1/mod.rs
@@ -15,10 +15,15 @@
  */
 
 mod error;
+mod protocol;
 mod util;
 
 pub mod client;
 pub mod server;
 
 pub use error::*;
+pub use protocol::{
+    parse_header_value, BodySize, Header, HeaderParamsIterator, ParseScratch, Request, Response,
+    EMPTY_HEADER,
+};
 pub use util::{RecvStatus, SendStatus};

--- a/src/core/http1/protocol.rs
+++ b/src/core/http1/protocol.rs
@@ -686,7 +686,7 @@ pub enum ServerState {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    ParseError(#[from] httparse::Error),
+    Parse(#[from] httparse::Error),
 
     #[error("invalid content length")]
     InvalidContentLength,
@@ -756,7 +756,7 @@ impl<'buf, 'headers> ServerProtocol {
         let size = match req.parse(buf) {
             Ok(httparse::Status::Complete(size)) => size,
             Ok(httparse::Status::Partial) => return None,
-            Err(e) => return Some(Err(Error::ParseError(e))),
+            Err(e) => return Some(Err(Error::Parse(e))),
         };
 
         let expect_100 = match self.process_request(&req) {
@@ -788,7 +788,7 @@ impl<'buf, 'headers> ServerProtocol {
                 return ParseStatus::Incomplete((), rbuf, scratch)
             }
             ParseStatus::Error(e, rbuf, scratch) => {
-                return ParseStatus::Error(Error::ParseError(e), rbuf, scratch)
+                return ParseStatus::Error(Error::Parse(e), rbuf, scratch)
             }
         };
 
@@ -901,7 +901,7 @@ impl<'buf, 'headers> ServerProtocol {
                                 return Ok((size, None));
                             }
                             Err(e) => {
-                                return Err(Error::ParseError(e));
+                                return Err(Error::Parse(e));
                             }
                         }
 
@@ -1390,7 +1390,7 @@ impl ClientResponse {
                 return ParseStatus::Incomplete(self, rbuf, scratch)
             }
             ParseStatus::Error(e, rbuf, scratch) => {
-                return ParseStatus::Error(Error::ParseError(e), rbuf, scratch)
+                return ParseStatus::Error(Error::Parse(e), rbuf, scratch)
             }
         };
 
@@ -1663,7 +1663,7 @@ impl ClientResponseBody {
                         return Ok(RecvStatus::Read(self, pos, size));
                     }
                     Err(e) => {
-                        return Err(Error::ParseError(e));
+                        return Err(Error::Parse(e));
                     }
                 }
             } else {
@@ -2272,7 +2272,7 @@ mod tests {
             Test {
                 name: "parse-error",
                 data: "G\n",
-                result: Some(Err(Error::ParseError(httparse::Error::Token))),
+                result: Some(Err(Error::Parse(httparse::Error::Token))),
                 state: ServerState::ReceivingRequest,
                 ver_min: 0,
                 chunk_left: None,
@@ -2757,7 +2757,7 @@ mod tests {
                 body_size: BodySize::Unknown,
                 chunk_left: None,
                 chunk_size: 0,
-                result: Err(Error::ParseError(httparse::Error::Token)),
+                result: Err(Error::Parse(httparse::Error::Token)),
                 state: ServerState::ReceivingBody,
                 chunk_left_after: Some(0),
                 chunk_size_after: 0,
@@ -4388,7 +4388,7 @@ mod tests {
             Test {
                 name: "parse-error",
                 data: "H\n",
-                result: Some(Err(Error::ParseError(httparse::Error::Token))),
+                result: Some(Err(Error::Parse(httparse::Error::Token))),
                 ver_min: 0,
                 chunk_left: None,
                 persistent: false,
@@ -4953,7 +4953,7 @@ mod tests {
                 chunk_left: None,
                 chunk_size: 0,
                 chunked: true,
-                result: Err(Error::ParseError(httparse::Error::Token)),
+                result: Err(Error::Parse(httparse::Error::Token)),
                 chunk_left_after: Some(0),
                 chunk_size_after: 0,
                 rbuf_position: 3,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub mod event;
 pub mod executor;
 pub mod ffi;
 pub mod future;
-pub mod http1;
 pub mod jwt;
 pub mod list;
 pub mod listener;

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2024 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 use crate::buffer::{
     trim_for_display, write_vectored_offset, Buffer, LimitBufsMut, RingBuffer, VECTORED_MAX,
 };
-use crate::http1::HeaderParamsIterator;
+use crate::core::http1::HeaderParamsIterator;
 use arrayvec::ArrayVec;
 use log::{log_enabled, trace};
 use miniz_oxide::deflate;


### PR DESCRIPTION
Recently, the HTTP convenience wrappers were moved into a new module, but the low-level state machine was still living outside of it. This PR moves that code into the new module as well so that everything's in the same place. There are no functional changes, only moved code and updated references.

Moving code around caused the compiler to warn about some unused functions (presumably due to visibility changes), so this unused code is removed.