### PR TITLE
don't use deleteLater with timer; it is safe to delete normally

### DIFF
--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1162,20 +1162,8 @@ class Subscription : public QObject
 
 public:
 	Subscription(const QString &channel) :
-		channel_(channel),
-		timer_(0)
+		channel_(channel)
 	{
-	}
-
-	~Subscription()
-	{
-		if(timer_)
-		{
-			timer_->stop();
-			timer_->disconnect(this);
-			timer_->setParent(0);
-			DeferCall::deleteLater(timer_);
-		}
 	}
 
 	const QString & channel() const
@@ -1185,7 +1173,7 @@ public:
 
 	void start()
 	{
-		timer_ = new Timer;
+		timer_ = std::make_unique<Timer>();
 		timer_->timeout.connect(boost::bind(&Subscription::timer_timeout, this));
 		timer_->setSingleShot(true);
 		timer_->start(SUBSCRIBED_DELAY);
@@ -1195,7 +1183,7 @@ public:
 
 private:
 	QString channel_;
-	Timer *timer_;
+	std::unique_ptr<Timer> timer_;
 
 	void timer_timeout()
 	{

--- a/src/handler/sequencer.cpp
+++ b/src/handler/sequencer.cpp
@@ -69,7 +69,7 @@ public:
 	PublishLastIds *lastIds;
 	QHash<QString, ChannelPendingItems> pendingItemsByChannel;
 	QMap<QPair<qint64, PendingItem*>, PendingItem*> pendingItemsByTime;
-	Timer *expireTimer;
+	std::unique_ptr<Timer> expireTimer;
 	int pendingExpireMSecs;
 	int idCacheTtl;
 	QHash<QPair<QString, QString>, CachedId*> idCacheById;
@@ -82,16 +82,12 @@ public:
 		pendingExpireMSecs(DEFAULT_PENDING_EXPIRE),
 		idCacheTtl(-1)
 	{
-		expireTimer = new Timer;
+		expireTimer = std::make_unique<Timer>();
 		expireTimer->timeout.connect(boost::bind(&Private::expireTimer_timeout, this));
 	}
 
 	~Private()
 	{
-		expireTimer->disconnect(this);
-		expireTimer->setParent(0);
-		DeferCall::deleteLater(expireTimer);
-
 		qDeleteAll(idCacheById);
 	}
 

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -43,33 +43,20 @@ WsSession::WsSession(QObject *parent) :
 	inProcessPublishQueue(false),
 	closed(false)
 {
-	expireTimer = new Timer;
+	expireTimer = std::make_unique<Timer>();
 	expireTimer->setSingleShot(true);
 	expireTimer->timeout.connect(boost::bind(&WsSession::expireTimer_timeout, this));
 
-	delayedTimer = new Timer;
+	delayedTimer = std::make_unique<Timer>();
 	delayedTimer->setSingleShot(true);
 	delayedTimer->timeout.connect(boost::bind(&WsSession::delayedTimer_timeout, this));
 
-	requestTimer = new Timer;
+	requestTimer = std::make_unique<Timer>();
 	requestTimer->setSingleShot(true);
 	requestTimer->timeout.connect(boost::bind(&WsSession::requestTimer_timeout, this));
 }
 
-WsSession::~WsSession()
-{
-	expireTimer->disconnect(this);
-	expireTimer->setParent(0);
-	DeferCall::deleteLater(expireTimer);
-
-	delayedTimer->disconnect(this);
-	delayedTimer->setParent(0);
-	DeferCall::deleteLater(delayedTimer);
-
-	requestTimer->disconnect(this);
-	requestTimer->setParent(0);
-	DeferCall::deleteLater(requestTimer);
-}
+WsSession::~WsSession() = default;
 
 void WsSession::refreshExpiration()
 {

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -71,9 +71,9 @@ public:
 	QByteArray delayedType;
 	QByteArray delayedMessage;
 	QHash<int, qint64> pendingRequests;
-	Timer *expireTimer;
-	Timer *delayedTimer;
-	Timer *requestTimer;
+	std::unique_ptr<Timer> expireTimer;
+	std::unique_ptr<Timer> delayedTimer;
+	std::unique_ptr<Timer> requestTimer;
 	QList<PublishItem> publishQueue;
 	ZhttpManager *zhttpOut;
 	std::shared_ptr<RateLimiter> filterLimiter;


### PR DESCRIPTION
This changes destruction of all `Timer` instances to happen immediately rather than via `deleteLater`. The use of `deleteLater` is a remnant from when we were using `QTimer` for timers which did not guarantee safe deletion after a timeout signal. The new `Timer` does not have this limitation.

Notably, if we don't need to use `deleteLater`, then we also don't need any of the related safeguards for non-immediate deletion, such as disconnecting signals (which in some cases we were doing incorrectly anyway) and detaching from the `QObject` parent. So, this PR removes all timer parenting (changing to `std::unique_ptr` as applicable) and any unnecessary disconnecting.