### PR TITLE
use std::pin::pin instead of our own macro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust-toolchain: [1.66.1]
+        rust-toolchain: [1.68.0]
         platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
This requires at least Rust 1.68.0.