### PR TITLE
tcpstream: test against both event loops

### DIFF
--- a/src/core/net.rs
+++ b/src/core/net.rs
@@ -754,7 +754,7 @@ mod ffi {
     use std::convert::TryInto;
     use std::ffi::{CStr, OsStr};
     use std::io::{Read, Write};
-    use std::os::fd::AsRawFd;
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
     use std::os::raw::{c_char, c_int};
     use std::os::unix::ffi::OsStrExt;
     use std::path::Path;
@@ -939,10 +939,82 @@ mod ffi {
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
+    pub unsafe extern "C" fn tcp_stream_connect(
+        ip: *const c_char,
+        port: u16,
+        out_errno: *mut c_int,
+    ) -> *mut TcpStream {
+        assert!(!out_errno.is_null());
+
+        let ip = unsafe { CStr::from_ptr(ip) };
+
+        let ip = match ip.to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                unsafe { out_errno.write(libc::EINVAL) };
+                return ptr::null_mut();
+            }
+        };
+
+        let ip: std::net::IpAddr = match ip.parse() {
+            Ok(ip) => ip,
+            Err(_) => {
+                unsafe { out_errno.write(libc::EINVAL) };
+                return ptr::null_mut();
+            }
+        };
+
+        let addr = std::net::SocketAddr::new(ip, port);
+
+        // use mio to ensure socket begins in non-blocking mode
+        let s = match mio::net::TcpStream::connect(addr) {
+            Ok(s) => s,
+            Err(e) => {
+                let code = e.raw_os_error().unwrap_or(libc::EINVAL);
+                unsafe { out_errno.write(code) };
+                return ptr::null_mut();
+            }
+        };
+
+        // SAFETY: converting from valid object
+        let s = unsafe { std::net::TcpStream::from_raw_fd(s.into_raw_fd()) };
+
+        Box::into_raw(Box::new(TcpStream(s)))
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    #[no_mangle]
     pub unsafe extern "C" fn tcp_stream_destroy(s: *mut TcpStream) {
         if !s.is_null() {
             drop(Box::from_raw(s));
         }
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    #[no_mangle]
+    pub unsafe extern "C" fn tcp_stream_check_connected(
+        s: *const TcpStream,
+        out_errno: *mut c_int,
+    ) -> c_int {
+        let s = s.as_ref().unwrap();
+
+        // mio documentation says to use take_error() and peer_addr() to
+        // check for connected
+
+        if let Ok(Some(e)) | Err(e) = s.0.take_error() {
+            let code = e.raw_os_error().unwrap_or(libc::EINVAL);
+            unsafe { out_errno.write(code) };
+            return -1;
+        }
+
+        // returns libc::ENOTCONN if not yet connected
+        if let Err(e) = s.0.peer_addr() {
+            let code = e.raw_os_error().unwrap_or(libc::EINVAL);
+            unsafe { out_errno.write(code) };
+            return -1;
+        }
+
+        0
     }
 
     #[allow(clippy::missing_safety_doc)]

--- a/src/core/net.rs
+++ b/src/core/net.rs
@@ -996,6 +996,8 @@ mod ffi {
         s: *const TcpStream,
         out_errno: *mut c_int,
     ) -> c_int {
+        assert!(!out_errno.is_null());
+        
         let s = s.as_ref().unwrap();
 
         // mio documentation says to use take_error() and peer_addr() to

--- a/src/core/net.rs
+++ b/src/core/net.rs
@@ -996,9 +996,8 @@ mod ffi {
         s: *const TcpStream,
         out_errno: *mut c_int,
     ) -> c_int {
-        assert!(!out_errno.is_null());
-        
         let s = s.as_ref().unwrap();
+        assert!(!out_errno.is_null());
 
         // mio documentation says to use take_error() and peer_addr() to
         // check for connected

--- a/src/core/tcplistener.h
+++ b/src/core/tcplistener.h
@@ -18,7 +18,6 @@
 #define TCPLISTENER_H
 
 #include <memory>
-#include <QtGlobal>
 #include <QHostAddress>
 #include <boost/signals2.hpp>
 #include "rust/bindings.h"
@@ -32,9 +31,10 @@ public:
 	TcpListener();
 	~TcpListener();
 
-	bool bind(const QHostAddress &addr, quint16 port);
-	std::tuple<QHostAddress, quint16> localAddress() const;
+	bool bind(const QHostAddress &addr, uint16_t port);
+	std::tuple<QHostAddress, uint16_t> localAddress() const;
 	std::unique_ptr<TcpStream> accept();
+	int errorCondition() const { return errorCondition_; }
 
 	boost::signals2::signal<void()> streamsReady;
 
@@ -43,6 +43,7 @@ private:
 	void sn_activated();
 
 	ffi::TcpListener *inner_;
+	int errorCondition_;
 	std::unique_ptr<SocketNotifier> sn_;
 };
 

--- a/src/core/tcpstream.h
+++ b/src/core/tcpstream.h
@@ -24,12 +24,22 @@
 #include "rust/bindings.h"
 #include "readwrite.h"
 
+class QHostAddress;
+
 class SocketNotifier;
 
 class TcpStream : public ReadWrite
 {
 public:
+	TcpStream();
 	~TcpStream();
+
+	// returns true if connection starting, false on error
+	bool connect(const QHostAddress &addr, uint16_t port);
+
+	// returns true if connected, false on error. if errorCondition() returns
+	// ENOTCONN, then it is not fatal and the socket is still connecting
+	bool checkConnected();
 
 	// reimplemented
 	virtual QByteArray read(int size = -1);
@@ -45,6 +55,8 @@ private:
 	std::shared_ptr<std::monostate> alive_;
 
 	TcpStream(ffi::TcpStream *inner);
+	void reset();
+	void setupNotifier();
 	void sn_activated(int socket, uint8_t readiness);
 };
 


### PR DESCRIPTION
This updates the tests to test against both the Qt event loop and the new event loop. In order to do this, the ability to make outbound connections is added to `TcpStream`, and then `TcpStream` is used as the connecting client instead of `QTcpSocket` since it works with both loops. The tests are also updated to properly treat the API as edge-triggered, always assuming I/O operations are possible until told otherwise by `EAGAIN`.