### PR TITLE
ensure timer preallocation counts timers used by filters

### DIFF
--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -613,6 +613,8 @@ Filter::Targets Filter::targets(const QString &name)
 
 Filter::MessageFilterStack::MessageFilterStack(const QStringList &filterNames)
 {
+	assert(filterNames.count() <= MESSAGEFILTERSTACK_SIZE_MAX);
+
 	foreach(const QString &name, filterNames)
 	{
 		MessageFilter *f = createMessageFilter(name);

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -31,6 +31,11 @@
 #include <QUrl>
 #include <boost/signals2.hpp>
 
+#define MESSAGEFILTERSTACK_SIZE_MAX 5
+
+// 2 timers per zhttprequest
+#define TIMERS_PER_MESSAGEFILTERSTACK (2 * MESSAGEFILTERSTACK_SIZE_MAX)
+
 class ZhttpManager;
 
 class Filter

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -89,12 +89,6 @@
 #define INSPECT_WORKERS_MAX 10
 #define ACCEPT_WORKERS_MAX 10
 
-// each session can have a bunch of timers:
-// 2 per incoming zhttprequest
-// 2 per outgoing zhttprequest
-// 2 per httpsession
-#define TIMERS_PER_SESSION 10
-
 using namespace VariantUtil;
 
 static QList<PublishItem> parseItems(const QVariantList &vitems, bool *ok = 0, QString *errorMessage = 0)
@@ -1337,8 +1331,10 @@ public:
 	{
 		config = _config;
 
+		int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION);
+
 		// enough timers for sessions, plus an extra 100 for misc
-		RTimer::init((config.connectionsMax * TIMERS_PER_SESSION) + 100);
+		RTimer::init((config.connectionsMax * timersPerSession) + 100);
 
 		publishLimiter->setRate(config.messageRate);
 		publishLimiter->setHwm(config.messageHwm);
@@ -2666,7 +2662,7 @@ private:
 				if(e.error != QJsonParseError::NoError || (!doc.isObject() && !doc.isArray()))
 				{
 					log_debug("grip control message is not valid json");
-					return;
+					continue;
 				}
 
 				if(doc.isObject())
@@ -2679,13 +2675,19 @@ private:
 				if(!ok)
 				{
 					log_debug("failed to parse grip control message: %s", qPrintable(errorMessage));
-					return;
+					continue;
 				}
 
 				if(cm.type == WsControlMessage::Subscribe)
 				{
 					if(s->channels.count() < config.connectionSubscriptionMax)
 					{
+						if(cm.filters.count() > MESSAGEFILTERSTACK_SIZE_MAX)
+						{
+							s->sendCloseError(QString("too many filters for channel '%1'").arg(cm.channel));
+							continue;
+						}
+
 						QString channel = s->channelPrefix + cm.channel;
 						s->channels += channel;
 						s->channelFilters[channel] = cm.filters;

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -31,7 +31,15 @@
 #include "inspectdata.h"
 #include "zhttprequest.h"
 #include "instruct.h"
+#include "filter.h"
 #include <boost/signals2.hpp>
+
+// each session can have a bunch of timers:
+// 2 per incoming zhttprequest
+// 2 per outgoing zhttprequest
+// 2 additional timers
+// filter timers
+#define TIMERS_PER_HTTPSESSION (10 + TIMERS_PER_MESSAGEFILTERSTACK)
 
 using Connection = boost::signals2::scoped_connection;
 

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -29,6 +29,7 @@
 #include "qtcompat.h"
 #include "variantutil.h"
 #include "statusreasons.h"
+#include "filter.h"
 
 #define DEFAULT_RESPONSE_TIMEOUT 55
 #define MINIMUM_RESPONSE_TIMEOUT 5
@@ -145,6 +146,12 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			const HttpHeaderParameter &param = gripChannel[n];
 			if(param.first == "filter")
 				c.filters += QString::fromUtf8(param.second);
+		}
+
+		if(c.filters.count() > MESSAGEFILTERSTACK_SIZE_MAX)
+		{
+			setError(ok, errorMessage, QString("too many filters for channel '%1'").arg(c.name));
+			return Instruct();
 		}
 
 		channels += c;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -244,7 +244,9 @@ void WsSession::sendCloseError(const QString &message)
 	i.cid = cid.toUtf8();
 	i.type = WsControlPacket::Item::Close;
 	i.code = 1011;
-	i.reason = message.toUtf8();
+
+	if(debug)
+		i.reason = message.toUtf8();
 
 	send(i);
 }

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -32,6 +32,10 @@
 #include "filter.h"
 #include <boost/signals2.hpp>
 
+// each session can have a bunch of timers:
+// filter timers
+#define TIMERS_PER_WSSESSION (0 + TIMERS_PER_MESSAGEFILTERSTACK)
+
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
@@ -84,6 +88,7 @@ public:
 	void sendDelayed(const QByteArray &type, const QByteArray &message, int timeout);
 	void ack(int reqId);
 	void publish(const PublishItem &item);
+	void sendCloseError(const QString &message);
 
 	boost::signals2::signal<void(const WsControlPacket::Item&)> send;
 	Signal expired;
@@ -93,7 +98,6 @@ private:
 	void processPublishQueue();
 	void filtersFinished(const Filter::MessageFilter::Result &result);
 	void afterFilters(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content);
-	void sendCloseError(const QString &message);
 	void setupRequestTimer();
 
 private slots:


### PR DESCRIPTION
The sessions-per-timer calculation needs to be updated now that filters might contain timers (the HTTP filters contain a ZhttpRequest which contains timers). In order to bound the number of filter-related timers, we establish a limit of 5 filters per session.