### PR TITLE
add support for gone links

### DIFF
--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -287,6 +287,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 	QUrl nextLink;
 	int nextLinkTimeout = -1;
+	QUrl goneLink;
 	foreach(const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link"))
 	{
 		if(params.count() < 2)
@@ -331,6 +332,10 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			{
 				nextLinkTimeout = DEFAULT_NEXTLINK_TIMEOUT;
 			}
+		}
+		else if(rel == "gone")
+		{
+			goneLink = link;
 		}
 	}
 
@@ -806,6 +811,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 	i.response = newResponse;
 	i.nextLink = nextLink;
 	i.nextLinkTimeout = nextLinkTimeout;
+	i.goneLink = goneLink;
 
 	if(ok)
 		*ok = true;

--- a/src/handler/instruct.h
+++ b/src/handler/instruct.h
@@ -67,6 +67,7 @@ public:
 	HttpResponseData response;
 	QUrl nextLink;
 	int nextLinkTimeout;
+	QUrl goneLink;
 
 	Instruct() :
 		holdMode(NoHold),

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -177,7 +177,7 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
 
 		requestData->headers.removeAll("Grip-Feature");
 		requestData->headers += HttpHeader("Grip-Feature",
-			"status, session, link:next, filter:skip-self, filter:skip-users, filter:require-sub, filter:build-id, filter:var-subst");
+			"status, session, link:next, link:gone, filter:skip-self, filter:skip-users, filter:require-sub, filter:build-id, filter:var-subst");
 
 		if(!idata.sid.isEmpty())
 		{


### PR DESCRIPTION
This introduces a way to send notifications when HTTP subscribers disconnect. Backends can supply a `gone` link in a response header:

```
Grip-Hold: stream
Grip-Channel: foo
Grip-Link: </disconnect/1234>; rel=gone
```

When the client disconnects for any reason, Pushpin will make a `POST` request to the specified URL with an empty body. It will expect an empty response. The notification is best-effort: if the request fails for any reason, it will not be retried. It is also not guaranteed to occur, for example if Pushpin is shut down while clients are connected.