### PR TITLE
when all batched items are removed, start clean

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -50,6 +50,7 @@ use slab::Slab;
 use socket2::{Domain, Socket, Type};
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::convert::TryFrom;
 use std::fs;
 use std::io;
 use std::io::Write;
@@ -285,6 +286,17 @@ impl Batch {
     }
 
     fn add(&mut self, to_addr: &[u8], ckey: usize) -> Result<BatchKey, ()> {
+        if self.nodes.len() == self.nodes.capacity() {
+            return Err(());
+        }
+
+        // if all existing nodes have been removed via remove() or take_group(),
+        // such that is_empty() returns true, start clean
+        if self.nodes.is_empty() {
+            self.addrs.clear();
+            self.addr_index = 0;
+        }
+
         let mut pos = self.addrs.len();
 
         for (i, a) in self.addrs.iter().enumerate() {
@@ -294,15 +306,19 @@ impl Batch {
         }
 
         if pos == self.addrs.len() {
+            if self.addrs.len() == self.addrs.capacity() {
+                return Err(());
+            }
+
             // connection limits to_addr to 64 so this is guaranteed to succeed
-            let mut a = ArrayVec::new();
-            a.try_extend_from_slice(to_addr).unwrap();
+            let a = ArrayVec::try_from(to_addr).unwrap();
 
             self.addrs.push((a, list::List::default()));
-        }
-
-        if self.nodes.len() == self.nodes.capacity() {
-            return Err(());
+        } else {
+            // adding not allowed if take_group() has already moved past the index
+            if pos < self.addr_index {
+                return Err(());
+            }
         }
 
         let nkey = self.nodes.insert(list::Node::new(ckey));
@@ -332,6 +348,7 @@ impl Batch {
 
         // if all are empty, we're done
         if self.addr_index == self.addrs.len() {
+            assert!(self.nodes.is_empty());
             return None;
         }
 
@@ -1166,8 +1183,6 @@ impl Worker {
                     Select2::R2(_) => break 'outer,
                 }
             }
-
-            stream_conns.batch_clear();
         }
     }
 
@@ -2010,14 +2025,12 @@ impl Worker {
                     }
                 }
                 None => {
-                    // this could happen if message construction failed
+                    // this could happen if items removed or message construction failed
                     sender.cancel();
                 }
             }
 
             if conns.batch_is_empty() {
-                conns.batch_clear();
-
                 let now = reactor.now();
 
                 if now >= next_keep_alive_time + KEEP_ALIVE_INTERVAL {
@@ -3018,6 +3031,37 @@ pub mod tests {
             .take_group(|ckey| { (ids[ckey - 1].as_bytes(), 0) })
             .is_none());
         assert_eq!(batch.last_group_ckeys(), &[3]);
+
+        let mut batch = Batch::new(3);
+
+        let bkey = batch.add(b"addr-a", 1).unwrap();
+        assert!(batch.add(b"addr-b", 2).is_ok());
+        assert_eq!(batch.len(), 2);
+        batch.remove(bkey);
+        assert_eq!(batch.len(), 1);
+
+        let group = batch
+            .take_group(|ckey| (ids[ckey - 1].as_bytes(), 0))
+            .unwrap();
+        assert_eq!(group.ids().len(), 1);
+        assert_eq!(group.ids()[0].id, b"id-2");
+        assert_eq!(group.ids()[0].seq, Some(0));
+        assert_eq!(group.addr(), b"addr-b");
+        drop(group);
+        assert_eq!(batch.is_empty(), true);
+
+        assert!(batch.add(b"addr-a", 3).is_ok());
+        assert_eq!(batch.len(), 1);
+        assert!(!batch.is_empty());
+        let group = batch
+            .take_group(|ckey| (ids[ckey - 1].as_bytes(), 0))
+            .unwrap();
+        assert_eq!(group.ids().len(), 1);
+        assert_eq!(group.ids()[0].id, b"id-3");
+        assert_eq!(group.ids()[0].seq, Some(0));
+        assert_eq!(group.addr(), b"addr-a");
+        drop(group);
+        assert_eq!(batch.is_empty(), true);
     }
 
     #[test]


### PR DESCRIPTION
`Batch` is stateful, building a table of ipc addresses when `add()` is called, and iterating over the table when `take_group()` is called. The API leaves some potential for misuse, notably calling `add()` with an address that is already in the table that has been iterated past, leading to a situation where `is_empty()` returns false yet `take_group()` returns None. Likely, this can happen in `keep_alives_task` when all items are removed during the await for channel writability and the channel turns out to not be writable and the loop continues from the start.

The `clear()` method can be used to reset everything, but having to call it after all items are removed is not intuitive and feels redundant. This PR fixes the issue by making `Batch` automatically clear its address table whenever all items have been removed. This means `clear()` is no longer required to repair the state, it simply becomes a convenience for removing all items.

A version of `Batch` exists in both client and server, so both are updated. In the future we may want to consider sharing one type.