### PR TITLE
connmgr: don't send keep-alives during handoff

### DIFF
--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -223,42 +223,48 @@ impl Batch {
         self.nodes.remove(key.nkey);
     }
 
-    fn take_group<'a, 'b: 'a, F>(&'a mut self, get_ids: F) -> Option<BatchGroup>
+    fn take_group<'a, 'b: 'a, F>(&'a mut self, get_id: F) -> Option<BatchGroup>
     where
-        F: Fn(usize) -> (&'b [u8], u32),
+        F: Fn(usize) -> Option<(&'b [u8], u32)>,
     {
-        // find the next addr with items
-        while self.addr_index < self.addrs.len() && self.addrs[self.addr_index].1.is_empty() {
-            self.addr_index += 1;
-        }
-
-        // if all are empty, we're done
-        if self.addr_index == self.addrs.len() {
-            assert!(self.nodes.is_empty());
-            return None;
-        }
-
-        let (addr, keys) = &mut self.addrs[self.addr_index];
-
-        self.last_group_ckeys.clear();
-
+        let addrs = &mut self.addrs;
         let mut ids = self.group_ids.get_as_new();
 
-        // get ids/seqs
-        while ids.len() < zhttppacket::IDS_MAX {
-            let nkey = match keys.pop_front(&mut self.nodes) {
-                Some(nkey) => nkey,
-                None => break,
-            };
+        while ids.is_empty() {
+            // find the next addr with items
+            while self.addr_index < addrs.len() && addrs[self.addr_index].1.is_empty() {
+                self.addr_index += 1;
+            }
 
-            let ckey = self.nodes[nkey].value;
-            self.nodes.remove(nkey);
+            // if all are empty, we're done
+            if self.addr_index == addrs.len() {
+                assert!(self.nodes.is_empty());
+                return None;
+            }
 
-            let (id, seq) = get_ids(ckey);
+            let keys = &mut addrs[self.addr_index].1;
 
-            self.last_group_ckeys.push(ckey);
-            ids.push(zhttppacket::Id { id, seq: Some(seq) });
+            self.last_group_ckeys.clear();
+            ids.clear();
+
+            // get ids/seqs
+            while ids.len() < zhttppacket::IDS_MAX {
+                let nkey = match keys.pop_front(&mut self.nodes) {
+                    Some(nkey) => nkey,
+                    None => break,
+                };
+
+                let ckey = self.nodes[nkey].value;
+                self.nodes.remove(nkey);
+
+                if let Some((id, seq)) = get_id(ckey) {
+                    self.last_group_ckeys.push(ckey);
+                    ids.push(zhttppacket::Id { id, seq: Some(seq) });
+                }
+            }
         }
+
+        let addr = &addrs[self.addr_index].0;
 
         Some(BatchGroup { addr, ids })
     }
@@ -547,19 +553,27 @@ impl Connections {
         let batch = &mut items.batch;
 
         while !batch.is_empty() {
-            let group = batch
-                .take_group(|ckey| {
+            let group = {
+                let group = batch.take_group(|ckey| {
                     let ci = &nodes[ckey].value;
                     let cshared = ci.shared.as_ref().unwrap().get();
+
+                    // addr could have been removed after adding to the batch
+                    cshared.to_addr().get()?;
 
                     // item is guaranteed to have an id. only items with an
                     // id are added to a batch, and if an item's id is
                     // removed then the item is removed from the batch
                     let id = ci.id.as_ref().unwrap();
 
-                    (&id.1, cshared.out_seq())
-                })
-                .unwrap();
+                    Some((&id.1, cshared.out_seq()))
+                });
+
+                match group {
+                    Some(group) => group,
+                    None => continue,
+                }
+            };
 
             let count = group.ids().len();
 
@@ -1642,48 +1656,51 @@ impl Worker {
         let sender = AsyncLocalSender::new(sender);
 
         'main: loop {
-            while conns.batch_is_empty() {
-                // wait for next keep alive time
-                match select_2(stop.recv(), next_keep_alive_timeout.elapsed()).await {
-                    Select2::R1(_) => break 'main,
-                    Select2::R2(_) => {}
-                }
-
-                for _ in 0..conns.batch_capacity() {
-                    if next_keep_alive_index >= conns.items_capacity() {
-                        break;
-                    }
-
-                    let key = next_keep_alive_index;
-
-                    next_keep_alive_index += 1;
-
-                    if conns.can_stream(key) {
-                        // ignore errors
-                        let _ = conns.batch_add(key);
-                    }
-                }
-
-                keep_alive_count += 1;
-
-                if keep_alive_count >= KEEP_ALIVE_BATCHES {
-                    keep_alive_count = 0;
-                    next_keep_alive_index = 0;
-                }
-
-                // keep steady pace
-                next_keep_alive_time += KEEP_ALIVE_INTERVAL;
-                next_keep_alive_timeout.set_deadline(next_keep_alive_time);
+            // wait for next keep alive time
+            match select_2(stop.recv(), next_keep_alive_timeout.elapsed()).await {
+                Select2::R1(_) => break,
+                Select2::R2(_) => {}
             }
 
-            let send = match select_2(stop.recv(), sender.wait_sendable()).await {
-                Select2::R1(_) => break,
-                Select2::R2(send) => send,
-            };
+            for _ in 0..conns.batch_capacity() {
+                if next_keep_alive_index >= conns.items_capacity() {
+                    break;
+                }
 
-            // there could be no message if items removed or message construction failed
-            if let Some((count, msg)) = conns.next_batch_message(&instance_id, BatchType::KeepAlive)
-            {
+                let key = next_keep_alive_index;
+
+                next_keep_alive_index += 1;
+
+                if conns.can_stream(key) {
+                    // ignore errors
+                    let _ = conns.batch_add(key);
+                }
+            }
+
+            keep_alive_count += 1;
+
+            if keep_alive_count >= KEEP_ALIVE_BATCHES {
+                keep_alive_count = 0;
+                next_keep_alive_index = 0;
+            }
+
+            // keep steady pace
+            next_keep_alive_time += KEEP_ALIVE_INTERVAL;
+            next_keep_alive_timeout.set_deadline(next_keep_alive_time);
+
+            while !conns.batch_is_empty() {
+                let send = match select_2(stop.recv(), sender.wait_sendable()).await {
+                    Select2::R1(_) => break 'main,
+                    Select2::R2(send) => send,
+                };
+
+                // there could be no message if items removed or message construction failed
+                let (count, msg) =
+                    match conns.next_batch_message(&instance_id, BatchType::KeepAlive) {
+                        Some(ret) => ret,
+                        None => continue,
+                    };
+
                 debug!(
                     "client-worker {}: sending keep alives for {} sessions",
                     id, count
@@ -1694,14 +1711,12 @@ impl Worker {
                 }
             }
 
-            if conns.batch_is_empty() {
-                let now = reactor.now();
+            let now = reactor.now();
 
-                if now >= next_keep_alive_time + KEEP_ALIVE_INTERVAL {
-                    // got really behind somehow. just skip ahead
-                    next_keep_alive_time = now + KEEP_ALIVE_INTERVAL;
-                    next_keep_alive_timeout.set_deadline(next_keep_alive_time);
-                }
+            if now >= next_keep_alive_time + KEEP_ALIVE_INTERVAL {
+                // got really behind somehow. just skip ahead
+                next_keep_alive_time = now + KEEP_ALIVE_INTERVAL;
+                next_keep_alive_timeout.set_deadline(next_keep_alive_time);
             }
         }
 
@@ -2644,7 +2659,7 @@ pub mod tests {
         let ids = ["id-1", "id-2", "id-3"];
 
         let group = batch
-            .take_group(|ckey| (ids[ckey - 1].as_bytes(), 0))
+            .take_group(|ckey| Some((ids[ckey - 1].as_bytes(), 0)))
             .unwrap();
         assert_eq!(group.ids().len(), 2);
         assert_eq!(group.ids()[0].id, b"id-1");
@@ -2657,7 +2672,7 @@ pub mod tests {
         assert_eq!(batch.last_group_ckeys(), &[1, 2]);
 
         let group = batch
-            .take_group(|ckey| (ids[ckey - 1].as_bytes(), 0))
+            .take_group(|ckey| Some((ids[ckey - 1].as_bytes(), 0)))
             .unwrap();
         assert_eq!(group.ids().len(), 1);
         assert_eq!(group.ids()[0].id, b"id-3");
@@ -2668,7 +2683,7 @@ pub mod tests {
         assert_eq!(batch.last_group_ckeys(), &[3]);
 
         assert!(batch
-            .take_group(|ckey| { (ids[ckey - 1].as_bytes(), 0) })
+            .take_group(|ckey| Some((ids[ckey - 1].as_bytes(), 0)))
             .is_none());
         assert_eq!(batch.last_group_ckeys(), &[3]);
 
@@ -2681,7 +2696,7 @@ pub mod tests {
         assert_eq!(batch.len(), 1);
 
         let group = batch
-            .take_group(|ckey| (ids[ckey - 1].as_bytes(), 0))
+            .take_group(|ckey| Some((ids[ckey - 1].as_bytes(), 0)))
             .unwrap();
         assert_eq!(group.ids().len(), 1);
         assert_eq!(group.ids()[0].id, b"id-2");
@@ -2694,12 +2709,31 @@ pub mod tests {
         assert_eq!(batch.len(), 1);
         assert!(!batch.is_empty());
         let group = batch
-            .take_group(|ckey| (ids[ckey - 1].as_bytes(), 0))
+            .take_group(|ckey| Some((ids[ckey - 1].as_bytes(), 0)))
             .unwrap();
         assert_eq!(group.ids().len(), 1);
         assert_eq!(group.ids()[0].id, b"id-3");
         assert_eq!(group.ids()[0].seq, Some(0));
         assert_eq!(group.addr(), b"addr-a");
+        drop(group);
+        assert_eq!(batch.is_empty(), true);
+
+        assert!(batch.add(b"addr-a", 1).is_ok());
+        assert!(batch.add(b"addr-b", 2).is_ok());
+        assert!(batch.add(b"addr-b", 3).is_ok());
+        let group = batch
+            .take_group(|ckey| {
+                if ckey < 3 {
+                    None
+                } else {
+                    Some((ids[ckey - 1].as_bytes(), 0))
+                }
+            })
+            .unwrap();
+        assert_eq!(group.ids().len(), 1);
+        assert_eq!(group.ids()[0].id, b"id-3");
+        assert_eq!(group.ids()[0].seq, Some(0));
+        assert_eq!(group.addr(), b"addr-b");
         drop(group);
         assert_eq!(batch.is_empty(), true);
     }

--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -1888,6 +1888,9 @@ where
     // check_send just finished, so this should succeed
     zsess_out.try_send_msg(zreq)?;
 
+    // unset to_addr so we don't send keep-alives
+    zsess_in.shared.set_to_addr(None);
+
     // pause until we get a msg
     zsess_in.peek_msg().await?;
 
@@ -1916,6 +1919,9 @@ where
 
     // check_send just finished, so this should succeed
     zsess_out.try_send_msg(zresp)?;
+
+    // unset to_addr so we don't send keep-alives
+    zsess_in.shared.set_to_addr(None);
 
     // pause until we get a msg
     zsess_in.peek_msg().await?;


### PR DESCRIPTION
Whenever proxy or handler want to hand off a session, they send a `handoff-start` message to connmgr, and connmgr replies with `handoff-proceed`. After this, connmgr is supposed to stay silent until it receives another message, at which point it assumes whoever sent the message is the new owner of the session and communication can resume as normal. However, in rare cases connmgr might send keep-alive messages to the old owner while it is waiting to hear from the new owner, leading to broken sessions and "received message out of sequence" warnings. This PR fixes connmgr to not send keep-alives during handoff.

There are two fixes:

1. In `accept_handoff()`, for both server and client mode, unset the `to_addr` (i.e. the known peer address) of the session. Keep-alives are only sent for sessions with a known peer address. This is an easy one line fix per mode.
2. In `keep_alives_task()`, for both server and client mode, account for the possibility that `to_addr` might get unset for sessions during batch preparation and processing. This is a bit more complicated, see below.

The `keep_alives_task()` tries to address keep-alive messages to multiple sessions at once, to reduce the number of messages sent. It does this by processing sessions in batches. It first decides which sessions it will be sending keep-alives for, and then it proceeds to generate and send the minimal number of messages with optimal packing. Notably, it waits for message sendability before generating and sending each message, and we need to tolerate `to_addr` getting unset for any sessions during this waiting. We do this by making it possible for `Batch::take_group()` to skip sessions via its `get_id` closure argument and updating the closure provided by `next_batch_message()` to skip sessions that don't have a `to_addr`.

The `Batch` type, including tests, is redundantly implemented twice (once in `connmgr::client` and once in `connmgr::server`). This PR updates both copies of the code. In the future we should consider sharing a single implementation of `Batch` to avoid having to make redundant updates.