### PR TITLE
call add_to_buffer when bytes needed and count recv of 0 as error

### DIFF
--- a/src/core/http1/util.rs
+++ b/src/core/http1/util.rs
@@ -140,6 +140,7 @@ pub enum SendStatus<T, P, E> {
 }
 
 pub enum RecvStatus<T, C> {
+    NeedBytes(T),
     Read(T, usize),
     Complete(C, usize),
 }


### PR DESCRIPTION
Notably, this fixes a busyloop when a websocket rejection body exceeds the buffer size, returning an error instead.

For clarity, `written` is renamed to `size` when handling `try_recv()` return values. Unlike the lower level methods that return multiple byte counts, `try_recv()` only returns one count (bytes written to the output buffer), and in that case `size` is a more natural name to use.

Tested locally:

```
[DEBUG] 2024-07-16 16:30:45.604 [connmgr] [pushpin::connmgr::connection] client-conn 0-0-277d6959-6930-486d-8b76-21871ad66fb3: process error: WebSocketRejectionTooLarge(8192)
```