### PR TITLE
proxy: ask for router-resp in requests

### DIFF
--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -1014,6 +1014,7 @@ public slots:
 				if(!requestBodyBuf.isEmpty() || !bodyFinished)
 					p.more = true;
 				p.stream = true;
+				p.routerResp = true;
 				p.connectHost = connectHost;
 				p.connectPort = connectPort;
 				if(ignorePolicies)

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -1037,6 +1037,7 @@ public slots:
 			p.type = ZhttpRequestPacket::Data;
 			p.uri = requestUri;
 			p.headers = requestHeaders;
+			p.routerResp = true;
 			p.connectHost = connectHost;
 			p.connectPort = connectPort;
 			if(ignorePolicies)


### PR DESCRIPTION
Now that connmgr supports sending response data over ROUTER, the proxy just needs to ask for it. This should ensure response data from connmgr->proxy (proxy receiving response data from outgoing connections) won't get dropped under high load.

Note that response data from proxy->connmgr (proxy sending response data to incoming connections) still goes over PUB. We'll want to look at that separately.

Tested locally.