### PR TITLE
rate limit http filter requests

### DIFF
--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -30,6 +30,7 @@
 #include <QMetaType>
 #include <QUrl>
 #include <boost/signals2.hpp>
+#include "ratelimiter.h"
 
 class ZhttpManager;
 
@@ -61,6 +62,7 @@ public:
 		QUrl currentUri;
 		QString route;
 		bool trusted;
+		std::shared_ptr<RateLimiter> limiter;
 
 		Context() :
 			zhttpOut(0),

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -30,6 +30,7 @@
 #include "rtimer.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
+#include "ratelimiter.h"
 #include "filter.h"
 
 class HttpFilterServer
@@ -156,6 +157,7 @@ class FilterTest : public QObject
 private:
 	std::unique_ptr<HttpFilterServer> filterServer;
 	std::unique_ptr<ZhttpManager> zhttpOut;
+	std::shared_ptr<RateLimiter> limiter;
 
 	Filter::MessageFilter::Result runMessageFilters(const QStringList &filterNames, const Filter::Context &context, const QByteArray &content)
 	{
@@ -194,6 +196,8 @@ private slots:
 		zhttpOut->setClientOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in")));
 		zhttpOut->setClientOutStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in-stream")));
 		zhttpOut->setClientInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-out")));
+
+		limiter = std::make_shared<RateLimiter>();
 
 		QTest::qWait(500);
 	}
@@ -242,6 +246,7 @@ private slots:
 		context.subscriptionMeta["url"] = "/filter/accept";
 		context.zhttpOut = zhttpOut.get();
 		context.currentUri = "http://localhost/";
+		context.limiter = limiter;
 
 		QByteArray content = "hello world";
 
@@ -277,6 +282,7 @@ private slots:
 		context.subscriptionMeta["url"] = "/filter/modify";
 		context.zhttpOut = zhttpOut.get();
 		context.currentUri = "http://localhost/";
+		context.limiter = limiter;
 
 		QByteArray content = "hello world";
 

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -88,7 +88,7 @@ public:
 		}
 	};
 
-	HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *outZhttp, StatsManager *stats, RateLimiter *updateLimiter, PublishLastIds *publishLastIds, HttpSessionUpdateManager *updateManager, int connectionSubscriptionMax, QObject *parent = 0);
+	HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *outZhttp, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, HttpSessionUpdateManager *updateManager, int connectionSubscriptionMax, QObject *parent = 0);
 	~HttpSession();
 
 	Instruct::HoldMode holdMode() const;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -155,6 +155,7 @@ void WsSession::processPublishQueue()
 		fc.currentUri = requestData.uri;
 		fc.route = route;
 		fc.trusted = targetTrusted;
+		fc.limiter = filterLimiter;
 
 		// may call filtersFinished immediately. if it does, queue processing
 		// will continue. else, the loop will end and queue processing will

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -29,6 +29,7 @@
 #include <QSet>
 #include "packet/httprequestdata.h"
 #include "packet/wscontrolpacket.h"
+#include "ratelimiter.h"
 #include "filter.h"
 #include <boost/signals2.hpp>
 
@@ -71,6 +72,7 @@ public:
 	QTimer *requestTimer;
 	QList<PublishItem> publishQueue;
 	ZhttpManager *zhttpOut;
+	std::shared_ptr<RateLimiter> filterLimiter;
 	std::unique_ptr<Filter::MessageFilter> filters;
 	Connection filtersFinishedConnection;
 	bool inProcessPublishQueue;


### PR DESCRIPTION
This adds a new rate limiter for limiting the number of concurrent requests made by the HTTP-based filters. The existing "update" rate limiter is not reused since that one enables a batching mode.