### PR TITLE
core: convert remaining tests to new style

### DIFF
--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -20,130 +20,120 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QtTest/QtTest>
+#include <QCoreApplication>
+#include "test.h"
 #include "timer.h"
 #include "defercall.h"
 #include "eventloop.h"
 
-class DeferCallTest : public QObject
+// loop_advance should process enough events to cause the calls to run,
+// without sleeping, in order to prove the calls are run immediately
+static std::tuple<int, int> runDeferCall(std::function<void ()> loop_advance)
 {
-	Q_OBJECT
+	DeferCall deferCall;
+	int count = 0;
 
-private:
-	// loop_advance should process enough events to cause the calls to run,
-	// without sleeping, in order to prove the calls are run immediately
-	std::tuple<int, int> runDeferCall(std::function<void ()> loop_advance)
-	{
-		DeferCall deferCall;
-		int count = 0;
+	deferCall.defer([&] {
+		++count;
 
 		deferCall.defer([&] {
 			++count;
-
-			deferCall.defer([&] {
-				++count;
-			});
 		});
+	});
 
-		loop_advance();
+	loop_advance();
 
-		return {deferCall.pendingCount(), count};
-	}
+	return {deferCall.pendingCount(), count};
+}
 
-private slots:
-	void deferCall()
+static void deferCall()
+{
+	EventLoop loop(1);
+
+	auto [pendingCount, count] = runDeferCall([&] {
+		// run the first call and queue the second
+		loop.step();
+
+		// run the second
+		loop.step();
+	});
+
+	TEST_ASSERT_EQ(pendingCount, 0);
+	TEST_ASSERT_EQ(count, 2);
+
+	DeferCall::cleanup();
+}
+
+static void deferCallQt()
+{
+	int argc = 1;
+	char *argv[] = { "zeroTimeoutQt" };
+	QCoreApplication qapp(argc, argv);
+	Timer::init(1);
+
+	auto [pendingCount, count] = runDeferCall([&] {
+		// the underlying timer's qt-based implementation will process
+		// both timeouts during a single timer processing pass.
+		// therefore, both calls should run within a single event loop
+		// pass
+		QCoreApplication::processEvents(QEventLoop::AllEvents);
+	});
+
+	TEST_ASSERT_EQ(pendingCount, 0);
+	TEST_ASSERT_EQ(count, 2);
+
+	DeferCall::cleanup();
+	Timer::deinit();
+}
+
+static void retract()
+{
+	Timer::init(1);
+
+	bool called = false;
+
 	{
-		EventLoop loop(1);
+		DeferCall deferCall;
 
-		auto [pendingCount, count] = runDeferCall([&] {
-			// run the first call and queue the second
-			loop.step();
-
-			// run the second
-			loop.step();
+		deferCall.defer([&] {
+			called = true;
 		});
-
-		QCOMPARE(pendingCount, 0);
-		QCOMPARE(count, 2);
-
-		DeferCall::cleanup();
 	}
 
-	void deferCallQt()
-	{
-		Timer::init(1);
+	DeferCall::cleanup();
+	TEST_ASSERT(!called);
 
-		auto [pendingCount, count] = runDeferCall([&] {
-			// the underlying timer's qt-based implementation will process
-			// both timeouts during a single timer processing pass.
-			// therefore, both calls should run within a single event loop
-			// pass
-			QCoreApplication::processEvents(QEventLoop::AllEvents);
-		});
+	Timer::deinit();
+}
 
-		QCOMPARE(pendingCount, 0);
-		QCOMPARE(count, 2);
+static void managerCleanup()
+{
+	Timer::init(1);
 
-		DeferCall::cleanup();
-		Timer::deinit();
-	}
+	int count = 0;
 
-	void retract()
-	{
-		Timer::init(1);
-
-		bool called = false;
-
-		{
-			DeferCall deferCall;
-
-			deferCall.defer([&] {
-				called = true;
-			});
-		}
-
-		DeferCall::cleanup();
-		QVERIFY(!called);
-
-		Timer::deinit();
-	}
-
-	void managerCleanup()
-	{
-		Timer::init(1);
-
-		int count = 0;
+	DeferCall::global()->defer([&] {
+		++count;
 
 		DeferCall::global()->defer([&] {
 			++count;
-
-			DeferCall::global()->defer([&] {
-				++count;
-			});
 		});
+	});
 
-		// cleanup should process deferred calls queued so far as well as
-		// those queued during processing
-		DeferCall::cleanup();
-		QCOMPARE(count, 2);
+	// cleanup should process deferred calls queued so far as well as
+	// those queued during processing
+	DeferCall::cleanup();
+	TEST_ASSERT_EQ(count, 2);
 
-		Timer::deinit();
-	}
-};
-
-namespace {
-namespace Main {
-QTEST_MAIN(DeferCallTest)
-}
+	Timer::deinit();
 }
 
-extern "C" {
-
-int defercall_test(int argc, char **argv)
+extern "C" int defercall_test(ffi::TestException *out_ex)
 {
-	return Main::main(argc, argv);
-}
+	TEST_CATCH(deferCall());
+	TEST_CATCH(deferCallQt());
+	TEST_CATCH(retract());
+	TEST_CATCH(managerCleanup());
 
+	return 0;
 }
-
-#include "defercalltest.moc"

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -20,7 +20,6 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QCoreApplication>
 #include "test.h"
 #include "timer.h"
 #include "defercall.h"
@@ -66,9 +65,7 @@ static void deferCall()
 
 static void deferCallQt()
 {
-	int argc = 1;
-	char *argv[] = { "zeroTimeoutQt" };
-	QCoreApplication qapp(argc, argv);
+	TestQCoreApplication qapp;
 	Timer::init(1);
 
 	auto [pendingCount, count] = runDeferCall([&] {

--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -21,7 +21,6 @@
 */
 
 #include <unistd.h>
-#include <QCoreApplication>
 #include <boost/signals2.hpp>
 #include "test.h"
 #include "defercall.h"

--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -21,93 +21,79 @@
 */
 
 #include <unistd.h>
-#include <QtTest/QtTest>
+#include <QCoreApplication>
 #include <boost/signals2.hpp>
+#include "test.h"
 #include "defercall.h"
 #include "eventloop.h"
 #include "socketnotifier.h"
 #include "timer.h"
 
-class EventLoopTest : public QObject
+static void socketNotifier()
 {
-	Q_OBJECT
+	EventLoop loop(1);
 
-private slots:
-	void socketNotifier()
-	{
-		EventLoop loop(1);
+	int fds[2];
+	TEST_ASSERT_EQ(pipe(fds), 0);
 
-		int fds[2];
-		QCOMPARE(pipe(fds), 0);
+	SocketNotifier *sn = new SocketNotifier(fds[0], SocketNotifier::Read);
+	sn->clearReadiness(SocketNotifier::Read);
 
-		SocketNotifier *sn = new SocketNotifier(fds[0], SocketNotifier::Read);
-		sn->clearReadiness(SocketNotifier::Read);
+	int activatedFd = -1;
+	uint8_t activatedReadiness = -1;
+	sn->activated.connect([&](int fd, uint8_t readiness) {
+		activatedFd = fd;
+		activatedReadiness = readiness;
+		loop.exit(123);
+	});
 
-		int activatedFd = -1;
-		uint8_t activatedReadiness = -1;
-		sn->activated.connect([&](int fd, uint8_t readiness) {
-			activatedFd = fd;
-			activatedReadiness = readiness;
-			loop.exit(123);
-		});
+	unsigned char c = 1;
+	TEST_ASSERT_EQ(write(fds[1], &c, 1), 1);
 
-		unsigned char c = 1;
-		QCOMPARE(write(fds[1], &c, 1), 1);
+	TEST_ASSERT_EQ(loop.exec(), 123);
+	TEST_ASSERT_EQ(activatedFd, fds[0]);
+	TEST_ASSERT_EQ(activatedReadiness, SocketNotifier::Read);
 
-		QCOMPARE(loop.exec(), 123);
-		QCOMPARE(activatedFd, fds[0]);
-		QCOMPARE(activatedReadiness, SocketNotifier::Read);
-
-		delete sn;
-		close(fds[1]);
-		close(fds[0]);
-	}
-
-	void timer()
-	{
-		EventLoop loop(2);
-
-		Timer *t1 = new Timer;
-		Timer *t2 = new Timer;
-
-		int timeoutCount = 0;
-
-		t1->timeout.connect([&] {
-			++timeoutCount;
-		});
-
-		t2->timeout.connect([&] {
-			++timeoutCount;
-			loop.exit(123);
-		});
-
-		t1->setSingleShot(true);
-		t1->start(0);
-
-		t2->setSingleShot(true);
-		t2->start(0);
-
-		QCOMPARE(loop.exec(), 123);
-		QCOMPARE(timeoutCount, 2);
-
-		delete t2;
-		delete t1;
-	}
-};
-
-namespace {
-namespace Main {
-QTEST_MAIN(EventLoopTest)
-}
+	delete sn;
+	close(fds[1]);
+	close(fds[0]);
 }
 
-extern "C" {
-
-int eventloop_test(int argc, char **argv)
+static void timer()
 {
-	return Main::main(argc, argv);
+	EventLoop loop(2);
+
+	Timer *t1 = new Timer;
+	Timer *t2 = new Timer;
+
+	int timeoutCount = 0;
+
+	t1->timeout.connect([&] {
+		++timeoutCount;
+	});
+
+	t2->timeout.connect([&] {
+		++timeoutCount;
+		loop.exit(123);
+	});
+
+	t1->setSingleShot(true);
+	t1->start(0);
+
+	t2->setSingleShot(true);
+	t2->start(0);
+
+	TEST_ASSERT_EQ(loop.exec(), 123);
+	TEST_ASSERT_EQ(timeoutCount, 2);
+
+	delete t2;
+	delete t1;
 }
 
-}
+extern "C" int eventloop_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(socketNotifier());
+	TEST_CATCH(timer());
 
-#include "eventlooptest.moc"
+	return 0;
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -102,44 +102,42 @@ pub fn ensure_example_config(dest: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::call_c_main;
     use crate::core::test::TestException;
     use crate::ffi;
-    use std::ffi::OsStr;
 
-    fn httpheaders_test(ex: &mut TestException) -> bool {
+    fn httpheaders_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { ffi::httpheaders_test(ex) == 0 }
+        unsafe { ffi::httpheaders_test(out_ex) == 0 }
     }
 
-    fn jwt_test(ex: &mut TestException) -> bool {
+    fn jwt_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { ffi::jwt_test(ex) == 0 }
+        unsafe { ffi::jwt_test(out_ex) == 0 }
     }
 
-    fn timer_test(args: &[&OsStr]) -> u8 {
+    fn timer_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::timer_test, args) as u8 }
+        unsafe { ffi::timer_test(out_ex) == 0 }
     }
 
-    fn defercall_test(args: &[&OsStr]) -> u8 {
+    fn defercall_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::defercall_test, args) as u8 }
+        unsafe { ffi::defercall_test(out_ex) == 0 }
     }
 
-    fn tcpstream_test(args: &[&OsStr]) -> u8 {
+    fn tcpstream_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::tcpstream_test, args) as u8 }
+        unsafe { ffi::tcpstream_test(out_ex) == 0 }
     }
 
-    fn unixstream_test(args: &[&OsStr]) -> u8 {
+    fn unixstream_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::unixstream_test, args) as u8 }
+        unsafe { ffi::unixstream_test(out_ex) == 0 }
     }
 
-    fn eventloop_test(args: &[&OsStr]) -> u8 {
+    fn eventloop_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::eventloop_test, args) as u8 }
+        unsafe { ffi::eventloop_test(out_ex) == 0 }
     }
 
     #[test]
@@ -154,26 +152,26 @@ mod tests {
 
     #[test]
     fn timer() {
-        assert!(qtest::run(timer_test));
+        qtest::run_no_main(timer_test);
     }
 
     #[test]
     fn defercall() {
-        assert!(qtest::run(defercall_test));
+        qtest::run_no_main(defercall_test);
     }
 
     #[test]
     fn tcpstream() {
-        assert!(qtest::run(tcpstream_test));
+        qtest::run_no_main(tcpstream_test);
     }
 
     #[test]
     fn unixstream() {
-        assert!(qtest::run(unixstream_test));
+        qtest::run_no_main(unixstream_test);
     }
 
     #[test]
     fn eventloop() {
-        assert!(qtest::run(eventloop_test));
+        qtest::run_no_main(eventloop_test);
     }
 }

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -20,312 +20,305 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QtTest/QtTest>
+#include <QCoreApplication>
 #include <QHostAddress>
+#include "test.h"
 #include "timer.h"
 #include "defercall.h"
 #include "eventloop.h"
 #include "tcplistener.h"
 #include "tcpstream.h"
 
-class TcpStreamTest : public QObject
+static void runAccept(std::function<void ()> loop_wait)
 {
-	Q_OBJECT
+	TcpListener l;
+	TEST_ASSERT(l.bind(QHostAddress("127.0.0.1"), 0));
 
-private:
-	void runAccept(std::function<void ()> loop_wait)
+	auto [addr, port] = l.localAddress();
+
+	// start by assuming operations are possible
+	bool streamsReady = true;
+
+	l.streamsReady.connect([&] {
+		streamsReady = true;
+	});
+
+	std::unique_ptr<TcpStream> s = l.accept();
+	TEST_ASSERT(!s);
+	TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
+	streamsReady = false;
+
+	TcpStream client;
+	TEST_ASSERT(client.connect(addr, port));
+
+	// start by assuming operations are possible
+	bool clientWriteReady = true;
+
+	client.writeReady.connect([&] {
+		clientWriteReady = true;
+	});
+
+	while(!streamsReady)
+		loop_wait();
+
+	s = l.accept();
+	TEST_ASSERT(s);
+
+	while(!client.checkConnected())
 	{
-		TcpListener l;
-		QVERIFY(l.bind(QHostAddress("127.0.0.1"), 0));
+		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		auto [addr, port] = l.localAddress();
-
-		// start by assuming operations are possible
-		bool streamsReady = true;
-
-		l.streamsReady.connect([&] {
-			streamsReady = true;
-		});
-
-		std::unique_ptr<TcpStream> s = l.accept();
-		QVERIFY(!s);
-		QCOMPARE(l.errorCondition(), EAGAIN);
-		streamsReady = false;
-
-		TcpStream client;
-		QVERIFY(client.connect(addr, port));
-
-		// start by assuming operations are possible
-		bool clientWriteReady = true;
-
-		client.writeReady.connect([&] {
-			clientWriteReady = true;
-		});
-
-		while(!streamsReady)
+		clientWriteReady = false;
+		while(!clientWriteReady)
 			loop_wait();
+	}
+}
 
+static void runIo(std::function<void ()> loop_wait)
+{
+	TcpListener l;
+	TEST_ASSERT(l.bind(QHostAddress("127.0.0.1"), 0));
+
+	auto [addr, port] = l.localAddress();
+
+	// start by assuming operations are possible
+	bool streamsReady = true;
+
+	l.streamsReady.connect([&] {
+		streamsReady = true;
+	});
+
+	TcpStream client;
+	TEST_ASSERT(client.connect(addr, port));
+
+	// start by assuming operations are possible
+	bool clientReadReady = true;
+	bool clientWriteReady = true;
+
+	client.readReady.connect([&] {
+		clientReadReady = true;
+	});
+
+	client.writeReady.connect([&] {
+		clientWriteReady = true;
+	});
+
+	std::unique_ptr<TcpStream> s;
+	while(!s)
+	{
 		s = l.accept();
-		QVERIFY(s);
 
-		while(!client.checkConnected())
+		if(!s)
 		{
-			QCOMPARE(client.errorCondition(), ENOTCONN);
+			TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
 
-			clientWriteReady = false;
-			while(!clientWriteReady)
+			streamsReady = false;
+			while(!streamsReady)
 				loop_wait();
 		}
 	}
 
-	void runIo(std::function<void ()> loop_wait)
+	// start by assuming operations are possible
+	bool readReady = true;
+	bool writeReady = true;
+
+	s->readReady.connect([&] {
+		readReady = true;
+	});
+
+	s->writeReady.connect([&] {
+		writeReady = true;
+	});
+
+	while(!client.checkConnected())
 	{
-		TcpListener l;
-		QVERIFY(l.bind(QHostAddress("127.0.0.1"), 0));
+		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		auto [addr, port] = l.localAddress();
-
-		// start by assuming operations are possible
-		bool streamsReady = true;
-
-		l.streamsReady.connect([&] {
-			streamsReady = true;
-		});
-
-		TcpStream client;
-		QVERIFY(client.connect(addr, port));
-
-		// start by assuming operations are possible
-		bool clientReadReady = true;
-		bool clientWriteReady = true;
-
-		client.readReady.connect([&] {
-			clientReadReady = true;
-		});
-
-		client.writeReady.connect([&] {
-			clientWriteReady = true;
-		});
-
-		std::unique_ptr<TcpStream> s;
-		while(!s)
-		{
-			s = l.accept();
-
-			if(!s)
-			{
-				QCOMPARE(l.errorCondition(), EAGAIN);
-
-				streamsReady = false;
-				while(!streamsReady)
-					loop_wait();
-			}
-		}
-
-		// start by assuming operations are possible
-		bool readReady = true;
-		bool writeReady = true;
-
-		s->readReady.connect([&] {
-			readReady = true;
-		});
-
-		s->writeReady.connect([&] {
-			writeReady = true;
-		});
-
-		while(!client.checkConnected())
-		{
-			QCOMPARE(client.errorCondition(), ENOTCONN);
-
-			clientWriteReady = false;
-			while(!clientWriteReady)
-				loop_wait();
-		}
-
-		QVERIFY(s->read().isNull());
-		QCOMPARE(s->errorCondition(), EAGAIN);
-		readReady = false;
-
-		QCOMPARE(client.write("hello\n"), 6);
-
-		QByteArray received;
-		while(!received.contains('\n'))
-		{
-			QByteArray buf = s->read();
-
-			if(buf.isNull())
-			{
-				QCOMPARE(s->errorCondition(), EAGAIN);
-
-				readReady = false;
-				while(!readReady)
-					loop_wait();
-
-				continue;
-			}
-
-			QVERIFY(!buf.isEmpty());
-
-			received += buf;
-		}
-
-		QCOMPARE(received, "hello\n");
-
-		QByteArray written;
-		received.clear();
-
-		// write until we fill the system buffer
-		while(true)
-		{
-			QByteArray chunk(100000, 'a');
-			int ret = s->write(chunk);
-
-			if(ret < 0)
-			{
-				QCOMPARE(s->errorCondition(), EAGAIN);
-				writeReady = false;
-				break;
-			}
-
-			written += chunk.mid(0, ret);
-		}
-
-		// wait for some bytes on the client side
-		while(received.isEmpty())
-		{
-			QByteArray buf = client.read(100000);
-
-			if(buf.isNull())
-			{
-				QCOMPARE(client.errorCondition(), EAGAIN);
-
-				clientReadReady = false;
-				while(!clientReadReady)
-					loop_wait();
-
-				continue;
-			}
-
-			received += buf;
-		}
-
-		// now read as much as possible on the client side. this helps the
-		// server side gain writability sooner
-		while(true)
-		{
-			QByteArray buf = client.read(100000);
-
-			if(buf.isNull())
-			{
-				QCOMPARE(client.errorCondition(), EAGAIN);
-				clientReadReady = false;
-				break;
-			}
-
-			received += buf;
-		}
-
-		// wait for writability
-		while(!writeReady)
+		clientWriteReady = false;
+		while(!clientWriteReady)
 			loop_wait();
+	}
 
-		// write more
+	TEST_ASSERT(s->read().isNull());
+	TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+	readReady = false;
+
+	TEST_ASSERT_EQ(client.write("hello\n"), 6);
+
+	QByteArray received;
+	while(!received.contains('\n'))
+	{
+		QByteArray buf = s->read();
+
+		if(buf.isNull())
 		{
-			QByteArray chunk(100000, 'a');
-			int ret = s->write(chunk);
-			QVERIFY(ret > 0);
+			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
 
-			written += chunk.mid(0, ret);
+			readReady = false;
+			while(!readReady)
+				loop_wait();
+
+			continue;
 		}
 
-		// close the server side
-		s.reset();
+		TEST_ASSERT(!buf.isEmpty());
 
-		// read until closed on the client side
-		while(true)
+		received += buf;
+	}
+
+	TEST_ASSERT_EQ(received, "hello\n");
+
+	QByteArray written;
+	received.clear();
+
+	// write until we fill the system buffer
+	while(true)
+	{
+		QByteArray chunk(100000, 'a');
+		int ret = s->write(chunk);
+
+		if(ret < 0)
 		{
-			QByteArray buf = client.read(100000);
-
-			if(buf.isNull())
-			{
-				QCOMPARE(client.errorCondition(), EAGAIN);
-
-				clientReadReady = false;
-				while(!clientReadReady)
-					loop_wait();
-
-				continue;
-			}
-
-			if(buf.isEmpty())
-				break;
-
-			received += buf;
+			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+			writeReady = false;
+			break;
 		}
 
-		QCOMPARE(received, written);
+		written += chunk.mid(0, ret);
 	}
 
-private slots:
-	void accept()
+	// wait for some bytes on the client side
+	while(received.isEmpty())
 	{
-		EventLoop loop(100);
+		QByteArray buf = client.read(100000);
 
-		runAccept([&] {
-			QThread::msleep(10);
-			loop.step();
-		});
+		if(buf.isNull())
+		{
+			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-		DeferCall::cleanup();
+			clientReadReady = false;
+			while(!clientReadReady)
+				loop_wait();
+
+			continue;
+		}
+
+		received += buf;
 	}
 
-	void acceptQt()
+	// now read as much as possible on the client side. this helps the
+	// server side gain writability sooner
+	while(true)
 	{
-		Timer::init(100);
+		QByteArray buf = client.read(100000);
 
-		runAccept([] { QTest::qWait(10); });
+		if(buf.isNull())
+		{
+			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+			clientReadReady = false;
+			break;
+		}
 
-		DeferCall::cleanup();
-		Timer::deinit();
+		received += buf;
 	}
 
-	void io()
+	// wait for writability
+	while(!writeReady)
+		loop_wait();
+
+	// write more
 	{
-		EventLoop loop(100);
+		QByteArray chunk(100000, 'a');
+		int ret = s->write(chunk);
+		TEST_ASSERT(ret > 0);
 
-		runIo([&] {
-			QThread::msleep(10);
-			loop.step();
-		});
-
-		DeferCall::cleanup();
+		written += chunk.mid(0, ret);
 	}
 
-	void ioQt()
+	// close the server side
+	s.reset();
+
+	// read until closed on the client side
+	while(true)
 	{
-		Timer::init(100);
+		QByteArray buf = client.read(100000);
 
-		runIo([] { QTest::qWait(10); });
+		if(buf.isNull())
+		{
+			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-		DeferCall::cleanup();
-		Timer::deinit();
+			clientReadReady = false;
+			while(!clientReadReady)
+				loop_wait();
+
+			continue;
+		}
+
+		if(buf.isEmpty())
+			break;
+
+		received += buf;
 	}
-};
 
-namespace {
-namespace Main {
-QTEST_MAIN(TcpStreamTest)
+	TEST_ASSERT_EQ(received, written);
 }
-}
 
-extern "C" {
-
-int tcpstream_test(int argc, char **argv)
+static void accept()
 {
-	return Main::main(argc, argv);
+	EventLoop loop(100);
+
+	runAccept([&] {
+		QThread::msleep(10);
+		loop.step();
+	});
+
+	DeferCall::cleanup();
 }
 
+static void acceptQt()
+{
+	int argc = 1;
+	char *argv[] = { "zeroTimeoutQt" };
+	QCoreApplication qapp(argc, argv);
+	Timer::init(100);
+
+	runAccept([] { QTest::qWait(10); });
+
+	DeferCall::cleanup();
+	Timer::deinit();
 }
 
-#include "tcpstreamtest.moc"
+static void io()
+{
+	EventLoop loop(100);
+
+	runIo([&] {
+		QThread::msleep(10);
+		loop.step();
+	});
+
+	DeferCall::cleanup();
+}
+
+static void ioQt()
+{
+	int argc = 1;
+	char *argv[] = { "zeroTimeoutQt" };
+	QCoreApplication qapp(argc, argv);
+	Timer::init(100);
+
+	runIo([] { QTest::qWait(10); });
+
+	DeferCall::cleanup();
+	Timer::deinit();
+}
+
+extern "C" int tcpstream_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(accept());
+	TEST_CATCH(acceptQt());
+	TEST_CATCH(io());
+	TEST_CATCH(ioQt());
+
+	return 0;
+}

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -20,7 +20,6 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QCoreApplication>
 #include <QHostAddress>
 #include "test.h"
 #include "timer.h"
@@ -277,9 +276,7 @@ static void accept()
 
 static void acceptQt()
 {
-	int argc = 1;
-	char *argv[] = { "zeroTimeoutQt" };
-	QCoreApplication qapp(argc, argv);
+	TestQCoreApplication qapp;
 	Timer::init(100);
 
 	runAccept([] { QTest::qWait(10); });
@@ -302,9 +299,7 @@ static void io()
 
 static void ioQt()
 {
-	int argc = 1;
-	char *argv[] = { "zeroTimeoutQt" };
-	QCoreApplication qapp(argc, argv);
+	TestQCoreApplication qapp;
 	Timer::init(100);
 
 	runIo([] { QTest::qWait(10); });

--- a/src/core/test.h
+++ b/src/core/test.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "string.h"
 #include <QtTest/QtTest>
 #include "rust/bindings.h"
 
@@ -73,5 +74,27 @@ do {\
 
 // for running a test and catching an exception if any. expects local variable ffi::TestException* out_ex to exist
 #define TEST_CATCH(statement) try { statement; } catch(const TestException &ex) { ex.toFfi(out_ex); return 1; }
+
+class TestQCoreApplication
+{
+public:
+    TestQCoreApplication()
+    {
+        argc_ = 1;
+        argv_[0] = strdup("qt-test");
+        qapp_ = new QCoreApplication(argc_, argv_);
+    }
+
+    ~TestQCoreApplication()
+    {
+        delete qapp_;
+        free(argv_[0]);
+    }
+
+private:
+    int argc_;
+    char *argv_[1];
+    QCoreApplication *qapp_;
+};
 
 #endif

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -20,7 +20,6 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QCoreApplication>
 #include "test.h"
 #include "timer.h"
 #include "eventloop.h"
@@ -65,9 +64,7 @@ static void zeroTimeout()
 
 static void zeroTimeoutQt()
 {
-	int argc = 1;
-	char *argv[] = { "zeroTimeoutQt" };
-	QCoreApplication qapp(argc, argv);
+	TestQCoreApplication qapp;
 	Timer::init(1);
 
 	int count = runZeroTimeout([] {

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -20,84 +20,73 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QtTest/QtTest>
+#include <QCoreApplication>
+#include "test.h"
 #include "timer.h"
 #include "eventloop.h"
 
-class TimerTest : public QObject
+// loop_advance should process enough events to cause the timers to
+// activate, without sleeping, in order to prove timeouts of zero are
+// processed immediately
+static int runZeroTimeout(std::function<void ()> loop_advance)
 {
-	Q_OBJECT
+	Timer t;
+	t.setSingleShot(true);
 
-private:
-	// loop_advance should process enough events to cause the timers to
-	// activate, without sleeping, in order to prove timeouts of zero are
-	// processed immediately
-	int runZeroTimeout(std::function<void ()> loop_advance)
-	{
-		Timer t;
-		t.setSingleShot(true);
+	int count = 0;
 
-		int count = 0;
+	t.timeout.connect([&] {
+		++count;
+		if(count < 2)
+			t.start(0);
+	});
 
-		t.timeout.connect([&] {
-			++count;
-			if(count < 2)
-				t.start(0);
-		});
+	t.start(0);
 
-		t.start(0);
+	loop_advance();
 
-		loop_advance();
-
-		return count;
-	}
-
-private slots:
-	void zeroTimeout()
-	{
-		EventLoop loop(1);
-
-		int count = runZeroTimeout([&] {
-			// activate the first timer and queue the second
-			loop.step();
-
-			// activate the second
-			loop.step();
-		});
-
-		QCOMPARE(count, 2);
-	}
-
-	void zeroTimeoutQt()
-	{
-		Timer::init(1);
-
-		int count = runZeroTimeout([] {
-			// the timer's qt-based implementation will process both timeouts
-			// during a single timer processing pass. therefore, both
-			// timeouts should get processed within a single event loop pass
-			QCoreApplication::processEvents(QEventLoop::AllEvents);
-		});
-
-		QCOMPARE(count, 2);
-
-		Timer::deinit();
-	}
-};
-
-namespace {
-namespace Main {
-QTEST_MAIN(TimerTest)
-}
+	return count;
 }
 
-extern "C" {
-
-int timer_test(int argc, char **argv)
+static void zeroTimeout()
 {
-	return Main::main(argc, argv);
+	EventLoop loop(1);
+
+	int count = runZeroTimeout([&] {
+		// activate the first timer and queue the second
+		loop.step();
+
+		// activate the second
+		loop.step();
+	});
+
+	TEST_ASSERT_EQ(count, 2);
 }
 
+static void zeroTimeoutQt()
+{
+	int argc = 1;
+	char *argv[] = { "zeroTimeoutQt" };
+	QCoreApplication qapp(argc, argv);
+	Timer::init(1);
+
+	int count = runZeroTimeout([] {
+		// the timer's qt-based implementation will process both timeouts
+		// during a single timer processing pass. therefore, both
+		// timeouts should get processed within a single event loop pass
+		QCoreApplication::processEvents(QEventLoop::AllEvents);
+	});
+
+	TEST_ASSERT_EQ(count, 2);
+
+	Timer::deinit();
 }
 
-#include "timertest.moc"
+
+extern "C" int timer_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(zeroTimeout());
+	TEST_CATCH(zeroTimeoutQt());
+
+	return 0;
+}

--- a/src/core/unixstreamtest.cpp
+++ b/src/core/unixstreamtest.cpp
@@ -20,7 +20,6 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QCoreApplication>
 #include <QHostAddress>
 #include "test.h"
 #include "timer.h"
@@ -285,9 +284,7 @@ static void accept()
 
 static void acceptQt()
 {
-	int argc = 1;
-	char *argv[] = { "zeroTimeoutQt" };
-	QCoreApplication qapp(argc, argv);
+	TestQCoreApplication qapp;
 	Timer::init(100);
 
 	runAccept([] { QTest::qWait(10); });
@@ -310,9 +307,7 @@ static void io()
 
 static void ioQt()
 {
-	int argc = 1;
-	char *argv[] = { "zeroTimeoutQt" };
-	QCoreApplication qapp(argc, argv);
+	TestQCoreApplication qapp;
 	Timer::init(100);
 
 	runIo([] { QTest::qWait(10); });

--- a/src/core/unixstreamtest.cpp
+++ b/src/core/unixstreamtest.cpp
@@ -20,320 +20,313 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QtTest/QtTest>
+#include <QCoreApplication>
 #include <QHostAddress>
+#include "test.h"
 #include "timer.h"
 #include "defercall.h"
 #include "eventloop.h"
 #include "unixlistener.h"
 #include "unixstream.h"
 
-class UnixStreamTest : public QObject
+static void runAccept(std::function<void ()> loop_wait)
 {
-	Q_OBJECT
+	// remove existing pipe file
+	QDir outDir(qgetenv("OUT_DIR"));
+	QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+	QString path = workDir.filePath("test-cpp-unixstream");
+	QFile::remove(path);
 
-private:
-	void runAccept(std::function<void ()> loop_wait)
+	UnixListener l;
+	TEST_ASSERT(l.bind(path));
+
+	// start by assuming operations are possible
+	bool streamsReady = true;
+
+	l.streamsReady.connect([&] {
+		streamsReady = true;
+	});
+
+	std::unique_ptr<UnixStream> s = l.accept();
+	TEST_ASSERT(!s);
+	TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
+	streamsReady = false;
+
+	UnixStream client;
+	TEST_ASSERT(client.connect(path));
+
+	// start by assuming operations are possible
+	bool clientWriteReady = true;
+
+	client.writeReady.connect([&] {
+		clientWriteReady = true;
+	});
+
+	while(!streamsReady)
+		loop_wait();
+
+	s = l.accept();
+	TEST_ASSERT(s);
+
+	while(!client.checkConnected())
 	{
-		// remove existing pipe file
-		QDir outDir(qgetenv("OUT_DIR"));
-		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
-		QString path = workDir.filePath("test-cpp-unixstream");
-		QFile::remove(path);
+		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		UnixListener l;
-		QVERIFY(l.bind(path));
-
-		// start by assuming operations are possible
-		bool streamsReady = true;
-
-		l.streamsReady.connect([&] {
-			streamsReady = true;
-		});
-
-		std::unique_ptr<UnixStream> s = l.accept();
-		QVERIFY(!s);
-		QCOMPARE(l.errorCondition(), EAGAIN);
-		streamsReady = false;
-
-		UnixStream client;
-		QVERIFY(client.connect(path));
-
-		// start by assuming operations are possible
-		bool clientWriteReady = true;
-
-		client.writeReady.connect([&] {
-			clientWriteReady = true;
-		});
-
-		while(!streamsReady)
+		clientWriteReady = false;
+		while(!clientWriteReady)
 			loop_wait();
+	}
+}
 
+static void runIo(std::function<void ()> loop_wait)
+{
+	// remove existing pipe file
+	QDir outDir(qgetenv("OUT_DIR"));
+	QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+	QString path = workDir.filePath("test-cpp-unixstream");
+	QFile::remove(path);
+
+	UnixListener l;
+	TEST_ASSERT(l.bind(path));
+
+	// start by assuming operations are possible
+	bool streamsReady = true;
+
+	l.streamsReady.connect([&] {
+		streamsReady = true;
+	});
+
+	UnixStream client;
+	TEST_ASSERT(client.connect(path));
+
+	// start by assuming operations are possible
+	bool clientReadReady = true;
+	bool clientWriteReady = true;
+
+	client.readReady.connect([&] {
+		clientReadReady = true;
+	});
+
+	client.writeReady.connect([&] {
+		clientWriteReady = true;
+	});
+
+	std::unique_ptr<UnixStream> s;
+	while(!s)
+	{
 		s = l.accept();
-		QVERIFY(s);
 
-		while(!client.checkConnected())
+		if(!s)
 		{
-			QCOMPARE(client.errorCondition(), ENOTCONN);
+			TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
 
-			clientWriteReady = false;
-			while(!clientWriteReady)
+			streamsReady = false;
+			while(!streamsReady)
 				loop_wait();
 		}
 	}
 
-	void runIo(std::function<void ()> loop_wait)
+	// start by assuming operations are possible
+	bool readReady = true;
+	bool writeReady = true;
+
+	s->readReady.connect([&] {
+		readReady = true;
+	});
+
+	s->writeReady.connect([&] {
+		writeReady = true;
+	});
+
+	while(!client.checkConnected())
 	{
-		// remove existing pipe file
-		QDir outDir(qgetenv("OUT_DIR"));
-		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
-		QString path = workDir.filePath("test-cpp-unixstream");
-		QFile::remove(path);
+		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		UnixListener l;
-		QVERIFY(l.bind(path));
-
-		// start by assuming operations are possible
-		bool streamsReady = true;
-
-		l.streamsReady.connect([&] {
-			streamsReady = true;
-		});
-
-		UnixStream client;
-		QVERIFY(client.connect(path));
-
-		// start by assuming operations are possible
-		bool clientReadReady = true;
-		bool clientWriteReady = true;
-
-		client.readReady.connect([&] {
-			clientReadReady = true;
-		});
-
-		client.writeReady.connect([&] {
-			clientWriteReady = true;
-		});
-
-		std::unique_ptr<UnixStream> s;
-		while(!s)
-		{
-			s = l.accept();
-
-			if(!s)
-			{
-				QCOMPARE(l.errorCondition(), EAGAIN);
-
-				streamsReady = false;
-				while(!streamsReady)
-					loop_wait();
-			}
-		}
-
-		// start by assuming operations are possible
-		bool readReady = true;
-		bool writeReady = true;
-
-		s->readReady.connect([&] {
-			readReady = true;
-		});
-
-		s->writeReady.connect([&] {
-			writeReady = true;
-		});
-
-		while(!client.checkConnected())
-		{
-			QCOMPARE(client.errorCondition(), ENOTCONN);
-
-			clientWriteReady = false;
-			while(!clientWriteReady)
-				loop_wait();
-		}
-
-		QVERIFY(s->read().isNull());
-		QCOMPARE(s->errorCondition(), EAGAIN);
-		readReady = false;
-
-		QCOMPARE(client.write("hello\n"), 6);
-
-		QByteArray received;
-		while(!received.contains('\n'))
-		{
-			QByteArray buf = s->read();
-
-			if(buf.isNull())
-			{
-				QCOMPARE(s->errorCondition(), EAGAIN);
-
-				readReady = false;
-				while(!readReady)
-					loop_wait();
-
-				continue;
-			}
-
-			QVERIFY(!buf.isEmpty());
-
-			received += buf;
-		}
-
-		QCOMPARE(received, "hello\n");
-
-		QByteArray written;
-		received.clear();
-
-		// write until we fill the system buffer
-		while(true)
-		{
-			QByteArray chunk(100000, 'a');
-			int ret = s->write(chunk);
-
-			if(ret < 0)
-			{
-				QCOMPARE(s->errorCondition(), EAGAIN);
-				writeReady = false;
-				break;
-			}
-
-			written += chunk.mid(0, ret);
-		}
-
-		// wait for some bytes on the client side
-		while(received.isEmpty())
-		{
-			QByteArray buf = client.read(100000);
-
-			if(buf.isNull())
-			{
-				QCOMPARE(client.errorCondition(), EAGAIN);
-
-				clientReadReady = false;
-				while(!clientReadReady)
-					loop_wait();
-
-				continue;
-			}
-
-			received += buf;
-		}
-
-		// now read as much as possible on the client side. this helps the
-		// server side gain writability sooner
-		while(true)
-		{
-			QByteArray buf = client.read(100000);
-
-			if(buf.isNull())
-			{
-				QCOMPARE(client.errorCondition(), EAGAIN);
-				clientReadReady = false;
-				break;
-			}
-
-			received += buf;
-		}
-
-		// wait for writability
-		while(!writeReady)
+		clientWriteReady = false;
+		while(!clientWriteReady)
 			loop_wait();
+	}
 
-		// write more
+	TEST_ASSERT(s->read().isNull());
+	TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+	readReady = false;
+
+	TEST_ASSERT_EQ(client.write("hello\n"), 6);
+
+	QByteArray received;
+	while(!received.contains('\n'))
+	{
+		QByteArray buf = s->read();
+
+		if(buf.isNull())
 		{
-			QByteArray chunk(100000, 'a');
-			int ret = s->write(chunk);
-			QVERIFY(ret > 0);
+			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
 
-			written += chunk.mid(0, ret);
+			readReady = false;
+			while(!readReady)
+				loop_wait();
+
+			continue;
 		}
 
-		// close the server side
-		s.reset();
+		TEST_ASSERT(!buf.isEmpty());
 
-		// read until closed on the client side
-		while(true)
+		received += buf;
+	}
+
+	TEST_ASSERT_EQ(received, "hello\n");
+
+	QByteArray written;
+	received.clear();
+
+	// write until we fill the system buffer
+	while(true)
+	{
+		QByteArray chunk(100000, 'a');
+		int ret = s->write(chunk);
+
+		if(ret < 0)
 		{
-			QByteArray buf = client.read(100000);
-
-			if(buf.isNull())
-			{
-				QCOMPARE(client.errorCondition(), EAGAIN);
-
-				clientReadReady = false;
-				while(!clientReadReady)
-					loop_wait();
-
-				continue;
-			}
-
-			if(buf.isEmpty())
-				break;
-
-			received += buf;
+			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+			writeReady = false;
+			break;
 		}
 
-		QCOMPARE(received, written);
+		written += chunk.mid(0, ret);
 	}
 
-private slots:
-	void accept()
+	// wait for some bytes on the client side
+	while(received.isEmpty())
 	{
-		EventLoop loop(100);
+		QByteArray buf = client.read(100000);
 
-		runAccept([&] {
-			QThread::msleep(10);
-			loop.step();
-		});
+		if(buf.isNull())
+		{
+			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-		DeferCall::cleanup();
+			clientReadReady = false;
+			while(!clientReadReady)
+				loop_wait();
+
+			continue;
+		}
+
+		received += buf;
 	}
 
-	void acceptQt()
+	// now read as much as possible on the client side. this helps the
+	// server side gain writability sooner
+	while(true)
 	{
-		Timer::init(100);
+		QByteArray buf = client.read(100000);
 
-		runAccept([] { QTest::qWait(10); });
+		if(buf.isNull())
+		{
+			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+			clientReadReady = false;
+			break;
+		}
 
-		DeferCall::cleanup();
-		Timer::deinit();
+		received += buf;
 	}
 
-	void io()
+	// wait for writability
+	while(!writeReady)
+		loop_wait();
+
+	// write more
 	{
-		EventLoop loop(100);
+		QByteArray chunk(100000, 'a');
+		int ret = s->write(chunk);
+		TEST_ASSERT(ret > 0);
 
-		runIo([&] {
-			QThread::msleep(10);
-			loop.step();
-		});
-
-		DeferCall::cleanup();
+		written += chunk.mid(0, ret);
 	}
 
-	void ioQt()
+	// close the server side
+	s.reset();
+
+	// read until closed on the client side
+	while(true)
 	{
-		Timer::init(100);
+		QByteArray buf = client.read(100000);
 
-		runIo([] { QTest::qWait(10); });
+		if(buf.isNull())
+		{
+			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-		DeferCall::cleanup();
-		Timer::deinit();
+			clientReadReady = false;
+			while(!clientReadReady)
+				loop_wait();
+
+			continue;
+		}
+
+		if(buf.isEmpty())
+			break;
+
+		received += buf;
 	}
-};
 
-namespace {
-namespace Main {
-QTEST_MAIN(UnixStreamTest)
+	TEST_ASSERT_EQ(received, written);
 }
-}
 
-extern "C" {
-
-int unixstream_test(int argc, char **argv)
+static void accept()
 {
-	return Main::main(argc, argv);
+	EventLoop loop(100);
+
+	runAccept([&] {
+		QThread::msleep(10);
+		loop.step();
+	});
+
+	DeferCall::cleanup();
 }
 
+static void acceptQt()
+{
+	int argc = 1;
+	char *argv[] = { "zeroTimeoutQt" };
+	QCoreApplication qapp(argc, argv);
+	Timer::init(100);
+
+	runAccept([] { QTest::qWait(10); });
+
+	DeferCall::cleanup();
+	Timer::deinit();
 }
 
-#include "unixstreamtest.moc"
+static void io()
+{
+	EventLoop loop(100);
+
+	runIo([&] {
+		QThread::msleep(10);
+		loop.step();
+	});
+
+	DeferCall::cleanup();
+}
+
+static void ioQt()
+{
+	int argc = 1;
+	char *argv[] = { "zeroTimeoutQt" };
+	QCoreApplication qapp(argc, argv);
+	Timer::init(100);
+
+	runIo([] { QTest::qWait(10); });
+
+	DeferCall::cleanup();
+	Timer::deinit();
+}
+
+extern "C" int unixstream_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(accept());
+	TEST_CATCH(acceptQt());
+	TEST_CATCH(io());
+	TEST_CATCH(ioQt());
+
+	return 0;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,11 +133,11 @@ pub mod ffi {
     import_cpptest! {
         pub fn httpheaders_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn jwt_test(out_ex: *mut TestException) -> libc::c_int;
-        pub fn timer_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn defercall_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn tcpstream_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn unixstream_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn eventloop_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn timer_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn defercall_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn tcpstream_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn unixstream_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn eventloop_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn filter_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;


### PR DESCRIPTION
This is mostly a straight conversion, except for the tests involving the Qt event loop. For those, we have to explicitly construct a `QCoreApplication` rather than relying on Qt's test harness to make one for us.