### PR TITLE
add StatsManager param to websocket  classes

### DIFF
--- a/src/cpp/proxy/websocketoverhttp.cpp
+++ b/src/cpp/proxy/websocketoverhttp.cpp
@@ -201,6 +201,7 @@ public:
 
 	WebSocketOverHttp *q;
 	ZhttpManager *zhttpManager;
+	StatsManager *statsManager;
 	QString connectHost;
 	int connectPort;
 	bool ignorePolicies;
@@ -1013,11 +1014,12 @@ private slots:
 	}
 };
 
-WebSocketOverHttp::WebSocketOverHttp(ZhttpManager *zhttpManager, QObject *parent) :
+WebSocketOverHttp::WebSocketOverHttp(ZhttpManager *zhttpManager, StatsManager *statsManager, QObject *parent) :
 	WebSocket(parent)
 {
 	d = new Private(this);
 	d->zhttpManager = zhttpManager;
+	d->statsManager = statsManager;
 }
 
 WebSocketOverHttp::WebSocketOverHttp(QObject *parent) :

--- a/src/cpp/proxy/websocketoverhttp.h
+++ b/src/cpp/proxy/websocketoverhttp.h
@@ -24,6 +24,7 @@
 #ifndef WEBSOCKETOVERHTTP_H
 #define WEBSOCKETOVERHTTP_H
 
+#include "statsmanager.h"
 #include "websocket.h"
 #include <boost/signals2.hpp>
 #include <map>
@@ -39,7 +40,7 @@ class WebSocketOverHttp : public WebSocket
 	Q_OBJECT
 
 public:
-	WebSocketOverHttp(ZhttpManager *zhttpManager, QObject *parent = 0);
+	WebSocketOverHttp(ZhttpManager *zhttpManager, StatsManager *statsManager, QObject *parent = 0);
 	~WebSocketOverHttp();
 
 	void setConnectionId(const QByteArray &id);

--- a/src/cpp/proxy/wsproxysession.cpp
+++ b/src/cpp/proxy/wsproxysession.cpp
@@ -561,7 +561,7 @@ public:
 
 			if(target.overHttp)
 			{
-				WebSocketOverHttp *woh = new WebSocketOverHttp(zhttpManager, this);
+				WebSocketOverHttp *woh = new WebSocketOverHttp(zhttpManager, statsManager, this);
 
 				woh->setConnectionId(publicCid);
 

--- a/src/cpp/zwebsocket.cpp
+++ b/src/cpp/zwebsocket.cpp
@@ -53,6 +53,7 @@ public:
 
 	ZWebSocket *q;
 	ZhttpManager *manager;
+	StatsManager *statsManager;
 	bool server;
 	InternalState state;
 	ZWebSocket::Rid rid;
@@ -96,10 +97,11 @@ public:
 	Connection expireTimerConnection;
 	Connection keppAliveTimerConnection;
 
-	Private(ZWebSocket *_q) :
+	Private(ZWebSocket *_q, StatsManager *_statsManager) :
 		QObject(_q),
 		q(_q),
 		manager(0),
+		statsManager(_statsManager),
 		server(false),
 		state(Idle),
 		connectPort(-1),
@@ -1091,10 +1093,10 @@ public:
 	}
 };
 
-ZWebSocket::ZWebSocket(QObject *parent) :
+ZWebSocket::ZWebSocket(StatsManager *statsManager, QObject *parent) :
 	WebSocket(parent)
 {
-	d = new Private(this);
+	d = new Private(this, statsManager);
 }
 
 ZWebSocket::~ZWebSocket()

--- a/src/cpp/zwebsocket.h
+++ b/src/cpp/zwebsocket.h
@@ -23,6 +23,7 @@
 #ifndef ZWEBSOCKET_H
 #define ZWEBSOCKET_H
 
+#include "statsmanager.h"
 #include "websocket.h"
 #include <boost/signals2.hpp>
 
@@ -83,7 +84,7 @@ private:
 	Private *d;
 
 	friend class ZhttpManager;
-	ZWebSocket(QObject *parent = 0);
+	ZWebSocket(StatsManager *stats = 0, QObject *parent = 0);
 	void setupClient(ZhttpManager *manager);
 	bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
 	void startServer();


### PR DESCRIPTION
integrate statistics management directly within the ZWebSocket & WebSocketOverHttp classes, enabling better monitoring and logging of tls handshake errors.