### PR TITLE
ratelimiter: ensure timeout connection does not outlive slot

### DIFF
--- a/src/handler/ratelimiter.cpp
+++ b/src/handler/ratelimiter.cpp
@@ -74,7 +74,7 @@ public:
 	bool batchWaitEnabled;
 	QMap<QString, Bucket> buckets;
 	QString lastKey;
-	Timer *timer;
+	std::unique_ptr<Timer> timer;
 	bool firstPass;
 	int batchInterval;
 	int batchSize;
@@ -90,15 +90,8 @@ public:
 		batchSize(-1),
 		lastBatchEmpty(false)
 	{
-		timer = new Timer;
+		timer = std::make_unique<Timer>();
 		timer->timeout.connect(boost::bind(&Private::timeout, this));
-	}
-
-	~Private()
-	{
-		timer->disconnect(this);
-		timer->setParent(0);
-		DeferCall::deleteLater(timer);
 	}
 
 	void setRate(int actionsPerSecond)


### PR DESCRIPTION
Currently, a deferred delete is used on the timer without disconnecting its signal, leading to the timer outliving the `Private` instance and the possibility of `Private::timeout` being called after it is gone. We'll fix this by simply not doing a deferred delete. We needed deferred deletes for `QTimer` instances, but our `Timer` replacement does not need this.

Notably, this is causing the handler to crash during error handling at startup, as the timer races with a rate limiter's destructor.