### PR TITLE
deferred: don't delete self, to allow smart pointers to manage

### DIFF
--- a/src/handler/conncheckworker.cpp
+++ b/src/handler/conncheckworker.cpp
@@ -61,8 +61,8 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 	if(!missing_.isEmpty())
 	{
 		// ask the proxy about any cids we don't know about
-		Deferred *d = ControlRequest::connCheck(proxyControlClient, missing_, this);
-		finishedConnection_ = d->finished.connect(boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
+		connCheck_ = std::unique_ptr<Deferred>(ControlRequest::connCheck(proxyControlClient, missing_));
+		finishedConnection_ = connCheck_->finished.connect(boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
 		return;
 	}
 

--- a/src/handler/conncheckworker.h
+++ b/src/handler/conncheckworker.h
@@ -46,6 +46,7 @@ private:
 	std::unique_ptr<ZrpcRequest> req_;
 	CidSet cids_;
 	CidSet missing_;
+	std::unique_ptr<Deferred> connCheck_;
 	Connection finishedConnection_;
 
 	void respondError(const QByteArray &condition);

--- a/src/handler/deferred.cpp
+++ b/src/handler/deferred.cpp
@@ -33,11 +33,6 @@ Deferred::~Deferred()
 {
 }
 
-void Deferred::cancel()
-{
-	delete this;
-}
-
 void Deferred::setFinished(bool ok, const QVariant &value)
 {
 	result_.success = ok;
@@ -49,5 +44,4 @@ void Deferred::setFinished(bool ok, const QVariant &value)
 void Deferred::doFinish()
 {
 	finished(result_);
-	delete this;
 }

--- a/src/handler/deferred.h
+++ b/src/handler/deferred.h
@@ -56,8 +56,6 @@ class Deferred : public QObject
 public:
 	virtual ~Deferred();
 
-	virtual void cancel();
-
 	boost::signals2::signal<void(const DeferredResult&)> finished;
 
 protected:

--- a/src/handler/refreshworker.cpp
+++ b/src/handler/refreshworker.cpp
@@ -90,8 +90,8 @@ void RefreshWorker::refreshNextCid()
 		return;
 	}
 
-	Deferred *d = ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8(), this);
-	finishedConnection_ = d->finished.connect(boost::bind(&RefreshWorker::proxyRefresh_finished, this, boost::placeholders::_1));
+	refresh_ = std::unique_ptr<Deferred>(ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8()));
+	finishedConnection_ = refresh_->finished.connect(boost::bind(&RefreshWorker::proxyRefresh_finished, this, boost::placeholders::_1));
 }
 
 void RefreshWorker::proxyRefresh_finished(const DeferredResult &result)

--- a/src/handler/refreshworker.h
+++ b/src/handler/refreshworker.h
@@ -27,18 +27,20 @@
 #include <QByteArray>
 #include <QHash>
 #include <QSet>
-#include "deferred.h"
 #include <boost/signals2.hpp>
+#include "deferred.h"
+#include "zrpcrequest.h"
 
 using Connection = boost::signals2::scoped_connection;
 
-class ZrpcRequest;
 class ZrpcManager;
 class StatsManager;
 class WsSession;
 
 class RefreshWorker : public Deferred
 {
+	Q_OBJECT
+
 public:
 	RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel);
 
@@ -47,6 +49,7 @@ private:
 	bool ignoreErrors_;
 	ZrpcManager *proxyControlClient_;
 	std::unique_ptr<ZrpcRequest> req_;
+	std::unique_ptr<Deferred> refresh_;
 	Connection finishedConnection_;
 
 	void refreshNextCid();


### PR DESCRIPTION
The `Deferred` class provides a generic interface for an async operation, signaling a `QVariant` result. Currently it deletes itself upon completion (literally with `delete this`), intended to enable a fire-and-forget developer experience when used along with `QObject` parenting. The idea is whether it completes or its parent goes away, it is automatically cleaned up, without the caller needing to explicitly track it. However, we are trying to avoid `QObject` parenting, preferring to use smart pointers instead, and self-destruction is incompatible with smart pointers.

In order to allow `Deferred` instances to be managed with smart pointers, this PR removes the self destruction and updates all the places `Deferred` is used to ensure instances are destroyed on completion or when the parent/owner goes away. In some places we were already using smart pointers to manage some instances, which was almost certainly wrong (possibly leading to double-deletions) and this PR fixes those cases too.

The resulting developer experience is not as nice but at least this fixes some wrongness and helps get us off `QObject`.