### PR TITLE
use short service names

### DIFF
--- a/examples/config/pushpin.conf
+++ b/examples/config/pushpin.conf
@@ -19,7 +19,7 @@ stats_connection_send=true
 
 [runner]
 # services to start
-services=connmgr,pushpin-proxy,pushpin-handler
+services=connmgr,proxy,handler
 
 # plain HTTP port to listen on for client connections
 http_port=7999

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,7 +359,7 @@ impl CustomConfig {
                 "runner",
                 Runner {
                     rundir: String::new(),
-                    services: String::from("connmgr,pushpin-proxy,pushpin-handler"),
+                    services: String::from("connmgr,proxy,handler"),
                     http_port: String::from("7999"),
                     https_ports: String::from("443"),
                     local_ports: String::from("{rundir}/{ipc_prefix}server"),

--- a/src/cpp/handler/handlerapp.cpp
+++ b/src/cpp/handler/handlerapp.cpp
@@ -353,7 +353,7 @@ public:
 
 		HandlerEngine::Configuration config;
 		config.appVersion = Config::get().version;
-		config.instanceId = "pushpin-handler_" + QByteArray::number(QCoreApplication::applicationPid());
+		config.instanceId = "handler_" + QByteArray::number(QCoreApplication::applicationPid());
 		if(!services.contains("mongrel2") && (!connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
 		{
 			config.serverInStreamSpecs = connmgr_in_stream_specs;

--- a/src/cpp/proxy/app.cpp
+++ b/src/cpp/proxy/app.cpp
@@ -559,7 +559,7 @@ public:
 
 		Engine::Configuration config;
 		config.appVersion = Config::get().version;
-		config.clientId = "pushpin-proxy_" + QByteArray::number(QCoreApplication::applicationPid());
+		config.clientId = "proxy_" + QByteArray::number(QCoreApplication::applicationPid());
 		if(!services.contains("mongrel2") && (!connmgr_in_specs.isEmpty() || !connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
 		{
 			config.serverInSpecs = connmgr_in_specs;

--- a/src/cpp/runner/runnerapp.cpp
+++ b/src/cpp/runner/runnerapp.cpp
@@ -573,10 +573,34 @@ public:
 			filePrefix = ipcPrefix;
 		}
 
+		if(logLevels.contains("pushpin-proxy"))
+		{
+			logLevels["proxy"] = logLevels["pushpin-proxy"];
+			logLevels.remove("pushpin-proxy");
+		}
+
+		if(logLevels.contains("pushpin-handler"))
+		{
+			logLevels["handler"] = logLevels["pushpin-handler"];
+			logLevels.remove("pushpin-handler");
+		}
+
 		if(serviceNames.contains("condure"))
 		{
 			serviceNames.removeAll("condure");
 			serviceNames += "connmgr";
+		}
+
+		if(serviceNames.contains("pushpin-proxy"))
+		{
+			serviceNames.removeAll("pushpin-proxy");
+			serviceNames += "proxy";
+		}
+
+		if(serviceNames.contains("pushpin-handler"))
+		{
+			serviceNames.removeAll("pushpin-handler");
+			serviceNames += "handler";
 		}
 
 		if(serviceNames.contains("connmgr") && (serviceNames.contains("mongrel2") || serviceNames.contains("m2adapter")))
@@ -642,11 +666,11 @@ public:
 			quietCheck = true;
 		}
 
-		if(serviceNames.contains("pushpin-proxy"))
-			services += new PushpinProxyService(proxyBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevels.value("pushpin-proxy", defaultLevel), args.routeLines, quietCheck);
+		if(serviceNames.contains("proxy"))
+			services += new PushpinProxyService(proxyBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevels.value("proxy", defaultLevel), args.routeLines, quietCheck);
 
-		if(serviceNames.contains("pushpin-handler"))
-			services += new PushpinHandlerService(handlerBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, portOffset, logLevels.value("pushpin-handler", defaultLevel));
+		if(serviceNames.contains("handler"))
+			services += new PushpinHandlerService(handlerBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, portOffset, logLevels.value("handler", defaultLevel));
 
 		foreach(Service *s, services)
 		{

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -823,8 +823,8 @@ mod tests {
             output: Ok(Settings {
                 service_names: vec![
                     "connmgr".to_string(),
-                    "pushpin-proxy".to_string(),
-                    "pushpin-handler".to_string(),
+                    "proxy".to_string(),
+                    "handler".to_string(),
                 ],
                 config_file: test_dir
                     .join("examples")


### PR DESCRIPTION
This allows "proxy" and "handler" to be used in place of "pushpin-proxy" and "pushpin-handler" in configuration. For example: `services=connmgr,proxy,handler` and `--loglevel proxy:3`. The longer names still work for compatibility. Also, short names are used in ipc IDs.