### PR TITLE
wssession: use rtimer

### DIFF
--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -44,7 +44,6 @@
 
 using Connection = boost::signals2::scoped_connection;
 
-class QTimer;
 class ZhttpManager;
 class StatsManager;
 class PublishItem;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,9 +23,9 @@
 
 #include "wssession.h"
 
-#include <QTimer>
 #include <QDateTime>
 #include "log.h"
+#include "rtimer.h"
 #include "defercall.h"
 #include "filter.h"
 #include "publishitem.h"
@@ -43,17 +43,17 @@ WsSession::WsSession(QObject *parent) :
 	inProcessPublishQueue(false),
 	closed(false)
 {
-	expireTimer = new QTimer(this);
+	expireTimer = new RTimer;
 	expireTimer->setSingleShot(true);
-	connect(expireTimer, &QTimer::timeout, this, &WsSession::expireTimer_timeout);
+	expireTimer->timeout.connect(boost::bind(&WsSession::expireTimer_timeout, this));
 
-	delayedTimer = new QTimer(this);
+	delayedTimer = new RTimer;
 	delayedTimer->setSingleShot(true);
-	connect(delayedTimer, &QTimer::timeout, this, &WsSession::delayedTimer_timeout);
+	delayedTimer->timeout.connect(boost::bind(&WsSession::delayedTimer_timeout, this));
 
-	requestTimer = new QTimer(this);
+	requestTimer = new RTimer;
 	requestTimer->setSingleShot(true);
-	connect(requestTimer, &QTimer::timeout, this, &WsSession::requestTimer_timeout);
+	requestTimer->timeout.connect(boost::bind(&WsSession::requestTimer_timeout, this));
 }
 
 WsSession::~WsSession()

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2020 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -34,14 +34,14 @@
 #include <boost/signals2.hpp>
 
 // each session can have a bunch of timers:
+// 3 misc timers
 // filter timers
-#define TIMERS_PER_WSSESSION (0 + TIMERS_PER_MESSAGEFILTERSTACK)
+#define TIMERS_PER_WSSESSION (3 + TIMERS_PER_MESSAGEFILTERSTACK)
 
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
-class QTimer;
-
+class RTimer;
 class ZhttpManager;
 class PublishItem;
 
@@ -71,9 +71,9 @@ public:
 	QByteArray delayedType;
 	QByteArray delayedMessage;
 	QHash<int, qint64> pendingRequests;
-	QTimer *expireTimer;
-	QTimer *delayedTimer;
-	QTimer *requestTimer;
+	RTimer *expireTimer;
+	RTimer *delayedTimer;
+	RTimer *requestTimer;
 	QList<PublishItem> publishQueue;
 	ZhttpManager *zhttpOut;
 	std::shared_ptr<RateLimiter> filterLimiter;
@@ -101,8 +101,6 @@ private:
 	void filtersFinished(const Filter::MessageFilter::Result &result);
 	void afterFilters(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content);
 	void setupRequestTimer();
-
-private slots:
 	void expireTimer_timeout();
 	void delayedTimer_timeout();
 	void requestTimer_timeout();


### PR DESCRIPTION
This works towards replacing the remaining use of `QTimer` with `RTimer`, our internal alternative.