### PR TITLE
don't use QObject parenting with http/ws session objects

### DIFF
--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -159,7 +159,7 @@ public:
 
 	HttpSession *q;
 	State state;
-	ZhttpRequest *req;
+	std::unique_ptr<ZhttpRequest> req;
 	AcceptData adata;
 	Instruct instruct;
 	int logLevel;
@@ -231,7 +231,6 @@ public:
 	{
 		state = NotStarted;
 
-		req->setParent(this);
 		bytesWrittenConnection = req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1));
 		writeBytesChangedConnection = req->writeBytesChanged.connect(boost::bind(&Private::req_writeBytesChanged, this));
 		errorConnection = req->error.connect(boost::bind(&Private::req_error, this));
@@ -1152,7 +1151,6 @@ private:
 		sentOutReqData = 0;
 
 		outReq.reset(outZhttp->createRequest());
-		outReq->setParent(this);
 		readyReadOutConnection = outReq->readyRead.connect(boost::bind(&Private::outReq_readyRead, this));
 		errorOutConnection = outReq->error.connect(boost::bind(&Private::outReq_error, this));
 


### PR DESCRIPTION
This is the first in a series of changes to remove our use of `QObject`. As we are deprecating our use of the Qt event loop (and longer term Qt in general), ideally we shouldn't use `QObject` anymore, and parenting is one of the last remaining dependencies on it.

Parenting has three main purposes that we don't need, or soon won't need:

1. Child auto-destruction. We can just use smart pointers like `std::unique_ptr` instead.
2. `QObject::moveToThread()`. This manages `QObject` thread-affinity which is mostly only meaningful with the Qt event loop.
3. Reflection of the object graph. We don't do anything with this and have no plans for such need.

To start out, this PR removes the use of parenting of `HttpRequest` and `WebSocket` subclasses. For `WebSocketOverHttp::DisconnectManager`, the existing map is used to manage the children. Everywhere else, `std::unique_ptr` is used.