### PR TITLE
limit http-modify filter response size

### DIFF
--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -37,6 +37,8 @@
 
 #define TIMERS_PER_MESSAGEFILTERSTACK (TIMERS_PER_ZHTTPREQUEST * MESSAGEFILTERSTACK_SIZE_MAX)
 
+#define DEFAULT_FILTER_RESPONSE_SIZE_MAX 100000
+
 class ZhttpManager;
 
 class Filter
@@ -68,10 +70,12 @@ public:
 		QString route;
 		bool trusted;
 		std::shared_ptr<RateLimiter> limiter;
+		int responseSizeMax;
 
 		Context() :
 			zhttpOut(0),
-			trusted(false)
+			trusted(false),
+			responseSizeMax(DEFAULT_FILTER_RESPONSE_SIZE_MAX)
 		{
 		}
 	};

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -143,6 +143,10 @@ public:
 			else
 				respondOk(req, 204, true, "");
 		}
+		else if(uri.path() == "/filter/large")
+		{
+			respondOk(req, 200, true, QByteArray(1001, 'a'));
+		}
 		else
 		{
 			respondError(req, 400, "Bad Request", "Bad Request\n");
@@ -301,6 +305,16 @@ private slots:
 			QVERIFY(r.errorMessage.isNull());
 			QCOMPARE(r.sendAction, Filter::Send);
 			QCOMPARE(r.content, "<<<hello world>>>");
+		}
+
+		context.subscriptionMeta.clear();
+		context.publishMeta.clear();
+		context.subscriptionMeta["url"] = "/filter/large";
+		context.responseSizeMax = 1000;
+
+		{
+			auto r = runMessageFilters(filterNames, context, content);
+			QCOMPARE(r.errorMessage, "network response exceeded 1000 bytes");
 		}
 	}
 };


### PR DESCRIPTION
The `http-modify` filter collects the entire response body in memory before processing it, so we need a limit.