### PR TITLE
batch: organize peers by whether router mode should be used

### DIFF
--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -381,7 +381,7 @@ impl Connections {
             None => return Err(()),
         };
 
-        let bkey = items.batch.add(addr, ckey)?;
+        let bkey = items.batch.add(addr, false, ckey)?;
 
         ci.batch_key = Some(bkey);
 

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -487,7 +487,7 @@ impl Connections {
             None => return Err(()),
         };
 
-        let bkey = items.batch.add(addr, ckey)?;
+        let bkey = items.batch.add(addr, false, ckey)?;
 
         ci.batch_key = Some(bkey);
 


### PR DESCRIPTION
Related to #48073, in order to enable a smooth transition to the use of ROUTER for backpressured response data, the plan will be to let each session indicate whether it wants to receive response data this way. As a result, when sending batched messages we'll need to organize the batches not only by peer address by also by whether ROUTER should be used or not. This PR allows indicating the mode (`use_router`) when adding to the batch. For now, the value is always set to false.