### PR TITLE
simplehttpserver: use new i/o classes

### DIFF
--- a/src/core/simplehttpserver.h
+++ b/src/core/simplehttpserver.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2022 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -40,7 +41,6 @@ class SimpleHttpRequest : public QObject
 	Q_OBJECT
 
 public:
-	SimpleHttpRequest(int maxHeadersSize, int maxBodySize, QObject* parent = 0);
 	~SimpleHttpRequest();
 
 	QString requestMethod() const;
@@ -59,7 +59,7 @@ private:
 	friend class SimpleHttpServerPrivate;
 	Private *d;
 
-	SimpleHttpRequest(QObject *parent = 0);
+	SimpleHttpRequest(int maxHeadersSize, int maxBodySize);
 };
 
 class SimpleHttpServer : public QObject


### PR DESCRIPTION
The new I/O classes provide a different API than the Qt classes, so the code is reworked to be more like a state machine. The `step()` method advances the state machine, and the `process()` method calls `step()` multiple times until progress can't be made. The `readReady` and `writeReady` signals are wired up to call `process()`.

Manually tested publishing and prometheus (the only things that use `SimpleHttpServer`), via tcp and unix sockets, and also 100-continue.