### PR TITLE
channel: add wait_sendable

### DIFF
--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -31,9 +31,7 @@ use crate::core::executor::{Executor, Spawner};
 use crate::core::list;
 use crate::core::reactor::Reactor;
 use crate::core::select::{select_2, select_5, select_6, select_option, Select2, Select5, Select6};
-use crate::core::task::{
-    self, event_wait, yield_to_local_events, CancellationSender, CancellationToken,
-};
+use crate::core::task::{self, yield_to_local_events, CancellationSender, CancellationToken};
 use crate::core::time::Timeout;
 use crate::core::tnetstring;
 use crate::core::zmq::{MultipartHeader, SpecInfo};
@@ -1641,11 +1639,7 @@ impl Worker {
         let next_keep_alive_timeout = Timeout::new(next_keep_alive_time);
         let mut next_keep_alive_index = 0;
 
-        let sender_registration = reactor
-            .register_custom_local(sender.get_write_registration(), mio::Interest::WRITABLE)
-            .unwrap();
-
-        sender_registration.set_readiness(Some(mio::Interest::WRITABLE));
+        let sender = AsyncLocalSender::new(sender);
 
         'main: loop {
             while conns.batch_is_empty() {
@@ -1682,38 +1676,21 @@ impl Worker {
                 next_keep_alive_timeout.set_deadline(next_keep_alive_time);
             }
 
-            match select_2(
-                stop.recv(),
-                pin!(event_wait(&sender_registration, mio::Interest::WRITABLE)),
-            )
-            .await
-            {
+            let send = match select_2(stop.recv(), sender.wait_sendable()).await {
                 Select2::R1(_) => break,
-                Select2::R2(_) => {}
-            }
+                Select2::R2(send) => send,
+            };
 
-            if !sender.check_send() {
-                // if check_send returns false, we'll be on the waitlist for a notification
-                sender_registration.clear_readiness(mio::Interest::WRITABLE);
-                continue;
-            }
+            // there could be no message if items removed or message construction failed
+            if let Some((count, msg)) = conns.next_batch_message(&instance_id, BatchType::KeepAlive)
+            {
+                debug!(
+                    "client-worker {}: sending keep alives for {} sessions",
+                    id, count
+                );
 
-            // if check_send returns true, we are guaranteed to be able to send
-
-            match conns.next_batch_message(&instance_id, BatchType::KeepAlive) {
-                Some((count, msg)) => {
-                    debug!(
-                        "client-worker {}: sending keep alives for {} sessions",
-                        id, count
-                    );
-
-                    if let Err(e) = sender.try_send(msg) {
-                        error!("zhttp write error: {}", e);
-                    }
-                }
-                None => {
-                    // this could happen if items removed or message construction failed
-                    sender.cancel();
+                if let Err(e) = send.try_send(msg) {
+                    error!("zhttp write error: {}", e);
                 }
             }
 


### PR DESCRIPTION
There are some places where instead of asynchronously sending a value to a channel (`sender.send(value).await`), we asynchronously wait for the ability to send to a channel and then immediately send the value after:

```rust
sender.check_send().await;

// immediate send without await
sender.try_send(value);
```

This API allows the opportunity to defer certain processing until the moment of the actual send. The problem is its usage is a bit fiddly and error-prone. Notably, if the code waiting for the ability to send decides to give up waiting, or if it finishes waiting but then decides not to send anything, it needs to explicitly cancel the operation (`sender.cancel()`). Failing to cancel can lead to broken coordination when there are multiple senders waiting to send.

This PR introduces a simpler API:

```rust
let send: SendOnce = sender.wait_sendable().await;
send.try_send(value);
```

If the future returned by `wait_sendable()` is dropped before completion, the operation is automatically canceled. If it completes, it produces a `SendOnce` struct which can be used to send up to one value via its `try_send()` method. If the `SendOnce` is dropped without sending anything, the operation is automatically canceled. Basically it makes the API hard to misuse.

Note that the method is named `try_send()` and not `send()` because the channel could still become full after obtaining the `SendOnce`, if another sender were to send to the channel.

This PR also uses the new API in a couple of places.