### PR TITLE
handlerengine: check dynamic_cast

### DIFF
--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1775,9 +1775,9 @@ private:
 
 	void publishSend(const std::shared_ptr<QObject> &target, const PublishItem &item, const QList<QByteArray> &exposeHeaders)
 	{
-		if(HttpSession *hs = dynamic_cast<HttpSession*>(target.get()))
+		if(auto hs = std::dynamic_pointer_cast<HttpSession>(target))
 			hs->publish(item, exposeHeaders);
-		else if(WsSession *s = dynamic_cast<WsSession*>(target.get()))
+		else if(auto s = std::dynamic_pointer_cast<WsSession>(target))
 			s->publish(item);
 	}
 

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1775,20 +1775,10 @@ private:
 
 	void publishSend(const std::shared_ptr<QObject> &target, const PublishItem &item, const QList<QByteArray> &exposeHeaders)
 	{
-		const PublishFormat &f = item.format;
-
-		if(f.type == PublishFormat::HttpResponse || f.type == PublishFormat::HttpStream)
-		{
-			HttpSession *hs = dynamic_cast<HttpSession*>(target.get());
-
+		if(HttpSession *hs = dynamic_cast<HttpSession*>(target.get()))
 			hs->publish(item, exposeHeaders);
-		}
-		else if(f.type == PublishFormat::WebSocketMessage)
-		{
-			WsSession *s = dynamic_cast<WsSession*>(target.get());
-
+		else if(WsSession *s = dynamic_cast<WsSession*>(target.get()))
 			s->publish(item);
-		}
 	}
 
 	int blocksForData(int size) const

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -105,6 +105,11 @@ void WsSession::ack(int reqId)
 
 void WsSession::publish(const PublishItem &item)
 {
+	const PublishFormat &f = item.format;
+
+	if(f.type != PublishFormat::WebSocketMessage)
+		return;
+
 	publishQueue += item;
 
 	if(!inProcessPublishQueue)


### PR DESCRIPTION
Currently we determine which session type to cast to based on the payload type, but since casts are fallible it is enough to simply try each of the known session types and go with whichever one succeeds (if any).