### PR TITLE
remove Q_Obj macro from inspectRequest

### DIFF
--- a/src/cpp/proxy/inspectrequest.cpp
+++ b/src/cpp/proxy/inspectrequest.cpp
@@ -105,8 +105,6 @@ static InspectData resultToData(const QVariant &in, bool *ok)
 
 class InspectRequest::Private : public QObject
 {
-	Q_OBJECT
-
 public:
 	InspectRequest *q;
 	InspectData idata;
@@ -176,4 +174,3 @@ void InspectRequest::onSuccess()
 	}
 }
 
-#include "inspectrequest.moc"

--- a/src/cpp/proxy/inspectrequest.h
+++ b/src/cpp/proxy/inspectrequest.h
@@ -32,8 +32,6 @@ class ZrpcManager;
 
 class InspectRequest : public ZrpcRequest
 {
-	Q_OBJECT
-
 public:
 	InspectRequest(ZrpcManager *manager, QObject *parent = 0);
 	~InspectRequest();


### PR DESCRIPTION
this PR attempts to remove Q_Obj macro only from inspectRequest 