### PR TITLE
proxy: init timer manager before engine

### DIFF
--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -288,6 +288,9 @@ public:
 		// will unlock during exec
 		m.lock();
 
+		// enough timers for sessions and zroutes, plus an extra 100 for misc
+		Timer::init((config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100);
+
 		worker = new EngineWorker(config, domainMap);
 		Connection startedConnection = worker->started.connect(boost::bind(&EngineThread::worker_started, this));
 		Connection stoppedConnection = worker->stopped.connect(boost::bind(&EngineThread::worker_stopped, this));

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -59,7 +59,6 @@
 #include "logutil.h"
 
 #define DEFAULT_HWM 1000
-#define ZROUTES_MAX 100
 
 class Engine::Private : public QObject
 {

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -61,17 +61,6 @@
 #define DEFAULT_HWM 1000
 #define ZROUTES_MAX 100
 
-// each session can have a bunch of timers:
-// 2 per incoming zhttprequest/zwebsocket
-// 2 per outgoing zhttprequest/zwebsocket
-// 1 per wsproxysession
-// 2 per websocketoverhttp
-// 1 per inspect/accept request
-#define TIMERS_PER_SESSION 10
-
-// each zroute has a zhttpmanager, which has up to 8 timers
-#define TIMERS_PER_ZROUTE 10
-
 class Engine::Private : public QObject
 {
 	Q_OBJECT
@@ -216,9 +205,6 @@ public:
 	bool start(const Configuration &_config)
 	{
 		config = _config;
-
-		// enough timers for sessions and zroutes, plus an extra 100 for misc
-		Timer::init((config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100);
 
 		logConfig.fromAddress = config.logFrom;
 		logConfig.userAgent = config.logUserAgent;

--- a/src/proxy/engine.h
+++ b/src/proxy/engine.h
@@ -32,6 +32,19 @@
 #include <boost/signals2.hpp>
 #include <map>
 
+#define ZROUTES_MAX 100
+
+// each session can have a bunch of timers:
+// 2 per incoming zhttprequest/zwebsocket
+// 2 per outgoing zhttprequest/zwebsocket
+// 1 per wsproxysession
+// 2 per websocketoverhttp
+// 1 per inspect/accept request
+#define TIMERS_PER_SESSION 10
+
+// each zroute has a zhttpmanager, which has up to 8 timers
+#define TIMERS_PER_ZROUTE 10
+
 using std::map;
 using Connection = boost::signals2::scoped_connection;
 

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -596,6 +596,8 @@ private slots:
 		QDir outDir(qgetenv("OUT_DIR"));
 		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
+		Timer::init(100);
+
 		wrapper = new Wrapper(this, workDir);
 		wrapper->startHttp();
 


### PR DESCRIPTION
This allows other things to use timers before starting the engine, needed for #48149.