### PR TITLE
simplehttpserver: enforce a connection maximum

### DIFF
--- a/src/core/simplehttpserver.h
+++ b/src/core/simplehttpserver.h
@@ -28,6 +28,8 @@
 #include <boost/signals2.hpp>
 #include <map>
 
+#define SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST 1
+
 using std::map;
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
@@ -59,7 +61,7 @@ private:
 	friend class SimpleHttpServerPrivate;
 	Private *d;
 
-	SimpleHttpRequest(int maxHeadersSize, int maxBodySize);
+	SimpleHttpRequest(int headersSizeMax, int bodySizeMax);
 };
 
 class SimpleHttpServer : public QObject
@@ -67,7 +69,7 @@ class SimpleHttpServer : public QObject
 	Q_OBJECT
 
 public:
-	SimpleHttpServer(int maxHeadersSize, int maxBodySize, QObject *parent = 0);
+	SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax, QObject *parent = 0);
 	~SimpleHttpServer();
 
 	bool listen(const QHostAddress &addr, int port);

--- a/src/core/statsmanager.h
+++ b/src/core/statsmanager.h
@@ -48,7 +48,7 @@ public:
 		JsonFormat
 	};
 
-	StatsManager(int connectionsMax, int subscriptionsMax, QObject *parent = 0);
+	StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax, QObject *parent = 0);
 	~StatsManager();
 
 	bool connectionSendEnabled() const;

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -34,6 +34,7 @@
 #include "eventloop.h"
 #include "processquit.h"
 #include "log.h"
+#include "simplehttpserver.h"
 #include "httpsession.h"
 #include "wssession.h"
 #include "httpsessionupdatemanager.h"
@@ -407,10 +408,9 @@ private:
 		{
 			log_debug("using new event loop");
 
-			// enough for lots of internal http api requests, prometheus
-			// requests, and zmq route targets. client sessions don't use
-			// socket notifiers
-			int socketNotifiersMax = 1000;
+			// enough for control requests and prometheus requests. client
+			// sessions don't use socket notifiers
+			int socketNotifiersMax = SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX);
 
 			int registrationsMax = timersMax + socketNotifiersMax;
 			loop = std::make_unique<EventLoop>(registrationsMax);

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1535,7 +1535,7 @@ public:
 			log_debug("ws control stream: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
 		}
 
-		stats = new StatsManager(config.connectionsMax, config.connectionsMax * config.connectionSubscriptionMax, this);
+		stats = new StatsManager(config.connectionsMax, config.connectionsMax * config.connectionSubscriptionMax, PROMETHEUS_CONNECTIONS_MAX, this);
 		connectionsRefreshedConnection = stats->connectionsRefreshed.connect(boost::bind(&Private::stats_connectionsRefreshed, this, boost::placeholders::_1));
 		unsubscribedConnection = stats->unsubscribed.connect(boost::bind(&Private::stats_unsubscribed, this, boost::placeholders::_1, boost::placeholders::_2));
 		reportedConnection = stats->reported.connect(boost::bind(&Private::stats_reported, this, boost::placeholders::_1));
@@ -1620,7 +1620,7 @@ public:
 
 		if(config.pushInHttpPort != -1)
 		{
-			controlHttpServer = new SimpleHttpServer(config.pushInHttpMaxHeadersSize, config.pushInHttpMaxBodySize, this);
+			controlHttpServer = new SimpleHttpServer(CONTROL_CONNECTIONS_MAX, config.pushInHttpMaxHeadersSize, config.pushInHttpMaxBodySize, this);
 			controlServerConnection = controlHttpServer->requestReady.connect(boost::bind(&Private::controlHttpServer_requestReady, this));
 			controlHttpServer->listen(config.pushInHttpAddr, config.pushInHttpPort);
 

--- a/src/handler/handlerengine.h
+++ b/src/handler/handlerengine.h
@@ -32,6 +32,9 @@
 
 #define TIMERS_PER_SUBSCRIPTION 1
 
+#define CONTROL_CONNECTIONS_MAX 128
+#define PROMETHEUS_CONNECTIONS_MAX 16
+
 using std::map;
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -316,7 +316,7 @@ public:
 
 		if(!config.statsSpec.isEmpty() || !config.prometheusPort.isEmpty())
 		{
-			stats = new StatsManager(config.sessionsMax, 0, this);
+			stats = new StatsManager(config.sessionsMax, 0, PROMETHEUS_CONNECTIONS_MAX, this);
 
 			connMaxConnection = stats->connMax.connect(boost::bind(&Private::stats_connMax, this, boost::placeholders::_1));
 

--- a/src/proxy/engine.h
+++ b/src/proxy/engine.h
@@ -32,8 +32,6 @@
 #include <boost/signals2.hpp>
 #include <map>
 
-#define ZROUTES_MAX 100
-
 // each session can have a bunch of timers:
 // 2 per incoming zhttprequest/zwebsocket
 // 2 per outgoing zhttprequest/zwebsocket
@@ -44,6 +42,9 @@
 
 // each zroute has a zhttpmanager, which has up to 8 timers
 #define TIMERS_PER_ZROUTE 10
+
+#define PROMETHEUS_CONNECTIONS_MAX 16
+#define ZROUTES_MAX 100
 
 using std::map;
 using Connection = boost::signals2::scoped_connection;


### PR DESCRIPTION
Now that `SimpleHttpRequest` uses `SocketNotifier` (via `TcpStream` or `UnixStream`), we need to limit the number of concurrent connections for when the new event loop is used. This PR implements this by making `SimpleHttpServer` pause accepting connections from its listener when a specified limit is reached.

Manually tested by temporarily changing `PROMETHEUS_CONNECTIONS_MAX` to 1 and connecting a few slow clients, to confirm queueing and eventual acceptance.