### PR TITLE
connmgr: add ability to respond via router instead of pub

### DIFF
--- a/src/connmgr/batch.rs
+++ b/src/connmgr/batch.rs
@@ -39,7 +39,6 @@ impl<'a> BatchGroup<'a, '_> {
         self.addr
     }
 
-    #[allow(dead_code)]
     pub fn use_router(&self) -> bool {
         self.use_router
     }


### PR DESCRIPTION
Related to #48073, this completes the implementation in connmgr for sending response data via router. After this, proxy will need to be updated to support receiving response data this way.

Notably, the following changes are made:

1. `make_zhttp_response()` is reworked to support producing either PUB-style or ROUTER-style message formats, returning a `Some(addr)` in the case of the latter. It is also made public and shared across modules to reduce code duplication.
2. If router-resp is indicated on the request, a flag is set to true on the `StreamSharedData` struct. Whenever response data needs to be sent, this flag can be checked to decide whether to respond via ROUTER or not.
3. When adding to a batch, specify whether router mode should be used.
4. Instead of always specifying `None` for the address, the value is specified as `Some` or `None` depending on whether router-resp was requested.

The rest of the changes are mainly tests.