### PR TITLE
defercall: use timers instead of QMetaObject::invokeMethod

### DIFF
--- a/src/core/coretests.h
+++ b/src/core/coretests.h
@@ -5,5 +5,6 @@ int httpheaders_test(int argc, char **argv);
 int jwt_test(int argc, char **argv);
 int timer_test(int argc, char **argv);
 int eventloop_test(int argc, char **argv);
+int defercall_test(int argc, char **argv);
 
 #endif

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -23,13 +23,13 @@
 #ifndef DEFERCALL_H
 #define DEFERCALL_H
 
-#include <QObject>
+#include <functional>
+#include <memory>
+#include <list>
 
 // queues calls to be run after returning to the event loop
-class DeferCall : public QObject
+class DeferCall
 {
-	Q_OBJECT
-
 public:
 	DeferCall();
 	~DeferCall();
@@ -51,9 +51,6 @@ public:
 		global()->defer([=] { delete p; });
 	}
 
-private slots:
-	void callNext();
-
 private:
 	class Call
 	{
@@ -61,7 +58,13 @@ private:
 		std::function<void ()> handler;
 	};
 
-	std::list<Call> deferredCalls_;
+	class Manager;
+	friend class Manager;
+
+	std::list<std::shared_ptr<Call>> deferredCalls_;
+
+	static thread_local Manager *manager;
+	static thread_local DeferCall *instance;
 };
 
 #endif

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -1,0 +1,118 @@
+/*
+* Copyright (C) 2025 Fastly, Inc.
+*
+* This file is part of Pushpin.
+*
+* $FANOUT_BEGIN_LICENSE:APACHE2$
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* $FANOUT_END_LICENSE$
+*/
+
+#include <QtTest/QtTest>
+#include "timer.h"
+#include "defercall.h"
+
+class DeferCallTest : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void initTestCase()
+	{
+		Timer::init(100);
+	}
+
+	void cleanupTestCase()
+	{
+		DeferCall::cleanup();
+		Timer::deinit();
+	}
+
+	void deferCall()
+	{
+		bool first = false;
+		bool second = false;
+
+		DeferCall::global()->defer([&] {
+			first = true;
+
+			DeferCall::global()->defer([&] {
+				second = true;
+			});
+		});
+
+		// the second deferred call should cause the underlying timer to
+		// re-arm. since we aren't contending with other timers within this
+		// test, both timeouts should get processed during a single timer
+		// processing pass. therefore, both calls should get processed within
+		// a single eventloop pass
+		QTest::qWait(10);
+		QVERIFY(first);
+		QVERIFY(second);
+	}
+
+	void retract()
+	{
+		bool called = false;
+
+		{
+			DeferCall deferCall;
+
+			deferCall.defer([&] {
+				called = true;
+			});
+		}
+
+		DeferCall::cleanup();
+		QVERIFY(!called);
+	}
+
+	void managerCleanup()
+	{
+		bool first = false;
+		bool second = false;
+
+		DeferCall::global()->defer([&] {
+			first = true;
+
+			DeferCall::global()->defer([&] {
+				second = true;
+			});
+		});
+
+		// cleanup should process deferred calls queued so far as well as
+		// those queued during processing
+		DeferCall::cleanup();
+		QVERIFY(first);
+		QVERIFY(second);
+	}
+};
+
+namespace {
+namespace Main {
+QTEST_MAIN(DeferCallTest)
+}
+}
+
+extern "C" {
+
+int defercall_test(int argc, char **argv)
+{
+	return Main::main(argc, argv);
+}
+
+}
+
+#include "defercalltest.moc"

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -1,24 +1,24 @@
 /*
-* Copyright (C) 2025 Fastly, Inc.
-*
-* This file is part of Pushpin.
-*
-* $FANOUT_BEGIN_LICENSE:APACHE2$
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* $FANOUT_END_LICENSE$
-*/
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
 
 #include <QtTest/QtTest>
 #include "timer.h"

--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -33,11 +33,6 @@ class EventLoopTest : public QObject
 	Q_OBJECT
 
 private slots:
-	void cleanupTestCase()
-	{
-		DeferCall::cleanup();
-	}
-
 	void socketNotifier()
 	{
 		EventLoop loop(1);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -120,6 +120,11 @@ mod tests {
         unsafe { call_c_main(ffi::timer_test, args) as u8 }
     }
 
+    fn defercall_test(args: &[&OsStr]) -> u8 {
+        // SAFETY: safe to call
+        unsafe { call_c_main(ffi::defercall_test, args) as u8 }
+    }
+
     fn eventloop_test(args: &[&OsStr]) -> u8 {
         // SAFETY: safe to call
         unsafe { call_c_main(ffi::eventloop_test, args) as u8 }
@@ -138,6 +143,11 @@ mod tests {
     #[test]
     fn timer() {
         assert!(qtest::run(timer_test));
+    }
+
+    #[test]
+    fn defercall() {
+        assert!(qtest::run(defercall_test));
     }
 
     #[test]

--- a/src/core/tests.pri
+++ b/src/core/tests.pri
@@ -5,4 +5,5 @@ SOURCES += \
 	$$PWD/httpheaderstest.cpp \
 	$$PWD/jwttest.cpp \
 	$$PWD/timertest.cpp \
+	$$PWD/defercalltest.cpp \
 	$$PWD/eventlooptest.cpp

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -208,14 +208,15 @@ private slots:
 
 	void cleanupTestCase()
 	{
+		limiter.reset();
 		zhttpOut.reset();
 		filterServer.reset();
 
 		// ensure deferred deletes are processed
 		QCoreApplication::instance()->sendPostedEvents();
 
-		Timer::deinit();
 		DeferCall::cleanup();
+		Timer::deinit();
 	}
 
 	void messageFilters()

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1340,6 +1340,10 @@ public:
 	{
 		config = _config;
 
+		// destroy known timers and deinit, so we can reinit below
+		DeferCall::cleanup();
+		Timer::deinit();
+
 		// includes worst-case subscriptions and update registrations
 		int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
 			(config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -312,8 +312,8 @@ private slots:
 		// ensure deferred deletes are processed
 		QCoreApplication::instance()->sendPostedEvents();
 
-		Timer::deinit();
 		DeferCall::cleanup();
+		Timer::deinit();
 	}
 
 	void acceptNoHold()

--- a/src/handler/handlermain.cpp
+++ b/src/handler/handlermain.cpp
@@ -60,8 +60,8 @@ int handler_main(int argc, char **argv)
 	QCoreApplication::instance()->sendPostedEvents();
 
 	// deinit here, after all event loop activity has completed
-	Timer::deinit();
 	DeferCall::cleanup();
+	Timer::deinit();
 
 	return ret;
 }

--- a/src/handler/handlermain.cpp
+++ b/src/handler/handlermain.cpp
@@ -51,6 +51,9 @@ int handler_main(int argc, char **argv)
 {
 	QCoreApplication qapp(argc, argv);
 
+	// plenty to kick things off. will reinit after loading config
+	Timer::init(100);
+
 	HandlerAppMain appMain;
 	DeferCall deferCall;
 	deferCall.defer([&] { appMain.start(); });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ pub mod ffi {
         pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn timer_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn defercall_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn eventloop_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -299,8 +299,8 @@ public:
 		QCoreApplication::instance()->sendPostedEvents();
 
 		// deinit here, after all event loop activity has completed
-		Timer::deinit();
 		DeferCall::cleanup();
+		Timer::deinit();
 	}
 
 private:

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -759,8 +759,8 @@ public:
 		startedConnection.disconnect();
 		delete worker;
 
-		Timer::deinit();
 		DeferCall::cleanup();
+		Timer::deinit();
 	}
 
 public:

--- a/src/proxy/main.cpp
+++ b/src/proxy/main.cpp
@@ -23,6 +23,7 @@
 
 #include <QCoreApplication>
 #include "app.h"
+#include "timer.h"
 #include "defercall.h"
 
 class AppMain
@@ -51,6 +52,8 @@ int proxy_main(int argc, char **argv)
 {
 	QCoreApplication qapp(argc, argv);
 
+	Timer::init(100);
+
 	AppMain appMain;
 	DeferCall deferCall;
 	deferCall.defer([&] { appMain.start(); });
@@ -61,6 +64,7 @@ int proxy_main(int argc, char **argv)
 
 	// deinit here, after all event loop activity has completed
 	DeferCall::cleanup();
+	Timer::deinit();
 
 	return ret;
 }

--- a/src/proxy/main.cpp
+++ b/src/proxy/main.cpp
@@ -52,6 +52,7 @@ int proxy_main(int argc, char **argv)
 {
 	QCoreApplication qapp(argc, argv);
 
+	// plenty for the main thread
 	Timer::init(100);
 
 	AppMain appMain;

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -638,8 +638,8 @@ private slots:
 		// ensure deferred deletes are processed
 		QCoreApplication::instance()->sendPostedEvents();
 
-		Timer::deinit();
 		DeferCall::cleanup();
+		Timer::deinit();
 	}
 
 	void passthrough()


### PR DESCRIPTION
This reworks `DeferCall` to trigger calls using timers of zero rather than relying on a special mechanism provided by the event loop. Notably, this makes `DeferCall` work with the new event loop, since timers work with the new event loop.

A side effect is the timer subsystem must be initialized before queuing any deferred calls, and all deferred calls must be resolved/cleared before the timer subsystem is deinitialized.