### PR TITLE
defercall: ensure elements for completed calls are removed

### DIFF
--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -42,6 +42,8 @@ public:
 	// guaranteed to live long enough.
 	void defer(std::function<void ()> handler);
 
+	int pendingCount() const { return deferredCalls_->size(); }
+
 	static DeferCall *global();
 	static void cleanup();
 
@@ -56,12 +58,14 @@ private:
 	{
 	public:
 		std::function<void ()> handler;
+		std::weak_ptr<std::list<std::shared_ptr<Call>>> source;
+		std::list<std::shared_ptr<Call>>::iterator sourceElement;
 	};
 
 	class Manager;
 	friend class Manager;
 
-	std::list<std::shared_ptr<Call>> deferredCalls_;
+	std::shared_ptr<std::list<std::shared_ptr<Call>>> deferredCalls_;
 
 	static thread_local Manager *manager;
 	static thread_local DeferCall *instance;


### PR DESCRIPTION
When a deferred call is processed, we need to remove the original `shared_ptr<Call>` from the owning `DeferCall`. To do this, we'll store some more things in the `Call`: a weak pointer to the backing list and an iterator to the element itself. Then, when the manager resolves the call, it can remove the element from the list via the iterator.

Stashing an iterator and using it later is safe because `std::list` iterators remain valid even during most list manipulations. The only way to make such an iterator invalid is to remove the element it refers to. This happens in two places: 1) when removing the element via the iterator, after which we never use the iterator again, and 2) when the backing list is destroyed, in which case any weak pointers to it will be expired (the iterator is only touched when the pointers are not expired).