### PR TITLE
avoid extra spaces in cargo command output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,20 @@
-ifdef RELEASE
-cargo_flags = --offline --locked --release
-else
 cargo_flags =
+ifdef RELEASE
+cargo_flags += --offline --locked --release
 endif
 
+cargo_toolchain =
 ifdef TOOLCHAIN
-CARGO_TOOLCHAIN=+$(TOOLCHAIN)
-else 
-CARGO_TOOLCHAIN = 
+cargo_toolchain += +$(TOOLCHAIN)
 endif
 
 all: postbuild
 
 build: FORCE
-	cargo $(CARGO_TOOLCHAIN) build $(cargo_flags)
+	cargo$(cargo_toolchain) build$(cargo_flags)
 
 cargo-test: FORCE
-	cargo $(CARGO_TOOLCHAIN) test $(cargo_flags) --all-features
+	cargo$(cargo_toolchain) test$(cargo_flags) --all-features
 
 cargo-clean: FORCE
 	cargo clean


### PR DESCRIPTION
This removes the extra space when vars are empty, e.g. empty `TOOLCHAIN` producing `cargo  build`. It works by relying on the args variables to bring along their own prepended space when non-empty. The `+=` operator is used to prepend a space. Also use lowercase name for consistency.