### PR TITLE
propagate trusted route flag to handler

### DIFF
--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -218,6 +218,9 @@ QVariant WsControlPacket::toVariant() const
 		if(item.logLevel >= 0)
 			vitem["log-level"] = item.logLevel;
 
+		if(item.trusted)
+			vitem["trusted"] = true;
+
 		if(!item.channel.isEmpty())
 			vitem["channel"] = item.channel;
 
@@ -393,6 +396,14 @@ bool WsControlPacket::fromVariant(const QVariant &in)
 				return false;
 
 			item.logLevel = vitem["log-level"].toInt();
+		}
+
+		if(vitem.contains("trusted"))
+		{
+			if(typeId(vitem["trusted"]) != QMetaType::Bool)
+				return false;
+
+			item.trusted = vitem["trusted"].toBool();
 		}
 
 		if(vitem.contains("channel"))

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -65,6 +65,7 @@ public:
 		bool separateStats;
 		QByteArray channelPrefix;
 		int logLevel;
+		bool trusted;
 		QByteArray channel;
 		int ttl;
 		int timeout;
@@ -76,6 +77,7 @@ public:
 			code(-1),
 			separateStats(false),
 			logLevel(-1),
+			trusted(false),
 			ttl(-1),
 			timeout(-1)
 		{

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -2701,6 +2701,7 @@ private:
 
 				s->route = item.route;
 				s->statsRoute = item.separateStats ? item.route : QString();
+				s->targetTrusted = item.trusted;
 				s->channelPrefix = QString::fromUtf8(item.channelPrefix);
 				if(item.logLevel >= 0)
 					s->logLevel = item.logLevel;

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -1229,7 +1229,7 @@ private:
 			passthroughData["prefer-internal"] = true;
 		}
 
-		// these fields are needed in case proxy routing is not used
+		// needed in case internal routing is not used
 		if(adata.trusted)
 			passthroughData["trusted"] = true;
 

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -32,7 +32,9 @@
 WsSession::WsSession(QObject *parent) :
 	QObject(parent),
 	nextReqId(0),
-	logLevel(LOG_LEVEL_DEBUG)
+	logLevel(LOG_LEVEL_DEBUG),
+	targetTrusted(false),
+	ttl(0)
 {
 	expireTimer = new QTimer(this);
 	expireTimer->setSingleShot(true);

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -48,6 +48,7 @@ public:
 	HttpRequestData requestData;
 	QString route;
 	QString statsRoute;
+	bool targetTrusted;
 	QString sid;
 	QHash<QString, QString> meta;
 	QHash<QString, QStringList> channelFilters; // k=channel, v=list(filters)

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -54,6 +54,7 @@ public:
 	QByteArray channelPrefix;
 	int logLevel;
 	QUrl uri;
+	bool targetTrusted;
 	Connection requestTimerConnection;
 
 	Private(WsControlSession *_q) :
@@ -62,7 +63,8 @@ public:
 		manager(0),
 		nextReqId(0),
 		separateStats(false),
-		logLevel(-1)
+		logLevel(-1),
+		targetTrusted(false)
 	{
 		requestTimer = std::make_unique<RTimer>();
 		requestTimerConnection = requestTimer->timeout.connect(boost::bind(&Private::requestTimer_timeout, this));
@@ -103,6 +105,7 @@ public:
 		i.channelPrefix = channelPrefix;
 		i.logLevel = logLevel;
 		i.uri = uri;
+		i.trusted = targetTrusted;
 		i.ttl = SESSION_TTL;
 		write(i, true);
 	}
@@ -326,13 +329,14 @@ QByteArray WsControlSession::cid() const
 	return d->cid;
 }
 
-void WsControlSession::start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri)
+void WsControlSession::start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted)
 {
 	d->route = routeId;
 	d->separateStats = separateStats;
 	d->channelPrefix = channelPrefix;
 	d->logLevel = logLevel;
 	d->uri = uri;
+	d->targetTrusted = targetTrusted;
 	d->start();
 }
 

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -45,7 +45,7 @@ public:
 	QByteArray peer() const;
 	QByteArray cid() const;
 
-	void start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri);
+	void start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted);
 	void sendGripMessage(const QByteArray &message);
 	void sendNeedKeepAlive();
 	void sendSubscribe(const QByteArray &channel);

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -949,7 +949,7 @@ private slots:
 					wsControl->cancelEventReceived.connect(boost::bind(&Private::wsControl_cancelEventReceived, this)),
 					wsControl->error.connect(boost::bind(&Private::wsControl_error, this))
 				};
-				wsControl->start(route.id, route.separateStats, channelPrefix, route.logLevel, inSock->requestUri());
+				wsControl->start(route.id, route.separateStats, channelPrefix, route.logLevel, inSock->requestUri(), target.trusted);
 
 				foreach(const QString &subChannel, target.subscriptions)
 				{


### PR DESCRIPTION
Currently, the proxy tells the handler whether an HTTP request is for a trusted route or not. This PR makes it so we do the same for WebSocket requests.

This is needed for the upcoming HTTP-based filter, so that, for example, localhost backends can use localhost filters.