### PR TITLE
move various things out of lib.rs to more specific modules

### DIFF
--- a/src/bin/pushpin-connmgr.rs
+++ b/src/bin/pushpin-connmgr.rs
@@ -17,10 +17,9 @@
 
 use clap::{Arg, ArgAction, Command};
 use log::{error, LevelFilter};
-use pushpin::connmgr::{run, App, Config};
+use pushpin::connmgr::{run, App, Config, ListenConfig, ListenSpec};
 use pushpin::core::log::{get_simple_logger, local_offset_check};
 use pushpin::version;
-use pushpin::{ListenConfig, ListenSpec};
 use std::error::Error;
 use std::path::PathBuf;
 use std::process;

--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use crate::can_move_mio_sockets_between_threads;
 use crate::connmgr::connection::{
     client_req_connection, client_stream_connection, ConnectionPool, StreamSharedData,
 };
@@ -1755,7 +1754,7 @@ impl Client {
 
         let resolver = Arc::new(Resolver::new(RESOLVER_THREADS, queries_max));
 
-        let pool_max = if can_move_mio_sockets_between_threads() {
+        let pool_max = if event::can_move_mio_sockets_between_threads() {
             (req_maxconn + stream_maxconn) / 10
         } else {
             // disable persistent connections

--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -47,6 +47,7 @@ use crate::core::arena;
 use crate::core::buffer::{
     Buffer, ContiguousBuffer, LimitBufsMut, TmpBuffer, VecRingBuffer, VECTORED_MAX,
 };
+use crate::core::defer::Defer;
 use crate::core::http1::Error as CoreHttpError;
 use crate::core::http1::{self, client, server, RecvStatus, SendStatus};
 use crate::core::net::SocketAddr;
@@ -60,7 +61,6 @@ use crate::future::{
     AsyncWrite, AsyncWriteExt, CancellationToken, ReadHalf, Select2, Select3, Select4,
     StdWriteWrapper, Timeout, TlsWaker, WriteHalf,
 };
-use crate::Defer;
 use arrayvec::{ArrayString, ArrayVec};
 use ipnet::IpNet;
 use log::{debug, log, warn, Level};

--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -32,7 +32,6 @@ pub mod websocket;
 use self::client::Client;
 use self::server::{Server, MSG_RETAINED_PER_CONNECTION_MAX, MSG_RETAINED_PER_WORKER_MAX};
 use crate::core::zmq::SpecInfo;
-use crate::ListenConfig;
 use ipnet::IpNet;
 use log::info;
 use signal_hook;
@@ -77,6 +76,25 @@ fn make_specs(base: &str, is_server: bool) -> Result<(String, String, String), S
     } else {
         Err("base spec must be ipc or tcp".into())
     }
+}
+
+pub enum ListenSpec {
+    Tcp {
+        addr: std::net::SocketAddr,
+        tls: bool,
+        default_cert: Option<String>,
+    },
+    Local {
+        path: PathBuf,
+        mode: Option<u32>,
+        user: Option<String>,
+        group: Option<String>,
+    },
+}
+
+pub struct ListenConfig {
+    pub spec: ListenSpec,
+    pub stream: bool,
 }
 
 pub struct Config {

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -23,11 +23,13 @@ use crate::connmgr::listener::Listener;
 use crate::connmgr::tls::{IdentityCache, TlsAcceptor, TlsStream};
 use crate::connmgr::zhttppacket;
 use crate::connmgr::zhttpsocket;
+use crate::connmgr::{ListenConfig, ListenSpec};
 use crate::core::arena;
 use crate::core::buffer::TmpBuffer;
 use crate::core::channel;
 use crate::core::event;
 use crate::core::executor::{Executor, Spawner};
+use crate::core::fs::{set_group, set_user};
 use crate::core::list;
 use crate::core::net::{set_socket_opts, NetListener, NetStream, SocketAddr};
 use crate::core::reactor::Reactor;
@@ -40,8 +42,6 @@ use crate::future::{
     AsyncUnixStream, CancellationSender, CancellationToken, Select2, Select3, Select6, Select8,
     Timeout, TlsWaker,
 };
-use crate::{set_group, set_user};
-use crate::{ListenConfig, ListenSpec};
 use arrayvec::{ArrayString, ArrayVec};
 use log::{debug, error, info, warn};
 use mio::net::{TcpListener, TcpStream, UnixListener};

--- a/src/core/defer.rs
+++ b/src/core/defer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2023 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,20 @@
  * limitations under the License.
  */
 
-pub mod arena;
-pub mod buffer;
-pub mod channel;
-pub mod config;
-pub mod defer;
-pub mod event;
-pub mod executor;
-pub mod ffi;
-pub mod fs;
-pub mod http1;
-pub mod jwt;
-pub mod list;
-pub mod log;
-pub mod net;
-pub mod reactor;
-pub mod shuffle;
-pub mod timer;
-pub mod tnetstring;
-pub mod waker;
-pub mod zmq;
+pub struct Defer<T: FnOnce()> {
+    f: Option<T>,
+}
+
+impl<T: FnOnce()> Defer<T> {
+    pub fn new(f: T) -> Self {
+        Self { f: Some(f) }
+    }
+}
+
+impl<T: FnOnce()> Drop for Defer<T> {
+    fn drop(&mut self) {
+        let f = self.f.take().unwrap();
+
+        f();
+    }
+}

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -28,6 +28,13 @@ use std::time::Duration;
 const EVENTS_MAX: usize = 1024;
 const LOCAL_BUDGET: u32 = 10;
 
+pub fn can_move_mio_sockets_between_threads() -> bool {
+    // on unix platforms, mio always uses epoll or kqueue, which support
+    // this. mio makes no guarantee about supporting this on non-unix
+    // platforms
+    cfg!(unix)
+}
+
 pub type Readiness = Option<Interest>;
 
 pub trait ReadinessExt {

--- a/src/core/fs.rs
+++ b/src/core/fs.rs
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::ffi::CString;
+use std::io;
+use std::mem;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::ptr;
+
+fn try_with_increasing_buffer<T, U>(starting_size: usize, f: T) -> Result<U, io::Error>
+where
+    T: Fn(&mut [u8]) -> Result<U, io::Error>,
+{
+    let mut buf = vec![0; starting_size];
+
+    loop {
+        match f(&mut buf) {
+            Ok(v) => return Ok(v),
+            Err(e) if e.raw_os_error() == Some(libc::ERANGE) => buf.resize(buf.len() * 2, 0),
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn get_user_uid(name: &str) -> Result<libc::gid_t, io::Error> {
+    let name = CString::new(name).unwrap();
+
+    try_with_increasing_buffer(1024, |buf| unsafe {
+        let mut pwd = mem::MaybeUninit::uninit();
+        let mut passwd = ptr::null_mut();
+
+        if libc::getpwnam_r(
+            name.as_ptr(),
+            pwd.as_mut_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+            &mut passwd,
+        ) != 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        let passwd = match passwd.as_ref() {
+            Some(r) => r,
+            None => return Err(io::Error::from(io::ErrorKind::NotFound)),
+        };
+
+        Ok(passwd.pw_uid)
+    })
+}
+
+fn get_group_gid(name: &str) -> Result<libc::gid_t, io::Error> {
+    let name = CString::new(name).unwrap();
+
+    try_with_increasing_buffer(1024, |buf| unsafe {
+        let mut grp = mem::MaybeUninit::uninit();
+        let mut group = ptr::null_mut();
+
+        if libc::getgrnam_r(
+            name.as_ptr(),
+            grp.as_mut_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+            &mut group,
+        ) != 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        let group = match group.as_ref() {
+            Some(r) => r,
+            None => return Err(io::Error::from(io::ErrorKind::NotFound)),
+        };
+
+        Ok(group.gr_gid)
+    })
+}
+
+pub fn set_user(path: &Path, user: &str) -> Result<(), io::Error> {
+    let uid = get_user_uid(user)?;
+
+    unsafe {
+        let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        if libc::chown(path.as_ptr(), uid, u32::MAX) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}
+
+pub fn set_group(path: &Path, group: &str) -> Result<(), io::Error> {
+    let gid = get_group_gid(group)?;
+
+    unsafe {
+        let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        if libc::chown(path.as_ptr(), u32::MAX, gid) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
lib.rs ought to be kept lean, with most code living in modules. This PR is a start.