### PR TITLE
close/error when debug is enabled and message processing fails

### DIFF
--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -206,6 +206,9 @@ QVariant WsControlPacket::toVariant() const
 		if(!item.reason.isEmpty())
 			vitem["reason"] = item.reason;
 
+		if(item.debug)
+			vitem["debug"] = true;
+
 		if(!item.route.isEmpty())
 			vitem["route"] = item.route;
 
@@ -360,6 +363,14 @@ bool WsControlPacket::fromVariant(const QVariant &in)
 				return false;
 
 			item.reason = vitem["reason"].toByteArray();
+		}
+
+		if(vitem.contains("debug"))
+		{
+			if(typeId(vitem["debug"]) != QMetaType::Bool)
+				return false;
+
+			item.debug = vitem["debug"].toBool();
 		}
 
 		if(vitem.contains("route"))

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -61,6 +61,7 @@ public:
 		bool queue;
 		int code;
 		QByteArray reason;
+		bool debug;
 		QByteArray route;
 		bool separateStats;
 		QByteArray channelPrefix;
@@ -75,6 +76,7 @@ public:
 			type((Type)-1),
 			queue(false),
 			code(-1),
+			debug(false),
 			separateStats(false),
 			logLevel(-1),
 			trusted(false),

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -2623,6 +2623,7 @@ private:
 					log_debug("added ws session: %s", qPrintable(s->cid));
 				}
 
+				s->debug = item.debug;
 				s->route = item.route;
 				s->statsRoute = item.separateStats ? item.route : QString();
 				s->targetTrusted = item.trusted;

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -805,9 +805,15 @@ private:
 				if(contentFilters != f.contentFilters)
 				{
 					publishQueue.removeFirst();
-					errorMessage = QString("content filter mismatch: subscription=%1 message=%2").arg(contentFilters.join(","), f.contentFilters.join(","));
-					doError();
-					break;
+
+					if(adata.debug)
+					{
+						errorMessage = QString("content filter mismatch: subscription=%1 message=%2").arg(contentFilters.join(","), f.contentFilters.join(","));
+						doError();
+						break;
+					}
+
+					continue;
 				}
 			}
 
@@ -1409,12 +1415,17 @@ private:
 
 		if(!result.errorMessage.isNull())
 		{
-			errorMessage = QString("filter error: %1").arg(result.errorMessage);
-			doError();
-			return;
+			if(adata.debug)
+			{
+				errorMessage = QString("filter error: %1").arg(result.errorMessage);
+				doError();
+				return;
+			}
 		}
-
-		processItem(qi.item, result.sendAction, result.content, qi.exposeHeaders);
+		else
+		{
+			processItem(qi.item, result.sendAction, result.content, qi.exposeHeaders);
+		}
 
 		// if filters finished asynchronously then we need to resume processing
 		if(!inProcessPublishQueue)

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -787,8 +787,6 @@ private:
 					update(LowPriority);
 					break;
 				}
-
-				channel.prevId = item.id;
 			}
 
 			const PublishFormat &f = item.format;
@@ -1435,6 +1433,11 @@ private:
 	void processItem(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content, const QList<QByteArray> &exposeHeaders)
 	{
 		const PublishFormat &f = item.format;
+
+		Instruct::Channel &channel = channels[item.channel];
+
+		if(!channel.prevId.isNull())
+			channel.prevId = item.id;
 
 		if(instruct.holdMode == Instruct::ResponseHold)
 		{

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -48,6 +48,7 @@ public:
 	QByteArray peer;
 	QString cid;
 	int nextReqId;
+	bool debug;
 	QString channelPrefix;
 	int logLevel;
 	HttpRequestData requestData;
@@ -72,7 +73,8 @@ public:
 	ZhttpManager *zhttpOut;
 	std::unique_ptr<Filter::MessageFilter> filters;
 	Connection filtersFinishedConnection;
-	bool processingSendQueue;
+	bool inProcessPublishQueue;
+	bool closed;
 
 	WsSession(QObject *parent = 0);
 	~WsSession();
@@ -88,9 +90,10 @@ public:
 	Signal error;
 
 private:
-	void trySendQueue();
+	void processPublishQueue();
 	void filtersFinished(const Filter::MessageFilter::Result &result);
 	void afterFilters(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content);
+	void sendCloseError(const QString &message);
 	void setupRequestTimer();
 
 private slots:

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -49,6 +49,7 @@ public:
 	std::unique_ptr<RTimer> requestTimer;
 	QByteArray peer;
 	QByteArray cid;
+	bool debug;
 	QByteArray route;
 	bool separateStats;
 	QByteArray channelPrefix;
@@ -62,6 +63,7 @@ public:
 		q(_q),
 		manager(0),
 		nextReqId(0),
+		debug(false),
 		separateStats(false),
 		logLevel(-1),
 		targetTrusted(false)
@@ -100,6 +102,7 @@ public:
 		WsControlPacket::Item i;
 		i.type = WsControlPacket::Item::Here;
 		i.requestId = QByteArray::number(reqId);
+		i.debug = debug;
 		i.route = route;
 		i.separateStats = separateStats;
 		i.channelPrefix = channelPrefix;
@@ -329,8 +332,9 @@ QByteArray WsControlSession::cid() const
 	return d->cid;
 }
 
-void WsControlSession::start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted)
+void WsControlSession::start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted)
 {
+	d->debug = debug;
 	d->route = routeId;
 	d->separateStats = separateStats;
 	d->channelPrefix = channelPrefix;

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -45,7 +45,7 @@ public:
 	QByteArray peer() const;
 	QByteArray cid() const;
 
-	void start(const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted);
+	void start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted);
 	void sendGripMessage(const QByteArray &message);
 	void sendNeedKeepAlive();
 	void sendSubscribe(const QByteArray &channel);

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -950,7 +950,7 @@ private slots:
 					wsControl->cancelEventReceived.connect(boost::bind(&Private::wsControl_cancelEventReceived, this)),
 					wsControl->error.connect(boost::bind(&Private::wsControl_error, this))
 				};
-				wsControl->start(route.id, route.separateStats, channelPrefix, route.logLevel, inSock->requestUri(), target.trusted);
+				wsControl->start(route.debug, route.id, route.separateStats, channelPrefix, route.logLevel, inSock->requestUri(), target.trusted);
 
 				foreach(const QString &subChannel, target.subscriptions)
 				{


### PR DESCRIPTION
Currently, each transport handles message processing failures differently. For HTTP, the connection is closed, optionally with an error message if debug is enabled on the route. For WebSockets, an error message is logged at debug level (to be potentially seen by an operator), but no message is sent to the client and the connection is left alone. This PR changes both transports to use the same, new behavior: if debug is enabled on the route, the connection is closed with an error message. If debug is not enabled on the route, the connection is left alone.

There are good reasons to close or not close the connection when a message processing error occurs. The reason *to* close is it helps surface the problem without needing access to pushpin logs. Otherwise, publishing goes into a black hole and clients are silent. The reason *to not* close, is that it is pretty unhelpful to close if an error message doesn't come along with it, which is normally the case since debug mode should be disabled in production. Also, one could argue that a filter failing is just one of many ways a message could get lost between the publisher and the subscriber and it does not indicate a problem with the actual subscription. As a compromise, this PR acts both ways. If debug is enabled, the connection is closed, else the connection is not closed.