### PR TITLE
clarify rtimer init values, and init from domainmap thread

### DIFF
--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -94,7 +94,7 @@ public:
 	int outContentType;
 	bool multi;
 	Connection expireTimerConnection;
-	Connection keppAliveTimerConnection;
+	Connection keepAliveTimerConnection;
 
 	Private(ZWebSocket *_q) :
 		QObject(_q),
@@ -131,7 +131,7 @@ public:
 		expireTimer->setSingleShot(true);
 
 		keepAliveTimer = new RTimer;
-		keppAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
+		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
 	}
 
 	~Private()
@@ -157,7 +157,7 @@ public:
 
 		if(keepAliveTimer)
 		{
-			keppAliveTimerConnection.disconnect();
+			keepAliveTimerConnection.disconnect();
 			keepAliveTimer->setParent(0);
 			keepAliveTimer->deleteLater();
 			keepAliveTimer = 0;

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -87,6 +87,12 @@
 #define INSPECT_WORKERS_MAX 10
 #define ACCEPT_WORKERS_MAX 10
 
+// each session can have a bunch of timers:
+// 2 per incoming zhttprequest
+// 2 per outgoing zhttprequest
+// 2 per httpsession
+#define TIMERS_PER_SESSION 10
+
 using namespace VariantUtil;
 
 static QList<PublishItem> parseItems(const QVariantList &vitems, bool *ok = 0, QString *errorMessage = 0)
@@ -1327,8 +1333,8 @@ public:
 	{
 		config = _config;
 
-		// up to 10 timers per connection, plus an extra 100 for misc
-		RTimer::init((config.connectionsMax * 10) + 100);
+		// enough timers for sessions, plus an extra 100 for misc
+		RTimer::init((config.connectionsMax * TIMERS_PER_SESSION) + 100);
 
 		publishLimiter->setRate(config.messageRate);
 		publishLimiter->setHwm(config.messageHwm);

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -37,6 +37,8 @@
 #include "rtimer.h"
 #include "routesfile.h"
 
+#define WORKER_THREAD_TIMERS 1
+
 class DomainMap::Worker : public QObject
 {
 	Q_OBJECT
@@ -735,6 +737,8 @@ public:
 
 	virtual void run()
 	{
+		RTimer::init(WORKER_THREAD_TIMERS);
+
 		worker = new Worker;
 		worker->fileName = fileName;
 		Connection startedConnection = worker->started.connect(boost::bind(&Thread::worker_started, this));
@@ -742,6 +746,8 @@ public:
 		exec();
 		startedConnection.disconnect();
 		delete worker;
+
+		RTimer::deinit();
 	}
 
 public:

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -60,6 +60,17 @@
 #define DEFAULT_HWM 1000
 #define ZROUTES_MAX 100
 
+// each session can have a bunch of timers:
+// 2 per incoming zhttprequest/zwebsocket
+// 2 per outgoing zhttprequest/zwebsocket
+// 1 per wsproxysession
+// 2 per websocketoverhttp
+// 1 per inspect/accept request
+#define TIMERS_PER_SESSION 10
+
+// each zroute has a zhttpmanager, which has up to 8 timers
+#define TIMERS_PER_ZROUTE 10
+
 class Engine::Private : public QObject
 {
 	Q_OBJECT
@@ -207,8 +218,8 @@ public:
 	{
 		config = _config;
 
-		// up to 10 timers per session, up to 10 per zroute, plus an extra 100 for misc
-		RTimer::init((config.sessionsMax * 10) + (ZROUTES_MAX * 10) + 100);
+		// enough timers for sessions and zroutes, plus an extra 100 for misc
+		RTimer::init((config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100);
 
 		logConfig.fromAddress = config.logFrom;
 		logConfig.userAgent = config.logUserAgent;


### PR DESCRIPTION
The number of allowed RTimers must be initialized in each thread (the engine is thread-local). Make it a little more clear how we are coming up with these numbers.