### PR TITLE
core: replace QPointer with shared_ptr/weak_ptr

### DIFF
--- a/src/core/qzmq/src/qzmqsocket.h
+++ b/src/core/qzmq/src/qzmqsocket.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2015 Justin Karneges
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
@@ -113,7 +113,7 @@ private:
 
 	class Private;
 	friend class Private;
-	Private *d;
+	std::shared_ptr<Private> d;
 };
 
 }

--- a/src/core/qzmq/src/qzmqvalve.h
+++ b/src/core/qzmq/src/qzmqvalve.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Justin Karneges
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
@@ -54,7 +55,7 @@ public:
 private:
 	class Private;
 	friend class Private;
-	Private *d;
+	std::shared_ptr<Private> d;
 };
 
 }

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -26,7 +26,6 @@
 #include <assert.h>
 #include <QVector>
 #include <QDateTime>
-#include <QPointer>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "qzmqsocket.h"

--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2013 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -79,7 +80,7 @@ public:
 private:
 	class Private;
 	friend class Private;
-	Private *d;
+	std::shared_ptr<Private> d;
 
 	friend class ZhttpRequest;
 	friend class ZWebSocket;

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2016 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -117,7 +118,7 @@ public:
 private:
 	class Private;
 	friend class Private;
-	Private *d;
+	std::shared_ptr<Private> d;
 
 	friend class ZhttpManager;
 	ZhttpRequest(QObject *parent = 0);

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2016 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -80,7 +81,7 @@ public:
 private:
 	class Private;
 	friend class Private;
-	Private *d;
+	std::shared_ptr<Private> d;
 
 	friend class ZhttpManager;
 	ZWebSocket(QObject *parent = 0);


### PR DESCRIPTION
This helps reduce dependence on `QObject` by replacing some uses of `QPointer` with `std::shared_ptr` and `std::weak_ptr`. `QPointer` is a smart pointer designed specifically for use with `QObject`, to watch objects for deletion. In our quest to remove dependence on `QObject`, we can instead use std smart pointers to accomplish the same thing.

The main question is deciding where to put the `shared_ptr` constructions. Either each object needs to be wrapped with `shared_ptr` (burden on the objects' users) or each object needs to manage its own `shared_ptr` member (burden on the objects themselves). Since we mostly use `QPointer` from within objects so they can watch themselves, I went with the latter approach. All classes in core doing watching are using the pimpl idiom (the `Private *d` pointers), so I simply wrapped those with `shared_ptr` rather than adding a separate member.

Also, I went ahead and removed the inner `QObject` from `QZmq::Socket` and `QZmq::Valve`, just to show that this is now possible to do. Will do the other classes later.