### PR TITLE
qzmq: remove remaining use of QObject

### DIFF
--- a/src/core/qzmq/src/qzmqreprouter.h
+++ b/src/core/qzmq/src/qzmqreprouter.h
@@ -24,8 +24,9 @@
 #ifndef QZMQREPROUTER_H
 #define QZMQREPROUTER_H
 
-#include <QObject>
 #include <boost/signals2.hpp>
+
+class QString;
 
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
@@ -55,7 +56,8 @@ public:
 	SignalInt messagesWritten;
 
 private:
-	Q_DISABLE_COPY(RepRouter)
+	RepRouter(const RepRouter &) = delete;
+	RepRouter &operator=(const RepRouter &) = delete;
 
 	class Private;
 	friend class Private;

--- a/src/core/qzmq/src/qzmqsocket.cpp
+++ b/src/core/qzmq/src/qzmqsocket.cpp
@@ -632,14 +632,12 @@ public:
 	}
 };
 
-Socket::Socket(Type type, QObject *parent) :
-	QObject(parent)
+Socket::Socket(Type type)
 {
 	d = std::make_shared<Private>(this, type, nullptr);
 }
 
-Socket::Socket(Type type, Context *context, QObject *parent) :
-	QObject(parent)
+Socket::Socket(Type type, Context *context)
 {
 	d = std::make_shared<Private>(this, type, context);
 }

--- a/src/core/qzmq/src/qzmqsocket.h
+++ b/src/core/qzmq/src/qzmqsocket.h
@@ -25,8 +25,11 @@
 #ifndef QZMQSOCKET_H
 #define QZMQSOCKET_H
 
-#include <QObject>
+#include <QByteArray>
+#include <QList>
 #include <boost/signals2.hpp>
+
+class QString;
 
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
@@ -36,10 +39,8 @@ namespace QZmq {
 
 class Context;
 
-class Socket : public QObject
+class Socket
 {
-	Q_OBJECT
-
 public:
 	enum Type
 	{
@@ -54,8 +55,8 @@ public:
 		Sub
 	};
 
-	Socket(Type type, QObject *parent = 0);
-	Socket(Type type, Context *context, QObject *parent = 0);
+	Socket(Type type);
+	Socket(Type type, Context *context);
 	~Socket();
 
 	// 0 means drop queue and don't block, -1 means infinite (default = -1)
@@ -109,7 +110,8 @@ public:
 	SignalInt messagesWritten;
 
 private:
-	Q_DISABLE_COPY(Socket)
+	Socket(const Socket &) = delete;
+	Socket &operator=(const Socket &) = delete;
 
 	class Private;
 	friend class Private;

--- a/src/core/qzmq/src/qzmqvalve.cpp
+++ b/src/core/qzmq/src/qzmqvalve.cpp
@@ -105,8 +105,7 @@ public:
 	}
 };
 
-Valve::Valve(QZmq::Socket *sock, QObject *parent) :
-	QObject(parent)
+Valve::Valve(QZmq::Socket *sock)
 {
 	d = std::make_shared<Private>(this);
 	d->setup(sock);

--- a/src/core/qzmq/src/qzmqvalve.h
+++ b/src/core/qzmq/src/qzmqvalve.h
@@ -25,7 +25,8 @@
 #ifndef QZMQVALVE_H
 #define QZMQVALVE_H
 
-#include <QObject>
+#include <QByteArray>
+#include <QList>
 #include <boost/signals2.hpp>
 
 using SignalList = boost::signals2::signal<void(const QList<QByteArray>&)>;
@@ -35,12 +36,10 @@ namespace QZmq {
 
 class Socket;
 
-class Valve : public QObject
+class Valve
 {
-	Q_OBJECT
-
 public:
-	Valve(QZmq::Socket *sock, QObject *parent = 0);
+	Valve(QZmq::Socket *sock);
 	~Valve();
 
 	bool isOpen() const;

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -43,17 +43,17 @@ class Wrapper : public QObject
 	Q_OBJECT
 
 public:
-	QZmq::Socket *zhttpClientOutStreamSock;
-	QZmq::Socket *zhttpClientInSock;
-	QZmq::Valve *zhttpClientInValve;
-	QZmq::Socket *zhttpServerInSock;
-	QZmq::Valve *zhttpServerInValve;
-	QZmq::Socket *zhttpServerInStreamSock;
-	QZmq::Valve *zhttpServerInStreamValve;
-	QZmq::Socket *zhttpServerOutSock;
-	QZmq::Socket *proxyAcceptSock;
-	QZmq::Valve *proxyAcceptValve;
-	QZmq::Socket *publishPushSock;
+	std::unique_ptr<QZmq::Socket> zhttpClientOutStreamSock;
+	std::unique_ptr<QZmq::Socket> zhttpClientInSock;
+	std::unique_ptr<QZmq::Valve> zhttpClientInValve;
+	std::unique_ptr<QZmq::Socket> zhttpServerInSock;
+	std::unique_ptr<QZmq::Valve> zhttpServerInValve;
+	std::unique_ptr<QZmq::Socket> zhttpServerInStreamSock;
+	std::unique_ptr<QZmq::Valve> zhttpServerInStreamValve;
+	std::unique_ptr<QZmq::Socket> zhttpServerOutSock;
+	std::unique_ptr<QZmq::Socket> proxyAcceptSock;
+	std::unique_ptr<QZmq::Valve> proxyAcceptValve;
+	std::unique_ptr<QZmq::Socket> publishPushSock;
 
 	QDir workDir;
 	bool acceptSuccess;
@@ -80,32 +80,32 @@ public:
 	{
 		// http sockets
 
-		zhttpClientOutStreamSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		zhttpClientOutStreamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 
-		zhttpClientInSock = new QZmq::Socket(QZmq::Socket::Sub, this);
-		zhttpClientInValve = new QZmq::Valve(zhttpClientInSock, this);
+		zhttpClientInSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Sub);
+		zhttpClientInValve = std::make_unique<QZmq::Valve>(zhttpClientInSock.get());
 		zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInSock = new QZmq::Socket(QZmq::Socket::Pull, this);
-		zhttpServerInValve = new QZmq::Valve(zhttpServerInSock, this);
+		zhttpServerInSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pull);
+		zhttpServerInValve = std::make_unique<QZmq::Valve>(zhttpServerInSock.get());
 		zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInStreamSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		zhttpServerInStreamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 		zhttpServerInStreamSock->setIdentity("test-server");
-		zhttpServerInStreamValve = new QZmq::Valve(zhttpServerInStreamSock, this);
+		zhttpServerInStreamValve = std::make_unique<QZmq::Valve>(zhttpServerInStreamSock.get());
 		zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerOutSock = new QZmq::Socket(QZmq::Socket::Pub, this);
+		zhttpServerOutSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pub);
 
 		// proxy sockets
 
-		proxyAcceptSock = new QZmq::Socket(QZmq::Socket::Dealer, this);
-		proxyAcceptValve = new QZmq::Valve(proxyAcceptSock, this);
+		proxyAcceptSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Dealer);
+		proxyAcceptValve = std::make_unique<QZmq::Valve>(proxyAcceptSock.get());
 		proxyAcceptValveConnection = proxyAcceptValve->readyRead.connect(boost::bind(&Wrapper::proxyAccept_readyRead, this, boost::placeholders::_1));
 
 		// publish sockets
 
-		publishPushSock = new QZmq::Socket(QZmq::Socket::Push, this);
+		publishPushSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
 	}
 
 	void startHttp()

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -259,7 +259,6 @@ public:
 		int reqStartTime;
 
 		ControlPort() :
-			sock(0),
 			state(Disabled),
 			works(false),
 			reqStartTime(-1)
@@ -418,17 +417,17 @@ public:
 	ArgsData args;
 	QByteArray zhttpInstanceId;
 	QByteArray zwsInstanceId;
-	QZmq::Socket *m2_in_sock;
-	QZmq::Socket *m2_out_sock;
-	QZmq::Socket *zhttp_in_sock;
-	QZmq::Socket *zhttp_out_sock;
-	QZmq::Socket *zhttp_out_stream_sock;
-	QZmq::Socket *zws_in_sock;
-	QZmq::Socket *zws_out_sock;
-	QZmq::Socket *zws_out_stream_sock;
-	QZmq::Valve *m2_in_valve;
-	QZmq::Valve *zhttp_in_valve;
-	QZmq::Valve *zws_in_valve;
+	std::unique_ptr<QZmq::Socket> m2_in_sock;
+	std::unique_ptr<QZmq::Socket> m2_out_sock;
+	std::unique_ptr<QZmq::Socket> zhttp_in_sock;
+	std::unique_ptr<QZmq::Socket> zhttp_out_sock;
+	std::unique_ptr<QZmq::Socket> zhttp_out_stream_sock;
+	std::unique_ptr<QZmq::Socket> zws_in_sock;
+	std::unique_ptr<QZmq::Socket> zws_out_sock;
+	std::unique_ptr<QZmq::Socket> zws_out_stream_sock;
+	std::unique_ptr<QZmq::Valve> m2_in_valve;
+	std::unique_ptr<QZmq::Valve> zhttp_in_valve;
+	std::unique_ptr<QZmq::Valve> zws_in_valve;
 	QList<QByteArray> m2_send_idents;
 	QHash<Rid, M2Connection*> m2ConnectionsByRid;
 	QHash<Rid, Session*> sessionsByM2Rid;
@@ -462,17 +461,6 @@ public:
 	Private(M2AdapterApp *_q) :
 		QObject(_q),
 		q(_q),
-		m2_in_sock(0),
-		m2_out_sock(0),
-		zhttp_in_sock(0),
-		zhttp_out_sock(0),
-		zhttp_out_stream_sock(0),
-		zws_in_sock(0),
-		zws_out_sock(0),
-		zws_out_stream_sock(0),
-		m2_in_valve(0),
-		zhttp_in_valve(0),
-		zws_in_valve(0),
 		currentM2RefreshBucket(0),
 		currentSessionRefreshBucket(0),
 		zhttpCancelMeter(0)
@@ -494,6 +482,13 @@ public:
 		qDeleteAll(sessionsByZhttpRid);
 		qDeleteAll(sessionsByZwsRid);
 		qDeleteAll(m2ConnectionsByRid);
+
+		for(int n = 0; n < controlPorts.count(); ++n)
+		{
+			ControlPort &c = controlPorts[n];
+			delete c.sock;
+			c.sock = 0;
+		}
 	}
 
 	void start()
@@ -650,7 +645,7 @@ public:
 		zhttpInstanceId = "m2zhttp_" + pidStr;
 		zwsInstanceId = "m2zws_" + pidStr;
 
-		m2_in_sock = new QZmq::Socket(QZmq::Socket::Pull, this);
+		m2_in_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pull);
 		m2_in_sock->setHwm(DEFAULT_HWM);
 		foreach(const QString &spec, m2_in_specs)
 		{
@@ -658,10 +653,10 @@ public:
 			m2_in_sock->connectToAddress(spec);
 		}
 
-		m2_in_valve = new QZmq::Valve(m2_in_sock, this);
+		m2_in_valve = std::make_unique<QZmq::Valve>(m2_in_sock.get());
 		m2InValveConnection = m2_in_valve->readyRead.connect(boost::bind(&Private::m2_in_readyRead, this, boost::placeholders::_1));
 
-		m2_out_sock = new QZmq::Socket(QZmq::Socket::Pub, this);
+		m2_out_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pub);
 		m2_out_sock->setShutdownWaitTime(0);
 		m2_out_sock->setHwm(DEFAULT_HWM);
 		m2_out_sock->setWriteQueueEnabled(false);
@@ -675,7 +670,7 @@ public:
 		{
 			const QString &spec = m2_control_specs[n];
 
-			QZmq::Socket *sock = new QZmq::Socket(QZmq::Socket::Dealer, this);
+			QZmq::Socket *sock = new QZmq::Socket(QZmq::Socket::Dealer);
 			sock->setShutdownWaitTime(0);
 			sock->setHwm(1); // queue up 1 outstanding request at most
 			sock->setWriteQueueEnabled(false);
@@ -691,7 +686,7 @@ public:
 
 		if(!zhttp_in_specs.isEmpty())
 		{
-			zhttp_in_sock = new QZmq::Socket(QZmq::Socket::Sub, this);
+			zhttp_in_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Sub);
 			zhttp_in_sock->setHwm(DEFAULT_HWM);
 			zhttp_in_sock->setShutdownWaitTime(0);
 			zhttp_in_sock->subscribe(zhttpInstanceId + ' ');
@@ -713,10 +708,10 @@ public:
 				}
 			}
 
-			zhttp_in_valve = new QZmq::Valve(zhttp_in_sock, this);
+			zhttp_in_valve = std::make_unique<QZmq::Valve>(zhttp_in_sock.get());
 			zhttpInValveConnection = zhttp_in_valve->readyRead.connect(boost::bind(&Private::zhttp_in_readyRead, this, boost::placeholders::_1));
 
-			zhttp_out_sock = new QZmq::Socket(QZmq::Socket::Push, this);
+			zhttp_out_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
 			zhttp_out_sock->setShutdownWaitTime(0);
 			zhttp_out_sock->setHwm(DEFAULT_HWM);
 			if(zhttp_connect)
@@ -737,7 +732,7 @@ public:
 				}
 			}
 
-			zhttp_out_stream_sock = new QZmq::Socket(QZmq::Socket::Router, this);
+			zhttp_out_stream_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 			zhttp_out_stream_sock->setShutdownWaitTime(0);
 			zhttp_out_stream_sock->setHwm(DEFAULT_HWM);
 			if(zhttp_connect)
@@ -761,7 +756,7 @@ public:
 
 		if(!zws_in_specs.isEmpty())
 		{
-			zws_in_sock = new QZmq::Socket(QZmq::Socket::Sub, this);
+			zws_in_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Sub);
 			zws_in_sock->setHwm(DEFAULT_HWM);
 			zws_in_sock->subscribe(zwsInstanceId + ' ');
 			if(zws_connect)
@@ -782,10 +777,10 @@ public:
 				}
 			}
 
-			zws_in_valve = new QZmq::Valve(zws_in_sock, this);
+			zws_in_valve = std::make_unique<QZmq::Valve>(zws_in_sock.get());
 			zwsInValveConnection = zws_in_valve->readyRead.connect(boost::bind(&Private::zws_in_readyRead, this, boost::placeholders::_1));
 
-			zws_out_sock = new QZmq::Socket(QZmq::Socket::Push, this);
+			zws_out_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
 			zws_out_sock->setShutdownWaitTime(0);
 			zws_out_sock->setHwm(DEFAULT_HWM);
 			if(zws_connect)
@@ -806,7 +801,7 @@ public:
 				}
 			}
 
-			zws_out_stream_sock = new QZmq::Socket(QZmq::Socket::Router, this);
+			zws_out_stream_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 			zws_out_stream_sock->setShutdownWaitTime(0);
 			zws_out_stream_sock->setHwm(DEFAULT_HWM);
 			if(zws_connect)

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -259,6 +259,7 @@ public:
 		int reqStartTime;
 
 		ControlPort() :
+			sock(0),
 			state(Disabled),
 			works(false),
 			reqStartTime(-1)

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -56,21 +56,21 @@ class Wrapper : public QObject
 	Q_OBJECT
 
 public:
-	QZmq::Socket *zhttpClientOutSock;
-	QZmq::Socket *zhttpClientOutStreamSock;
-	QZmq::Socket *zhttpClientInSock;
-	QZmq::Valve *zhttpClientInValve;
-	QZmq::Socket *zhttpServerInSock;
-	QZmq::Valve *zhttpServerInValve;
-	QZmq::Socket *zhttpServerInStreamSock;
-	QZmq::Valve *zhttpServerInStreamValve;
-	QZmq::Socket *zhttpServerOutSock;
+	std::unique_ptr<QZmq::Socket> zhttpClientOutSock;
+	std::unique_ptr<QZmq::Socket> zhttpClientOutStreamSock;
+	std::unique_ptr<QZmq::Socket> zhttpClientInSock;
+	std::unique_ptr<QZmq::Valve> zhttpClientInValve;
+	std::unique_ptr<QZmq::Socket> zhttpServerInSock;
+	std::unique_ptr<QZmq::Valve> zhttpServerInValve;
+	std::unique_ptr<QZmq::Socket> zhttpServerInStreamSock;
+	std::unique_ptr<QZmq::Valve> zhttpServerInStreamValve;
+	std::unique_ptr<QZmq::Socket> zhttpServerOutSock;
 
-	QZmq::Socket *handlerInspectSock;
-	QZmq::Valve *handlerInspectValve;
-	QZmq::Socket *handlerAcceptSock;
-	QZmq::Valve *handlerAcceptValve;
-	QZmq::Socket *handlerRetryOutSock;
+	std::unique_ptr<QZmq::Socket> handlerInspectSock;
+	std::unique_ptr<QZmq::Valve> handlerInspectValve;
+	std::unique_ptr<QZmq::Socket> handlerAcceptSock;
+	std::unique_ptr<QZmq::Valve> handlerAcceptValve;
+	std::unique_ptr<QZmq::Socket> handlerRetryOutSock;
 
 	QDir workDir;
 	QHash<QByteArray, HttpRequestData> serverReqs;
@@ -108,37 +108,37 @@ public:
 	{
 		// http sockets
 
-		zhttpClientOutSock = new QZmq::Socket(QZmq::Socket::Push, this);
+		zhttpClientOutSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
 
-		zhttpClientOutStreamSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		zhttpClientOutStreamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 
-		zhttpClientInSock = new QZmq::Socket(QZmq::Socket::Sub, this);
-		zhttpClientInValve = new QZmq::Valve(zhttpClientInSock, this);
+		zhttpClientInSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Sub);
+		zhttpClientInValve = std::make_unique<QZmq::Valve>(zhttpClientInSock.get());
 		zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInSock = new QZmq::Socket(QZmq::Socket::Pull, this);
-		zhttpServerInValve = new QZmq::Valve(zhttpServerInSock, this);
+		zhttpServerInSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pull);
+		zhttpServerInValve = std::make_unique<QZmq::Valve>(zhttpServerInSock.get());
 		zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInStreamSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		zhttpServerInStreamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 		zhttpServerInStreamSock->setIdentity("test-server");
-		zhttpServerInStreamValve = new QZmq::Valve(zhttpServerInStreamSock, this);
+		zhttpServerInStreamValve = std::make_unique<QZmq::Valve>(zhttpServerInStreamSock.get());
 		zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerOutSock = new QZmq::Socket(QZmq::Socket::Pub, this);
+		zhttpServerOutSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pub);
 
 		// handler sockets
 
-		handlerInspectSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		handlerInspectSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 
-		handlerAcceptSock = new QZmq::Socket(QZmq::Socket::Router, this);
-		handlerAcceptValve = new QZmq::Valve(handlerAcceptSock, this);
+		handlerAcceptSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
+		handlerAcceptValve = std::make_unique<QZmq::Valve>(handlerAcceptSock.get());
 		handlerAcceptValveConnection = handlerAcceptValve->readyRead.connect(boost::bind(&Wrapper::handlerAccept_readyRead, this, boost::placeholders::_1));
 
-		handlerInspectValve = new QZmq::Valve(handlerInspectSock, this);
+		handlerInspectValve = std::make_unique<QZmq::Valve>(handlerInspectSock.get());
 		handlerInspectValveConnection = handlerInspectValve->readyRead.connect(boost::bind(&Wrapper::handlerInspect_readyRead, this, boost::placeholders::_1));
 
-		handlerRetryOutSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		handlerRetryOutSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 	}
 
 	void startHttp()

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2020 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -68,9 +68,9 @@ public:
 	int ipcFileMode;
 	QStringList initSpecs;
 	QStringList streamSpecs;
-	QZmq::Socket *initSock;
-	QZmq::Socket *streamSock;
-	QZmq::Valve *streamValve;
+	std::unique_ptr<QZmq::Socket> initSock;
+	std::unique_ptr<QZmq::Socket> streamSock;
+	std::unique_ptr<QZmq::Valve> streamValve;
 	QHash<QByteArray, WsControlSession*> sessionsByCid;
 	std::unique_ptr<RTimer> refreshTimer;
 	QHash<WsControlSession*, KeepAliveRegistration*> keepAliveRegistrations;
@@ -84,9 +84,6 @@ public:
 		QObject(_q),
 		q(_q),
 		ipcFileMode(-1),
-		initSock(0),
-		streamSock(0),
-		streamValve(0),
 		currentSessionRefreshBucket(0)
 	{
 		refreshTimer = std::make_unique<RTimer>();
@@ -101,9 +98,9 @@ public:
 
 	bool setupInit()
 	{
-		delete initSock;
+		initSock.reset();
 
-		initSock = new QZmq::Socket(QZmq::Socket::Push, this);
+		initSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
 
 		initSock->setHwm(DEFAULT_HWM);
 		initSock->setShutdownWaitTime(0);
@@ -111,7 +108,7 @@ public:
 		foreach(const QString &spec, initSpecs)
 		{
 			QString errorMessage;
-			if(!ZUtil::setupSocket(initSock, spec, true, ipcFileMode, &errorMessage))
+			if(!ZUtil::setupSocket(initSock.get(), spec, true, ipcFileMode, &errorMessage))
 			{
 				log_error("%s", qPrintable(errorMessage));
 				return false;
@@ -123,9 +120,10 @@ public:
 
 	bool setupStream()
 	{
-		delete streamSock;
+		streamValve.reset();
+		streamSock.reset();
 
-		streamSock = new QZmq::Socket(QZmq::Socket::Router, this);
+		streamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
 
 		streamSock->setIdentity(identity);
 		streamSock->setHwm(DEFAULT_HWM);
@@ -134,14 +132,14 @@ public:
 		foreach(const QString &spec, streamSpecs)
 		{
 			QString errorMessage;
-			if(!ZUtil::setupSocket(streamSock, spec, true, ipcFileMode, &errorMessage))
+			if(!ZUtil::setupSocket(streamSock.get(), spec, true, ipcFileMode, &errorMessage))
 			{
 				log_error("%s", qPrintable(errorMessage));
 				return false;
 			}
 		}
 
-		streamValve = new QZmq::Valve(streamSock, this);
+		streamValve = std::make_unique<QZmq::Valve>(streamSock.get());
 		streamValveConnection = streamValve->readyRead.connect(boost::bind(&Private::stream_readyRead, this, boost::placeholders::_1));
 
 		streamValve->open();


### PR DESCRIPTION
This removes `QObject` usage from `QZmq::Socket` and `QZmq::Valve` and updates the rest of the codebase accordingly. Notably, instances of these classes can no longer be assigned parent `QObject`s, so all the constructor calls had to be updated, and lifetimes managed with `std::unique_ptr` instead.