### PR TITLE
rename rtimer to timer

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -53,7 +53,7 @@ HEADERS += \
 	$$PWD/config.h \
 	$$PWD/timerwheel.h \
 	$$PWD/jwt.h \
-	$$PWD/rtimer.h \
+	$$PWD/timer.h \
 	$$PWD/defercall.h \
 	$$PWD/socketnotifier.h \
 	$$PWD/eventloop.h \
@@ -79,7 +79,7 @@ SOURCES += \
 	$$PWD/config.cpp \
 	$$PWD/timerwheel.cpp \
 	$$PWD/jwt.cpp \
-	$$PWD/rtimer.cpp \
+	$$PWD/timer.cpp \
 	$$PWD/defercall.cpp \
 	$$PWD/socketnotifier.cpp \
 	$$PWD/eventloop.cpp \

--- a/src/core/qzmqsocket.cpp
+++ b/src/core/qzmqsocket.cpp
@@ -31,7 +31,7 @@
 #include <boost/signals2.hpp>
 #include "rust/bindings.h"
 #include "qzmqcontext.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "socketnotifier.h"
 
 using Connection = boost::signals2::scoped_connection;
@@ -372,7 +372,7 @@ public:
 	bool canWrite, canRead;
 	QList< QList<QByteArray> > pendingWrites;
 	int pendingWritten;
-	std::unique_ptr<RTimer> updateTimer;
+	std::unique_ptr<Timer> updateTimer;
 	Connection updateTimerConnection;
 	bool pendingUpdate;
 	int shutdownWaitTime;
@@ -421,7 +421,7 @@ public:
 		sn_read->activated.connect(boost::bind(&Private::sn_read_activated, this));
 		sn_read->setEnabled(true);
 
-		updateTimer = std::make_unique<RTimer>();
+		updateTimer = std::make_unique<Timer>();
 		updateTimerConnection = updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));
 		updateTimer->setSingleShot(true);
 	}

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -36,7 +36,7 @@
 #include "httpheaders.h"
 #include "simplehttpserver.h"
 #include "zutil.h"
-#include "rtimer.h"
+#include "timer.h"
 
 // make this somewhat big since PUB is lossy
 #define OUT_HWM 200000
@@ -425,10 +425,10 @@ public:
 	QHash<QByteArray, Report*> reports;
 	Counts combinedCounts;
 	Report combinedReport;
-	std::unique_ptr<RTimer> activityTimer;
-	std::unique_ptr<RTimer> reportTimer;
-	std::unique_ptr<RTimer> refreshTimer;
-	std::unique_ptr<RTimer> externalConnectionsMaxTimer;
+	std::unique_ptr<Timer> activityTimer;
+	std::unique_ptr<Timer> reportTimer;
+	std::unique_ptr<Timer> refreshTimer;
+	std::unique_ptr<Timer> externalConnectionsMaxTimer;
 	Connection activityTimerConnection;
 	Connection reportTimerConnection;
 	Connection refreshTimerConnection;
@@ -455,15 +455,15 @@ public:
 		currentSubscriptionRefreshBucket(0),
 		wheel(TimerWheel((_connectionsMax * 2) + _subscriptionsMax))
 	{
-		activityTimer = std::make_unique<RTimer>();
+		activityTimer = std::make_unique<Timer>();
 		activityTimerConnection = activityTimer->timeout.connect(boost::bind(&Private::activity_timeout, this));
 		activityTimer->setSingleShot(true);
 
-		refreshTimer = std::make_unique<RTimer>();
+		refreshTimer = std::make_unique<Timer>();
 		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
 		refreshTimer->start(REFRESH_INTERVAL);
 
-		externalConnectionsMaxTimer = std::make_unique<RTimer>();
+		externalConnectionsMaxTimer = std::make_unique<Timer>();
 		externalConnectionsMaxTimerConnection = externalConnectionsMaxTimer->timeout.connect(boost::bind(&Private::externalConnectionsMax_timeout, this));
 		externalConnectionsMaxTimer->start(EXTERNAL_CONNECTIONS_MAX_INTERVAL);
 
@@ -606,7 +606,7 @@ public:
 	{
 		if(reportInterval > 0 && !reportTimer)
 		{
-			reportTimer = std::make_unique<RTimer>();
+			reportTimer = std::make_unique<Timer>();
 			reportTimerConnection = reportTimer->timeout.connect(boost::bind(&Private::report_timeout, this));
 			reportTimer->start(reportInterval);
 		}

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -21,8 +21,8 @@
  * $FANOUT_END_LICENSE$
  */
 
-#ifndef RTIMER_H
-#define RTIMER_H
+#ifndef TIMER_H
+#define TIMER_H
 
 #include <qobject.h>
 #include <boost/signals2.hpp>
@@ -31,13 +31,13 @@ using Signal = boost::signals2::signal<void()>;
 
 class TimerManager;
 
-class RTimer : public QObject
+class Timer : public QObject
 {
 	Q_OBJECT
 
 public:
-	RTimer();
-	~RTimer();
+	Timer();
+	~Timer();
 
 	bool isActive() const;
 
@@ -50,7 +50,7 @@ public:
 	// initialization is thread local
 	static void init(int capacity);
 
-	// only call if there are no active RTimers
+	// only call if there are no active timers
 	static void deinit();
 
 	Signal timeout;

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -34,7 +34,7 @@
 #include "log.h"
 #include "zutil.h"
 #include "logutil.h"
-#include "rtimer.h"
+#include "timer.h"
 
 #define OUT_HWM 100
 #define IN_HWM 100
@@ -102,7 +102,7 @@ public:
 	QHash<ZWebSocket::Rid, ZWebSocket*> clientSocksByRid;
 	QHash<ZWebSocket::Rid, ZWebSocket*> serverSocksByRid;
 	QList<ZWebSocket*> serverPendingSocks;
-	std::unique_ptr<RTimer> refreshTimer;
+	std::unique_ptr<Timer> refreshTimer;
 	QHash<void*, KeepAliveRegistration*> keepAliveRegistrations;
 	QSet<KeepAliveRegistration*> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
 	int currentSessionRefreshBucket;
@@ -123,7 +123,7 @@ public:
 		doBind(false),
 		currentSessionRefreshBucket(0)
 	{
-		refreshTimer = std::make_unique<RTimer>();
+		refreshTimer = std::make_unique<Timer>();
 		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
 	}
 

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -28,7 +28,7 @@
 #include "zhttpresponsepacket.h"
 #include "bufferlist.h"
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
 #include "uuidutil.h"
@@ -100,9 +100,9 @@ public:
 	bool writableChanged;
 	bool errored;
 	ErrorCondition errorCondition;
-	RTimer *expireTimer;
-	RTimer *keepAliveTimer;
-	RTimer *finishTimer;
+	Timer *expireTimer;
+	Timer *keepAliveTimer;
+	Timer *finishTimer;
 	bool multi;
 	bool quiet;
 	Connection expTimerConnection;
@@ -143,11 +143,11 @@ public:
 		multi(false),
 		quiet(false)
 	{
-		expireTimer = new RTimer;
+		expireTimer = new Timer;
 		expTimerConnection = expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
 		expireTimer->setSingleShot(true);
 
-		keepAliveTimer = new RTimer;
+		keepAliveTimer = new Timer;
 		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
 	}
 
@@ -296,7 +296,7 @@ public:
 
 		if(timeout > 0)
 		{
-			finishTimer = new RTimer;
+			finishTimer = new Timer;
 			finishTimerConnection = finishTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
 			finishTimer->setSingleShot(true);
 			finishTimer->start(timeout);

--- a/src/core/zrpcrequest.cpp
+++ b/src/core/zrpcrequest.cpp
@@ -30,7 +30,7 @@
 #include "zrpcmanager.h"
 #include "uuidutil.h"
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 
 using Connection = boost::signals2::scoped_connection;
@@ -51,7 +51,7 @@ public:
 	QVariant result;
 	ErrorCondition condition;
 	QByteArray conditionString;
-	std::unique_ptr<RTimer> timer;
+	std::unique_ptr<Timer> timer;
 	Connection timerConnection;
 	DeferCall deferCall;
 
@@ -157,7 +157,7 @@ public:
 
 		if(manager->timeout() >= 0)
 		{
-			timer = std::make_unique<RTimer>();
+			timer = std::make_unique<Timer>();
 			timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
 			timer->setSingleShot(true);
 			timer->start(manager->timeout());

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -27,7 +27,7 @@
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
 #include "uuidutil.h"
@@ -84,8 +84,8 @@ public:
 	bool readableChanged;
 	bool writableChanged;
 	ErrorCondition errorCondition;
-	RTimer *expireTimer;
-	RTimer *keepAliveTimer;
+	Timer *expireTimer;
+	Timer *keepAliveTimer;
 	QList<Frame> inFrames;
 	QList<Frame> outFrames;
 	int inSize;
@@ -127,11 +127,11 @@ public:
 		outContentType((int)Frame::Text),
 		multi(false)
 	{
-		expireTimer = new RTimer;
+		expireTimer = new Timer;
 		expireTimerConnection = expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
 		expireTimer->setSingleShot(true);
 
-		keepAliveTimer = new RTimer;
+		keepAliveTimer = new Timer;
 		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
 	}
 

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -27,7 +27,7 @@
 #include <QJsonObject>
 #include <boost/signals2.hpp>
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
 #include "ratelimiter.h"
@@ -191,7 +191,7 @@ private slots:
 		QDir outDir(qgetenv("OUT_DIR"));
 		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
-		RTimer::init(100);
+		Timer::init(100);
 
 		filterServer = std::make_unique<HttpFilterServer>(workDir);
 
@@ -214,7 +214,7 @@ private slots:
 		// ensure deferred deletes are processed
 		QCoreApplication::instance()->sendPostedEvents();
 
-		RTimer::deinit();
+		Timer::deinit();
 		DeferCall::cleanup();
 	}
 

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -34,7 +34,7 @@
 #include "qzmqreqmessage.h"
 #include "qtcompat.h"
 #include "tnetstring.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "log.h"
 #include "logutil.h"
@@ -1186,7 +1186,7 @@ public:
 
 	void start()
 	{
-		timer_ = new RTimer;
+		timer_ = new Timer;
 		timer_->timeout.connect(boost::bind(&Subscription::timer_timeout, this));
 		timer_->setSingleShot(true);
 		timer_->start(SUBSCRIBED_DELAY);
@@ -1196,7 +1196,7 @@ public:
 
 private:
 	QString channel_;
-	RTimer *timer_;
+	Timer *timer_;
 
 	void timer_timeout()
 	{
@@ -1345,7 +1345,7 @@ public:
 			TIMERS_PER_UNIQUE_UPDATE_REGISTRATION;
 
 		// enough timers for sessions, plus an extra 100 for misc
-		RTimer::init((config.connectionsMax * timersPerSession) + 100);
+		Timer::init((config.connectionsMax * timersPerSession) + 100);
 
 		publishLimiter->setRate(config.messageRate);
 		publishLimiter->setHwm(config.messageHwm);

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -32,7 +32,7 @@
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
 #include "packet/httpresponsedata.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "handlerengine.h"
 
@@ -312,7 +312,7 @@ private slots:
 		// ensure deferred deletes are processed
 		QCoreApplication::instance()->sendPostedEvents();
 
-		RTimer::deinit();
+		Timer::deinit();
 		DeferCall::cleanup();
 	}
 

--- a/src/handler/handlermain.cpp
+++ b/src/handler/handlermain.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <QCoreApplication>
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "handlerapp.h"
 
@@ -60,7 +60,7 @@ int handler_main(int argc, char **argv)
 	QCoreApplication::instance()->sendPostedEvents();
 
 	// deinit here, after all event loop activity has completed
-	RTimer::deinit();
+	Timer::deinit();
 	DeferCall::cleanup();
 
 	return ret;

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -29,7 +29,7 @@
 #include <QJsonArray>
 #include <QRandomGenerator>
 #include "qtcompat.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "log.h"
 #include "bufferlist.h"
@@ -164,8 +164,8 @@ public:
 	Instruct instruct;
 	int logLevel;
 	QHash<QString, Instruct::Channel> channels;
-	RTimer *timer;
-	RTimer *retryTimer;
+	Timer *timer;
+	Timer *retryTimer;
 	StatsManager *stats;
 	ZhttpManager *outZhttp;
 	std::unique_ptr<ZhttpRequest> outReq; // for fetching links
@@ -236,10 +236,10 @@ public:
 		writeBytesChangedConnection = req->writeBytesChanged.connect(boost::bind(&Private::req_writeBytesChanged, this));
 		errorConnection = req->error.connect(boost::bind(&Private::req_error, this));
 
-		timer = new RTimer;
+		timer = new Timer;
 		timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
 
-		retryTimer = new RTimer;
+		retryTimer = new Timer;
 		retryTimerConnection = retryTimer->timeout.connect(boost::bind(&Private::retryTimer_timeout, this));
 		retryTimer->setSingleShot(true);
 

--- a/src/handler/httpsessionupdatemanager.cpp
+++ b/src/handler/httpsessionupdatemanager.cpp
@@ -24,7 +24,7 @@
 #include "httpsessionupdatemanager.h"
 
 #include <QUrl>
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "httpsession.h"
 
@@ -39,12 +39,12 @@ public:
 		QPair<int, QUrl> key;
 		QSet<HttpSession*> sessions;
 		QSet<HttpSession*> deferredSessions;
-		RTimer *timer;
+		Timer *timer;
 	};
 
 	HttpSessionUpdateManager *q;
 	QHash<QPair<int, QUrl>, Bucket*> buckets;
-	QHash<RTimer*, Bucket*> bucketsByTimer;
+	QHash<Timer*, Bucket*> bucketsByTimer;
 	QHash<HttpSession*, Bucket*> bucketsBySession;
 
 	Private(HttpSessionUpdateManager *_q) :
@@ -116,7 +116,7 @@ public:
 			bucket = new Bucket;
 			bucket->key = key;
 			bucket->sessions += hs;
-			bucket->timer = new RTimer;
+			bucket->timer = new Timer;
 			bucket->timer->timeout.connect(boost::bind(&Private::timer_timeout, this, bucket->timer));
 
 			buckets[key] = bucket;
@@ -142,7 +142,7 @@ public:
 	}
 
 private:
-	void timer_timeout(RTimer *timer)
+	void timer_timeout(Timer *timer)
 	{
 		Bucket *bucket = bucketsByTimer.value(timer);
 		if(!bucket)

--- a/src/handler/ratelimiter.cpp
+++ b/src/handler/ratelimiter.cpp
@@ -25,7 +25,7 @@
 
 #include <QList>
 #include <QMap>
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 
 #define MIN_BATCH_INTERVAL 25
@@ -74,7 +74,7 @@ public:
 	bool batchWaitEnabled;
 	QMap<QString, Bucket> buckets;
 	QString lastKey;
-	RTimer *timer;
+	Timer *timer;
 	bool firstPass;
 	int batchInterval;
 	int batchSize;
@@ -90,7 +90,7 @@ public:
 		batchSize(-1),
 		lastBatchEmpty(false)
 	{
-		timer = new RTimer;
+		timer = new Timer;
 		timer->timeout.connect(boost::bind(&Private::timeout, this));
 	}
 

--- a/src/handler/sequencer.cpp
+++ b/src/handler/sequencer.cpp
@@ -25,7 +25,7 @@
 
 #include <QDateTime>
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "publishitem.h"
 #include "publishlastids.h"
@@ -69,7 +69,7 @@ public:
 	PublishLastIds *lastIds;
 	QHash<QString, ChannelPendingItems> pendingItemsByChannel;
 	QMap<QPair<qint64, PendingItem*>, PendingItem*> pendingItemsByTime;
-	RTimer *expireTimer;
+	Timer *expireTimer;
 	int pendingExpireMSecs;
 	int idCacheTtl;
 	QHash<QPair<QString, QString>, CachedId*> idCacheById;
@@ -82,7 +82,7 @@ public:
 		pendingExpireMSecs(DEFAULT_PENDING_EXPIRE),
 		idCacheTtl(-1)
 	{
-		expireTimer = new RTimer;
+		expireTimer = new Timer;
 		expireTimer->timeout.connect(boost::bind(&Private::expireTimer_timeout, this));
 	}
 

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -25,7 +25,7 @@
 
 #include <QDateTime>
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "filter.h"
 #include "publishitem.h"
@@ -43,15 +43,15 @@ WsSession::WsSession(QObject *parent) :
 	inProcessPublishQueue(false),
 	closed(false)
 {
-	expireTimer = new RTimer;
+	expireTimer = new Timer;
 	expireTimer->setSingleShot(true);
 	expireTimer->timeout.connect(boost::bind(&WsSession::expireTimer_timeout, this));
 
-	delayedTimer = new RTimer;
+	delayedTimer = new Timer;
 	delayedTimer->setSingleShot(true);
 	delayedTimer->timeout.connect(boost::bind(&WsSession::delayedTimer_timeout, this));
 
-	requestTimer = new RTimer;
+	requestTimer = new Timer;
 	requestTimer->setSingleShot(true);
 	requestTimer->timeout.connect(boost::bind(&WsSession::requestTimer_timeout, this));
 }

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -41,7 +41,7 @@
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
-class RTimer;
+class Timer;
 class ZhttpManager;
 class PublishItem;
 
@@ -71,9 +71,9 @@ public:
 	QByteArray delayedType;
 	QByteArray delayedMessage;
 	QHash<int, qint64> pendingRequests;
-	RTimer *expireTimer;
-	RTimer *delayedTimer;
-	RTimer *requestTimer;
+	Timer *expireTimer;
+	Timer *delayedTimer;
+	Timer *requestTimer;
 	QList<PublishItem> publishQueue;
 	ZhttpManager *zhttpOut;
 	std::shared_ptr<RateLimiter> filterLimiter;

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -30,7 +30,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include "processquit.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "log.h"
 #include "settings.h"
@@ -299,7 +299,7 @@ public:
 		QCoreApplication::instance()->sendPostedEvents();
 
 		// deinit here, after all event loop activity has completed
-		RTimer::deinit();
+		Timer::deinit();
 		DeferCall::cleanup();
 	}
 

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -34,7 +34,7 @@
 #include <QTextStream>
 #include <QFileSystemWatcher>
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "routesfile.h"
 
@@ -202,7 +202,7 @@ public:
 	QList<Rule> allRules;
 	QHash< QString, QList<Rule> > rulesByDomain;
 	QHash<QString, Rule> rulesById;
-	RTimer t;
+	Timer t;
 	Connection tConnection;
 	QFileSystemWatcher watcher;
 	DeferCall deferCall;
@@ -747,7 +747,7 @@ public:
 
 	virtual void run()
 	{
-		RTimer::init(WORKER_THREAD_TIMERS);
+		Timer::init(WORKER_THREAD_TIMERS);
 
 		worker = new Worker;
 		worker->fileName = fileName;
@@ -757,7 +757,7 @@ public:
 		startedConnection.disconnect();
 		delete worker;
 
-		RTimer::deinit();
+		Timer::deinit();
 		DeferCall::cleanup();
 	}
 

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -33,7 +33,7 @@
 #include "packet/statspacket.h"
 #include "packet/zrpcrequestpacket.h"
 #include "qtcompat.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "log.h"
 #include "inspectdata.h"
@@ -218,7 +218,7 @@ public:
 		config = _config;
 
 		// enough timers for sessions and zroutes, plus an extra 100 for misc
-		RTimer::init((config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100);
+		Timer::init((config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100);
 
 		logConfig.fromAddress = config.logFrom;
 		logConfig.userAgent = config.logUserAgent;

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -37,7 +37,7 @@
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "packet/statspacket.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
 #include "statsmanager.h"
@@ -638,7 +638,7 @@ private slots:
 		// ensure deferred deletes are processed
 		QCoreApplication::instance()->sendPostedEvents();
 
-		RTimer::deinit();
+		Timer::deinit();
 		DeferCall::cleanup();
 	}
 

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -34,7 +34,7 @@
 #include "qtcompat.h"
 #include "log.h"
 #include "bufferlist.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include "sockjssession.h"
@@ -99,7 +99,7 @@ public:
 		QByteArray lastPart;
 		bool pending;
 		SockJsSession *ext;
-		std::unique_ptr<RTimer> timer;
+		std::unique_ptr<Timer> timer;
 		QVariant closeValue;
 		Connection timerConnection;
 
@@ -141,7 +141,7 @@ public:
 	QHash<ZWebSocket*, Session*> sessionsBySocket;
 	QHash<QByteArray, Session*> sessionsById;
 	QHash<SockJsSession*, Session*> sessionsByExt;
-	QHash<RTimer*, Session*> sessionsByTimer;
+	QHash<Timer*, Session*> sessionsByTimer;
 	QList<Session*> pendingSessions;
 	QByteArray iframeHtml;
 	QByteArray iframeHtmlEtag;
@@ -199,7 +199,7 @@ public:
 		if(s->closeValue.isValid())
 		{
 			// if there's a close value, hang around for a little bit
-			s->timer = std::make_unique<RTimer>();
+			s->timer = std::make_unique<Timer>();
 			s->timerConnection = s->timer->timeout.connect(boost::bind(&Private::timer_timeout, this, s->timer.get()));
 			s->timer->setSingleShot(true);
 			sessionsByTimer.insert(s->timer.get(), s);
@@ -674,7 +674,7 @@ private:
 	}
 
 private:
-	void timer_timeout(RTimer *timer)
+	void timer_timeout(Timer *timer)
 	{
 		Session *s = sessionsByTimer.value(timer);
 		assert(s);

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -32,7 +32,7 @@
 #include "log.h"
 #include "bufferlist.h"
 #include "packet/httprequestdata.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
@@ -155,7 +155,7 @@ public:
 	int pendingWrittenBytes;
 	QList<WriteItem> pendingWrites;
 	QHash<ZhttpRequest*, RequestItem*> requests;
-	std::unique_ptr<RTimer> keepAliveTimer;
+	std::unique_ptr<Timer> keepAliveTimer;
 	int closeCode;
 	QString closeReason;
 	bool closeSent;
@@ -188,7 +188,7 @@ public:
 		peerCloseCode(-1),
 		updating(false)
 	{
-		keepAliveTimer = std::make_unique<RTimer>();
+		keepAliveTimer = std::make_unique<Timer>();
 		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
 	}
 

--- a/src/proxy/updater.cpp
+++ b/src/proxy/updater.cpp
@@ -32,7 +32,7 @@
 #include <QHostInfo>
 #include "qtcompat.h"
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "httpheaders.h"
 #include "zhttpmanager.h"
 #include "zhttprequest.h"
@@ -83,7 +83,7 @@ public:
 	QString currentVersion;
 	QString org;
 	ZhttpManager *zhttpManager;
-	std::unique_ptr<RTimer> timer;
+	std::unique_ptr<Timer> timer;
 	ZhttpRequest *req;
 	Report report;
 	QDateTime lastLogTime;
@@ -100,7 +100,7 @@ public:
 		zhttpManager(zhttp),
 		req(0)
 	{
-		timer = std::make_unique<RTimer>();
+		timer = std::make_unique<Timer>();
 		timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
 		timer->setInterval(mode == ReportMode ? REPORT_INTERVAL : CHECK_INTERVAL);
 		timer->start();

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -32,7 +32,7 @@
 #include "zhttprequest.h"
 #include "zhttpmanager.h"
 #include "uuidutil.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 
 #define BUFFER_SIZE 200000
@@ -233,8 +233,8 @@ public:
 	bool disconnecting;
 	bool disconnectSent;
 	bool updateQueued;
-	std::unique_ptr<RTimer> keepAliveTimer;
-	std::unique_ptr<RTimer> retryTimer;
+	std::unique_ptr<Timer> keepAliveTimer;
+	std::unique_ptr<Timer> retryTimer;
 	int retries;
 	int maxEvents;
 	ReqConnections reqConnections;
@@ -272,11 +272,11 @@ public:
 		if(!g_disconnectManager)
 			g_disconnectManager = new DisconnectManager;
 
-		keepAliveTimer = std::make_unique<RTimer>();
+		keepAliveTimer = std::make_unique<Timer>();
 		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
 		keepAliveTimer->setSingleShot(true);
 
-		retryTimer = std::make_unique<RTimer>();
+		retryTimer = std::make_unique<Timer>();
 		retryTimerConnection = retryTimer->timeout.connect(boost::bind(&Private::retryTimer_timeout, this));
 		retryTimer->setSingleShot(true);
 	}

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -30,7 +30,7 @@
 #include "qzmqvalve.h"
 #include "qzmqreqmessage.h"
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "tnetstring.h"
 #include "zutil.h"
 #include "logutil.h"
@@ -71,7 +71,7 @@ public:
 	std::unique_ptr<QZmq::Socket> streamSock;
 	std::unique_ptr<QZmq::Valve> streamValve;
 	QHash<QByteArray, WsControlSession*> sessionsByCid;
-	std::unique_ptr<RTimer> refreshTimer;
+	std::unique_ptr<Timer> refreshTimer;
 	QHash<WsControlSession*, KeepAliveRegistration*> keepAliveRegistrations;
 	QMap<QPair<qint64, KeepAliveRegistration*>, KeepAliveRegistration*> sessionsByLastRefresh;
 	QSet<KeepAliveRegistration*> sessionRefreshBuckets[SESSION_REFRESH_BUCKETS];
@@ -85,7 +85,7 @@ public:
 		ipcFileMode(-1),
 		currentSessionRefreshBucket(0)
 	{
-		refreshTimer = std::make_unique<RTimer>();
+		refreshTimer = std::make_unique<Timer>();
 		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
 	}
 

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -27,7 +27,7 @@
 #include <QDateTime>
 #include <QUrl>
 #include <boost/signals2.hpp>
-#include "rtimer.h"
+#include "timer.h"
 #include "wscontrolmanager.h"
 
 #define SESSION_TTL 60
@@ -46,7 +46,7 @@ public:
 	QList<WsControlPacket::Item> pendingItems;
 	QHash<int, qint64> pendingRequests;
 	QList<QByteArray> pendingSendEventWrites;
-	std::unique_ptr<RTimer> requestTimer;
+	std::unique_ptr<Timer> requestTimer;
 	QByteArray peer;
 	QByteArray cid;
 	bool debug;
@@ -68,7 +68,7 @@ public:
 		logLevel(-1),
 		targetTrusted(false)
 	{
-		requestTimer = std::make_unique<RTimer>();
+		requestTimer = std::make_unique<Timer>();
 		requestTimerConnection = requestTimer->timeout.connect(boost::bind(&Private::requestTimer_timeout, this));
 		requestTimer->setSingleShot(true);
 	}

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -32,7 +32,7 @@
 #include <QRandomGenerator>
 #include "packet/httprequestdata.h"
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 #include "defercall.h"
 #include "jwt.h"
 #include "zhttpmanager.h"
@@ -303,7 +303,7 @@ public:
 	bool detached;
 	QDateTime activityTime;
 	QByteArray publicCid;
-	RTimer *keepAliveTimer;
+	Timer *keepAliveTimer;
 	WsControl::KeepAliveMode keepAliveMode;
 	int keepAliveTimeout;
 	QList<QueuedFrame> queuedInFrames; // frames to deliver after out read finishes
@@ -1110,7 +1110,7 @@ private:
 
 			if(!keepAliveTimer)
 			{
-				keepAliveTimer = new RTimer;
+				keepAliveTimer = new Timer;
 				keepAliveConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
 				keepAliveTimer->setSingleShot(true);
 			}

--- a/src/proxy/zroutes.cpp
+++ b/src/proxy/zroutes.cpp
@@ -27,7 +27,7 @@
 #include <QStringList>
 #include <boost/signals2.hpp>
 #include "log.h"
-#include "rtimer.h"
+#include "timer.h"
 
 using Connection = boost::signals2::scoped_connection;
 
@@ -96,7 +96,7 @@ public:
 	Item *defaultItem;
 	QHash<QString, Item*> itemsBySpec;
 	QHash<ZhttpManager*, Item*> itemsByManager;
-	std::unique_ptr<RTimer> cleanupTimer;
+	std::unique_ptr<Timer> cleanupTimer;
 	Connection cleanupTimerConnection;
 
 	Private(ZRoutes *_q) :
@@ -104,7 +104,7 @@ public:
 		q(_q),
 		defaultItem(0)
 	{
-		cleanupTimer = std::make_unique<RTimer>();
+		cleanupTimer = std::make_unique<Timer>();
 		cleanupTimerConnection = cleanupTimer->timeout.connect(boost::bind(&Private::removeUnused, this));
 		cleanupTimer->setInterval(10000);
 		cleanupTimer->start();

--- a/src/proxy/zrpcchecker.cpp
+++ b/src/proxy/zrpcchecker.cpp
@@ -24,7 +24,7 @@
 
 #include <assert.h>
 #include <QHash>
-#include "rtimer.h"
+#include "timer.h"
 #include "zrpcrequest.h"
 
 #define CHECK_TIMEOUT 8
@@ -62,7 +62,7 @@ public:
 
 	ZrpcChecker *q;
 	bool avail;
-	std::unique_ptr<RTimer> timer;
+	std::unique_ptr<Timer> timer;
 	QHash<ZrpcRequest*, Item*> requestsByReq;
 	map<ZrpcRequest*, ZrpcReqConnections> reqConnectionMap;
 	Connection timerConnection;
@@ -72,7 +72,7 @@ public:
 		q(_q),
 		avail(true)
 	{
-		timer = std::make_unique<RTimer>();
+		timer = std::make_unique<Timer>();
 		timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
 		timer->setSingleShot(true);
 	}


### PR DESCRIPTION
Originally, RTimer ("rust timer") was only used in certain areas for performance reasons. However, we're now using it everywhere, and so it ought to have a more generic name consistent with how other types are named.