### PR TITLE
core: remove slots

### DIFF
--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -22,10 +22,8 @@
 
 class EventLoop;
 
-class SocketNotifier : public QObject
+class SocketNotifier
 {
-	Q_OBJECT
-
 public:
 	enum Interest
 	{
@@ -54,10 +52,6 @@ public:
 
 	boost::signals2::signal<void(int, uint8_t)> activated;
 
-private slots:
-	void innerReadActivated(int socket);
-	void innerWriteActivated(int socket);
-
 private:
 	int socket_;
 	uint8_t interest_;
@@ -65,10 +59,14 @@ private:
 	bool writeEnabled_;
 	QSocketNotifier *readInner_;
 	QSocketNotifier *writeInner_;
+	QMetaObject::Connection readInnerConnection_;
+	QMetaObject::Connection writeInnerConnection_;
 	uint8_t readiness_;
 	EventLoop *loop_;
 	int regId_;
 
+	void innerReadActivated(int socket);
+	void innerWriteActivated(int socket);
 	void apply(uint8_t readiness);
 	static void cb_fd_activated(void *ctx, uint8_t readiness);
 	void fd_activated(uint8_t readiness);


### PR DESCRIPTION
We are generally using Boost signals/slots everywhere, however we still have a few Qt slots used for receiving signals emitted from the Qt library itself. Such slots depend on `QObject`, which we are trying to avoid. Fortunately, Qt signals are able to call arbitrary closures, so we can actually replace these Qt slots with closures if we are careful about ensuring the connections don't outlive any references in the closures.