### PR TITLE
wssession: use async filters

### DIFF
--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -29,6 +29,7 @@
 #include <QSet>
 #include "packet/httprequestdata.h"
 #include "packet/wscontrolpacket.h"
+#include "filter.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -67,7 +68,11 @@ public:
 	QTimer *expireTimer;
 	QTimer *delayedTimer;
 	QTimer *requestTimer;
+	QList<PublishItem> publishQueue;
 	ZhttpManager *zhttpOut;
+	std::unique_ptr<Filter::MessageFilter> filters;
+	Connection filtersFinishedConnection;
+	bool processingSendQueue;
 
 	WsSession(QObject *parent = 0);
 	~WsSession();
@@ -83,6 +88,9 @@ public:
 	Signal error;
 
 private:
+	void trySendQueue();
+	void filtersFinished(const Filter::MessageFilter::Result &result);
+	void afterFilters(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content);
 	void setupRequestTimer();
 
 private slots:


### PR DESCRIPTION
This runs filters asynchronously when publishing to a WebSocket session, using `MessageFilterStack` instead of the synchronous `FilterStack`. The `WsSession::publish()` method queues messages internally, so that new messages are always acceptable even while an existing message is undergoing async processing. For each session, messages are processed one at a time.

Care is taken to avoid returning to the event loop unnecessarily, but also to avoid recursion. If multiple messages can be processed in a single event loop pass, it is done iteratively.