### PR TITLE
ensure additional blocks are always returned

### DIFF
--- a/src/core/http1/client.rs
+++ b/src/core/http1/client.rs
@@ -174,7 +174,7 @@ impl<'a, R: AsyncRead, W: AsyncWrite> RequestBody<'a, R, W> {
 
     pub fn expand_write_buffer<F>(&self, blocks_max: usize, reserve: F) -> Result<usize, Error>
     where
-        F: Fn() -> bool,
+        F: FnMut() -> bool,
     {
         if let Some(inner) = &*self.inner.borrow() {
             let w = &mut *inner.w.borrow_mut();

--- a/src/core/http1/server.rs
+++ b/src/core/http1/server.rs
@@ -639,7 +639,7 @@ impl<'a, R: AsyncRead, W: AsyncWrite> ResponseBody<'a, R, W> {
 
     pub fn expand_write_buffer<F>(&self, blocks_max: usize, reserve: F) -> Result<usize, Error>
     where
-        F: Fn() -> bool,
+        F: FnMut() -> bool,
     {
         if let Some(inner) = &*self.inner.borrow() {
             let w = &mut *inner.w.borrow_mut();

--- a/src/core/http1/util.rs
+++ b/src/core/http1/util.rs
@@ -30,10 +30,10 @@ pub fn resize_write_buffer_if_full<F>(
     buf: &mut VecRingBuffer,
     block_size: usize,
     blocks_max: usize,
-    reserve: F,
+    mut reserve: F,
 ) -> usize
 where
-    F: Fn() -> bool,
+    F: FnMut() -> bool,
 {
     assert!(blocks_max >= 2);
 

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -133,6 +133,7 @@ mod tests {
             assert!(c.dec(1).is_err());
         }
 
-        assert!(c.dec(1).is_ok());
+        assert!(c.dec(2).is_ok());
+        assert!(c.dec(1).is_err());
     }
 }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -121,4 +121,18 @@ mod tests {
         assert!(c.inc(usize::MAX).is_ok());
         assert!(c.inc(1).is_err());
     }
+
+    #[test]
+    fn counter_dec() {
+        let c = Counter::new(2);
+
+        {
+            let mut c = CounterDec::new(&c);
+            assert!(c.dec(1).is_ok());
+            assert!(c.dec(1).is_ok());
+            assert!(c.dec(1).is_err());
+        }
+
+        assert!(c.dec(1).is_ok());
+    }
 }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -78,6 +78,30 @@ impl Counter {
     }
 }
 
+pub struct CounterDec<'a> {
+    counter: &'a Counter,
+    amount: usize,
+}
+
+impl<'a> CounterDec<'a> {
+    pub fn new(counter: &'a Counter) -> Self {
+        Self { counter, amount: 0 }
+    }
+
+    pub fn dec(&mut self, amount: usize) -> Result<(), CounterError> {
+        self.counter.dec(amount)?;
+        self.amount += amount;
+
+        Ok(())
+    }
+}
+
+impl Drop for CounterDec<'_> {
+    fn drop(&mut self) {
+        assert!(self.counter.inc(self.amount).is_ok());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Connections are only allowed to increase their buffer sizes by so many "blocks", and the available blocks are managed globally in a `Counter` (basically an atomic int with increment/decrement operations). Connections decrement the value whenever they want to use additional blocks and increment the value whenever they are done. However, in some cases the value is not being incremented when it needs to be. To fix this, and to reduce the chance of mistakes in the future, this PR adds a wrapper type `CounterDec` that keeps track of decrements and then on drop will increment by the same amount. This way, the blocks automatically get put back when the wrapper goes out of scope.