### PR TITLE
fix http disconnect detection

### DIFF
--- a/src/core/http1/server.rs
+++ b/src/core/http1/server.rs
@@ -704,6 +704,26 @@ impl<'a, R: AsyncRead, W: AsyncWrite> ResponseBody<'a, R, W> {
         }
     }
 
+    #[allow(clippy::await_holding_refcell_ref)]
+    pub async fn fill_recv_buffer(&self) -> Error {
+        if let Some(inner) = &*self.inner.borrow() {
+            let r = &mut *inner.r.borrow_mut();
+
+            loop {
+                if let Err(e) = recv_nonzero(&mut r.stream, r.buf).await {
+                    if e.kind() == io::ErrorKind::WriteZero {
+                        // if there's no more space, suspend forever
+                        std::future::pending::<()>().await;
+                    }
+
+                    return e.into();
+                }
+            }
+        } else {
+            Error::Unusable
+        }
+    }
+
     // assumes self.inner is Some
     #[allow(clippy::await_holding_refcell_ref)]
     async fn process(&self) -> Option<Result<usize, Error>> {


### PR DESCRIPTION
Apparently this was lost in recent refactoring. When the state of a connection is sending a body, but we have nothing to send at the moment, we need to be attempting to read from the socket in order to detect disconnects.