### PR TITLE
socketnotifier: support read & write interest at the same time

### DIFF
--- a/src/core/eventloop.cpp
+++ b/src/core/eventloop.cpp
@@ -58,7 +58,7 @@ void EventLoop::exit(int code)
 	ffi::event_loop_exit(inner_, code);
 }
 
-int EventLoop::registerFd(int fd, unsigned char interest, void (*cb)(void *), void *ctx)
+int EventLoop::registerFd(int fd, uint8_t interest, void (*cb)(void *, uint8_t), void *ctx)
 {
 	size_t id;
 
@@ -68,7 +68,7 @@ int EventLoop::registerFd(int fd, unsigned char interest, void (*cb)(void *), vo
 	return (int)id;
 }
 
-int EventLoop::registerTimer(int timeout, void (*cb)(void *), void *ctx)
+int EventLoop::registerTimer(int timeout, void (*cb)(void *, uint8_t), void *ctx)
 {
 	size_t id;
 

--- a/src/core/eventloop.h
+++ b/src/core/eventloop.h
@@ -36,8 +36,8 @@ public:
 	int exec();
 	void exit(int code);
 
-	int registerFd(int fd, unsigned char interest, void (*cb)(void *), void *ctx);
-	int registerTimer(int timeout, void (*cb)(void *), void *ctx);
+	int registerFd(int fd, uint8_t interest, void (*cb)(void *, uint8_t), void *ctx);
+	int registerTimer(int timeout, void (*cb)(void *, uint8_t), void *ctx);
 	void deregister(int id);
 
 	static EventLoop *instance();

--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -226,7 +226,7 @@ impl<C: Callback> Registrations<C> {
                 (nkey, callback, readiness)
             };
 
-            callback.call(readiness as u8);
+            callback.call(readiness);
 
             if let Some(nkey) = nkey {
                 let data = &mut *self.data.borrow_mut();

--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use crate::core::event::ReadinessExt;
 use crate::core::list;
 use crate::core::reactor;
 use crate::core::waker;
@@ -30,20 +31,20 @@ pub const READABLE: u8 = 0x01;
 pub const WRITABLE: u8 = 0x02;
 
 pub trait Callback {
-    fn call(&mut self);
+    fn call(&mut self, readiness: u8);
 }
 
 impl Callback for Box<dyn Callback> {
-    fn call(&mut self) {
-        (**self).call();
+    fn call(&mut self, readiness: u8) {
+        (**self).call(readiness);
     }
 }
 
 pub struct FnCallback<T>(T);
 
-impl<T: FnMut()> Callback for FnCallback<T> {
-    fn call(&mut self) {
-        self.0();
+impl<T: FnMut(u8)> Callback for FnCallback<T> {
+    fn call(&mut self, readiness: u8) {
+        self.0(readiness);
     }
 }
 
@@ -177,7 +178,7 @@ impl<C: Callback> Registrations<C> {
         // release borrows before each call. this way, callbacks can access
         // the eventloop, for example to add registrations
         loop {
-            let (nkey, mut callback) = {
+            let (nkey, mut callback, readiness) = {
                 let data = &mut *self.data.borrow_mut();
 
                 let nkey = match activated.pop_front(&mut data.nodes) {
@@ -191,6 +192,22 @@ impl<C: Callback> Registrations<C> {
                     .callback
                     .take()
                     .expect("registration should have a callback");
+
+                let readiness = {
+                    let readiness = reg.evented.registration().readiness();
+
+                    let mut r = 0;
+
+                    if readiness.contains_any(mio::Interest::READABLE) {
+                        r |= READABLE;
+                    }
+
+                    if readiness.contains_any(mio::Interest::WRITABLE) {
+                        r |= WRITABLE;
+                    }
+
+                    r
+                };
 
                 let nkey = if let Evented::Timer(_) = &reg.evented {
                     // remove timer registrations after activation
@@ -206,10 +223,10 @@ impl<C: Callback> Registrations<C> {
                     Some(nkey)
                 };
 
-                (nkey, callback)
+                (nkey, callback, readiness)
             };
 
-            callback.call();
+            callback.call(readiness as u8);
 
             if let Some(nkey) = nkey {
                 let data = &mut *self.data.borrow_mut();
@@ -407,7 +424,7 @@ mod ffi {
 
     pub struct RawCallback {
         // SAFETY: must be called with the associated ctx value
-        f: unsafe extern "C" fn(*mut libc::c_void),
+        f: unsafe extern "C" fn(*mut libc::c_void, u8),
 
         ctx: *mut libc::c_void,
     }
@@ -416,7 +433,7 @@ mod ffi {
         // SAFETY: caller must ensure f is safe to call for the lifetime
         // of the registration
         pub unsafe fn new(
-            f: unsafe extern "C" fn(*mut libc::c_void),
+            f: unsafe extern "C" fn(*mut libc::c_void, u8),
             ctx: *mut libc::c_void,
         ) -> Self {
             Self { f, ctx }
@@ -424,10 +441,10 @@ mod ffi {
     }
 
     impl Callback for RawCallback {
-        fn call(&mut self) {
+        fn call(&mut self, readiness: u8) {
             // SAFETY: we are passing the ctx value that was provided
             unsafe {
-                (self.f)(self.ctx);
+                (self.f)(self.ctx, readiness);
             }
         }
     }
@@ -496,8 +513,8 @@ mod ffi {
     pub unsafe extern "C" fn event_loop_register_fd(
         l: *mut EventLoopRaw,
         fd: std::os::raw::c_int,
-        interest: libc::c_uchar,
-        cb: unsafe extern "C" fn(*mut libc::c_void),
+        interest: u8,
+        cb: unsafe extern "C" fn(*mut libc::c_void, u8),
         ctx: *mut libc::c_void,
         out_id: *mut libc::size_t,
     ) -> libc::c_int {
@@ -522,7 +539,7 @@ mod ffi {
     pub unsafe extern "C" fn event_loop_register_timer(
         l: *mut EventLoopRaw,
         timeout: u64,
-        cb: unsafe extern "C" fn(*mut libc::c_void),
+        cb: unsafe extern "C" fn(*mut libc::c_void, u8),
         ctx: *mut libc::c_void,
         out_id: *mut libc::size_t,
     ) -> libc::c_int {
@@ -572,7 +589,7 @@ mod tests {
     struct NoopCallback;
 
     impl Callback for NoopCallback {
-        fn call(&mut self) {}
+        fn call(&mut self, _readiness: u8) {}
     }
 
     #[test]
@@ -609,7 +626,9 @@ mod tests {
             let listener = Rc::clone(&listener);
             let count = Rc::clone(&count);
 
-            Box::new(FnCallback(move || {
+            Box::new(FnCallback(move |readiness| {
+                assert_eq!(readiness, READABLE);
+
                 let _stream = listener.accept().unwrap();
 
                 let e = listener.accept().unwrap_err();
@@ -656,7 +675,11 @@ mod tests {
         let cb = {
             let l = Rc::clone(&l);
 
-            Box::new(FnCallback(move || l.exit(0)))
+            Box::new(FnCallback(move |readiness| {
+                assert_eq!(readiness, READABLE);
+
+                l.exit(0);
+            }))
         };
 
         let id = l.register_timer(Duration::from_millis(0), cb).unwrap();
@@ -697,7 +720,9 @@ mod tests {
                     let l = Rc::clone(&l);
                     let listener = Rc::clone(&listener);
 
-                    Box::new(FnCallback(move || {
+                    Box::new(FnCallback(move |readiness| {
+                        assert_eq!(readiness, READABLE);
+
                         let _stream = listener.accept().unwrap();
                         l.exit(0);
                     }))

--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -43,8 +43,10 @@ private slots:
 		SocketNotifier *sn = new SocketNotifier(fds[0], SocketNotifier::Read);
 
 		int activatedFd = -1;
-		sn->activated.connect([&](int fd) {
+		uint8_t activatedReadiness = -1;
+		sn->activated.connect([&](int fd, uint8_t readiness) {
 			activatedFd = fd;
+			activatedReadiness = readiness;
 			loop.exit(123);
 		});
 
@@ -53,6 +55,7 @@ private slots:
 
 		QCOMPARE(loop.exec(), 123);
 		QCOMPARE(activatedFd, fds[0]);
+		QCOMPARE(activatedReadiness, SocketNotifier::Read);
 
 		delete sn;
 		close(fds[1]);

--- a/src/core/qzmqsocket.cpp
+++ b/src/core/qzmqsocket.cpp
@@ -419,7 +419,7 @@ public:
 
 		sn_read = std::make_unique<SocketNotifier>(get_fd(sock), SocketNotifier::Read);
 		sn_read->activated.connect(boost::bind(&Private::sn_read_activated, this));
-		sn_read->setEnabled(true);
+		sn_read->setReadEnabled(true);
 
 		updateTimer = std::make_unique<Timer>();
 		updateTimerConnection = updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -36,8 +36,8 @@ public:
 	SocketNotifier(int socket, uint8_t interest);
 	~SocketNotifier();
 
-	bool isReadEnabled() const { return writeEnabled_; }
-	bool isWriteEnabled() const { return readEnabled_; }
+	bool isReadEnabled() const { return readEnabled_; }
+	bool isWriteEnabled() const { return writeEnabled_; }
 	int socket() const { return socket_; }
 
 	void setReadEnabled(bool enable);

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -37,7 +37,7 @@ public:
 	~SocketNotifier();
 
 	bool isReadEnabled() const { return writeEnabled_; }
-	bool isWrieEnabled() const { return readEnabled_; }
+	bool isWriteEnabled() const { return readEnabled_; }
 	int socket() const { return socket_; }
 
 	void setReadEnabled(bool enable);

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -27,36 +27,40 @@ class SocketNotifier : public QObject
 	Q_OBJECT
 
 public:
-	enum Type
+	enum Interest
 	{
-		Read = 1,
-		Write = 2,
+		Read = 0x01,
+		Write = 0x02,
 	};
 
-	SocketNotifier(int socket, Type type);
+	SocketNotifier(int socket, uint8_t interest);
 	~SocketNotifier();
 
-	bool isEnabled() const { return enabled_; }
+	bool isReadEnabled() const { return writeEnabled_; }
+	bool isWrieEnabled() const { return readEnabled_; }
 	int socket() const { return socket_; }
-	Type type() const { return type_; }
 
-	void setEnabled(bool enable);
+	void setReadEnabled(bool enable);
+	void setWriteEnabled(bool enable);
 
-	boost::signals2::signal<void(int)> activated;
+	boost::signals2::signal<void(int, uint8_t)> activated;
 
 private slots:
-	void innerActivated(int socket);
+	void innerReadActivated(int socket);
+	void innerWriteActivated(int socket);
 
 private:
 	int socket_;
-	Type type_;
-	bool enabled_;
-	QSocketNotifier *inner_;
+	uint8_t interest_;
+	bool readEnabled_;
+	bool writeEnabled_;
+	QSocketNotifier *readInner_;
+	QSocketNotifier *writeInner_;
 	EventLoop *loop_;
 	int regId_;
 
-	static void cb_fd_activated(void *ctx);
-	void fd_activated();
+	static void cb_fd_activated(void *ctx, uint8_t readiness);
+	void fd_activated(uint8_t readiness);
 };
 
 #endif

--- a/src/core/tcplistener.cpp
+++ b/src/core/tcplistener.cpp
@@ -43,7 +43,7 @@ bool TcpListener::bind(const QHostAddress &addr, quint16 port)
 
 	sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
 	sn_->activated.connect(boost::bind(&TcpListener::sn_activated, this));
-	sn_->setEnabled(true);
+	sn_->setReadEnabled(true);
 
 	return true;
 }

--- a/src/core/tcpstream.h
+++ b/src/core/tcpstream.h
@@ -18,6 +18,7 @@
 #define TCPSTREAM_H
 
 #include <memory>
+#include <variant>
 #include <QByteArray>
 #include <boost/signals2.hpp>
 #include "rust/bindings.h"
@@ -46,12 +47,12 @@ private:
 	friend class TcpListener;
 
 	ffi::TcpStream *inner_;
-	std::unique_ptr<SocketNotifier> snRead_, snWrite_;
+	std::unique_ptr<SocketNotifier> sn_;
 	int errorCondition_;
+	std::shared_ptr<std::monostate> alive_;
 
 	TcpStream(ffi::TcpStream *inner);
-	void snRead_activated();
-	void snWrite_activated();
+	void sn_activated(int socket, uint8_t readiness);
 };
 
 #endif

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -263,8 +263,10 @@ void Timer::stop()
 	}
 }
 
-void Timer::cb_timer_activated(void *ctx)
+void Timer::cb_timer_activated(void *ctx, uint8_t readiness)
 {
+	Q_UNUSED(readiness);
+
 	Timer *self = (Timer *)ctx;
 
 	self->timerReady();

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -64,7 +64,7 @@ private:
 	int interval_;
 	int timerId_;
 
-	static void cb_timer_activated(void *ctx);
+	static void cb_timer_activated(void *ctx, uint8_t readiness);
 	void timerReady();
 };
 


### PR DESCRIPTION
We originally modeled `SocketNotifier` after `QSocketNotifier`, which takes only one kind of I/O interest at a time. If both read and write interest are needed, then two notifiers must be created. However, creating two notifiers (and thus, two registrations) for the same file descriptor can cause problems with our new event loop, which is based on `epoll` (via the `mio` crate). This PR addresses this issue by updating `SocketNotifier` to support multiple interests in a single instance, avoiding the need for multiple registrations of the same file descriptor when the new event loop is used.

Notably, this change means the `activated` signal needs to indicate which interest caused the callback (which we call "readiness" in that context). Also, when the Qt event loop is used and multiple interests are indicated then we need to use multiple `QSocketNotifier` instances as backing.