### PR TITLE
core, proxy, handler: use DeferCall::defer everywhere

### DIFF
--- a/src/handler/deferred.cpp
+++ b/src/handler/deferred.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -42,7 +43,7 @@ void Deferred::setFinished(bool ok, const QVariant &value)
 	result_.success = ok;
 	result_.value = value;
 
-	QMetaObject::invokeMethod(this, "doFinish", Qt::QueuedConnection);
+	deferCall_.defer([=] { doFinish(); });
 }
 
 void Deferred::doFinish()

--- a/src/handler/deferred.h
+++ b/src/handler/deferred.h
@@ -65,12 +65,11 @@ protected:
 
 	void setFinished(bool ok, const QVariant &value = QVariant());
 
-private slots:
-	void doFinish();
-
 private:
 	DeferredResult result_;
 	DeferCall deferCall_;
+
+	void doFinish();
 };
 
 #endif

--- a/src/handler/deferred.h
+++ b/src/handler/deferred.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -26,6 +27,7 @@
 #include <QVariant>
 #include <QObject>
 #include <boost/signals2.hpp>
+#include "defercall.h"
 
 class DeferredResult
 {
@@ -68,6 +70,7 @@ private slots:
 
 private:
 	DeferredResult result_;
+	DeferCall deferCall_;
 };
 
 #endif

--- a/src/handler/handlermain.cpp
+++ b/src/handler/handlermain.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -22,7 +22,6 @@
  */
 
 #include <QCoreApplication>
-#include <QTimer>
 #include "rtimer.h"
 #include "defercall.h"
 #include "handlerapp.h"
@@ -53,7 +52,8 @@ int handler_main(int argc, char **argv)
 	QCoreApplication qapp(argc, argv);
 
 	HandlerAppMain appMain;
-	QTimer::singleShot(0, [&appMain]() {appMain.start();});
+	DeferCall deferCall;
+	deferCall.defer([&] { appMain.start(); });
 	int ret = qapp.exec();
 
 	// ensure deferred deletes are processed

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -1458,7 +1458,6 @@ private:
 		}
 	}
 
-private slots:
 	void doError()
 	{
 		if(instruct.holdMode == Instruct::ResponseHold)
@@ -1622,7 +1621,6 @@ private slots:
 		}
 	}
 
-private:
 	void timer_timeout()
 	{
 		if(instruct.holdMode == Instruct::ResponseHold)

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -206,6 +206,7 @@ public:
 	Connection timerConnection;
 	Connection retryTimerConnection;
 	Connection messageFiltersFinishedConnection;
+	DeferCall deferCall;
 
 	Private(HttpSession *_q, ZhttpRequest *_req, const HttpSession::AcceptData &_adata, const Instruct &_instruct, ZhttpManager *_outZhttp, StatsManager *_stats, RateLimiter *_updateLimiter, PublishLastIds *_publishLastIds, HttpSessionUpdateManager *_updateManager, int _connectionSubscriptionMax) :
 		QObject(_q),
@@ -1164,7 +1165,7 @@ private:
 		if(!outZhttp)
 		{
 			errorMessage = "Instruct contained link, but handler not configured for outbound requests.";
-			QMetaObject::invokeMethod(this, "doError", Qt::QueuedConnection);
+			deferCall.defer([=] { doError(); });
 			return;
 		}
 

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2022 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -205,6 +205,7 @@ public:
 	RTimer t;
 	Connection tConnection;
 	QFileSystemWatcher watcher;
+	DeferCall deferCall;
 
 	Worker() :
 		watcher(this)
@@ -292,7 +293,7 @@ public:
 
 		log_info("routes loaded with %d entries", allRules.count());
 
-		QMetaObject::invokeMethod(this, "doChanged", Qt::QueuedConnection);
+		deferCall.defer([=] { doChanged(); });
 	}
 
 	// mutex must be locked when calling this method
@@ -312,11 +313,6 @@ public:
 	Signal changed;
 
 public slots:
-	void doChanged()
-	{
-		changed();
-	}
-
 	void start()
 	{
 		if(!fileName.isEmpty())
@@ -718,6 +714,11 @@ private:
 		}
 
 		return AddRuleOk;
+	}
+
+	void doChanged()
+	{
+		changed();
 	}
 };
 

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -975,7 +975,6 @@ public:
 		}
 	}
 
-public slots:
 	void doResponseUpdate()
 	{
 		pendingResponseUpdate = false;

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -36,6 +36,7 @@
 #include "qtcompat.h"
 #include "bufferlist.h"
 #include "log.h"
+#include "defercall.h"
 #include "layertracker.h"
 #include "sockjsmanager.h"
 #include "inspectdata.h"
@@ -200,6 +201,7 @@ public:
 	ZhttpReqConnections zhttpReqConnections;
 	Connection inspectFinishedConnection;
 	Connection acceptFinishedConnection;
+	DeferCall deferCall;
 
 	Private(RequestSession *_q, int _workerId, DomainMap *_domainMap = 0, SockJsManager *_sockJsManager = 0, ZrpcManager *_inspectManager = 0, ZrpcChecker *_inspectChecker = 0, ZrpcManager *_acceptManager = 0, StatsManager *_stats = 0) :
 		QObject(_q),
@@ -308,7 +310,7 @@ public:
 				isSockJs = true;
 				sockJsManager->giveRequest(zhttpRequest, route.sockJsPath.length(), route.sockJsAsPath, route);
 				zhttpRequest = 0;
-				QMetaObject::invokeMethod(this, "doFinished", Qt::QueuedConnection);
+				deferCall.defer([=] { doFinished(); });
 				return;
 			}
 		}
@@ -480,7 +482,7 @@ public:
 				if(!inspectRequest)
 				{
 					log_debug("inspect not available");
-					QMetaObject::invokeMethod(this, "doInspectError", Qt::QueuedConnection);
+					deferCall.defer([=] { doInspectError(); });
 				}
 			}
 		}
@@ -559,7 +561,7 @@ public:
 		if(!pendingResponseUpdate)
 		{
 			pendingResponseUpdate = true;
-			QMetaObject::invokeMethod(this, "doResponseUpdate", Qt::QueuedConnection);
+			deferCall.defer([=] { doResponseUpdate(); });
 		}
 	}
 

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -1046,7 +1046,6 @@ public:
 		q->error();
 	}
 
-private slots:
 	void doUpdate()
 	{
 		updating = false;

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -66,7 +66,6 @@ public:
 	{
 	}
 
-public slots:
 	void doBytesWritten(int cnt){
 		q->bytesWritten(cnt);
 	}

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -68,7 +68,6 @@ public:
 	{
 	}
 
-public slots:
 	void handleConnect()
 	{
 		QString path = request.uri.path();

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -27,6 +27,7 @@
 #include <QUrlQuery>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include "defercall.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "statusreasons.h"
@@ -55,6 +56,7 @@ public:
 	int peerCloseCode;
 	QString peerCloseReason;
 	ErrorCondition errorCondition;
+	DeferCall deferCall;
 
 	Private(TestWebSocket *_q) :
 		QObject(_q),
@@ -118,7 +120,7 @@ public slots:
 			q->connected();
 
 			if(gripEnabled && !channels.isEmpty())
-				QMetaObject::invokeMethod(this, "doReadyRead", Qt::QueuedConnection);
+				deferCall.defer([=] { doReadyRead(); });
 		}
 		else
 		{
@@ -203,7 +205,7 @@ void TestWebSocket::start(const QUrl &uri, const HttpHeaders &headers)
 
 	d->state = Private::Connecting;
 
-	QMetaObject::invokeMethod(d, "handleConnect", Qt::QueuedConnection);
+	d->deferCall.defer([=] { d->handleConnect(); });
 }
 
 void TestWebSocket::respondSuccess(const QByteArray &reason, const HttpHeaders &headers)
@@ -311,13 +313,14 @@ void TestWebSocket::writeFrame(const Frame &frame)
 
 	d->inFrames += tmp;
 
-	QMetaObject::invokeMethod(d, "doFramesWritten", Qt::QueuedConnection, Q_ARG(int, 1), Q_ARG(int, tmp.data.size()));
-	QMetaObject::invokeMethod(d, "doReadyRead", Qt::QueuedConnection);
+	int contentBytesWritten = tmp.data.size();
+	d->deferCall.defer([=] { d->doFramesWritten(1, contentBytesWritten); });
+	d->deferCall.defer([=] { d->doReadyRead(); });
 }
 
 WebSocket::Frame TestWebSocket::readFrame()
 {
-	QMetaObject::invokeMethod(d, "doWriteBytesChanged", Qt::QueuedConnection);
+	d->deferCall.defer([=] { d->doWriteBytesChanged(); });
 
 	return d->inFrames.takeFirst();
 }
@@ -328,7 +331,7 @@ void TestWebSocket::close(int code, const QString &reason)
 	d->peerCloseCode = code;
 	d->peerCloseReason = reason;
 
-	QMetaObject::invokeMethod(d, "handleClose", Qt::QueuedConnection);
+	d->deferCall.defer([=] { d->handleClose(); });
 }
 
 #include "testwebsocket.moc"

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -986,7 +986,6 @@ private:
 		q->error();
 	}
 
-private slots:
 	void keepAliveTimer_timeout()
 	{
 		update();

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -34,6 +34,7 @@
 #include "zhttpmanager.h"
 #include "uuidutil.h"
 #include "rtimer.h"
+#include "defercall.h"
 
 #define BUFFER_SIZE 200000
 #define FRAME_SIZE_MAX 16384
@@ -240,6 +241,7 @@ public:
 	ReqConnections reqConnections;
 	Connection keepAliveTimerConnection;
 	Connection retryTimerConnection;
+	DeferCall deferCall;
 
 	Private(WebSocketOverHttp *_q) :
 		QObject(_q),
@@ -475,7 +477,7 @@ private:
 		if((int)pendingErrorCondition == -1)
 		{
 			pendingErrorCondition = e;
-			QMetaObject::invokeMethod(this, "doError", Qt::QueuedConnection);
+			deferCall.defer([=] { doError(); });
 		}
 	}
 


### PR DESCRIPTION
This also removes `slots:` annotations which were only needed for `QMetaObject::invokeMethod`.

Tested with valgrind.