### PR TITLE
add DeferCall to replace QMetaObject::invokeMethod

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -43,6 +43,7 @@ HEADERS += \
 	$$PWD/timerwheel.h \
 	$$PWD/jwt.h \
 	$$PWD/rtimer.h \
+	$$PWD/defercall.h \
 	$$PWD/logutil.h \
 	$$PWD/uuidutil.h \
 	$$PWD/zutil.h \
@@ -66,6 +67,7 @@ SOURCES += \
 	$$PWD/timerwheel.cpp \
 	$$PWD/jwt.cpp \
 	$$PWD/rtimer.cpp \
+	$$PWD/defercall.cpp \
 	$$PWD/logutil.cpp \
 	$$PWD/uuidutil.cpp \
 	$$PWD/zutil.cpp \

--- a/src/core/defercall.cpp
+++ b/src/core/defercall.cpp
@@ -1,0 +1,65 @@
+/*
+* Copyright (C) 2025 Fastly, Inc.
+*
+* This file is part of Pushpin.
+*
+* $FANOUT_BEGIN_LICENSE:APACHE2$
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* $FANOUT_END_LICENSE$
+*/
+
+#include "defercall.h"
+#include <assert.h>
+
+static thread_local DeferCall *g_instance = nullptr;
+
+DeferCall::DeferCall() = default;
+
+DeferCall::~DeferCall() = default;
+
+void DeferCall::defer(std::function<void ()> handler)
+{
+	Call c;
+	c.handler = handler;
+
+	deferredCalls_.push_back(c);
+
+	QMetaObject::invokeMethod(this, "callNext", Qt::QueuedConnection);
+}
+
+DeferCall *DeferCall::global()
+{
+	if(!g_instance)
+		g_instance = new DeferCall;
+
+	return g_instance;
+}
+
+void DeferCall::cleanup()
+{
+	delete g_instance;
+	g_instance = nullptr;
+}
+
+void DeferCall::callNext()
+{
+	// there can't be more invokeMethod resolutions than queued calls
+	assert(!deferredCalls_.empty());
+
+	Call c = deferredCalls_.front();
+	deferredCalls_.pop_front();
+
+	c.handler();
+}

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -48,7 +48,7 @@ public:
 	template <typename T>
 	static void deleteLater(T *p)
 	{
-		DeferCall::global()->defer([=]() { delete p; });
+		global()->defer([=]() { delete p; });
 	}
 
 private slots:

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -45,6 +45,12 @@ public:
 	static DeferCall *global();
 	static void cleanup();
 
+	template <typename T>
+	static void deleteLater(T *p)
+	{
+		DeferCall::global()->defer([=]() { delete p; });
+	}
+
 private slots:
 	void callNext();
 

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -1,0 +1,61 @@
+/*
+* Copyright (C) 2025 Fastly, Inc.
+*
+* This file is part of Pushpin.
+*
+* $FANOUT_BEGIN_LICENSE:APACHE2$
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* $FANOUT_END_LICENSE$
+*/
+
+#ifndef DEFERCALL_H
+#define DEFERCALL_H
+
+#include <QVariant>
+
+// queues calls to be run after returning to the event loop
+class DeferCall : public QObject
+{
+	Q_OBJECT
+
+public:
+	DeferCall();
+	~DeferCall();
+
+	// queue handler to be called after returning to the event loop. if
+	// handler contains references, they must outlive DeferCall. the
+	// recommended usage is for each object needing to perform deferred calls
+	// to keep a DeferCall as a member variable, and only refer to the
+	// object's own data in the handler. that way, any references are
+	// guaranteed to live long enough.
+	void defer(std::function<void ()> handler);
+
+	static DeferCall *global();
+	static void cleanup();
+
+private slots:
+	void callNext();
+
+private:
+	class Call
+	{
+	public:
+		std::function<void ()> handler;
+	};
+
+	std::list<Call> deferredCalls_;
+};
+
+#endif

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -23,7 +23,7 @@
 #ifndef DEFERCALL_H
 #define DEFERCALL_H
 
-#include <QVariant>
+#include <QObject>
 
 // queues calls to be run after returning to the event loop
 class DeferCall : public QObject

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -165,7 +165,7 @@ public:
 		{
 			expTimerConnection.disconnect();
 			expireTimer->setParent(0);
-			DeferCall::global()->defer([=]() { delete expireTimer; });
+			DeferCall::deleteLater(expireTimer);
 			expireTimer = 0;
 		}
 
@@ -173,7 +173,7 @@ public:
 		{
 			keepAliveTimerConnection.disconnect();
 			keepAliveTimer->setParent(0);
-			DeferCall::global()->defer([=]() { delete keepAliveTimer; });
+			DeferCall::deleteLater(keepAliveTimer);
 			keepAliveTimer = 0;
 		}
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -33,6 +33,7 @@
 #include "zhttpresponsepacket.h"
 #include "packet/httpresponsedata.h"
 #include "rtimer.h"
+#include "defercall.h"
 #include "handlerengine.h"
 
 namespace {
@@ -309,6 +310,7 @@ private slots:
 		delete wrapper;
 
 		RTimer::deinit();
+		DeferCall::cleanup();
 	}
 
 	void acceptNoHold()

--- a/src/handler/handlermain.cpp
+++ b/src/handler/handlermain.cpp
@@ -24,6 +24,7 @@
 #include <QCoreApplication>
 #include <QTimer>
 #include "rtimer.h"
+#include "defercall.h"
 #include "handlerapp.h"
 
 class HandlerAppMain
@@ -60,6 +61,7 @@ int handler_main(int argc, char **argv)
 
 	// deinit here, after all event loop activity has completed
 	RTimer::deinit();
+	DeferCall::cleanup();
 
 	return ret;
 }

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -31,6 +31,7 @@
 #include <QFileInfo>
 #include "processquit.h"
 #include "rtimer.h"
+#include "defercall.h"
 #include "log.h"
 #include "settings.h"
 #include "xffrule.h"
@@ -299,6 +300,7 @@ public:
 
 		// deinit here, after all event loop activity has completed
 		RTimer::deinit();
+		DeferCall::cleanup();
 	}
 
 private:

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -35,6 +35,7 @@
 #include <QFileSystemWatcher>
 #include "log.h"
 #include "rtimer.h"
+#include "defercall.h"
 #include "routesfile.h"
 
 #define WORKER_THREAD_TIMERS 1
@@ -756,6 +757,7 @@ public:
 		delete worker;
 
 		RTimer::deinit();
+		DeferCall::cleanup();
 	}
 
 public:

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -38,6 +38,7 @@
 #include "packet/httpresponsedata.h"
 #include "packet/statspacket.h"
 #include "rtimer.h"
+#include "defercall.h"
 #include "zhttpmanager.h"
 #include "statsmanager.h"
 #include "domainmap.h"
@@ -636,6 +637,7 @@ private slots:
 
 		QCoreApplication::instance()->sendPostedEvents();
 		RTimer::deinit();
+		DeferCall::cleanup();
 	}
 
 	void passthrough()


### PR DESCRIPTION
This helps reduce direct dependence on `QObject` by wrapping `QMetaObject::invokeMethod` with our own internal API for doing the same. It introduces the `DeferCall` type and updates a few places to use it. The goal is to use `DeferCall` for all delayed invocations in the entire project, such that the only direct usage of `invokeMethod` occurs within `DeferCall` itself. Then when we replace the Qt event loop we can substitute out that final usage.

Unlike `invokeMethod`, which takes a method name by string and a variable number of dynamically typed args, `DeferCall::defer` simply takes a function/closure. This allows static type-checking, and any data that would have normally been supplied by args can be captured instead.

A single `DeferCall` instance can be used to queue multiple calls. Destroying it will cancel the calls. Objects that need to make deferred calls to themselves are expected to do it through a `DeferCall` kept as a member variable. That way, when the object is destroyed so are its queued calls.

`DeferCall` also provides a replacement for `QObject::deleteLater`, via the static method `DeferCall::deleteLater`. Deferred deletions are often applied to child objects during parent object destruction, so it is important for the queued calls to remain in effect after the parent object goes away. To help with that, these calls are made against a singleton (thread local) instead of a member instance. `DeferCall::cleanup` is used to destroy the singleton at thread/program exit.

Tested with valgrind and came up clean.