### PR TITLE
remove unnecessary slots labels

### DIFF
--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -3101,7 +3101,6 @@ private:
 		}
 	}
 
-private slots:
 	void hs_subscribe(HttpSession *hs, const QString &channel)
 	{
 		Instruct::HoldMode mode = hs->holdMode();

--- a/src/handler/refreshworker.h
+++ b/src/handler/refreshworker.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -50,8 +51,6 @@ private:
 
 	void refreshNextCid();
 	void respondError(const QByteArray &condition);
-
-private slots:
 	void proxyRefresh_finished(const DeferredResult &result);
 };
 

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2022 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -666,6 +666,13 @@ public:
 		log_info("started");
 	}
 
+private:
+	void domainMap_changed()
+	{
+		for(EngineThread *t : threads)
+			t->routesChanged();
+	}
+
 private slots:
 	void reload()
 	{
@@ -673,12 +680,6 @@ private slots:
 		log_rotate();
 
 		domainMap->reload();
-	}
-
-	void domainMap_changed()
-	{
-		for(EngineThread *t : threads)
-			t->routesChanged();
 	}
 
 	void doQuit()

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -316,7 +316,6 @@ private:
 		}
 	}
 
-private slots:
 	void refresh_timeout()
 	{
 		qint64 now = QDateTime::currentMSecsSinceEpoch();

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -304,7 +304,6 @@ public:
 		}
 	}
 
-private slots:
 	void requestTimer_timeout()
 	{
 		// on error, destroy any other pending requests

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2023 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -826,7 +826,6 @@ public:
 			statsManager->incCounter(route.statsRoute(), c, count);
 	}
 
-private slots:
 	void in_readyRead()
 	{
 		if((outSock && outSock->state() == WebSocket::Connected) || detached)

--- a/src/proxy/zroutes.cpp
+++ b/src/proxy/zroutes.cpp
@@ -180,7 +180,6 @@ public:
 		delete i;
 	}
 
-public slots:
 	void removeUnused()
 	{
 		QList<Item*> toRemove;

--- a/src/proxy/zrpcchecker.cpp
+++ b/src/proxy/zrpcchecker.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -212,7 +213,6 @@ public:
 		delete i;
 	}
 
-public slots:
 	void timer_timeout()
 	{
 		avail = false;


### PR DESCRIPTION
After this, the remaining use of `slots:` in non-deprecated modules will be:

* Marking C++ tests as required by Qt's test harness.
* SocketNotifier, (R)Timer, and DeferCall, due to internal use of Qt types.
* ProcessQuit, in unused code (Windows Ctrl-C handler).
* Proxy worker/domainmap thread management using QMetaObject::invokeMethod for cross-thread communication.

Note: we are not using `signals:` labels in any non-deprecated modules.