### PR TITLE
use dynamic_cast instead of qobject_cast

### DIFF
--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1776,13 +1776,13 @@ private:
 
 		if(f.type == PublishFormat::HttpResponse || f.type == PublishFormat::HttpStream)
 		{
-			HttpSession *hs = qobject_cast<HttpSession*>(target);
+			HttpSession *hs = dynamic_cast<HttpSession*>(target);
 
 			hs->publish(item, exposeHeaders);
 		}
 		else if(f.type == PublishFormat::WebSocketMessage)
 		{
-			WsSession *s = qobject_cast<WsSession*>(target);
+			WsSession *s = dynamic_cast<WsSession*>(target);
 
 			s->publish(item);
 		}

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -1025,7 +1025,7 @@ private:
 				return;
 			}
 
-			WebSocketOverHttp *woh = qobject_cast<WebSocketOverHttp*>(ps->outSocket());
+			WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp*>(ps->outSocket());
 			if(woh)
 				woh->refresh();
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -1125,7 +1125,7 @@ private:
 
 	void wsControl_refreshEventReceived()
 	{
-		WebSocketOverHttp *woh = qobject_cast<WebSocketOverHttp*>(outSock);
+		WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp*>(outSock);
 		if(woh)
 			woh->refresh();
 	}


### PR DESCRIPTION
Found one more `QObject` capability we were dependent on: `qobject_cast`.

Per the [Qt docs](https://doc.qt.io/qt-6/qobject.html#qobject_cast):
> The qobject_cast() function behaves similarly to the standard C++ dynamic_cast(), with the advantages that it doesn't require RTTI support and it works across dynamic library boundaries.

We aren't working in an environment where we need this flexibility.