### PR TITLE
add timeout to http filters

### DIFF
--- a/src/core/httprequest.h
+++ b/src/core/httprequest.h
@@ -61,6 +61,7 @@ public:
 	virtual void setIgnorePolicies(bool on) = 0;
 	virtual void setTrustConnectHost(bool on) = 0;
 	virtual void setIgnoreTlsErrors(bool on) = 0;
+	virtual void setTimeout(int msecs) = 0;
 
 	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers) = 0;
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) = 0;

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -28,6 +28,8 @@
 #include "httprequest.h"
 #include <boost/signals2.hpp>
 
+#define TIMERS_PER_ZHTTPREQUEST 3
+
 using Connection = boost::signals2::scoped_connection;
 
 class ZhttpRequestPacket;
@@ -89,6 +91,7 @@ public:
 	virtual void setIgnorePolicies(bool on);
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
+	virtual void setTimeout(int msecs);
 
 	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers);
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -30,12 +30,12 @@
 #include <QMetaType>
 #include <QUrl>
 #include <boost/signals2.hpp>
+#include "zhttprequest.h"
 #include "ratelimiter.h"
 
 #define MESSAGEFILTERSTACK_SIZE_MAX 5
 
-// 2 timers per zhttprequest
-#define TIMERS_PER_MESSAGEFILTERSTACK (2 * MESSAGEFILTERSTACK_SIZE_MAX)
+#define TIMERS_PER_MESSAGEFILTERSTACK (TIMERS_PER_ZHTTPREQUEST * MESSAGEFILTERSTACK_SIZE_MAX)
 
 class ZhttpManager;
 

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -35,11 +35,12 @@
 #include <boost/signals2.hpp>
 
 // each session can have a bunch of timers:
-// 2 per incoming zhttprequest
-// 2 per outgoing zhttprequest
+// incoming request
+// outgoing request
 // 2 additional timers
 // filter timers
-#define TIMERS_PER_HTTPSESSION (10 + TIMERS_PER_MESSAGEFILTERSTACK)
+// a few more just in case
+#define TIMERS_PER_HTTPSESSION ((TIMERS_PER_ZHTTPREQUEST * 2) + 2 + TIMERS_PER_MESSAGEFILTERSTACK + 4)
 
 using Connection = boost::signals2::scoped_connection;
 

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -183,6 +183,11 @@ void TestHttpRequest::setIgnoreTlsErrors(bool on)
 	Q_UNUSED(on);
 }
 
+void TestHttpRequest::setTimeout(int msecs)
+{
+	Q_UNUSED(msecs);
+}
+
 void TestHttpRequest::start(const QString &method, const QUrl &uri, const HttpHeaders &headers)
 {
 	assert(d->state == Private::Idle);

--- a/src/proxy/testhttprequest.h
+++ b/src/proxy/testhttprequest.h
@@ -45,6 +45,7 @@ public:
 	virtual void setIgnorePolicies(bool on);
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
+	virtual void setTimeout(int msecs);
 
 	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers);
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);


### PR DESCRIPTION
Message filters are intended to complete quickly, so let's set some kind of time limit on the filters that make HTTP requests. Ideally, these filters should complete within milliseconds to avoid introducing too much latency, however we ought to leave some room for inefficient filters just in case. This PR sets a timeout of 10 seconds. Long enough to not be a problem under normal operation, but short enough to catch runaway filters and prevent calls from stacking up.