### PR TITLE
processquit: remove internal use of QObject

### DIFF
--- a/src/core/processquit.h
+++ b/src/core/processquit.h
@@ -29,25 +29,14 @@ using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
 using Connection = boost::signals2::scoped_connection;
 
-#ifdef NO_IRISNET
-# include <QtCore>
-# define IRISNET_EXPORT
-#else
-# include "irisnetglobal.h"
-#endif
-
-#ifndef NO_IRISNET
-namespace XMPP {
-#endif
-
 /**
    \brief Listens for termination requests
 
-   ProcessQuit listens for requests to terminate the application process.  On Unix platforms, these are the signals SIGINT, SIGHUP, and SIGTERM.  On Windows, these are the console control events for Ctrl+C, console window close, and system shutdown.  For Windows GUI programs, ProcessQuit has no effect.
+   ProcessQuit listens for requests to terminate the application process.  These are the signals SIGINT, SIGHUP, and SIGTERM.
 
-   For GUI programs, ProcessQuit is not a substitute for QSessionManager.  The only safe way to handle termination of a GUI program in the usual way is to use QSessionManager.  However, ProcessQuit does give additional benefit to Unix GUI programs that might be terminated unconventionally, so it can't hurt to support both.
+   For GUI programs, ProcessQuit is not a substitute for QSessionManager.  The only safe way to handle termination of a GUI program in the usual way is to use QSessionManager.  However, ProcessQuit does give additional benefit to GUI programs that might be terminated unconventionally, so it can't hurt to support both.
 
-   When a termination request is received, the application should exit gracefully, and generally without user interaction.  Otherwise, it is at risk of being terminated outside of its control.  For example, if a Windows console application does not exit after just a few seconds of attempting to close the console window, Windows will display a prompt to the user asking if the process should be ended immediately.
+   When a termination request is received, the application should exit gracefully, and generally without user interaction.  Otherwise, it is at risk of being terminated outside of its control.
 
    Using ProcessQuit is easy, and it usually amounts to a single line:
    \code
@@ -56,7 +45,7 @@ myapp.connect(ProcessQuit::instance(), SIGNAL(quit()), SLOT(do_quit()));
 
    Calling instance() returns a pointer to the global ProcessQuit instance, which will be created if necessary.  The quit() signal is emitted when a request to terminate is received.    The quit() signal is only emitted once, future termination requests are ignored.  Call reset() to allow the quit() signal to be emitted again.
 */
-class IRISNET_EXPORT ProcessQuit
+class ProcessQuit
 {
 public:
 	/**
@@ -82,8 +71,6 @@ public:
 
 	   This function will free any resources used by ProcessQuit, including the global instance, and the termination handlers will be uninstalled (reverted to default).  Future termination requests will cause the application to exit abruptly.
 
-	   \note You normally do not need to call this function directly.  When IrisNet cleans up, it will be called.
-
 	   \sa instance
 	*/
 	static void cleanup();
@@ -99,9 +86,5 @@ private:
 	ProcessQuit();
 	~ProcessQuit();
 };
-
-#ifndef NO_IRISNET
-}
-#endif
 
 #endif

--- a/src/cpp.pro
+++ b/src/cpp.pro
@@ -18,8 +18,6 @@ QMAKE_LFLAGS += $$(LDFLAGS)
 
 SRC_DIR = $$PWD
 
-DEFINES += NO_IRISNET
-
 INCLUDEPATH += $$SRC_DIR/../target/include
 INCLUDEPATH += $$SRC_DIR/core
 

--- a/src/cpptests.pro
+++ b/src/cpptests.pro
@@ -14,8 +14,6 @@ include($$cpp_build_dir/conf.pri)
 
 SRC_DIR = $$PWD
 
-DEFINES += NO_IRISNET
-
 INCLUDEPATH += $$SRC_DIR/../target/include
 INCLUDEPATH += $$SRC_DIR/core
 

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -29,6 +29,7 @@
 #include <QStringList>
 #include <QFile>
 #include <QFileInfo>
+#include <QDir>
 #include "timer.h"
 #include "defercall.h"
 #include "eventloop.h"

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -31,6 +31,8 @@
 #include <QDateTime>
 #include <QElapsedTimer>
 #include <QTimer>
+#include <QDir>
+#include <QSettings>
 #include "qzmqsocket.h"
 #include "qzmqvalve.h"
 #include "qtcompat.h"

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -29,6 +29,9 @@
 #include <QStringList>
 #include <QFile>
 #include <QFileInfo>
+#include <QThread>
+#include <QMutex>
+#include <QWaitCondition>
 #include "processquit.h"
 #include "timer.h"
 #include "defercall.h"

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -29,6 +29,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QUrl>
+#include <QUrlQuery>
 #include "processquit.h"
 #include "log.h"
 #include "settings.h"


### PR DESCRIPTION
As a consequence, remove Windows support which was using a slot. Also remove the "IrisNet" bits while we're at it as it's just noise. This class was forked from the Iris XMPP library but we don't track upstream, so it is fine to strip it down to the bits we're actually using.