### PR TITLE
Makefile: leading whitespace fix for Ubuntu 24.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-cargo_flags =
+# controlled leading whitespace, per the GNU make manual
+nullstring :=
+space := $(nullstring) # end of the line
+
 ifdef RELEASE
-cargo_flags += --offline --locked --release
+cargo_flags = $(space)--offline --locked --release
 endif
 
-cargo_toolchain =
 ifdef TOOLCHAIN
-cargo_toolchain += +$(TOOLCHAIN)
+cargo_toolchain = $(space)+$(TOOLCHAIN)
 endif
 
 all: postbuild


### PR DESCRIPTION
We are relying on Make to prepend a space when `+=` is used, but there seems to be some recent Ubuntu packaging change that causes it to not do this if the original value is empty. This PR makes our intention more explicit, based on [advice from the manual](https://www.gnu.org/software/make/manual/make.html#Simple-Assignment).