### PR TITLE
less verbose info-level logging

### DIFF
--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -37,7 +37,7 @@ use crate::future::{
 };
 use arrayvec::ArrayVec;
 use ipnet::IpNet;
-use log::{debug, error, info, warn};
+use log::{debug, error, warn};
 use mio::unix::SourceFd;
 use slab::Slab;
 use std::cell::Cell;
@@ -1763,7 +1763,7 @@ impl Client {
         let pool = Arc::new(ConnectionPool::new(pool_max));
 
         if !deny.is_empty() {
-            info!("default policy: block outgoing connections to {:?}", deny);
+            debug!("default policy: block outgoing connections to {:?}", deny);
         }
 
         let blocks_avail = Arc::new(Counter::new(blocks_max - (stream_maxconn * 2)));

--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -33,7 +33,7 @@ use self::client::Client;
 use self::server::{Server, MSG_RETAINED_PER_CONNECTION_MAX, MSG_RETAINED_PER_WORKER_MAX};
 use crate::core::zmq::SpecInfo;
 use ipnet::IpNet;
-use log::info;
+use log::{debug, info};
 use signal_hook;
 use signal_hook::consts::TERM_SIGNALS;
 use signal_hook::iterator::Signals;
@@ -173,9 +173,9 @@ impl App {
 
                 for spec in config.zclient_req.iter() {
                     if config.zclient_connect {
-                        info!("zhttp client connect {}", spec);
+                        debug!("zhttp client connect {}", spec);
                     } else {
-                        info!("zhttp client bind {}", spec);
+                        debug!("zhttp client bind {}", spec);
                     }
 
                     specs.push(SpecInfo {
@@ -199,12 +199,12 @@ impl App {
                     let (out_spec, out_stream_spec, in_spec) = make_specs(spec, false)?;
 
                     if config.zclient_connect {
-                        info!(
+                        debug!(
                             "zhttp client connect {} {} {}",
                             out_spec, out_stream_spec, in_spec
                         );
                     } else {
-                        info!(
+                        debug!(
                             "zhttp client bind {} {} {}",
                             out_spec, out_stream_spec, in_spec
                         );
@@ -275,9 +275,9 @@ impl App {
 
                 for spec in config.zserver_req.iter() {
                     if config.zserver_connect {
-                        info!("zhttp server connect {}", spec);
+                        debug!("zhttp server connect {}", spec);
                     } else {
-                        info!("zhttp server bind {}", spec);
+                        debug!("zhttp server bind {}", spec);
                     }
 
                     specs.push(SpecInfo {
@@ -322,12 +322,12 @@ impl App {
                     let (in_spec, in_stream_spec, out_spec) = make_specs(spec, true)?;
 
                     if config.zserver_connect {
-                        info!(
+                        debug!(
                             "zhttp server connect {} {} {}",
                             in_spec, in_stream_spec, out_spec
                         );
                     } else {
-                        info!(
+                        debug!(
                             "zhttp server bind {} {} {}",
                             in_spec, in_stream_spec, out_spec
                         );
@@ -407,7 +407,7 @@ impl App {
 }
 
 pub fn run(config: &Config) -> Result<(), Box<dyn Error>> {
-    info!("starting...");
+    debug!("starting...");
 
     {
         let a = match App::new(config) {
@@ -424,7 +424,7 @@ pub fn run(config: &Config) -> Result<(), Box<dyn Error>> {
         info!("stopping...");
     }
 
-    info!("stopped");
+    debug!("stopped");
 
     Ok(())
 }

--- a/src/core/log.rs
+++ b/src/core/log.rs
@@ -98,15 +98,20 @@ impl Log for SimpleLogger {
             log::Level::Trace => "TRACE",
         };
 
-        writeln!(
-            &mut output,
-            "[{}] {} [{}] {}",
-            lname,
-            ts,
-            record.target(),
-            record.args()
-        )
-        .expect("failed to write log output");
+        if record.level() <= log::Level::Info {
+            writeln!(&mut output, "[{}] {} {}", lname, ts, record.args())
+                .expect("failed to write log output");
+        } else {
+            writeln!(
+                &mut output,
+                "[{}] {} [{}] {}",
+                lname,
+                ts,
+                record.target(),
+                record.args()
+            )
+            .expect("failed to write log output");
+        }
     }
 
     fn flush(&self) {}

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -231,7 +231,7 @@ public:
 			}
 		}
 
-		log_info("starting...");
+		log_debug("starting...");
 
 		QString configFile = args.configFile;
 		if(configFile.isEmpty())
@@ -430,7 +430,7 @@ private:
 		delete engine;
 		engine = 0;
 
-		log_info("stopped");
+		log_debug("stopped");
 		q->quit(0);
 	}
 };

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1356,8 +1356,8 @@ public:
 		zhttpOut->setClientOutStreamSpecs(config.clientOutStreamSpecs);
 		zhttpOut->setClientInSpecs(config.clientInSpecs);
 
-		log_info("zhttp in stream: %s", qPrintable(config.serverInStreamSpecs.join(", ")));
-		log_info("zhttp out: %s", qPrintable(config.serverOutSpecs.join(", ")));
+		log_debug("zhttp in stream: %s", qPrintable(config.serverInStreamSpecs.join(", ")));
+		log_debug("zhttp out: %s", qPrintable(config.serverOutSpecs.join(", ")));
 
 		if(!config.inspectSpecs.isEmpty())
 		{
@@ -1372,7 +1372,7 @@ public:
 				return false;
 			}
 
-			log_info("inspect server: %s", qPrintable(config.inspectSpecs.join(", ")));
+			log_debug("inspect server: %s", qPrintable(config.inspectSpecs.join(", ")));
 		}
 
 		if(!config.acceptSpecs.isEmpty())
@@ -1388,7 +1388,7 @@ public:
 				return false;
 			}
 
-			log_info("accept server: %s", qPrintable(config.acceptSpecs.join(", ")));
+			log_debug("accept server: %s", qPrintable(config.acceptSpecs.join(", ")));
 		}
 
 		if(!config.stateSpec.isEmpty())
@@ -1404,7 +1404,7 @@ public:
 				return false;
 			}
 
-			log_info("state client: %s", qPrintable(config.stateSpec));
+			log_debug("state client: %s", qPrintable(config.stateSpec));
 		}
 
 		if(!config.commandSpec.isEmpty())
@@ -1420,7 +1420,7 @@ public:
 				return false;
 			}
 
-			log_info("control server: %s", qPrintable(config.commandSpec));
+			log_debug("control server: %s", qPrintable(config.commandSpec));
 		}
 
 		if(!config.pushInSpec.isEmpty())
@@ -1438,7 +1438,7 @@ public:
 			inPullValve = new QZmq::Valve(inPullSock, this);
 			pullConnection = inPullValve->readyRead.connect(boost::bind(&Private::inPull_readyRead, this, boost::placeholders::_1));
 
-			log_info("in pull: %s", qPrintable(config.pushInSpec));
+			log_debug("in pull: %s", qPrintable(config.pushInSpec));
 		}
 
 		if(!config.pushInSubSpecs.isEmpty())
@@ -1465,7 +1465,7 @@ public:
 			inSubValve = new QZmq::Valve(inSubSock, this);
 			inSubValveConnection = inSubValve->readyRead.connect(boost::bind(&Private::inSub_readyRead, this, boost::placeholders::_1));
 
-			log_info("in sub: %s", qPrintable(config.pushInSubSpecs.join(", ")));
+			log_debug("in sub: %s", qPrintable(config.pushInSubSpecs.join(", ")));
 		}
 
 		if(!config.retryOutSpecs.isEmpty())
@@ -1486,7 +1486,7 @@ public:
 				}
 			}
 
-			log_info("retry: %s", qPrintable(config.retryOutSpecs.join(", ")));
+			log_debug("retry: %s", qPrintable(config.retryOutSpecs.join(", ")));
 		}
 
 		if(!config.wsControlInitSpecs.isEmpty() && !config.wsControlStreamSpecs.isEmpty())
@@ -1507,7 +1507,7 @@ public:
 			wsControlInitValve = new QZmq::Valve(wsControlInitSock, this);
 			controlInitValveConnection = wsControlInitValve->readyRead.connect(boost::bind(&Private::wsControlInit_readyRead, this, boost::placeholders::_1));
 
-			log_info("ws control init: %s", qPrintable(config.wsControlInitSpecs.join(", ")));
+			log_debug("ws control init: %s", qPrintable(config.wsControlInitSpecs.join(", ")));
 
 			wsControlStreamSock = new QZmq::Socket(QZmq::Socket::Router, this);
 			wsControlStreamSock->setIdentity(config.instanceId);
@@ -1528,7 +1528,7 @@ public:
 			wsControlStreamValve = new QZmq::Valve(wsControlStreamSock, this);
 			controlStreamValveConnection = wsControlStreamValve->readyRead.connect(boost::bind(&Private::wsControlStream_readyRead, this, boost::placeholders::_1));
 
-			log_info("ws control stream: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
+			log_debug("ws control stream: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
 		}
 
 		stats = new StatsManager(config.connectionsMax, config.connectionsMax * config.connectionSubscriptionMax, this);
@@ -1562,7 +1562,7 @@ public:
 				return false;
 			}
 
-			log_info("stats: %s", qPrintable(config.statsSpec));
+			log_debug("stats: %s", qPrintable(config.statsSpec));
 		}
 
 		if(!config.prometheusPort.isEmpty())
@@ -1596,7 +1596,7 @@ public:
 			proxyStatsValve = new QZmq::Valve(proxyStatsSock, this);
 			proxyStatConnection = proxyStatsValve->readyRead.connect(boost::bind(&Private::proxyStats_readyRead, this, boost::placeholders::_1));
 
-			log_info("proxy stats: %s", qPrintable(config.proxyStatsSpecs.join(", ")));
+			log_debug("proxy stats: %s", qPrintable(config.proxyStatsSpecs.join(", ")));
 		}
 
 		if(!config.proxyCommandSpec.isEmpty())
@@ -1611,7 +1611,7 @@ public:
 				return false;
 			}
 
-			log_info("proxy control client: %s", qPrintable(config.proxyCommandSpec));
+			log_debug("proxy control client: %s", qPrintable(config.proxyCommandSpec));
 		}
 
 		if(config.pushInHttpPort != -1)
@@ -1761,7 +1761,7 @@ private:
 		if(items > -1)
 			msg += QString(" items=%1").arg(items);
 
-		log_info("%s", qPrintable(msg));
+		log_debug("%s", qPrintable(msg));
 	}
 
 	void publishSend(QObject *target, const PublishItem &item, const QList<QByteArray> &exposeHeaders)

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -398,7 +398,7 @@ public:
 			}
 		}
 
-		log_info("starting...");
+		log_debug("starting...");
 
 		QString configFile = args.configFile;
 		if(configFile.isEmpty())
@@ -694,7 +694,7 @@ private slots:
 
 		threads.clear();
 
-		log_info("stopped");
+		log_debug("stopped");
 		q->quit(0);
 	}
 };

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -311,8 +311,6 @@ public:
 			}
 		}
 
-		log_info("starting...");
-
 		QStringList configFileList;
 
 		if(!args.configFile.isEmpty())
@@ -363,6 +361,11 @@ public:
 				return;
 			}
 		}
+
+		int defaultArgsLevel = args.logLevels.value("", LOG_LEVEL_INFO);
+		log_setOutputLevel(args.logLevels.value("runner", defaultArgsLevel));
+
+		log_debug("starting...");
 
 		if(args.configFile.isEmpty())
 			log_info("using config: %s", qPrintable(configFile));
@@ -728,7 +731,7 @@ private:
 	{
 		if(services.isEmpty())
 		{
-			log_info("stopped");
+			log_debug("stopped");
 			doQuit();
 		}
 	}
@@ -751,7 +754,7 @@ private:
 		}
 
 		if(allStarted)
-			log_info("started");
+			log_debug("started");
 	}
 
 	void service_stopped(Service *s)
@@ -811,6 +814,9 @@ private:
 	{
 		if(!stopping)
 		{
+			// let a potential "^C" get overwritten
+			printf("\r");
+
 			stopping = true;
 			ProcessQuit::reset(); // allow user to quit again
 

--- a/src/runner/service.rs
+++ b/src/runner/service.rs
@@ -110,6 +110,9 @@ pub fn start_services(mut settings: Settings) {
                 break;
             }
             Ok(Err(ServiceError::TermSignal(error_message))) => {
+                // let a potential "^C" get overwritten
+                print!("\r");
+
                 error!("signal received: {}", error_message);
                 break;
             }


### PR DESCRIPTION
Pushpin logs a bunch of lines at info-level on startup that are internal and/or typically not interesting. To make the UX a little cleaner, this PR changes the levels on these lines to debug-level. Additionally, handler logging when publishing is reduced from 2 lines to 1 line, connmgr logging doesn't include the rust module (unless level >= debug), and `^C` is removed from output on termination.

Resulting start/stop:

```
% ./pushpin                                     
using config: "/Users/jkarneges/dev/pushpin/config/pushpin.conf"
[INFO] 2024-07-01 14:47:26.898 [connmgr] listening on 0.0.0.0:7999
[INFO] 2024-07-01 14:47:27.008 [handler] http control server: 127.0.0.1:5561
[INFO] 2024-07-01 14:47:27.009 [handler] started
[INFO] 2024-07-01 14:47:27.011 [proxy] routes loaded with 7 entries
[INFO] 2024-07-01 14:47:27.018 [proxy] started
[INFO] 2024-07-01 14:47:27.032 [connmgr] started
signal received: termination signal received
[INFO] 2024-07-01 14:47:28.182 [proxy] stopping...
[INFO] 2024-07-01 14:47:28.182 [handler] stopping...
[INFO] 2024-07-01 14:47:28.181 [connmgr] stopping...
```