### PR TITLE
add a way to run c++ tests without QTEST_MAIN, and use with httpheaders

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -15,6 +15,7 @@ HEADERS += $$PWD/processquit.h
 SOURCES += $$PWD/processquit.cpp
 
 HEADERS += \
+	$$PWD/test.h \
 	$$PWD/tnetstring.h \
 	$$PWD/httpheaders.h \
 	$$PWD/zhttprequestpacket.h \

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,6 +33,7 @@ pub mod reactor;
 pub mod select;
 pub mod shuffle;
 pub mod task;
+pub mod test;
 pub mod time;
 pub mod timer;
 pub mod tnetstring;
@@ -102,12 +103,13 @@ pub fn ensure_example_config(dest: &Path) {
 mod tests {
     use super::*;
     use crate::core::call_c_main;
+    use crate::core::test::TestException;
     use crate::ffi;
     use std::ffi::OsStr;
 
-    fn httpheaders_test(args: &[&OsStr]) -> u8 {
+    fn httpheaders_test(ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::httpheaders_test, args) as u8 }
+        unsafe { ffi::httpheaders_test(ex) == 0 }
     }
 
     fn jwt_test(args: &[&OsStr]) -> u8 {
@@ -142,7 +144,7 @@ mod tests {
 
     #[test]
     fn httpheaders() {
-        assert!(qtest::run(httpheaders_test));
+        qtest::run_no_main(httpheaders_test);
     }
 
     #[test]

--- a/src/core/test.h
+++ b/src/core/test.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ *
+ */
+
+#include <QtTest/QtTest>
+#include "rust/bindings.h"
+
+#ifndef PUSHPIN_TEST_H
+#define PUSHPIN_TEST_H
+
+class TestException
+{
+public:
+    std::string file;
+    int line;
+    std::string message;
+
+    TestException(const std::string &file, int line, const std::string &message) :
+        file(file),
+        line(line),
+        message(message)
+    {
+    }
+
+    void toFfi(ffi::TestException *dest) const
+    {
+        ffi::test_exception_set(dest, file.c_str(), line, message.c_str());
+    }
+};
+
+void test_assert(bool cond, const char *condStr, const char *file, int line)
+{
+    if(!cond)
+        throw TestException(file, line, std::string("assertion failed: ") + condStr);
+}
+
+// uses QtTest to stringify values
+template <typename T1, typename T2>
+void test_assert_eq(const T1 &left, const T2 &right, const char *file, int line)
+{
+    if(!(left == right))
+        throw TestException(file, line, std::string("assertion `left == right` failed\n  left: ") + QTest::toString(left) + "\n right: " + QTest::toString(right));
+}
+
+// if cond is false, throws an exception with similar message as rust's assert macro
+#define TEST_ASSERT(cond) \
+do {\
+    test_assert(static_cast<bool>(cond), #cond, __FILE__, __LINE__);\
+} while (false)
+
+// if left != right, throws an exception with similar message as rust's assert_eq macro
+#define TEST_ASSERT_EQ(left, right) \
+do {\
+    test_assert_eq(left, right, __FILE__, __LINE__);\
+} while (false)
+
+// for running a test and catching an exception if any. expects local variable ffi::TestException* out_ex to exist
+#define TEST_CATCH(statement) try { statement; } catch(const TestException &ex) { ex.toFfi(out_ex); return 1; }
+
+#endif

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[derive(Default)]
+pub struct TestException {
+    pub file: String,
+    pub line: u32,
+    pub message: String,
+}
+
+pub mod ffi {
+    use super::*;
+    use std::ffi::CStr;
+    use std::os::raw::{c_char, c_int};
+
+    #[allow(clippy::missing_safety_doc)]
+    #[no_mangle]
+    pub unsafe extern "C" fn test_exception_set(
+        f: *mut TestException,
+        file: *const c_char,
+        line: libc::c_uint,
+        message: *const c_char,
+    ) -> c_int {
+        let f = f.as_mut().unwrap();
+
+        let file = unsafe { CStr::from_ptr(file) };
+
+        let file = match file.to_str() {
+            Ok(s) => s,
+            Err(_) => return -1,
+        };
+
+        let message = unsafe { CStr::from_ptr(message) };
+
+        let message = match message.to_str() {
+            Ok(s) => s,
+            Err(_) => return -1,
+        };
+
+        f.file = file.to_string();
+        f.line = line;
+        f.message = message.to_string();
+
+        0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ macro_rules! import_cpptest {
         #[cfg_attr(target_os = "macos", link(name = "c++"))]
         #[cfg_attr(not(target_os = "macos"), link(name = "stdc++"))]
         extern "C" {
+            #[allow(improper_ctypes)]
             $($tt)*
         }
     };
@@ -126,8 +127,11 @@ macro_rules! import_cpptest {
 
 pub mod ffi {
     #[cfg(test)]
+    use crate::core::test::TestException;
+
+    #[cfg(test)]
     import_cpptest! {
-        pub fn httpheaders_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn httpheaders_test(f: *mut TestException) -> libc::c_int;
         pub fn jwt_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn timer_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn defercall_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;


### PR DESCRIPTION
This enables writing C++ tests as regular functions that can be called directly, rather than using `QtTest` which expects tests to be declared as slots that are invoked via a generated `main`-like function. It removes the need to use `QObject` in C++ tests and makes the way we write C++ tests closer to how we write Rust tests. This PR also updates the httpheaders tests to use this new approach.

Tests make assertions using the `TEST_ASSERT` and `TEST_ASSERT_EQ` macros. They take the same inputs as the `QVERIFY` and `QCOMPARE` macros, but have Rust-like naming as well as Rust-like behavior: instead of returning, they throw a C++ exception in order to cause an unwinding effect similar to the `assert!` and `assert_eq!` macros.

Because we have an FFI boundary between Rust and C++, exceptions from tests must be caught on the C++ side with the `TEST_CATCH` macro which populates a `TestException` struct and returns normally. On the Rust side, the `TestException` struct is examined and a panic is raised.

The failure output is designed to be similar to Rust as well. For example, breaking the tests by changing line 34 of httpheaderstest.cpp to:

```
TEST_ASSERT_EQ(params.count(), 2);
```

will result in the output:

```
---- core::tests::httpheaders stdout ----

thread 'core::tests::httpheaders' panicked at src/core/mod.rs:147:9:
exception thrown at src/core/httpheaderstest.cpp:34:
assertion `left == right` failed
  left: 3
 right: 2
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The only difference compared to a normal Rust test failure is that extra "exception thrown" line.

The tests still run serially, in order to support tests that create their own `QCoreApplication`.

Note that `TEST_ASSERT_EQ` relies on `QtTest` for stringifying the inputs, so while this new approach does remove dependence on `QObject` it does not remove dependence on Qt.