### PR TITLE
convert some more c++ tests to the new style

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/handler/instructtest.cpp
+++ b/src/handler/instructtest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -20,297 +21,285 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QtTest/QtTest>
+#include "test.h"
 #include "httpheaders.h"
 #include "packet/httpresponsedata.h"
 #include "instruct.h"
 
-class InstructTest : public QObject
+static void noHold()
 {
-	Q_OBJECT
+	HttpResponseData data;
+	data.code = 200;
+	data.reason = "OK";
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Channel", "test");
+	data.body = "hello world";
 
-private slots:
-	void noHold()
-	{
-		HttpResponseData data;
-		data.code = 200;
-		data.reason = "OK";
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Channel", "test");
-		data.body = "hello world";
+	Instruct i;
+	bool ok;
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+	TEST_ASSERT_EQ(i.response.code, 200);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 
-		Instruct i;
-		bool ok;
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::NoHold);
-		QCOMPARE(i.response.code, 200);
-		QCOMPARE(i.response.reason, QByteArray("OK"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QVERIFY(!i.response.headers.contains("Grip-Channel"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
+	data.headers += HttpHeader("Grip-Status", "404");
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+	TEST_ASSERT_EQ(i.response.code, 404);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("Not Found"));
 
-		data.headers += HttpHeader("Grip-Status", "404");
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::NoHold);
-		QCOMPARE(i.response.code, 404);
-		QCOMPARE(i.response.reason, QByteArray("Not Found"));
+	data.headers.removeAll("Grip-Status");
+	data.headers += HttpHeader("Grip-Status", "404 Nothing To See Here");
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+	TEST_ASSERT_EQ(i.response.code, 404);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("Nothing To See Here"));
 
-		data.headers.removeAll("Grip-Status");
-		data.headers += HttpHeader("Grip-Status", "404 Nothing To See Here");
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::NoHold);
-		QCOMPARE(i.response.code, 404);
-		QCOMPARE(i.response.reason, QByteArray("Nothing To See Here"));
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+	data.body = "{\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
 
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-		data.body = "{\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::NoHold);
-		QCOMPARE(i.response.code, 200);
-		QCOMPARE(i.response.reason, QByteArray("OK"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-	}
-
-	void responseHold()
-	{
-		HttpResponseData data;
-		data.code = 200;
-		data.reason = "OK";
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "response");
-		data.headers += HttpHeader("Grip-Channel", "apple");
-		data.headers += HttpHeader("Grip-Channel", "banana, cherry");
-		data.headers += HttpHeader("Grip-Timeout", "120");
-		data.headers += HttpHeader("Grip-Set-Meta", "foo=bar, bar=baz");
-		data.body = "hello world";
-
-		Instruct i;
-		bool ok;
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::ResponseHold);
-		QCOMPARE(i.channels.count(), 3);
-		QCOMPARE(i.channels[0].name, QString("apple"));
-		QCOMPARE(i.channels[1].name, QString("banana"));
-		QCOMPARE(i.channels[2].name, QString("cherry"));
-		QCOMPARE(i.timeout, 120);
-		QCOMPARE(i.meta.count(), 2);
-		QCOMPARE(i.meta.value("foo"), QString("bar"));
-		QCOMPARE(i.meta.value("bar"), QString("baz"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QVERIFY(!i.response.headers.contains("Grip-Channel"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-		data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":\"test\"}],\"timeout\":120,\"meta\":{\"foo\":\"bar\",\"bar\":\"baz\"}},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::ResponseHold);
-		QCOMPARE(i.channels.count(), 1);
-		QCOMPARE(i.channels[0].name, QString("test"));
-		QCOMPARE(i.timeout, 120);
-		QCOMPARE(i.meta.count(), 2);
-		QCOMPARE(i.meta.value("foo"), QString("bar"));
-		QCOMPARE(i.meta.value("bar"), QString("baz"));
-		QCOMPARE(i.response.code, 200);
-		QCOMPARE(i.response.reason, QByteArray("OK"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-	}
-
-	void responseHoldChannelParams()
-	{
-		HttpResponseData data;
-		data.code = 200;
-		data.reason = "OK";
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "response");
-		data.headers += HttpHeader("Grip-Channel", "apple; prev-id=item1; filter=f1");
-		data.headers += HttpHeader("Grip-Channel", "banana; filter=f2, cherry; filter=f1; filter=f2");
-		data.body = "hello world";
-
-		Instruct i;
-		bool ok;
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::ResponseHold);
-		QCOMPARE(i.channels.count(), 3);
-		QCOMPARE(i.channels[0].name, QString("apple"));
-		QCOMPARE(i.channels[0].prevId, QString("item1"));
-		QCOMPARE(i.channels[0].filters.count(), 1);
-		QCOMPARE(i.channels[0].filters[0], QString("f1"));
-		QCOMPARE(i.channels[1].name, QString("banana"));
-		QVERIFY(i.channels[1].prevId.isNull());
-		QCOMPARE(i.channels[1].filters.count(), 1);
-		QCOMPARE(i.channels[1].filters[0], QString("f2"));
-		QCOMPARE(i.channels[2].name, QString("cherry"));
-		QVERIFY(i.channels[2].prevId.isNull());
-		QCOMPARE(i.channels[2].filters.count(), 2);
-		QCOMPARE(i.channels[2].filters[0], QString("f1"));
-		QCOMPARE(i.channels[2].filters[1], QString("f2"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QVERIFY(!i.response.headers.contains("Grip-Channel"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-		data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":\"apple\",\"prev-id\":\"item1\",\"filters\":[\"f1\"]},{\"name\":\"banana\",\"filters\":[\"f2\"]},{\"name\":\"cherry\",\"filters\":[\"f1\",\"f2\"]}]},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::ResponseHold);
-		QCOMPARE(i.channels.count(), 3);
-		QCOMPARE(i.channels[0].name, QString("apple"));
-		QCOMPARE(i.channels[0].prevId, QString("item1"));
-		QCOMPARE(i.channels[0].filters.count(), 1);
-		QCOMPARE(i.channels[0].filters[0], QString("f1"));
-		QCOMPARE(i.channels[1].name, QString("banana"));
-		QVERIFY(i.channels[1].prevId.isNull());
-		QCOMPARE(i.channels[1].filters.count(), 1);
-		QCOMPARE(i.channels[1].filters[0], QString("f2"));
-		QCOMPARE(i.channels[2].name, QString("cherry"));
-		QVERIFY(i.channels[2].prevId.isNull());
-		QCOMPARE(i.channels[2].filters.count(), 2);
-		QCOMPARE(i.channels[2].filters[0], QString("f1"));
-		QCOMPARE(i.channels[2].filters[1], QString("f2"));
-		QCOMPARE(i.response.code, 200);
-		QCOMPARE(i.response.reason, QByteArray("OK"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-	}
-
-	void streamHold()
-	{
-		HttpResponseData data;
-		data.code = 200;
-		data.reason = "OK";
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "stream");
-		data.headers += HttpHeader("Grip-Channel", "apple");
-		data.headers += HttpHeader("Grip-Channel", "banana, cherry");
-		data.body = "hello world";
-
-		Instruct i;
-		bool ok;
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.channels.count(), 3);
-		QCOMPARE(i.channels[0].name, QString("apple"));
-		QCOMPARE(i.channels[1].name, QString("banana"));
-		QCOMPARE(i.channels[2].name, QString("cherry"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QVERIFY(!i.response.headers.contains("Grip-Channel"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-		data.body = "{\"hold\":{\"mode\":\"stream\",\"channels\":[{\"name\":\"test\"}]},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.channels.count(), 1);
-		QCOMPARE(i.channels[0].name, QString("test"));
-		QCOMPARE(i.response.code, 200);
-		QCOMPARE(i.response.reason, QByteArray("OK"));
-		QCOMPARE(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
-		QCOMPARE(i.response.body, QByteArray("hello world"));
-	}
-
-	void streamHoldKeepAlive()
-	{
-		HttpResponseData data;
-		data.code = 200;
-		data.reason = "OK";
-		data.body = "hello world";
-
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "stream");
-		data.headers += HttpHeader("Grip-Channel", "test");
-		Instruct i;
-		bool ok;
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.keepAliveMode, Instruct::NoKeepAlive);
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "stream");
-		data.headers += HttpHeader("Grip-Channel", "test");
-		data.headers += HttpHeader("Grip-Keep-Alive", "ping1\\n; timeout=10");
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.keepAliveMode, Instruct::Idle);
-		QCOMPARE(i.keepAliveData, QByteArray("ping1\\n"));
-		QCOMPARE(i.keepAliveTimeout, 10);
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "stream");
-		data.headers += HttpHeader("Grip-Channel", "test");
-		data.headers += HttpHeader("Grip-Keep-Alive", "ping2\\n; format=cstring");
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.keepAliveMode, Instruct::Idle);
-		QCOMPARE(i.keepAliveData, QByteArray("ping2\n"));
-		QVERIFY(i.keepAliveTimeout > 0);
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "stream");
-		data.headers += HttpHeader("Grip-Channel", "test");
-		data.headers += HttpHeader("Grip-Keep-Alive", "cGluZzMK; format=base64");
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.keepAliveMode, Instruct::Idle);
-		QCOMPARE(i.keepAliveData, QByteArray("ping3\n"));
-		QVERIFY(i.keepAliveTimeout > 0);
-
-		data.headers.clear();
-		data.headers += HttpHeader("Content-Type", "text/plain");
-		data.headers += HttpHeader("Grip-Hold", "stream");
-		data.headers += HttpHeader("Grip-Channel", "test");
-		data.headers += HttpHeader("Grip-Keep-Alive", "ping4\\n; mode=interval");
-
-		i = Instruct::fromResponse(data, &ok);
-		QVERIFY(ok);
-		QCOMPARE(i.holdMode, Instruct::StreamHold);
-		QCOMPARE(i.keepAliveMode, Instruct::Interval);
-		QCOMPARE(i.keepAliveData, QByteArray("ping4\\n"));
-		QVERIFY(i.keepAliveTimeout > 0);
-	}
-};
-
-namespace {
-namespace Main {
-QTEST_MAIN(InstructTest)
-}
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+	TEST_ASSERT_EQ(i.response.code, 200);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
-extern "C" {
-
-int instruct_test(int argc, char **argv)
+static void responseHold()
 {
-	return Main::main(argc, argv);
+	HttpResponseData data;
+	data.code = 200;
+	data.reason = "OK";
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "response");
+	data.headers += HttpHeader("Grip-Channel", "apple");
+	data.headers += HttpHeader("Grip-Channel", "banana, cherry");
+	data.headers += HttpHeader("Grip-Timeout", "120");
+	data.headers += HttpHeader("Grip-Set-Meta", "foo=bar, bar=baz");
+	data.body = "hello world";
+
+	Instruct i;
+	bool ok;
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+	TEST_ASSERT_EQ(i.channels.count(), 3);
+	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+	TEST_ASSERT_EQ(i.timeout, 120);
+	TEST_ASSERT_EQ(i.meta.count(), 2);
+	TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
+	TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+	data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":\"test\"}],\"timeout\":120,\"meta\":{\"foo\":\"bar\",\"bar\":\"baz\"}},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+	TEST_ASSERT_EQ(i.channels.count(), 1);
+	TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
+	TEST_ASSERT_EQ(i.timeout, 120);
+	TEST_ASSERT_EQ(i.meta.count(), 2);
+	TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
+	TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
+	TEST_ASSERT_EQ(i.response.code, 200);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
+static void responseHoldChannelParams()
+{
+	HttpResponseData data;
+	data.code = 200;
+	data.reason = "OK";
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "response");
+	data.headers += HttpHeader("Grip-Channel", "apple; prev-id=item1; filter=f1");
+	data.headers += HttpHeader("Grip-Channel", "banana; filter=f2, cherry; filter=f1; filter=f2");
+	data.body = "hello world";
+
+	Instruct i;
+	bool ok;
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+	TEST_ASSERT_EQ(i.channels.count(), 3);
+	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+	TEST_ASSERT_EQ(i.channels[0].prevId, QString("item1"));
+	TEST_ASSERT_EQ(i.channels[0].filters.count(), 1);
+	TEST_ASSERT_EQ(i.channels[0].filters[0], QString("f1"));
+	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+	TEST_ASSERT(i.channels[1].prevId.isNull());
+	TEST_ASSERT_EQ(i.channels[1].filters.count(), 1);
+	TEST_ASSERT_EQ(i.channels[1].filters[0], QString("f2"));
+	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+	TEST_ASSERT(i.channels[2].prevId.isNull());
+	TEST_ASSERT_EQ(i.channels[2].filters.count(), 2);
+	TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
+	TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+	data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":\"apple\",\"prev-id\":\"item1\",\"filters\":[\"f1\"]},{\"name\":\"banana\",\"filters\":[\"f2\"]},{\"name\":\"cherry\",\"filters\":[\"f1\",\"f2\"]}]},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+	TEST_ASSERT_EQ(i.channels.count(), 3);
+	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+	TEST_ASSERT_EQ(i.channels[0].prevId, QString("item1"));
+	TEST_ASSERT_EQ(i.channels[0].filters.count(), 1);
+	TEST_ASSERT_EQ(i.channels[0].filters[0], QString("f1"));
+	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+	TEST_ASSERT(i.channels[1].prevId.isNull());
+	TEST_ASSERT_EQ(i.channels[1].filters.count(), 1);
+	TEST_ASSERT_EQ(i.channels[1].filters[0], QString("f2"));
+	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+	TEST_ASSERT(i.channels[2].prevId.isNull());
+	TEST_ASSERT_EQ(i.channels[2].filters.count(), 2);
+	TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
+	TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
+	TEST_ASSERT_EQ(i.response.code, 200);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
-#include "instructtest.moc"
+static void streamHold()
+{
+	HttpResponseData data;
+	data.code = 200;
+	data.reason = "OK";
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "stream");
+	data.headers += HttpHeader("Grip-Channel", "apple");
+	data.headers += HttpHeader("Grip-Channel", "banana, cherry");
+	data.body = "hello world";
+
+	Instruct i;
+	bool ok;
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.channels.count(), 3);
+	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+	data.body = "{\"hold\":{\"mode\":\"stream\",\"channels\":[{\"name\":\"test\"}]},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.channels.count(), 1);
+	TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
+	TEST_ASSERT_EQ(i.response.code, 200);
+	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), QByteArray("text/plain"));
+	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+}
+
+static void streamHoldKeepAlive()
+{
+	HttpResponseData data;
+	data.code = 200;
+	data.reason = "OK";
+	data.body = "hello world";
+
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "stream");
+	data.headers += HttpHeader("Grip-Channel", "test");
+	Instruct i;
+	bool ok;
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::NoKeepAlive);
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "stream");
+	data.headers += HttpHeader("Grip-Channel", "test");
+	data.headers += HttpHeader("Grip-Keep-Alive", "ping1\\n; timeout=10");
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
+	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping1\\n"));
+	TEST_ASSERT_EQ(i.keepAliveTimeout, 10);
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "stream");
+	data.headers += HttpHeader("Grip-Channel", "test");
+	data.headers += HttpHeader("Grip-Keep-Alive", "ping2\\n; format=cstring");
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
+	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping2\n"));
+	TEST_ASSERT(i.keepAliveTimeout > 0);
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "stream");
+	data.headers += HttpHeader("Grip-Channel", "test");
+	data.headers += HttpHeader("Grip-Keep-Alive", "cGluZzMK; format=base64");
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
+	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping3\n"));
+	TEST_ASSERT(i.keepAliveTimeout > 0);
+
+	data.headers.clear();
+	data.headers += HttpHeader("Content-Type", "text/plain");
+	data.headers += HttpHeader("Grip-Hold", "stream");
+	data.headers += HttpHeader("Grip-Channel", "test");
+	data.headers += HttpHeader("Grip-Keep-Alive", "ping4\\n; mode=interval");
+
+	i = Instruct::fromResponse(data, &ok);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Interval);
+	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping4\\n"));
+	TEST_ASSERT(i.keepAliveTimeout > 0);
+}
+
+extern "C" int instruct_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(noHold());
+	TEST_CATCH(responseHold());
+	TEST_CATCH(responseHoldChannelParams());
+	TEST_CATCH(streamHold());
+	TEST_CATCH(streamHoldKeepAlive());
+
+	return 0;
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,29 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::core::test::TestException;
     use crate::core::{call_c_main, qtest};
     use crate::ffi;
     use std::ffi::OsStr;
 
-    fn filter_test(args: &[&OsStr]) -> u8 {
+    fn filter_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::filter_test, args) as u8 }
+        unsafe { ffi::filter_test(out_ex) == 0 }
     }
 
-    fn jsonpatch_test(args: &[&OsStr]) -> u8 {
+    fn jsonpatch_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::jsonpatch_test, args) as u8 }
+        unsafe { ffi::jsonpatch_test(out_ex) == 0 }
     }
 
-    fn instruct_test(args: &[&OsStr]) -> u8 {
+    fn instruct_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::instruct_test, args) as u8 }
+        unsafe { ffi::instruct_test(out_ex) == 0 }
     }
 
-    fn idformat_test(args: &[&OsStr]) -> u8 {
+    fn idformat_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::idformat_test, args) as u8 }
+        unsafe { ffi::idformat_test(out_ex) == 0 }
     }
 
     fn publishformat_test(args: &[&OsStr]) -> u8 {
@@ -57,22 +58,22 @@ mod tests {
 
     #[test]
     fn filter() {
-        assert!(qtest::run(filter_test));
+        qtest::run_no_main(filter_test);
     }
 
     #[test]
     fn jsonpatch() {
-        assert!(qtest::run(jsonpatch_test));
+        qtest::run_no_main(jsonpatch_test);
     }
 
     #[test]
     fn instruct() {
-        assert!(qtest::run(instruct_test));
+        qtest::run_no_main(instruct_test);
     }
 
     #[test]
     fn idformat() {
-        assert!(qtest::run(idformat_test));
+        qtest::run_no_main(idformat_test);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021-2022 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -140,10 +140,10 @@ pub mod ffi {
         pub fn eventloop_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn filter_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn jsonpatch_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn instruct_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
-        pub fn idformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn filter_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn jsonpatch_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn instruct_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn idformat_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn publishformat_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn publishitem_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn handlerengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;


### PR DESCRIPTION
This converts the filter, jsonpatch, instruct, and idformat tests.

Note that per-test-module logic (`initTestCase`/`cleanupTestCase`) is changed to be per-test, for symmetry with the Rust tests which normally don't share state. This means the converted tests execute a little slower. We can consider optimizing this later, if appropriate.