### PR TITLE
add socketnotifier wrapper, to centralize qsocketnotifier usage

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -44,6 +44,7 @@ HEADERS += \
 	$$PWD/jwt.h \
 	$$PWD/rtimer.h \
 	$$PWD/defercall.h \
+	$$PWD/socketnotifier.h \
 	$$PWD/logutil.h \
 	$$PWD/uuidutil.h \
 	$$PWD/zutil.h \
@@ -68,6 +69,7 @@ SOURCES += \
 	$$PWD/jwt.cpp \
 	$$PWD/rtimer.cpp \
 	$$PWD/defercall.cpp \
+	$$PWD/socketnotifier.cpp \
 	$$PWD/logutil.cpp \
 	$$PWD/uuidutil.cpp \
 	$$PWD/zutil.cpp \

--- a/src/core/socketnotifier.cpp
+++ b/src/core/socketnotifier.cpp
@@ -1,0 +1,46 @@
+/*
+* Copyright (C) 2025 Fastly, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "socketnotifier.h"
+
+#include "defercall.h"
+
+SocketNotifier::SocketNotifier(int socket, Type type)
+{
+	QSocketNotifier::Type qType = type == Read ? QSocketNotifier::Read : QSocketNotifier::Write;
+
+	inner_ = new QSocketNotifier(socket, qType);
+	connect(inner_, &QSocketNotifier::activated, this, &SocketNotifier::innerActivated);
+}
+
+SocketNotifier::~SocketNotifier()
+{
+	inner_->setEnabled(false);
+
+	inner_->disconnect(this);
+	inner_->setParent(0);
+	DeferCall::deleteLater(inner_);
+}
+
+void SocketNotifier::setEnabled(bool enable)
+{
+	inner_->setEnabled(enable);
+}
+
+void SocketNotifier::innerActivated(int socket)
+{
+	activated(socket);
+}

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -1,0 +1,52 @@
+/*
+* Copyright (C) 2025 Fastly, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef SOCKETNOTIFIER_H
+#define SOCKETNOTIFIER_H
+
+#include <QSocketNotifier>
+#include <boost/signals2.hpp>
+
+class SocketNotifier : public QObject
+{
+	Q_OBJECT
+
+public:
+	enum Type
+	{
+		Read = 1,
+		Write = 2,
+	};
+
+	SocketNotifier(int socket, Type type);
+	~SocketNotifier();
+
+	bool isEnabled() const { return inner_->isEnabled(); }
+	int socket() const { return inner_->socket(); }
+	Type type() const { return inner_->type() == QSocketNotifier::Read ? Read : Write; }
+
+	void setEnabled(bool enable);
+
+	boost::signals2::signal<void(int)> activated;
+
+private slots:
+	void innerActivated(int socket);
+
+private:
+	QSocketNotifier *inner_;
+};
+
+#endif

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -28,6 +28,7 @@
 #include <boost/signals2.hpp>
 #include "log.h"
 #include "rtimer.h"
+#include "defercall.h"
 #include "zhttpmanager.h"
 #include "filter.h"
 
@@ -202,7 +203,11 @@ private slots:
 		zhttpOut.reset();
 		filterServer.reset();
 
+		// ensure deferred deletes are processed
+		QCoreApplication::instance()->sendPostedEvents();
+
 		RTimer::deinit();
+		DeferCall::cleanup();
 	}
 
 	void messageFilters()


### PR DESCRIPTION
This helps reduce direct dependence on `QObject` by wrapping `QSocketNotifier` with our own internal API for doing the same, that notifies using a boost signal. Further, when we eventually replace the Qt event loop, we'll only need to update the socket/fd registration code in one spot.

Currently, we are using `QSocketNotifier` in three places:

* `ProcessQuit` (via a wrapper `SafeSocketNotifier`, supporting deletion during signal emit)
* `QZmq::Socket`
* Indirectly via `QTcpSocket`

This PR updates the first two. The `SafeSocketNotifier` class is discarded since `SocketNotifier` itself supports safe deletion.

To address the usage within `QTcpSocket` we'll need to replace that whole class, which we'll do in a later change.