### PR TITLE
socketnotifier: present an edge-triggered style api

### DIFF
--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -41,6 +41,7 @@ private slots:
 		QCOMPARE(pipe(fds), 0);
 
 		SocketNotifier *sn = new SocketNotifier(fds[0], SocketNotifier::Read);
+		sn->clearReadiness(SocketNotifier::Read);
 
 		int activatedFd = -1;
 		uint8_t activatedReadiness = -1;

--- a/src/core/processquit.cpp
+++ b/src/core/processquit.cpp
@@ -90,6 +90,7 @@ public:
 
 		sig_notifier = std::make_unique<SocketNotifier>(sig_pipe[0], SocketNotifier::Read);
 		activatedConnection = sig_notifier->activated.connect(boost::bind(&Private::sig_activated, this, boost::placeholders::_1));
+		sig_notifier->clearReadiness(SocketNotifier::Read);
 		unixWatchAdd(SIGINT);
 		unixWatchAdd(SIGHUP);
 		unixWatchAdd(SIGTERM);

--- a/src/core/qzmqsocket.cpp
+++ b/src/core/qzmqsocket.cpp
@@ -424,6 +424,13 @@ public:
 		updateTimer = std::make_unique<Timer>();
 		updateTimerConnection = updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));
 		updateTimer->setSingleShot(true);
+
+		// socket notifier starts out ready. attempt to read events
+		if(processEvents())
+		{
+			// if there are events, queue them for processing
+			update();
+		}
 	}
 
 	~Private()
@@ -527,6 +534,8 @@ public:
 	bool processEvents()
 	{
 		int flags = get_events(sock);
+
+		sn_read->clearReadiness(SocketNotifier::Read);
 
 		bool canWriteOld = canWrite;
 		bool canReadOld = canRead;

--- a/src/core/socketnotifier.cpp
+++ b/src/core/socketnotifier.cpp
@@ -27,10 +27,14 @@ SocketNotifier::SocketNotifier(int socket, uint8_t interest) :
 	writeEnabled_(true),
 	readInner_(nullptr),
 	writeInner_(nullptr),
+	readiness_(0),
 	loop_(EventLoop::instance()),
 	regId_(-1)
 {
-	assert((interest & SocketNotifier::Read) || (interest & SocketNotifier::Write));
+	assert((interest & Read) || (interest & Write));
+
+	// start by assuming ready
+	readiness_ = interest;
 
 	if(loop_)
 	{
@@ -38,10 +42,10 @@ SocketNotifier::SocketNotifier(int socket, uint8_t interest) :
 
 		uint8_t einterest = 0;
 
-		if(interest & SocketNotifier::Read)
+		if(interest & Read)
 			einterest |= EventLoop::Readable;
 
-		if(interest & SocketNotifier::Write)
+		if(interest & Write)
 			einterest |= EventLoop::Writable;
 
 		regId_ = loop_->registerFd(socket_, einterest, SocketNotifier::cb_fd_activated, this);
@@ -51,16 +55,22 @@ SocketNotifier::SocketNotifier(int socket, uint8_t interest) :
 	{
 		// else fall back to qt eventloop
 
-		if(interest & SocketNotifier::Read)
+		if(interest & Read)
 		{
 			readInner_ = new QSocketNotifier(socket, QSocketNotifier::Read);
 			connect(readInner_, &QSocketNotifier::activated, this, &SocketNotifier::innerReadActivated);
+
+			// start out disabled. will enable when initial readiness cleared
+			readInner_->setEnabled(false);
 		}
 
-		if(interest & SocketNotifier::Write)
+		if(interest & Write)
 		{
 			writeInner_ = new QSocketNotifier(socket, QSocketNotifier::Write);
 			connect(writeInner_, &QSocketNotifier::activated, this, &SocketNotifier::innerWriteActivated);
+
+			// start out disabled. will enable when initial readiness cleared
+			writeInner_->setEnabled(false);
 		}
 	}
 }
@@ -92,45 +102,72 @@ SocketNotifier::~SocketNotifier()
 void SocketNotifier::setReadEnabled(bool enable)
 {
 	readEnabled_ = enable;
-
-	if(readInner_)
-		readInner_->setEnabled(readEnabled_);
 }
 
 void SocketNotifier::setWriteEnabled(bool enable)
 {
 	writeEnabled_ = enable;
+}
 
-	if(writeInner_)
-		writeInner_->setEnabled(writeEnabled_);
+void SocketNotifier::clearReadiness(uint8_t readiness)
+{
+	readiness_ &= ~readiness;
+
+	if(readInner_ && !(readiness_ & Read))
+		readInner_->setEnabled(true);
+
+	if(writeInner_ && !(readiness_ & Write))
+		writeInner_->setEnabled(true);
 }
 
 void SocketNotifier::innerReadActivated(int socket)
 {
-	activated(socket, SocketNotifier::Read);
+	Q_UNUSED(socket);
+
+	// QSocketNotifier is level-triggered. disable until readiness cleared
+	readInner_->setEnabled(false);
+
+	apply(Read);
 }
 
 void SocketNotifier::innerWriteActivated(int socket)
 {
-	activated(socket, SocketNotifier::Write);
+	Q_UNUSED(socket);
+
+	// QSocketNotifier is level-triggered. disable until readiness cleared
+	writeInner_->setEnabled(false);
+
+	apply(Write);
 }
 
-void SocketNotifier::cb_fd_activated(void *ctx, uint8_t readiness)
+void SocketNotifier::apply(uint8_t readiness)
+{
+	// calculate which bits went from 0->1
+	uint8_t changes = readiness & ~readiness_;
+
+	readiness_ = readiness;
+
+	if((readEnabled_ && (changes & Read)) || (writeEnabled_ && (changes & Write)))
+		activated(socket_, changes);
+}
+
+void SocketNotifier::cb_fd_activated(void *ctx, uint8_t ereadiness)
 {
 	SocketNotifier *self = (SocketNotifier *)ctx;
 
-	self->fd_activated(readiness);
+	self->fd_activated(ereadiness);
 }
 
 void SocketNotifier::fd_activated(uint8_t ereadiness)
 {
 	uint8_t readiness = 0;
 
-	if(readEnabled_ && (ereadiness & EventLoop::Readable))
-		readiness |= SocketNotifier::Read;
-	if(writeEnabled_ && (ereadiness & EventLoop::Writable))
-		readiness |= SocketNotifier::Write;
+	if(ereadiness & EventLoop::Readable)
+		readiness |= Read;
+
+	if(ereadiness & EventLoop::Writable)
+		readiness |= Write;
 
 	if(readiness)
-		activated(socket_, readiness);
+		apply(readiness);
 }

--- a/src/core/socketnotifier.cpp
+++ b/src/core/socketnotifier.cpp
@@ -145,7 +145,7 @@ void SocketNotifier::apply(uint8_t readiness)
 	// calculate which bits went from 0->1
 	uint8_t changes = readiness & ~readiness_;
 
-	readiness_ = readiness;
+	readiness_ |= readiness;
 
 	if((readEnabled_ && (changes & Read)) || (writeEnabled_ && (changes & Write)))
 		activated(socket_, changes);

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -33,7 +33,13 @@ public:
 		Write = 0x02,
 	};
 
+	// initializes notifier with interest and considers the socket ready for
+	// the specified interest. readiness must be cleared via clearReadiness()
+	// in order for the activated signal to be emitted. the expected way to
+	// use this class is to initialize it, perform I/O until progress can no
+	// longer be made, clear readiness, then await the signal.
 	SocketNotifier(int socket, uint8_t interest);
+
 	~SocketNotifier();
 
 	bool isReadEnabled() const { return readEnabled_; }
@@ -42,6 +48,9 @@ public:
 
 	void setReadEnabled(bool enable);
 	void setWriteEnabled(bool enable);
+
+	uint8_t readiness() const { return readiness_; }
+	void clearReadiness(uint8_t readiness);
 
 	boost::signals2::signal<void(int, uint8_t)> activated;
 
@@ -56,9 +65,11 @@ private:
 	bool writeEnabled_;
 	QSocketNotifier *readInner_;
 	QSocketNotifier *writeInner_;
+	uint8_t readiness_;
 	EventLoop *loop_;
 	int regId_;
 
+	void apply(uint8_t readiness);
 	static void cb_fd_activated(void *ctx, uint8_t readiness);
 	void fd_activated(uint8_t readiness);
 };

--- a/src/core/tcplistener.cpp
+++ b/src/core/tcplistener.cpp
@@ -76,11 +76,12 @@ std::unique_ptr<TcpStream> TcpListener::accept()
 
 	errorCondition_ = 0;
 
-	int e;
-	ffi::TcpStream *s_inner = ffi::tcp_listener_accept(inner_, &e);
+	ffi::TcpStream *s_inner = ffi::tcp_listener_accept(inner_, &errorCondition_);
 	if(!s_inner)
 	{
-		errorCondition_ = e;
+		if(errorCondition_ == EAGAIN)
+			sn_->clearReadiness(SocketNotifier::Read);
+
 		return std::unique_ptr<TcpStream>(); // null
 	}
 


### PR DESCRIPTION
Instead of making `TcpStream` and other things that depend `SocketNotifier` tolerant to different triggering behaviors, let's make `SocketNotifier` always present an edge-triggered interface. This helps simplify the things that depend on it.

Notably, since this change considers notifiers to be immediately ready, `QZmq::Socket` must do an immediate read on its file descriptor in its constructor, potentially starting a timer to defer handling of the result. Previously, `QZmq::Socket` was relying on its notifier to activate shortly after construction, either via level-triggered behavior or getting lucky with edge-triggered behavior.