### PR TITLE
zhttppacket: add router-resp

### DIFF
--- a/src/connmgr/zhttppacket.rs
+++ b/src/connmgr/zhttppacket.rs
@@ -325,6 +325,7 @@ pub struct RequestData<'buf, 'headers> {
     pub credits: u32,
     pub more: bool,
     pub stream: bool,
+    pub router_resp: bool,
     pub max_size: u32,
     pub timeout: u32,
     pub method: &'buf str,
@@ -349,6 +350,7 @@ impl RequestData<'_, '_> {
             credits: 0,
             more: false,
             stream: false,
+            router_resp: false,
             max_size: 0,
             timeout: 0,
             method: "",
@@ -425,6 +427,11 @@ impl<'a> Serialize<'a> for RequestData<'a, 'a> {
             w.write_bool(true)?;
         }
 
+        if self.router_resp {
+            w.write_string(b"router-resp")?;
+            w.write_bool(true)?;
+        }
+
         if self.max_size > 0 {
             w.write_string(b"max-size")?;
             w.write_int(self.max_size as isize)?;
@@ -457,6 +464,7 @@ impl<'buf: 'scratch, 'scratch> Parse<'buf, 'scratch> for RequestData<'buf, 'scra
         let mut credits = 0;
         let mut more = false;
         let mut stream = false;
+        let mut router_resp = false;
         let mut max_size = 0;
         let mut timeout = 0;
         let mut method = "";
@@ -494,6 +502,11 @@ impl<'buf: 'scratch, 'scratch> Parse<'buf, 'scratch> for RequestData<'buf, 'scra
                     let b = tnetstring::parse_bool(e.data).field("stream")?;
 
                     stream = b;
+                }
+                "router-resp" => {
+                    let b = tnetstring::parse_bool(e.data).field("router-resp")?;
+
+                    router_resp = b;
                 }
                 "max-size" => {
                     let x = tnetstring::parse_int(e.data).field("max-size")?;
@@ -641,6 +654,7 @@ impl<'buf: 'scratch, 'scratch> Parse<'buf, 'scratch> for RequestData<'buf, 'scra
             credits,
             more,
             stream,
+            router_resp,
             max_size,
             timeout,
             method,
@@ -1783,6 +1797,7 @@ mod tests {
                         credits: 0,
                         more: true,
                         stream: false,
+                        router_resp: false,
                         max_size: 0,
                         timeout: 0,
                         method: "POST",

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -88,6 +88,9 @@ QVariant ZhttpRequestPacket::toVariant() const
 	if(stream)
 		obj["stream"] = true;
 
+	if(routerResp)
+		obj["router-resp"] = true;
+
 	if(maxSize != -1)
 		obj["max-size"] = maxSize;
 
@@ -307,6 +310,15 @@ bool ZhttpRequestPacket::fromVariant(const QVariant &in)
 			return false;
 
 		stream = obj["stream"].toBool();
+	}
+
+	routerResp = false;
+	if(obj.contains("router-resp"))
+	{
+		if(typeId(obj["router-resp"]) != QMetaType::Bool)
+			return false;
+
+		routerResp = obj["router-resp"].toBool();
 	}
 
 	maxSize = -1;

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2016 Fanout, Inc.
+ * Copyright (C) 2024 Fastly, Inc.
  *
  * $FANOUT_BEGIN_LICENSE:APACHE2$
  *
@@ -70,6 +71,7 @@ public:
 	int credits;
 	bool more;
 	bool stream;
+	bool routerResp;
 	int maxSize;
 	int timeout;
 
@@ -101,6 +103,7 @@ public:
 		credits(-1),
 		more(false),
 		stream(false),
+		routerResp(false),
 		maxSize(-1),
 		timeout(-1),
 		code(-1),


### PR DESCRIPTION
Related to #48073, this adds a field to request packets to indicate if the sender prefers receiving response data via ROUTER instead of PUB.