### PR TITLE
core: use rtimer instead of qtimer for everything

### DIFF
--- a/src/core/qzmq/src/qzmqsocket.cpp
+++ b/src/core/qzmq/src/qzmqsocket.cpp
@@ -375,7 +375,7 @@ public:
 	bool canWrite, canRead;
 	QList< QList<QByteArray> > pendingWrites;
 	int pendingWritten;
-	RTimer *updateTimer;
+	std::unique_ptr<RTimer> updateTimer;
 	Connection updateTimerConnection;
 	bool pendingUpdate;
 	int shutdownWaitTime;
@@ -425,16 +425,13 @@ public:
 		connect(sn_read, &QSocketNotifier::activated, this, &Private::sn_read_activated);
 		sn_read->setEnabled(true);
 
-		updateTimer = new RTimer;
+		updateTimer = std::make_unique<RTimer>();
 		updateTimerConnection = updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));
 		updateTimer->setSingleShot(true);
 	}
 
 	~Private()
 	{
-		updateTimerConnection.disconnect();
-		updateTimer->deleteLater();
-
 		set_linger(sock, shutdownWaitTime);
 		wzmq_close(sock);
 

--- a/src/core/qzmq/src/qzmqsocket.cpp
+++ b/src/core/qzmq/src/qzmqsocket.cpp
@@ -28,11 +28,14 @@
 #include <assert.h>
 #include <QStringList>
 #include <QPointer>
-#include <QTimer>
 #include <QSocketNotifier>
 #include <QMutex>
+#include <boost/signals2.hpp>
 #include "rust/bindings.h"
 #include "qzmqcontext.h"
+#include "rtimer.h"
+
+using Connection = boost::signals2::scoped_connection;
 
 using namespace ffi;
 
@@ -372,7 +375,8 @@ public:
 	bool canWrite, canRead;
 	QList< QList<QByteArray> > pendingWrites;
 	int pendingWritten;
-	QTimer *updateTimer;
+	RTimer *updateTimer;
+	Connection updateTimerConnection;
 	bool pendingUpdate;
 	int shutdownWaitTime;
 	bool writeQueueEnabled;
@@ -421,15 +425,14 @@ public:
 		connect(sn_read, &QSocketNotifier::activated, this, &Private::sn_read_activated);
 		sn_read->setEnabled(true);
 
-		updateTimer = new QTimer(this);
-		connect(updateTimer, SIGNAL(timeout()), SLOT(update_timeout()));
+		updateTimer = new RTimer;
+		updateTimerConnection = updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));
 		updateTimer->setSingleShot(true);
 	}
 
 	~Private()
 	{
-		updateTimer->disconnect(this);
-		updateTimer->setParent(0);
+		updateTimerConnection.disconnect();
 		updateTimer->deleteLater();
 
 		set_linger(sock, shutdownWaitTime);
@@ -612,6 +615,13 @@ public:
 		}
 	}
 
+	void update_timeout()
+	{
+		pendingUpdate = false;
+
+		doUpdate();
+	}
+
 public slots:
 	void sn_read_activated()
 	{
@@ -623,13 +633,6 @@ public slots:
 			pendingUpdate = false;
 			updateTimer->stop();
 		}
-
-		doUpdate();
-	}
-
-	void update_timeout()
-	{
-		pendingUpdate = false;
 
 		doUpdate();
 	}

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -27,7 +27,6 @@
 #include <QVector>
 #include <QDateTime>
 #include <QPointer>
-#include <QTimer>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "qzmqsocket.h"
@@ -37,6 +36,7 @@
 #include "httpheaders.h"
 #include "simplehttpserver.h"
 #include "zutil.h"
+#include "rtimer.h"
 
 // make this somewhat big since PUB is lossy
 #define OUT_HWM 200000
@@ -425,10 +425,14 @@ public:
 	QHash<QByteArray, Report*> reports;
 	Counts combinedCounts;
 	Report combinedReport;
-	QTimer *activityTimer;
-	QTimer *reportTimer;
-	QTimer *refreshTimer;
-	QTimer *externalConnectionsMaxTimer;
+	RTimer *activityTimer;
+	RTimer *reportTimer;
+	RTimer *refreshTimer;
+	RTimer *externalConnectionsMaxTimer;
+	Connection activityTimerConnection;
+	Connection reportTimerConnection;
+	Connection refreshTimerConnection;
+	Connection externalConnectionsMaxTimerConnection;
 	Connection promServerConnection;
 
 	Private(StatsManager *_q, int _connectionsMax, int _subscriptionsMax) :
@@ -453,16 +457,16 @@ public:
 		wheel(TimerWheel((_connectionsMax * 2) + _subscriptionsMax)),
 		reportTimer(0)
 	{
-		activityTimer = new QTimer(this);
-		connect(activityTimer, &QTimer::timeout, this, &Private::activity_timeout);
+		activityTimer = new RTimer;
+		activityTimerConnection = activityTimer->timeout.connect(boost::bind(&Private::activity_timeout, this));
 		activityTimer->setSingleShot(true);
 
-		refreshTimer = new QTimer(this);
-		connect(refreshTimer, &QTimer::timeout, this, &Private::refresh_timeout);
+		refreshTimer = new RTimer;
+		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
 		refreshTimer->start(REFRESH_INTERVAL);
 
-		externalConnectionsMaxTimer = new QTimer(this);
-		connect(externalConnectionsMaxTimer, &QTimer::timeout, this, &Private::externalConnectionsMax_timeout);
+		externalConnectionsMaxTimer = new RTimer;
+		externalConnectionsMaxTimerConnection = externalConnectionsMaxTimer->timeout.connect(boost::bind(&Private::externalConnectionsMax_timeout, this));
 		externalConnectionsMaxTimer->start(EXTERNAL_CONNECTIONS_MAX_INTERVAL);
 
 		setupConnectionBuckets();
@@ -483,32 +487,28 @@ public:
 	{
 		if(activityTimer)
 		{
-			activityTimer->disconnect(this);
-			activityTimer->setParent(0);
+			activityTimerConnection.disconnect();
 			activityTimer->deleteLater();
 			activityTimer = 0;
 		}
 
 		if(reportTimer)
 		{
-			reportTimer->disconnect(this);
-			reportTimer->setParent(0);
+			reportTimerConnection.disconnect();
 			reportTimer->deleteLater();
 			reportTimer = 0;
 		}
 
 		if(refreshTimer)
 		{
-			refreshTimer->disconnect(this);
-			refreshTimer->setParent(0);
+			refreshTimerConnection.disconnect();
 			refreshTimer->deleteLater();
 			refreshTimer = 0;
 		}
 
 		if(externalConnectionsMaxTimer)
 		{
-			externalConnectionsMaxTimer->disconnect(this);
-			externalConnectionsMaxTimer->setParent(0);
+			externalConnectionsMaxTimerConnection.disconnect();
 			externalConnectionsMaxTimer->deleteLater();
 			externalConnectionsMaxTimer = 0;
 		}
@@ -636,14 +636,13 @@ public:
 	{
 		if(reportInterval > 0 && !reportTimer)
 		{
-			reportTimer = new QTimer(this);
-			connect(reportTimer, &QTimer::timeout, this, &Private::report_timeout);
+			reportTimer = new RTimer;
+			reportTimerConnection = reportTimer->timeout.connect(boost::bind(&Private::report_timeout, this));
 			reportTimer->start(reportInterval);
 		}
 		else if(reportInterval <= 0 && reportTimer)
 		{
-			reportTimer->disconnect(this);
-			reportTimer->setParent(0);
+			reportTimerConnection.disconnect();
 			reportTimer->deleteLater();
 			reportTimer = 0;
 		}
@@ -1452,7 +1451,7 @@ public:
 		return p;
 	}
 
-private slots:
+private:
 	void activity_timeout()
 	{
 		QHashIterator<QByteArray, quint32> it(routeActivity);
@@ -1562,7 +1561,6 @@ private slots:
 		expireExternalConnectionsMaxes(currentTime);
 	}
 
-private:
 	void prometheus_requestReady()
 	{
 		SimpleHttpRequest *req = prometheusServer->takeNext();

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -101,7 +101,7 @@ public:
 	QHash<ZWebSocket::Rid, ZWebSocket*> clientSocksByRid;
 	QHash<ZWebSocket::Rid, ZWebSocket*> serverSocksByRid;
 	QList<ZWebSocket*> serverPendingSocks;
-	RTimer *refreshTimer;
+	std::unique_ptr<RTimer> refreshTimer;
 	QHash<void*, KeepAliveRegistration*> keepAliveRegistrations;
 	QSet<KeepAliveRegistration*> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
 	int currentSessionRefreshBucket;
@@ -131,7 +131,7 @@ public:
 		doBind(false),
 		currentSessionRefreshBucket(0)
 	{
-		refreshTimer = new RTimer;
+		refreshTimer = std::make_unique<RTimer>();
 		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
 	}
 
@@ -156,9 +156,6 @@ public:
 		assert(clientSocksByRid.isEmpty());
 		assert(serverSocksByRid.isEmpty());
 		assert(keepAliveRegistrations.isEmpty());
-
-		refreshTimerConnection.disconnect();
-		refreshTimer->deleteLater();
 	}
 
 	bool setupClientOut()

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -26,7 +26,6 @@
 #include <QStringList>
 #include <QHash>
 #include <QPointer>
-#include <QTimer>
 #include "qzmqsocket.h"
 #include "qzmqvalve.h"
 #include "tnetstring.h"
@@ -35,6 +34,7 @@
 #include "log.h"
 #include "zutil.h"
 #include "logutil.h"
+#include "rtimer.h"
 
 #define OUT_HWM 100
 #define IN_HWM 100
@@ -101,7 +101,7 @@ public:
 	QHash<ZWebSocket::Rid, ZWebSocket*> clientSocksByRid;
 	QHash<ZWebSocket::Rid, ZWebSocket*> serverSocksByRid;
 	QList<ZWebSocket*> serverPendingSocks;
-	QTimer *refreshTimer;
+	RTimer *refreshTimer;
 	QHash<void*, KeepAliveRegistration*> keepAliveRegistrations;
 	QSet<KeepAliveRegistration*> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
 	int currentSessionRefreshBucket;
@@ -112,6 +112,7 @@ public:
 	Connection clientConnection;
 	Connection serverConnection;
 	Connection serverStreamConnection;
+	Connection refreshTimerConnection;
 
 	Private(ZhttpManager *_q) :
 		QObject(_q),
@@ -130,8 +131,8 @@ public:
 		doBind(false),
 		currentSessionRefreshBucket(0)
 	{
-		refreshTimer = new QTimer(this);
-		connect(refreshTimer, &QTimer::timeout, this, &Private::refresh_timeout);
+		refreshTimer = new RTimer;
+		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
 	}
 
 	~Private()
@@ -156,8 +157,7 @@ public:
 		assert(serverSocksByRid.isEmpty());
 		assert(keepAliveRegistrations.isEmpty());
 
-		refreshTimer->disconnect(this);
-		refreshTimer->setParent(0);
+		refreshTimerConnection.disconnect();
 		refreshTimer->deleteLater();
 	}
 
@@ -804,7 +804,6 @@ public:
 		}
 	}
 
-public slots:
 	void refresh_timeout()
 	{
 		QHash<QByteArray, QList<KeepAliveRegistration*> > clientSessionsBySender[2]; // index corresponds to type

--- a/src/core/zrpcrequest.cpp
+++ b/src/core/zrpcrequest.cpp
@@ -50,7 +50,7 @@ public:
 	QVariant result;
 	ErrorCondition condition;
 	QByteArray conditionString;
-	RTimer *timer;
+	std::unique_ptr<RTimer> timer;
 	Connection timerConnection;
 
 	Private(ZrpcRequest *_q) :
@@ -58,8 +58,7 @@ public:
 		q(_q),
 		manager(0),
 		success(false),
-		condition(ErrorGeneric),
-		timer(0)
+		condition(ErrorGeneric)
 	{
 	}
 
@@ -73,8 +72,7 @@ public:
 		if(timer)
 		{
 			timerConnection.disconnect();
-			timer->deleteLater();
-			timer = 0;
+			timer.reset();
 		}
 
 		if(manager)
@@ -158,7 +156,7 @@ private slots:
 
 		if(manager->timeout() >= 0)
 		{
-			timer = new RTimer;
+			timer = std::make_unique<RTimer>();
 			timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
 			timer->setSingleShot(true);
 			timer->start(manager->timeout());

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1327,8 +1327,8 @@ public:
 	{
 		config = _config;
 
-		// up to 10 timers per connection
-		RTimer::init(config.connectionsMax * 10);
+		// up to 10 timers per connection, plus an extra 100 for misc
+		RTimer::init((config.connectionsMax * 10) + 100);
 
 		publishLimiter->setRate(config.messageRate);
 		publishLimiter->setHwm(config.messageHwm);

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -381,7 +381,7 @@ public:
 
 	void routesChanged()
 	{
-		QList<DomainMap::ZhttpRoute> zhttpRoutes = domainMap->zhttpRoutes();
+		auto zhttpRoutes = domainMap->zhttpRoutes();
 
 		if(zhttpRoutes.count() > ZROUTES_MAX)
 		{

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -58,6 +58,7 @@
 #include "logutil.h"
 
 #define DEFAULT_HWM 1000
+#define ZROUTES_MAX 100
 
 class Engine::Private : public QObject
 {
@@ -206,8 +207,8 @@ public:
 	{
 		config = _config;
 
-		// up to 10 timers per session
-		RTimer::init(config.sessionsMax * 10);
+		// up to 10 timers per session, up to 10 per zroute, plus an extra 100 for misc
+		RTimer::init((config.sessionsMax * 10) + (ZROUTES_MAX * 10) + 100);
 
 		logConfig.fromAddress = config.logFrom;
 		logConfig.userAgent = config.logUserAgent;
@@ -380,8 +381,16 @@ public:
 
 	void routesChanged()
 	{
+		QList<DomainMap::ZhttpRoute> zhttpRoutes = domainMap->zhttpRoutes();
+
+		if(zhttpRoutes.count() > ZROUTES_MAX)
+		{
+			log_warning("too many unique zhttp route targets, limiting to %d", ZROUTES_MAX);
+			zhttpRoutes = zhttpRoutes.mid(0, ZROUTES_MAX);
+		}
+
 		// connect to new zhttp targets, disconnect from old
-		zroutes->setup(domainMap->zhttpRoutes());
+		zroutes->setup(zhttpRoutes);
 	}
 
 	void doProxy(RequestSession *rs, const InspectData *idata = 0)


### PR DESCRIPTION
The max number of allowed RTimers is configured at start time, so this number needs to be adjusted in proxy & handler to cover any new usages. Currently, RTimer usage is per-session, with a limit of 10 per session (an overestimate). This PR adds an extra 100 miscellaneous timers to cover per-thread timers such as the ones in StatsManager, the default ZhttpManager, and various QZmqSockets.

For the proxy, it also adds 10 per "zroute" (a route with a zhttp target), since each zroute contains a ZhttpManager which contains timers. This required introducing a zroutes maximum. Routes with zhttp targets are likely not used much by anyone, and having a lot of them would be even more unusual, so the max is hardcoded rather than configurable.