### PR TITLE
httpsession: prep work for supporting fetches other than next

### DIFF
--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -289,21 +289,27 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 	int nextLinkTimeout = -1;
 	foreach(const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link"))
 	{
-		if(params.count() >= 2 && params.get("rel") == "next")
-		{
-			QByteArray linkParam = params[0].first;
-			if(linkParam.length() <= 2 || linkParam[0] != '<' || linkParam[linkParam.length() - 1] != '>')
-			{
-				setError(ok, errorMessage, "failed to parse Grip-Link value");
-				return Instruct();
-			}
+		if(params.count() < 2)
+			continue;
 
-			nextLink = QUrl::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
-			if(!nextLink.isValid())
-			{
-				setError(ok, errorMessage, "Grip-Link contains invalid link");
-				return Instruct();
-			}
+		QByteArray linkParam = params[0].first;
+		if(linkParam.length() <= 2 || linkParam[0] != '<' || linkParam[linkParam.length() - 1] != '>')
+		{
+			setError(ok, errorMessage, "failed to parse Grip-Link value");
+			return Instruct();
+		}
+
+		QUrl link = QUrl::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
+		if(!link.isValid())
+		{
+			setError(ok, errorMessage, "Grip-Link contains invalid link");
+			return Instruct();
+		}
+
+		QByteArray rel = params.get("rel");
+		if(rel == "next")
+		{
+			nextLink = link;
 
 			if(params.contains("timeout"))
 			{


### PR DESCRIPTION
This reworks the next link handling in `HttpSession` to make it reusable for other things in the future. It should not introduce any change in behavior. Some `if(state == Proxying)` conditionals are added in places where `state` is known/assumed to already be of that value.