### PR TITLE
core: remove parenting from all public interfaces

### DIFF
--- a/src/core/simplehttpserver.cpp
+++ b/src/core/simplehttpserver.cpp
@@ -638,8 +638,7 @@ public:
 	}
 };
 
-SimpleHttpServer::SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax, QObject *parent) :
-	QObject(parent)
+SimpleHttpServer::SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax)
 {
 	d = new SimpleHttpServerPrivate(connectionsMax, headersSizeMax, bodySizeMax, this);
 }

--- a/src/core/simplehttpserver.h
+++ b/src/core/simplehttpserver.h
@@ -22,8 +22,8 @@
  */
 
 #ifndef SIMPLEHTTPSERVER_H
+#define SIMPLEHTTPSERVER_H
 
-#include <QObject>
 #include <QHostAddress>
 #include <boost/signals2.hpp>
 #include <map>
@@ -38,10 +38,8 @@ class HttpHeaders;
 
 class SimpleHttpServerPrivate;
 
-class SimpleHttpRequest : public QObject
+class SimpleHttpRequest
 {
-	Q_OBJECT
-
 public:
 	~SimpleHttpRequest();
 
@@ -64,12 +62,10 @@ private:
 	SimpleHttpRequest(int headersSizeMax, int bodySizeMax);
 };
 
-class SimpleHttpServer : public QObject
+class SimpleHttpServer
 {
-	Q_OBJECT
-
 public:
-	SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax, QObject *parent = 0);
+	SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax);
 	~SimpleHttpServer();
 
 	bool listen(const QHostAddress &addr, int port);

--- a/src/core/statsmanager.h
+++ b/src/core/statsmanager.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -24,17 +24,14 @@
 #ifndef STATSMANAGER_H
 #define STATSMANAGER_H
 
-#include <QObject>
 #include "packet/statspacket.h"
 #include "stats.h"
 #include <boost/signals2.hpp>
 
 class QHostAddress;
 
-class StatsManager : public QObject
+class StatsManager
 {
-	Q_OBJECT
-
 public:
 	enum ConnectionType
 	{
@@ -48,7 +45,7 @@ public:
 		JsonFormat
 	};
 
-	StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax, QObject *parent = 0);
+	StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax);
 	~StatsManager();
 
 	bool connectionSendEnabled() const;

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -24,7 +24,6 @@
 #ifndef TIMER_H
 #define TIMER_H
 
-#include <qobject.h>
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -32,10 +31,8 @@ using Signal = boost::signals2::signal<void()>;
 class EventLoop;
 class TimerManager;
 
-class Timer : public QObject
+class Timer
 {
-	Q_OBJECT
-
 public:
 	Timer();
 	~Timer();

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -117,7 +117,6 @@ public:
 	Connection refreshTimerConnection;
 
 	Private(ZhttpManager *_q) :
-		QObject(_q),
 		q(_q),
 		ipcFileMode(-1),
 		doBind(false),
@@ -968,8 +967,7 @@ public:
 	}
 };
 
-ZhttpManager::ZhttpManager(QObject *parent) :
-	QObject(parent)
+ZhttpManager::ZhttpManager()
 {
 	d = std::make_shared<Private>(this);
 }

--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -24,7 +24,6 @@
 #ifndef ZHTTPMANAGER_H
 #define ZHTTPMANAGER_H
 
-#include <QObject>
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include <boost/signals2.hpp>
@@ -34,12 +33,10 @@ using Signal = boost::signals2::signal<void()>;
 class ZhttpRequestPacket;
 class ZhttpResponsePacket;
 
-class ZhttpManager : public QObject
+class ZhttpManager
 {
-	Q_OBJECT
-
 public:
-	ZhttpManager(QObject *parent = 0);
+	ZhttpManager();
 	~ZhttpManager();
 
 	int connectionCount() const;

--- a/src/core/zrpcmanager.cpp
+++ b/src/core/zrpcmanager.cpp
@@ -73,7 +73,6 @@ public:
 	Connection serverValveConnection;
 
 	Private(ZrpcManager *_q) :
-		QObject(_q),
 		q(_q),
 		ipcFileMode(-1),
 		doBind(false),
@@ -251,8 +250,7 @@ public:
 	}
 };
 
-ZrpcManager::ZrpcManager(QObject *parent) :
-	QObject(parent)
+ZrpcManager::ZrpcManager()
 {
 	d = new Private(this);
 }

--- a/src/core/zrpcmanager.h
+++ b/src/core/zrpcmanager.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -24,7 +24,8 @@
 #ifndef ZRPCMANAGER_H
 #define ZRPCMANAGER_H
 
-#include <QObject>
+#include <QByteArray>
+#include <QList>
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -33,12 +34,10 @@ class ZrpcRequestPacket;
 class ZrpcResponsePacket;
 class ZrpcRequest;
 
-class ZrpcManager : public QObject
+class ZrpcManager
 {
-	Q_OBJECT
-
 public:
-	ZrpcManager(QObject *parent = 0);
+	ZrpcManager();
 	~ZrpcManager();
 
 	int timeout() const;

--- a/src/core/zrpcrequest.cpp
+++ b/src/core/zrpcrequest.cpp
@@ -56,7 +56,6 @@ public:
 	DeferCall deferCall;
 
 	Private(ZrpcRequest *_q) :
-		QObject(_q),
 		q(_q),
 		manager(0),
 		success(false),
@@ -176,14 +175,12 @@ public:
 	}
 };
 
-ZrpcRequest::ZrpcRequest(QObject *parent) :
-	QObject(parent)
+ZrpcRequest::ZrpcRequest()
 {
 	d = new Private(this);
 }
 
-ZrpcRequest::ZrpcRequest(ZrpcManager *manager, QObject *parent) :
-	QObject(parent)
+ZrpcRequest::ZrpcRequest(ZrpcManager *manager)
 {
 	d = new Private(this);
 	setupClient(manager);

--- a/src/core/zrpcrequest.h
+++ b/src/core/zrpcrequest.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2015 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -24,7 +24,6 @@
 #ifndef ZRPCREQUEST_H
 #define ZRPCREQUEST_H
 
-#include <QObject>
 #include <QVariant>
 #include <boost/signals2.hpp>
 
@@ -34,10 +33,8 @@ class ZrpcRequestPacket;
 class ZrpcResponsePacket;
 class ZrpcManager;
 
-class ZrpcRequest : public QObject
+class ZrpcRequest
 {
-	Q_OBJECT
-
 public:
 	enum ErrorCondition
 	{
@@ -47,8 +44,8 @@ public:
 		ErrorTimeout
 	};
 
-	ZrpcRequest(ZrpcManager *manager, QObject *parent = 0);
-	~ZrpcRequest();
+	ZrpcRequest(ZrpcManager *manager);
+	virtual ~ZrpcRequest();
 
 	QByteArray from() const;
 	QByteArray id() const;
@@ -77,7 +74,7 @@ private:
 	Private *d;
 
 	friend class ZrpcManager;
-	ZrpcRequest(QObject *parent = 0);
+	ZrpcRequest();
 	void setupClient(ZrpcManager *manager);
 	void setupServer(ZrpcManager *manager);
 	void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet);

--- a/src/proxy/inspectrequest.h
+++ b/src/proxy/inspectrequest.h
@@ -33,8 +33,6 @@ class ZrpcManager;
 
 class InspectRequest : public ZrpcRequest
 {
-	Q_OBJECT
-
 public:
 	InspectRequest(ZrpcManager *manager);
 	~InspectRequest();


### PR DESCRIPTION
Now that we are no longer parenting these objects, we can remove the ability to do this from their APIs.