### PR TITLE
handler: read config before starting event loop

### DIFF
--- a/src/handler/handlerapp.h
+++ b/src/handler/handlerapp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,28 +24,18 @@
 #ifndef HANDLERAPP_H
 #define HANDLERAPP_H
 
-#include <QObject>
-#include <boost/signals2.hpp>
+#include <memory>
 
-using SignalInt = boost::signals2::signal<void(int)>;
-using Connection = boost::signals2::scoped_connection;
-
-class HandlerApp : public QObject
+class HandlerApp
 {
-	Q_OBJECT
-
 public:
-	HandlerApp(QObject *parent = 0);
+	HandlerApp();
 	~HandlerApp();
 
-	void start();
-
-	SignalInt quit;
+	int run();
 
 private:
 	class Private;
-	friend class Private;
-	Private *d;
 };
 
 #endif

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1156,8 +1156,6 @@ private:
 	}
 };
 
-#define TIMERS_PER_SUBSCRIPTION 1
-
 class Subscription : public QObject
 {
 	Q_OBJECT
@@ -1339,18 +1337,6 @@ public:
 	bool start(const Configuration &_config)
 	{
 		config = _config;
-
-		// destroy known timers and deinit, so we can reinit below
-		DeferCall::cleanup();
-		Timer::deinit();
-
-		// includes worst-case subscriptions and update registrations
-		int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
-			(config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +
-			TIMERS_PER_UNIQUE_UPDATE_REGISTRATION;
-
-		// enough timers for sessions, plus an extra 100 for misc
-		Timer::init((config.connectionsMax * timersPerSession) + 100);
 
 		publishLimiter->setRate(config.messageRate);
 		publishLimiter->setHwm(config.messageHwm);

--- a/src/handler/handlerengine.h
+++ b/src/handler/handlerengine.h
@@ -30,6 +30,8 @@
 #include <boost/signals2.hpp>
 #include <map>
 
+#define TIMERS_PER_SUBSCRIPTION 1
+
 using std::map;
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -280,6 +280,8 @@ private slots:
 		QDir outDir(qgetenv("OUT_DIR"));
 		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
+		Timer::init(100);
+
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();
 		wrapper->startProxy();

--- a/src/handler/handlermain.cpp
+++ b/src/handler/handlermain.cpp
@@ -22,28 +22,7 @@
  */
 
 #include <QCoreApplication>
-#include "timer.h"
-#include "defercall.h"
 #include "handlerapp.h"
-
-class HandlerAppMain
-{
-public:
-	HandlerApp *app;
-
-	void start()
-	{
-		app = new HandlerApp;
-		app->quit.connect(boost::bind(&HandlerAppMain::app_quit, this, boost::placeholders::_1));
-		app->start();
-	}
-
-	void app_quit(int returnCode)
-	{
-		delete app;
-		QCoreApplication::exit(returnCode);
-	}
-};
 
 extern "C" {
 
@@ -51,22 +30,8 @@ int handler_main(int argc, char **argv)
 {
 	QCoreApplication qapp(argc, argv);
 
-	// plenty to kick things off. will reinit after loading config
-	Timer::init(100);
-
-	HandlerAppMain appMain;
-	DeferCall deferCall;
-	deferCall.defer([&] { appMain.start(); });
-	int ret = qapp.exec();
-
-	// ensure deferred deletes are processed
-	QCoreApplication::instance()->sendPostedEvents();
-
-	// deinit here, after all event loop activity has completed
-	DeferCall::cleanup();
-	Timer::deinit();
-
-	return ret;
+	HandlerApp app;
+	return app.run();
 }
 
 }


### PR DESCRIPTION
This is prep work for moving to the new event loop which requires the config in advance. The handler initialization process is refactored to use synchronous code for parsing CLI args and reading the config file, then the event loop is started and further initialization continues from there within the event loop.

Idiomatic Qt apps typically start the event loop immediately in `main` so that pretty much all initialization occurs within the event loop, but as we prepare to move away from the Qt event loop in the proxy and handler we can adopt the more precise style used by connmgr which only instantiates event loops when/where actually needed. During early initialization steps such as CLI arg parsing there's not much value in having an event loop, and so it's fine to wait until later to start one.