### PR TITLE
remove parenting api from http/ws session objects

### DIFF
--- a/src/core/httprequest.h
+++ b/src/core/httprequest.h
@@ -24,7 +24,6 @@
 #ifndef HTTPREQUEST_H
 #define HTTPREQUEST_H
 
-#include <QObject>
 #include <QUrl>
 #include <QHostAddress>
 #include "httpheaders.h"
@@ -33,10 +32,8 @@
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
 
-class HttpRequest : public QObject
+class HttpRequest
 {
-	Q_OBJECT
-
 public:
 	enum ErrorCondition
 	{
@@ -52,7 +49,7 @@ public:
 		ErrorRequestTooLarge
 	};
 
-	HttpRequest(QObject *parent = 0) : QObject(parent) {}
+	virtual ~HttpRequest() = default;
 
 	virtual QHostAddress peerAddress() const = 0;
 

--- a/src/core/websocket.h
+++ b/src/core/websocket.h
@@ -24,7 +24,6 @@
 #ifndef WEBSOCKET_H
 #define WEBSOCKET_H
 
-#include <QObject>
 #include <QUrl>
 #include <QHostAddress>
 #include "httpheaders.h"
@@ -32,10 +31,8 @@
 
 using Signal = boost::signals2::signal<void()>;
 
-class WebSocket : public QObject
+class WebSocket
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -81,7 +78,7 @@ public:
 		}
 	};
 
-	WebSocket(QObject *parent = 0) : QObject(parent) {}
+	virtual ~WebSocket() = default;
 
 	virtual QHostAddress peerAddress() const = 0;
 

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -111,7 +111,6 @@ public:
 	DeferCall deferCall;
 
 	Private(ZhttpRequest *_q) :
-		QObject(_q),
 		q(_q),
 		manager(0),
 		server(false),
@@ -1204,8 +1203,7 @@ public:
 	}
 };
 
-ZhttpRequest::ZhttpRequest(QObject *parent) :
-	HttpRequest(parent)
+ZhttpRequest::ZhttpRequest()
 {
 	d = std::make_shared<Private>(this);
 }

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -38,8 +38,6 @@ class ZhttpManager;
 
 class ZhttpRequest : public HttpRequest
 {
-	Q_OBJECT
-
 public:
 	// pair of sender + request id
 	typedef QPair<QByteArray, QByteArray> Rid;
@@ -124,7 +122,7 @@ private:
 	std::shared_ptr<Private> d;
 
 	friend class ZhttpManager;
-	ZhttpRequest(QObject *parent = 0);
+	ZhttpRequest();
 	void setupClient(ZhttpManager *manager, bool req);
 	bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
 	void setupServer(ZhttpManager *manager, const ServerState &state);

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -98,7 +98,6 @@ public:
 	DeferCall deferCall;
 
 	Private(ZWebSocket *_q) :
-		QObject(_q),
 		q(_q),
 		manager(0),
 		server(false),
@@ -1091,8 +1090,7 @@ public:
 	}
 };
 
-ZWebSocket::ZWebSocket(QObject *parent) :
-	WebSocket(parent)
+ZWebSocket::ZWebSocket()
 {
 	d = std::make_shared<Private>(this);
 }

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -35,8 +35,6 @@ class ZhttpManager;
 
 class ZWebSocket : public WebSocket
 {
-	Q_OBJECT
-
 public:
 	// pair of sender + request id
 	typedef QPair<QByteArray, QByteArray> Rid;
@@ -84,7 +82,7 @@ private:
 	std::shared_ptr<Private> d;
 
 	friend class ZhttpManager;
-	ZWebSocket(QObject *parent = 0);
+	ZWebSocket();
 	void setupClient(ZhttpManager *manager);
 	bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
 	void startServer();

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -169,7 +169,6 @@ public:
 	DeferCall deferCall;
 
 	Private(SockJsSession *_q) :
-		QObject(_q),
 		q(_q),
 		manager(0),
 		mode((Mode)-1),
@@ -1112,8 +1111,7 @@ public:
 	}
 };
 
-SockJsSession::SockJsSession(QObject *parent) :
-	WebSocket(parent)
+SockJsSession::SockJsSession()
 {
 	d = std::make_shared<Private>(this);
 }

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -40,8 +40,6 @@ class SockJsManager;
 
 class SockJsSession : public WebSocket
 {
-	Q_OBJECT
-
 public:
 	~SockJsSession();
 
@@ -86,7 +84,7 @@ private:
 	std::shared_ptr<Private> d;
 
 	friend class SockJsManager;
-	SockJsSession(QObject *parent = 0);
+	SockJsSession();
 	void setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const QUrl &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route);
 	void setupServer(SockJsManager *manager, ZWebSocket *sock, const QUrl &asUri, const DomainMap::Entry &route);
 	void setupServer(SockJsManager *manager, ZWebSocket *sock, const QUrl &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route);

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -58,7 +58,6 @@ public:
 	DeferCall deferCall;
 
 	Private(TestHttpRequest *_q) :
-		QObject(_q),
 		q(_q),
 		state(Idle),
 		requestBodyFinished(false),
@@ -141,8 +140,7 @@ public:
 	}
 };
 
-TestHttpRequest::TestHttpRequest(QObject *parent) :
-	HttpRequest(parent)
+TestHttpRequest::TestHttpRequest()
 {
 	d = new Private(this);
 }

--- a/src/proxy/testhttprequest.h
+++ b/src/proxy/testhttprequest.h
@@ -27,13 +27,11 @@
 
 class TestHttpRequest : public HttpRequest
 {
-	Q_OBJECT
-
 public:
 	// pair of sender + request id
 	typedef QPair<QByteArray, QByteArray> Rid;
 
-	TestHttpRequest(QObject *parent = 0);
+	TestHttpRequest();
 	~TestHttpRequest();
 
 	// reimplemented

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -59,7 +59,6 @@ public:
 	DeferCall deferCall;
 
 	Private(TestWebSocket *_q) :
-		QObject(_q),
 		q(_q),
 		state(Idle),
 		gripEnabled(false),
@@ -155,8 +154,7 @@ public:
 	}
 };
 
-TestWebSocket::TestWebSocket(QObject *parent) :
-	WebSocket(parent)
+TestWebSocket::TestWebSocket()
 {
 	d = new Private(this);
 }

--- a/src/proxy/testwebsocket.h
+++ b/src/proxy/testwebsocket.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -30,10 +30,8 @@ class ZhttpManager;
 
 class TestWebSocket : public WebSocket
 {
-	Q_OBJECT
-
 public:
-	TestWebSocket(QObject *parent = 0);
+	TestWebSocket();
 	~TestWebSocket();
 
 	// reimplemented

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -251,7 +251,6 @@ public:
 	DeferCall deferCall;
 
 	Private(WebSocketOverHttp *_q) :
-		QObject(_q),
 		q(_q),
 		connectPort(-1),
 		ignorePolicies(false),
@@ -1007,17 +1006,13 @@ private:
 	}
 };
 
-WebSocketOverHttp::WebSocketOverHttp(ZhttpManager *zhttpManager, QObject *parent) :
-	WebSocket(parent)
+WebSocketOverHttp::WebSocketOverHttp(ZhttpManager *zhttpManager)
 {
 	d = std::make_shared<Private>(this);
 	d->zhttpManager = zhttpManager;
 }
 
-WebSocketOverHttp::WebSocketOverHttp(QObject *parent) :
-	WebSocket(parent)
-{
-}
+WebSocketOverHttp::WebSocketOverHttp() = default;
 
 WebSocketOverHttp::~WebSocketOverHttp()
 {

--- a/src/proxy/websocketoverhttp.h
+++ b/src/proxy/websocketoverhttp.h
@@ -36,10 +36,8 @@ class ZhttpManager;
 
 class WebSocketOverHttp : public WebSocket
 {
-	Q_OBJECT
-
 public:
-	WebSocketOverHttp(ZhttpManager *zhttpManager, QObject *parent = 0);
+	WebSocketOverHttp(ZhttpManager *zhttpManager);
 	~WebSocketOverHttp();
 
 	void setConnectionId(const QByteArray &id);
@@ -91,7 +89,7 @@ private:
 	class DisconnectManager;
 	friend class DisconnectManager;
 
-	WebSocketOverHttp(QObject *parent = 0);
+	WebSocketOverHttp();
 	void sendDisconnect();
 
 	class Private;


### PR DESCRIPTION
Now that we are no longer parenting these objects, we can remove the ability to do this from their APIs.

Note: the `HttpRequest` and `WebSocket` destructors need to be marked virtual since they won't inherit this from `QObject` anymore, and virtual destructors are needed for subclassing.