### PR TITLE
processquit: don't use QObject

### DIFF
--- a/src/core/processquit.cpp
+++ b/src/core/processquit.cpp
@@ -45,7 +45,7 @@ namespace XMPP {
 #endif
 
 Q_GLOBAL_STATIC(QMutex, pq_mutex)
-static ProcessQuit *g_pq = 0;
+static ProcessQuit *g_pq = nullptr;
 
 inline bool is_gui_app()
 {
@@ -73,7 +73,8 @@ public:
 	std::unique_ptr<SocketNotifier> sig_notifier;
 #endif
 
-	Private(ProcessQuit *_q) : QObject(_q), q(_q)
+	Private(ProcessQuit *_q) :
+		q(_q)
 	{
 		done = false;
 #ifdef Q_OS_WIN
@@ -206,8 +207,7 @@ private:
 	}
 };
 
-ProcessQuit::ProcessQuit(QObject *parent)
-:QObject(parent)
+ProcessQuit::ProcessQuit()
 {
 	d = new Private(this);
 }
@@ -223,7 +223,6 @@ ProcessQuit *ProcessQuit::instance()
 	if(!g_pq)
 	{
 		g_pq = new ProcessQuit;
-		g_pq->moveToThread(QCoreApplication::instance()->thread());
 #ifndef NO_IRISNET
 		irisNetAddPostRoutine(cleanup);
 #endif
@@ -241,7 +240,7 @@ void ProcessQuit::reset()
 void ProcessQuit::cleanup()
 {
 	delete g_pq;
-	g_pq = 0;
+	g_pq = nullptr;
 }
 
 #ifndef NO_IRISNET

--- a/src/core/processquit.h
+++ b/src/core/processquit.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2006 Justin Karneges
  * Copyright (C) 2017 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * $FANOUT_BEGIN_LICENSE:APACHE2$
  *
@@ -55,9 +56,8 @@ myapp.connect(ProcessQuit::instance(), SIGNAL(quit()), SLOT(do_quit()));
 
    Calling instance() returns a pointer to the global ProcessQuit instance, which will be created if necessary.  The quit() signal is emitted when a request to terminate is received.    The quit() signal is only emitted once, future termination requests are ignored.  Call reset() to allow the quit() signal to be emitted again.
 */
-class IRISNET_EXPORT ProcessQuit : public QObject
+class IRISNET_EXPORT ProcessQuit
 {
-	Q_OBJECT
 public:
 	/**
 	   \brief Returns the global ProcessQuit instance
@@ -89,7 +89,6 @@ public:
 	static void cleanup();
 
 	Signal quit;
-
 	Signal hup;
 
 private:
@@ -97,7 +96,7 @@ private:
 	friend class Private;
 	Private *d;
 
-	ProcessQuit(QObject *parent = 0);
+	ProcessQuit();
 	~ProcessQuit();
 };
 


### PR DESCRIPTION
We always create `ProcessQuit` in the main thread and don't need the `moveToThread`.