### PR TITLE
websocketoverhttp: split frame conversion/consumption logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub mod ffi {
         pub fn tcpstream_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn unixstream_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn eventloop_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn websocketoverhttp_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn routesfile_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn proxyengine_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
         pub fn filter_test(out_ex: *mut TestException) -> libc::c_int;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,15 @@
 
 #[cfg(test)]
 mod tests {
+    use crate::core::test::TestException;
     use crate::core::{call_c_main, qtest};
     use crate::ffi;
     use std::ffi::OsStr;
+
+    fn websocketoverhttp_test(out_ex: &mut TestException) -> bool {
+        // SAFETY: safe to call
+        unsafe { ffi::websocketoverhttp_test(out_ex) == 0 }
+    }
 
     fn routesfile_test(args: &[&OsStr]) -> u8 {
         // SAFETY: safe to call
@@ -28,6 +34,11 @@ mod tests {
     fn proxyengine_test(args: &[&OsStr]) -> u8 {
         // SAFETY: safe to call
         unsafe { call_c_main(ffi::proxyengine_test, args) as u8 }
+    }
+
+    #[test]
+    fn websocketoverhttp() {
+        qtest::run_no_main(websocketoverhttp_test);
     }
 
     #[test]

--- a/src/proxy/tests.pri
+++ b/src/proxy/tests.pri
@@ -2,5 +2,6 @@ INCLUDES += \
 	$$PWD/proxytests.h
 
 SOURCES += \
+	$$PWD/websocketoverhttptest.cpp \
 	$$PWD/routesfiletest.cpp \
 	$$PWD/proxyenginetest.cpp

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#include "test.h"
+#include "websocketoverhttp.h"
+
+static void convertFrames()
+{
+	QList<WebSocket::Frame> frames;
+	frames += WebSocket::Frame(WebSocket::Frame::Text, "hello", true);
+	frames += WebSocket::Frame(WebSocket::Frame::Continuation, " world", false);
+
+	bool ok = false;
+	int framesRepresented = 0;
+	int contentRepresented = 0;
+	QList<WebSocketOverHttp::Event> events = WebSocketOverHttp::framesToEvents(frames, -1, -1, &ok, &framesRepresented, &contentRepresented);
+	TEST_ASSERT(ok);
+	TEST_ASSERT_EQ(events.count(), 1);
+	TEST_ASSERT_EQ(events[0].type, "TEXT");
+	TEST_ASSERT_EQ(events[0].content, "hello world");
+
+	int removed = WebSocketOverHttp::removeContentFromFrames(&frames, contentRepresented);
+	TEST_ASSERT_EQ(removed, contentRepresented);
+	TEST_ASSERT(frames.isEmpty());
+}
+
+static void removePartial()
+{
+	QList<WebSocket::Frame> frames;
+	frames += WebSocket::Frame(WebSocket::Frame::Text, "hello", true);
+	frames += WebSocket::Frame(WebSocket::Frame::Continuation, " world", false);
+	frames += WebSocket::Frame(WebSocket::Frame::Text, "", false);
+	frames += WebSocket::Frame(WebSocket::Frame::Text, "foo", false);
+
+	int removed = WebSocketOverHttp::removeContentFromFrames(&frames, 3);
+	TEST_ASSERT_EQ(removed, 3);
+	TEST_ASSERT_EQ(frames.count(), 4);
+	TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
+	TEST_ASSERT_EQ(frames[0].data, "lo");
+
+	removed = WebSocketOverHttp::removeContentFromFrames(&frames, 2);
+	TEST_ASSERT_EQ(removed, 2);
+	TEST_ASSERT_EQ(frames.count(), 3);
+	TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
+	TEST_ASSERT_EQ(frames[0].data, " world");
+
+	removed = WebSocketOverHttp::removeContentFromFrames(&frames, 6);
+	TEST_ASSERT_EQ(removed, 6);
+	TEST_ASSERT_EQ(frames.count(), 1);
+	TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
+	TEST_ASSERT_EQ(frames[0].data, "foo");
+
+	removed = WebSocketOverHttp::removeContentFromFrames(&frames, 10);
+	TEST_ASSERT_EQ(removed, 3);
+	TEST_ASSERT(frames.isEmpty());
+}
+
+extern "C" int websocketoverhttp_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(convertFrames());
+	TEST_CATCH(removePartial());
+
+	return 0;
+}


### PR DESCRIPTION
Currently, outbound frames are converted (into events for HTTP enveloping) and consumed in a single pass. We are planning to implement a feature for replaying outbound frame data, and in order to prepare for that this PR splits the conversion and consumption logic into separate functions. All frames are still consumed immediately after conversion, so there is no change in behavior. However, this groundwork will make it easy to change that behavior in the future, for example to consume frames later or partially. The functions are made public so they can have tests.