### PR TITLE
add fields to filter context for making http requests

### DIFF
--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -28,7 +28,10 @@
 #include <QStringList>
 #include <QHash>
 #include <QMetaType>
+#include <QUrl>
 #include <boost/signals2.hpp>
+
+class ZhttpManager;
 
 class Filter
 {
@@ -52,6 +55,18 @@ public:
 		QHash<QString, QString> prevIds;
 		QHash<QString, QString> subscriptionMeta;
 		QHash<QString, QString> publishMeta;
+
+		// for network access
+		ZhttpManager *zhttpOut;
+		QUrl currentUri;
+		QString route;
+		bool trusted;
+
+		Context() :
+			zhttpOut(0),
+			trusted(false)
+		{
+		}
 	};
 
 	class MessageFilter

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1813,6 +1813,10 @@ private:
 			Filter::Context fc;
 			fc.subscriptionMeta = s->meta;
 			fc.publishMeta = item.meta;
+			fc.zhttpOut = zhttpOut;
+			fc.currentUri = s->requestData.uri;
+			fc.route = s->route;
+			fc.trusted = s->targetTrusted;
 
 			FilterStack filters(fc, s->channelFilters[item.channel]);
 

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -468,6 +468,10 @@ public:
 			fc.prevIds = prevIds;
 			fc.subscriptionMeta = instruct.meta;
 			fc.publishMeta = item.meta;
+			fc.zhttpOut = outZhttp;
+			fc.currentUri = currentUri;
+			fc.route = adata.route;
+			fc.trusted = adata.trusted;
 
 			FilterStack fs(fc, channels[item.channel].filters);
 
@@ -875,6 +879,10 @@ private:
 			fc.prevIds = prevIds;
 			fc.subscriptionMeta = instruct.meta;
 			fc.publishMeta = item.meta;
+			fc.zhttpOut = outZhttp;
+			fc.currentUri = currentUri;
+			fc.route = adata.route;
+			fc.trusted = adata.trusted;
 
 			FilterStack fs(fc, channels[item.channel].filters);
 


### PR DESCRIPTION
This adds enough extra fields to `Filter::Context` to allow filters to make HTTP requests, and updates the filtering call sites (long-polling, streaming, and websockets) to set them. For now the fields are not actually used by any filters, but the upcoming HTTP filter will use them.