### PR TITLE
timer: process zero timeouts immediately

### DIFF
--- a/src/core/coretests.h
+++ b/src/core/coretests.h
@@ -3,6 +3,7 @@
 
 int httpheaders_test(int argc, char **argv);
 int jwt_test(int argc, char **argv);
+int timer_test(int argc, char **argv);
 int eventloop_test(int argc, char **argv);
 
 #endif

--- a/src/core/eventloop.cpp
+++ b/src/core/eventloop.cpp
@@ -37,6 +37,17 @@ EventLoop::~EventLoop()
 	g_instance = nullptr;
 }
 
+std::optional<int> EventLoop::step()
+{
+	std::optional<int> code;
+
+	int x;
+	if(ffi::event_loop_step(inner_, &x) == 0)
+		code = x;
+
+	return code;
+}
+
 int EventLoop::exec()
 {
 	return ffi::event_loop_exec(inner_);

--- a/src/core/eventloop.h
+++ b/src/core/eventloop.h
@@ -17,6 +17,7 @@
 #ifndef EVENTLOOP_H
 #define EVENTLOOP_H
 
+#include <optional>
 #include "rust/bindings.h"
 
 class EventLoop
@@ -31,6 +32,7 @@ public:
 	EventLoop(int capacity);
 	~EventLoop();
 
+	std::optional<int> step();
 	int exec();
 	void exit(int code);
 

--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -459,7 +459,10 @@ mod ffi {
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
-    pub unsafe extern "C" fn event_loop_step(l: *mut EventLoopRaw, out_code: *mut libc::c_int) -> libc::c_int {
+    pub unsafe extern "C" fn event_loop_step(
+        l: *mut EventLoopRaw,
+        out_code: *mut libc::c_int,
+    ) -> libc::c_int {
         let l = l.as_mut().unwrap();
 
         match l.step() {

--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -459,6 +459,21 @@ mod ffi {
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
+    pub unsafe extern "C" fn event_loop_step(l: *mut EventLoopRaw, out_code: *mut libc::c_int) -> libc::c_int {
+        let l = l.as_mut().unwrap();
+
+        match l.step() {
+            Some(code) => {
+                unsafe { out_code.write(code) };
+
+                0
+            }
+            None => -1,
+        }
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    #[no_mangle]
     pub unsafe extern "C" fn event_loop_exec(l: *mut EventLoopRaw) -> libc::c_int {
         let l = l.as_mut().unwrap();
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -115,6 +115,11 @@ mod tests {
         unsafe { call_c_main(ffi::jwt_test, args) as u8 }
     }
 
+    fn timer_test(args: &[&OsStr]) -> u8 {
+        // SAFETY: safe to call
+        unsafe { call_c_main(ffi::timer_test, args) as u8 }
+    }
+
     fn eventloop_test(args: &[&OsStr]) -> u8 {
         // SAFETY: safe to call
         unsafe { call_c_main(ffi::eventloop_test, args) as u8 }
@@ -128,6 +133,11 @@ mod tests {
     #[test]
     fn jwt() {
         assert!(qtest::run(jwt_test));
+    }
+
+    #[test]
+    fn timer() {
+        assert!(qtest::run(timer_test));
     }
 
     #[test]

--- a/src/core/tests.pri
+++ b/src/core/tests.pri
@@ -4,4 +4,5 @@ INCLUDES += \
 SOURCES += \
 	$$PWD/httpheaderstest.cpp \
 	$$PWD/jwttest.cpp \
+	$$PWD/timertest.cpp \
 	$$PWD/eventlooptest.cpp

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -86,10 +86,19 @@ int TimerManager::add(int msec, Timer *r)
 {
 	qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
 
-	// expireTime must be >= startTime_
-	qint64 expireTime = qMax(currentTime + msec, startTime_);
+	qint64 expiresTicks;
+	if(msec <= 0)
+	{
+		// for timeouts of zero, set immediate expiration with no rounding up
+		expiresTicks = currentTicks_;
+	}
+	else
+	{
+		// expireTime must be >= startTime_
+		qint64 expireTime = qMax(currentTime + msec, startTime_);
 
-	qint64 expiresTicks = durationToTicksRoundUp(expireTime - startTime_);
+		expiresTicks = durationToTicksRoundUp(expireTime - startTime_);
+	}
 
 	int id = wheel_.add(expiresTicks, (size_t)r);
 

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#include <QtTest/QtTest>
+#include "timer.h"
+
+class TimerTest : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void initTestCase()
+	{
+		Timer::init(100);
+	}
+
+	void cleanupTestCase()
+	{
+		Timer::deinit();
+	}
+
+	void zeroTimeout()
+	{
+		Timer t;
+		t.setSingleShot(true);
+
+		int count = 0;
+
+		t.timeout.connect([&] {
+			++count;
+			if(count < 2)
+				t.start(0);
+		});
+
+		t.start(0);
+
+		// since we aren't contending with other timers in this test, both
+		// timeouts should get processed during a single timer processing
+		// pass. therefore, both calls should get processed within a single
+		// eventloop pass
+		QTest::qWait(10);
+		QCOMPARE(count, 2);
+	}
+};
+
+namespace {
+namespace Main {
+QTEST_MAIN(TimerTest)
+}
+}
+
+extern "C" {
+
+int timer_test(int argc, char **argv)
+{
+	return Main::main(argc, argv);
+}
+
+}
+
+#include "timertest.moc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub mod ffi {
     import_cpptest! {
         pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn timer_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn eventloop_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;


### PR DESCRIPTION
Our timers have an accuracy of 10ms, and sometimes this can cause a timer of zero to get scheduled for 10ms. This is not desirable behavior, especially since we plan to rework `DeferCall` on top of timers, so this PR treats a zero timeout as a special case to be processed as soon as possible.