### PR TITLE
httpsession/wssession: don't use QObject

### DIFF
--- a/src/handler/clientsession.h
+++ b/src/handler/clientsession.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#ifndef CLIENTSESSION_H
+#define CLIENTSESSION_H
+
+class ClientSession
+{
+public:
+	virtual ~ClientSession() = default;
+};
+
+#endif

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1209,11 +1209,11 @@ public:
 	{
 	public:
 		std::weak_ptr<HandlerEngine::Private> ep;
-		std::weak_ptr<QObject> target;
+		std::weak_ptr<ClientSession> target;
 		PublishItem item;
 		QList<QByteArray> exposeHeaders;
 
-		PublishAction(const std::weak_ptr<HandlerEngine::Private> _ep, const std::weak_ptr<QObject> _target, const PublishItem &_item, const QList<QByteArray> &_exposeHeaders = QList<QByteArray>()) :
+		PublishAction(const std::weak_ptr<HandlerEngine::Private> _ep, const std::weak_ptr<ClientSession> _target, const PublishItem &_item, const QList<QByteArray> &_exposeHeaders = QList<QByteArray>()) :
 			ep(_ep),
 			target(_target),
 			item(_item),
@@ -1749,7 +1749,7 @@ private:
 		log_debug("%s", qPrintable(msg));
 	}
 
-	void publishSend(const std::shared_ptr<QObject> &target, const PublishItem &item, const QList<QByteArray> &exposeHeaders)
+	void publishSend(const std::shared_ptr<ClientSession> &target, const PublishItem &item, const QList<QByteArray> &exposeHeaders)
 	{
 		if(auto hs = std::dynamic_pointer_cast<HttpSession>(target))
 			hs->publish(item, exposeHeaders);

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -101,10 +101,8 @@ static QByteArray applyBodyPatch(const QByteArray &in, const QVariantList &bodyP
 	return body;
 }
 
-class HttpSession::Private : public QObject
+class HttpSession::Private
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -209,7 +207,6 @@ public:
 	DeferCall deferCall;
 
 	Private(HttpSession *_q, ZhttpRequest *_req, const HttpSession::AcceptData &_adata, const Instruct &_instruct, ZhttpManager *_outZhttp, StatsManager *_stats, RateLimiter *_updateLimiter, const std::shared_ptr<RateLimiter> _filterLimiter, PublishLastIds *_publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &_updateManager, int _connectionSubscriptionMax) :
-		QObject(_q),
 		q(_q),
 		req(_req),
 		logLevel(LOG_LEVEL_DEBUG),
@@ -1677,8 +1674,7 @@ private:
 	}
 };
 
-HttpSession::HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *zhttpOut, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &updateManager, int connectionSubscriptionMax, QObject *parent) :
-	QObject(parent)
+HttpSession::HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *zhttpOut, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &updateManager, int connectionSubscriptionMax)
 {
 	d = std::make_shared<Private>(this, req, adata, instruct, zhttpOut, stats, updateLimiter, filterLimiter, publishLastIds, updateManager, connectionSubscriptionMax);
 }
@@ -1770,5 +1766,3 @@ Callback<std::tuple<HttpSession *>> & HttpSession::finishedCallback()
 {
 	return d->finishedCallback;
 }
-
-#include "httpsession.moc"

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -24,7 +24,7 @@
 #ifndef HTTPSESSION_H
 #define HTTPSESSION_H
 
-#include <QObject>
+#include <boost/signals2.hpp>
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "callback.h"
@@ -32,7 +32,7 @@
 #include "zhttprequest.h"
 #include "instruct.h"
 #include "filter.h"
-#include <boost/signals2.hpp>
+#include "clientsession.h"
 
 // each session can have a bunch of timers:
 // incoming request
@@ -52,12 +52,8 @@ class PublishLastIds;
 class HttpSessionUpdateManager;
 class RetryRequestPacket;
 
-class HttpSession;
-
-class HttpSession : public QObject
+class HttpSession : public ClientSession
 {
-	Q_OBJECT
-
 public:
 	class AcceptData
 	{
@@ -96,7 +92,7 @@ public:
 		}
 	};
 
-	HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *outZhttp, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &updateManager, int connectionSubscriptionMax, QObject *parent = 0);
+	HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *outZhttp, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &updateManager, int connectionSubscriptionMax);
 	~HttpSession();
 
 	Instruct::HoldMode holdMode() const;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -33,8 +33,7 @@
 
 #define WSCONTROL_REQUEST_TIMEOUT 8000
 
-WsSession::WsSession(QObject *parent) :
-	QObject(parent),
+WsSession::WsSession() :
 	nextReqId(0),
 	debug(false),
 	logLevel(LOG_LEVEL_DEBUG),

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -24,14 +24,14 @@
 #ifndef WSSESSION_H
 #define WSSESSION_H
 
-#include <QObject>
 #include <QHash>
 #include <QSet>
+#include <boost/signals2.hpp>
 #include "packet/httprequestdata.h"
 #include "packet/wscontrolpacket.h"
 #include "ratelimiter.h"
 #include "filter.h"
-#include <boost/signals2.hpp>
+#include "clientsession.h"
 
 // each session can have a bunch of timers:
 // 3 misc timers
@@ -45,10 +45,8 @@ class Timer;
 class ZhttpManager;
 class PublishItem;
 
-class WsSession : public QObject
+class WsSession : public ClientSession
 {
-	Q_OBJECT
-
 public:
 	QByteArray peer;
 	QString cid;
@@ -82,7 +80,7 @@ public:
 	bool inProcessPublishQueue;
 	bool closed;
 
-	WsSession(QObject *parent = 0);
+	WsSession();
 	~WsSession();
 
 	void refreshExpiration();


### PR DESCRIPTION
This adds `ClientSession` as a base class to ensure we can still have generalized pointers to either session type.