### PR TITLE
wssession: allow send signal to provide arbitrary packets

### DIFF
--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -2690,7 +2690,7 @@ private:
 				{
 					s = new WsSession(this);
 					wsSessionConnectionMap[s] = {
-						s->send.connect(boost::bind(&Private::wssession_send, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, s)),
+						s->send.connect(boost::bind(&Private::wssession_send, this, boost::placeholders::_1, s)),
 						s->expired.connect(boost::bind(&Private::wssession_expired, this, s)),
 						s->error.connect(boost::bind(&Private::wssession_error, this, s))
 					};
@@ -3229,16 +3229,8 @@ private slots:
 			writeRetryPacket(addr, rp);
 	}
 
-	void wssession_send(int reqId, const QByteArray &type, const QByteArray &message, WsSession *s)
+	void wssession_send(const WsControlPacket::Item &i, WsSession *s)
 	{
-		WsControlPacket::Item i;
-		i.cid = s->cid.toUtf8();
-		i.requestId = QByteArray::number(reqId);
-		i.type = WsControlPacket::Item::Send;
-		i.contentType = type;
-		i.message = message;
-		i.queue = true;
-
 		writeWsControlItems(s->peer, QList<WsControlPacket::Item>() << i);
 	}
 

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -139,7 +139,15 @@ void WsSession::delayedTimer_timeout()
 	pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + WSCONTROL_REQUEST_TIMEOUT;
 	setupRequestTimer();
 
-	send(reqId, delayedType, message);
+	WsControlPacket::Item i;
+	i.cid = cid.toUtf8();
+	i.requestId = QByteArray::number(reqId);
+	i.type = WsControlPacket::Item::Send;
+	i.contentType = delayedType;
+	i.message = message;
+	i.queue = true;
+
+	send(i);
 }
 
 void WsSession::requestTimer_timeout()

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -28,6 +28,7 @@
 #include <QHash>
 #include <QSet>
 #include "packet/httprequestdata.h"
+#include "packet/wscontrolpacket.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -72,7 +73,7 @@ public:
 	void sendDelayed(const QByteArray &type, const QByteArray &message, int timeout);
 	void ack(int reqId);
 
-	boost::signals2::signal<void(int, const QByteArray&, const QByteArray&)> send;
+	boost::signals2::signal<void(const WsControlPacket::Item&)> send;
 	Signal expired;
 	Signal error;
 


### PR DESCRIPTION
Currently, `WsSession` can produce its own packets for a session via its `send` signal, but it does not have control over all the packet fields. This PR updates the signal to allow sending arbitrary packets, needed to implement async filters.