### PR TITLE
finish c++ wrapper for tcpstream

### DIFF
--- a/src/core/tcplistener.cpp
+++ b/src/core/tcplistener.cpp
@@ -69,8 +69,7 @@ std::unique_ptr<TcpStream> TcpListener::accept()
 	if(!s_inner)
 		return std::unique_ptr<TcpStream>(); // null
 
-	TcpStream *s = new TcpStream;
-	s->inner_ = s_inner;
+	TcpStream *s = new TcpStream(s_inner);
 
 	return std::unique_ptr<TcpStream>(s);
 }

--- a/src/core/tcpstream.cpp
+++ b/src/core/tcpstream.cpp
@@ -16,12 +16,86 @@
 
 #include "tcpstream.h"
 
-TcpStream::TcpStream() :
-	inner_(nullptr)
+#include "socketnotifier.h"
+
+#define DEFAULT_READ_SIZE 16384
+
+TcpStream::TcpStream(ffi::TcpStream *inner) :
+	inner_(inner),
+	errorCondition_(0)
 {
+	int fd = ffi::tcp_stream_as_raw_fd(inner_);
+
+	snRead_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
+	snRead_->activated.connect(boost::bind(&TcpStream::snRead_activated, this));
+	snRead_->setEnabled(true);
+
+	snWrite_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Write);
+	snWrite_->activated.connect(boost::bind(&TcpStream::snWrite_activated, this));
+	snWrite_->setEnabled(true);
 }
 
 TcpStream::~TcpStream()
 {
 	ffi::tcp_stream_destroy(inner_);
+}
+
+QByteArray TcpStream::read(int size)
+{
+	if(size < 0)
+		size = DEFAULT_READ_SIZE;
+
+	QByteArray buf(size, 0);
+	errorCondition_ = 0;
+
+	int ret = ffi::tcp_stream_read(inner_, (uint8_t *)buf.data(), buf.size(), &errorCondition_);
+
+	// re-enable the notifier. we always do this regardless of the outcome of
+	// the read, in case the notifier is edge-triggered. if the notifier is
+	// level-triggered and there are still bytes to read, this re-enabling
+	// will cause readability to be signaled again, but only once
+	snRead_->setEnabled(true);
+
+	if(ret < 0)
+		return QByteArray();
+
+	buf.resize(ret);
+
+	return buf;
+}
+
+int TcpStream::write(const QByteArray &buf)
+{
+	errorCondition_ = 0;
+
+	int ret = ffi::tcp_stream_write(inner_, (const uint8_t *)buf.constData(), buf.size(), &errorCondition_);
+
+	// re-enable the notifier. we always do this regardless of the outcome of
+	// the write, in case the notifier is edge-triggered. if the notifier is
+	// level-triggered and the socket is able to accept more bytes, this
+	// re-enabling will cause writability to be signaled again, but only once
+	snWrite_->setEnabled(true);
+
+	if(ret < 0)
+		return -1;
+
+	return ret;
+}
+
+void TcpStream::snRead_activated()
+{
+	// in case notifier is level-triggered, disable in order to avoid
+	// repeated signaling. will turn it back on after a read is attempted
+	snRead_->setEnabled(false);
+
+	readReady();
+}
+
+void TcpStream::snWrite_activated()
+{
+	// in case notifier is level-triggered, disable in order to avoid
+	// repeated signaling. will turn it back on after a write is attempted
+	snWrite_->setEnabled(false);
+
+	writeReady();
 }

--- a/src/core/tcpstream.h
+++ b/src/core/tcpstream.h
@@ -36,6 +36,7 @@ public:
 	// returns amount accepted, or -1 for error
 	int write(const QByteArray &buf);
 
+	// returns errno of latest operation
 	int errorCondition() const { return errorCondition_; }
 
 	boost::signals2::signal<void()> readReady;

--- a/src/core/tcpstream.h
+++ b/src/core/tcpstream.h
@@ -17,19 +17,40 @@
 #ifndef TCPSTREAM_H
 #define TCPSTREAM_H
 
+#include <memory>
+#include <QByteArray>
+#include <boost/signals2.hpp>
 #include "rust/bindings.h"
+
+class SocketNotifier;
 
 class TcpStream
 {
 public:
 	~TcpStream();
 
+	// size < 0 means default read size
+	// returns buffer of bytes read. null buffer means error. empty means end
+	QByteArray read(int size = -1);
+
+	// returns amount accepted, or -1 for error
+	int write(const QByteArray &buf);
+
+	int errorCondition() const { return errorCondition_; }
+
+	boost::signals2::signal<void()> readReady;
+	boost::signals2::signal<void()> writeReady;
+
 private:
 	friend class TcpListener;
 
 	ffi::TcpStream *inner_;
+	std::unique_ptr<SocketNotifier> snRead_, snWrite_;
+	int errorCondition_;
 
-	TcpStream();
+	TcpStream(ffi::TcpStream *inner);
+	void snRead_activated();
+	void snWrite_activated();
 };
 
 #endif

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -69,8 +69,134 @@ private slots:
 		QVERIFY(s);
 
 		client.waitForConnected(-1);
+	}
 
+	void io()
+	{
+		TcpListener l;
+		QVERIFY(l.bind(QHostAddress("127.0.0.1"), 0));
+
+		auto [addr, port] = l.localAddress();
+
+		bool streamsReady = false;
+		l.streamsReady.connect([&] {
+			streamsReady = true;
+		});
+
+		std::unique_ptr<TcpStream> s = l.accept();
+		QVERIFY(!s);
+
+		QTcpSocket client;
+		client.connectToHost(addr, port);
+
+		while(!streamsReady)
+			QTest::qWait(10);
+
+		s = l.accept();
+		QVERIFY(s);
+
+		// start by assuming operations are possible
+		bool readReady = true;
+		bool writeReady = true;
+
+		s->readReady.connect([&] {
+			readReady = true;
+		});
+
+		s->writeReady.connect([&] {
+			writeReady = true;
+		});
+
+		client.waitForConnected(-1);
+
+		client.write("hello\n");
+
+		QByteArray received;
+		while(!received.contains('\n'))
+		{
+			QByteArray buf = s->read();
+
+			if(buf.isNull())
+			{
+				QCOMPARE(s->errorCondition(), EAGAIN);
+
+				readReady = false;
+				while(!readReady)
+					QTest::qWait(10);
+
+				continue;
+			}
+
+			if(buf.isEmpty())
+				break;
+
+			received += buf;
+		}
+
+		QCOMPARE(received, "hello\n");
+
+		QByteArray written;
+		received.clear();
+
+		// without running the event loop, write until we fill the system
+		// buffer
+		while(true)
+		{
+			QByteArray chunk(100000, 'a');
+			int ret = s->write(chunk);
+
+			if(ret < 0)
+			{
+				QCOMPARE(s->errorCondition(), EAGAIN);
+				writeReady = false;
+				break;
+			}
+
+			written += chunk.mid(0, ret);
+		}
+
+		// read some on the client side
+		while(received.isEmpty())
+		{
+			QByteArray buf = client.read(100000);
+			if(buf.isEmpty())
+			{
+				QTest::qWait(10);
+				continue;
+			}
+
+			received += buf;
+		}
+
+		// wait for writability
+		while(!writeReady)
+			QTest::qWait(10);
+
+		// write more
+		{
+			QByteArray chunk(100000, 'a');
+			int ret = s->write(chunk);
+			QVERIFY(ret > 0);
+
+			written += chunk.mid(0, ret);
+		}
+
+		// close the server side
 		s.reset();
+
+		// read until closed on the client side
+		while(true)
+		{
+			while(client.bytesAvailable())
+				received += client.read(100000);
+
+			if(client.state() != QTcpSocket::ConnectedState)
+				break;
+
+			QTest::qWait(10);
+		}
+
+		QCOMPARE(received, written);
 	}
 };
 

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -127,8 +127,7 @@ private slots:
 				continue;
 			}
 
-			if(buf.isEmpty())
-				break;
+			QVERIFY(!buf.isEmpty());
 
 			received += buf;
 		}


### PR DESCRIPTION
Following up on #48140, this finishes the `TcpStream` class.

Instead of designing it like `QTcpSocket`, which has internal buffering and special state change signals, I opted to make it a more direct wrapper around the underlying FFI / Rust type. The `read` and `write` methods perform immediate non-blocking I/O and return `errno` codes (with reads of zero indicating end-of-stream), and the signals act like edge-triggered I/O notifications (even if the underlying notifiers act level-triggered, as `QSocketNotifier` does under the Qt event loop). I think this will be a better place to evolve from as we try to converge Rust & C++ behavior, even if it means the API isn't a drop-in substitute.