### PR TITLE
split ffi.rs into core/ffi.rs and lib.rs

### DIFF
--- a/src/core/ffi.rs
+++ b/src/core/ffi.rs
@@ -32,9 +32,6 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
-#[cfg(test)]
-use crate::import_cpptest;
-
 #[repr(C)]
 pub struct ExpiredTimer {
     key: libc::c_int,
@@ -1098,19 +1095,4 @@ pub unsafe extern "C" fn build_config_destroy(c: *mut BuildConfig) {
     drop(CString::from_raw(c.version));
     drop(CString::from_raw(c.config_dir));
     drop(CString::from_raw(c.lib_dir));
-}
-
-#[cfg(test)]
-import_cpptest! {
-    pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn jsonpatch_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn instruct_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn idformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn publishformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn publishitem_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn handlerengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-    pub fn template_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,6 +20,7 @@ pub mod channel;
 pub mod config;
 pub mod event;
 pub mod executor;
+pub mod ffi;
 pub mod http1;
 pub mod jwt;
 pub mod list;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 /// cbindgen:ignore
 pub mod connmgr;
 pub mod core;
-pub mod ffi;
 /// cbindgen:ignore
 pub mod future;
 /// cbindgen:ignore
@@ -321,6 +320,23 @@ pub fn ensure_example_config(dest: &Path) {
         fs::copy(src_dir.join("pushpin.conf"), dest_dir.join("pushpin.conf")).unwrap();
         fs::copy(src_dir.join("routes"), dest_dir.join("routes")).unwrap();
     });
+}
+
+mod ffi {
+    #[cfg(test)]
+    import_cpptest! {
+        pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn jsonpatch_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn instruct_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn idformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn publishformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn publishitem_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn handlerengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn template_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of having a master `ffi.rs` at the root, let's start allowing FFI code to be spread out across multiple files, so that each part can live closer to any relevant native code. This should make FFI code easier to maintain as our Rust & C++ interfacing needs increase.

This PR initially moves most of the existing FFI code into a single file within core, to establish that there is no longer a project-wide FFI module. However, it still leaves most of the FFI code consolidated there. Later, we may want to consider splitting the FFI code even further, for example moving JWT FFI code into `jwt.rs`, timer FFI code into `timer.rs`, etc. This can be done in later commits.