### PR TITLE
handler: make message filtering async-capable

### DIFF
--- a/src/cpp.pro
+++ b/src/cpp.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 CONFIG -= app_bundle
-CONFIG += staticlib c++14
+CONFIG += staticlib c++17
 QT -= gui
 QT += network
 TARGET = pushpin-cpp

--- a/src/cpptests.pro
+++ b/src/cpptests.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 CONFIG -= app_bundle
-CONFIG += staticlib c++14
+CONFIG += staticlib c++17
 QT -= gui
 QT *= network testlib
 TARGET = pushpin-cpptest

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -306,18 +306,14 @@ public:
 
 }
 
-Filter::MessageFilter::~MessageFilter()
-{
-}
+Filter::MessageFilter::~MessageFilter() = default;
 
 Filter::Filter(const QString &name) :
 	name_(name)
 {
 }
 
-Filter::~Filter()
-{
-}
+Filter::~Filter() = default;
 
 Filter::SendAction Filter::sendAction() const
 {
@@ -463,6 +459,7 @@ void Filter::MessageFilterStack::filterFinished(const Result &result)
 			filters_.erase(filters_.begin());
 			break;
 		case Drop:
+			// stop filtering. remove the finished filter and any remaining
 			filters_.clear();
 			break;
 	}

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#include <QtTest/QtTest>
+#include <boost/signals2.hpp>
+#include "filter.h"
+
+class FilterTest : public QObject
+{
+	Q_OBJECT
+
+private:
+	std::tuple<bool, Filter::MessageFilter::Result> runMessageFilters(const QStringList &filterNames, const Filter::Context &context, const QByteArray &content)
+	{
+		Filter::MessageFilterStack fs(filterNames);
+
+		bool finished = false;
+		Filter::MessageFilter::Result r;
+
+		fs.finished.connect([&](const Filter::MessageFilter::Result &_r) {
+			finished = true;
+			r = _r;
+		});
+
+		fs.start(context, content);
+
+		return {finished, r};
+	}
+
+private slots:
+	void messageFilters()
+	{
+		QStringList filterNames = QStringList() << "skip-self" << "var-subst";
+
+		Filter::Context context;
+		context.subscriptionMeta["user"] = "alice";
+
+		QByteArray content = "hello %(user)s";
+
+		{
+			auto [finished, r] = runMessageFilters(filterNames, context, content);
+			QVERIFY(finished);
+			QVERIFY(r.errorMessage.isNull());
+			QCOMPARE(r.sendAction, Filter::Send);
+			QCOMPARE(r.content, "hello alice");
+		}
+
+		{
+			context.publishMeta["sender"] = "alice";
+			auto [finished, r] = runMessageFilters(filterNames, context, content);
+			QVERIFY(finished);
+			QVERIFY(r.errorMessage.isNull());
+			QCOMPARE(r.sendAction, Filter::Drop);
+		}
+	}
+};
+
+namespace {
+namespace Main {
+QTEST_MAIN(FilterTest)
+}
+}
+
+extern "C" {
+
+int filter_test(int argc, char **argv)
+{
+	return Main::main(argc, argv);
+}
+
+}
+
+#include "filtertest.moc"

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -930,13 +930,13 @@ private:
 
 			if(!responseSent)
 			{
-				// apply ProxyContent filters of all channels
+				// apply ResponseContent filters of all channels
 				QStringList allFilters;
 				foreach(const Instruct::Channel &c, instruct.channels)
 				{
 					foreach(const QString &filter, c.filters)
 					{
-						if((Filter::targets(filter) & Filter::ProxyContent) && !allFilters.contains(filter))
+						if((Filter::targets(filter) & Filter::ResponseContent) && !allFilters.contains(filter))
 							allFilters += filter;
 					}
 				}

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -298,13 +298,13 @@ public:
 
 			if(!instruct.response.body.isEmpty())
 			{
-				// apply ProxyContent filters of all channels
+				// apply ResponseContent filters of all channels
 				QStringList allFilters;
 				foreach(const Instruct::Channel &c, instruct.channels)
 				{
 					foreach(const QString &filter, c.filters)
 					{
-						if((Filter::targets(filter) & Filter::ProxyContent) && !allFilters.contains(filter))
+						if((Filter::targets(filter) & Filter::ResponseContent) && !allFilters.contains(filter))
 							allFilters += filter;
 					}
 				}
@@ -1558,13 +1558,13 @@ private slots:
 				// won't be used for anything else
 				instruct = i;
 
-				// apply ProxyContent filters of all channels
+				// apply ResponseContent filters of all channels
 				QStringList allFilters;
 				foreach(const Instruct::Channel &c, instruct.channels)
 				{
 					foreach(const QString &filter, c.filters)
 					{
-						if((Filter::targets(filter) & Filter::ProxyContent) && !allFilters.contains(filter))
+						if((Filter::targets(filter) & Filter::ResponseContent) && !allFilters.contains(filter))
 							allFilters += filter;
 					}
 				}

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -20,6 +20,11 @@ mod tests {
     use crate::ffi;
     use std::ffi::OsStr;
 
+    fn filter_test(args: &[&OsStr]) -> u8 {
+        // SAFETY: safe to call
+        unsafe { call_c_main(ffi::filter_test, args) as u8 }
+    }
+
     fn jsonpatch_test(args: &[&OsStr]) -> u8 {
         // SAFETY: safe to call
         unsafe { call_c_main(ffi::jsonpatch_test, args) as u8 }
@@ -48,6 +53,11 @@ mod tests {
     fn handlerengine_test(args: &[&OsStr]) -> u8 {
         // SAFETY: safe to call
         unsafe { call_c_main(ffi::handlerengine_test, args) as u8 }
+    }
+
+    #[test]
+    fn filter() {
+        assert!(qtest::run(filter_test));
     }
 
     #[test]

--- a/src/handler/tests.pri
+++ b/src/handler/tests.pri
@@ -2,6 +2,7 @@ INCLUDES += \
 	$$PWD/handlertests.h
 
 SOURCES += \
+	$$PWD/filtertest.cpp \
 	$$PWD/jsonpatchtest.cpp \
 	$$PWD/instructtest.cpp \
 	$$PWD/idformattest.cpp \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ pub mod ffi {
         pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn filter_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn jsonpatch_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn instruct_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn idformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;


### PR DESCRIPTION
This introduces the `MessageFilter` class for implementing async filtering operations, specifically for messages. Response content (formerly "proxy" content) must still be filtered using the synchronous `Filter` API.

There are no actual async filters implemented yet, although all of the existing synchronous filters have been updated to derive from `MessageFilter` and emit async results immediately. This way we can start using the async API in connection handlers.

Longer term, the plan is to introduce a `ResponseFilter` class for similarly handling response content, and then turn `Filter` into a namespace. In preparation for this, `MessageFilter` and related types are nested under the `Filter` class.

The goal of this reworking is not only to enable async operations but also to make the filtering API more clear. Instead of a single class with different modes, we'll have different classes with single modes.