### PR TITLE
statsmanager: count minutes from external reports in prometheus metrics

### DIFF
--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -1335,7 +1335,10 @@ public:
 
 			Report &r = report->externalReports[packet.from];
 
-			r.connectionsMinutes += qMax(packet.connectionsMinutes, 0);
+			int mins = qMax(packet.connectionsMinutes, 0);
+
+			r.connectionsMinutes += mins;
+			combinedReport.addConnectionsMinutes(mins, now);
 		}
 	}
 


### PR DESCRIPTION
Prometheus queries read from `combinedReport`, which we need to update here.