### PR TITLE
timer: add optional support for rust event loop

### DIFF
--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -26,6 +26,7 @@
 #include "defercall.h"
 #include "eventloop.h"
 #include "socketnotifier.h"
+#include "timer.h"
 
 class EventLoopTest : public QObject
 {
@@ -61,6 +62,37 @@ private slots:
 		delete sn;
 		close(fds[1]);
 		close(fds[0]);
+	}
+
+	void timer()
+	{
+		EventLoop loop(2);
+
+		Timer *t1 = new Timer;
+		Timer *t2 = new Timer;
+
+		int timeoutCount = 0;
+
+		t1->timeout.connect([&] {
+			++timeoutCount;
+		});
+
+		t2->timeout.connect([&] {
+			++timeoutCount;
+			loop.exit(123);
+		});
+
+		t1->setSingleShot(true);
+		t1->start(0);
+
+		t2->setSingleShot(true);
+		t2->start(0);
+
+		QCOMPARE(loop.exec(), 123);
+		QCOMPARE(timeoutCount, 2);
+
+		delete t2;
+		delete t1;
 	}
 };
 

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -29,6 +29,7 @@
 
 using Signal = boost::signals2::signal<void()>;
 
+class EventLoop;
 class TimerManager;
 
 class Timer : public QObject
@@ -58,10 +59,12 @@ public:
 private:
 	friend class TimerManager;
 
+	EventLoop *loop_;
 	bool singleShot_;
 	int interval_;
 	int timerId_;
 
+	static void cb_timer_activated(void *ctx);
 	void timerReady();
 };
 


### PR DESCRIPTION
Similar to #48108, but for timers. If an EventLoop instance is present in the thread, use it, else fall back to the Qt event loop. This will allow us to introduce the new event loop gradually.

Note: deferred calls and tcp sockets don't work with the new event loop yet, so the new event loop is not fully ready to use, but this is another step towards making it usable.