### PR TITLE
proxy: support IPv6 addresses in route targets

### DIFF
--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -579,17 +579,38 @@ private:
 			}
 			else
 			{
-				target.type = Target::Default;
+				QString host;
+				int portPos = -1;
 
-				int at = val.indexOf(':');
-				if(at == -1)
+				if(val.startsWith("["))
+				{
+					// ipv6 address
+					int at = val.indexOf("]:");
+					if(at >= 0)
+					{
+						host = val.mid(1, at - 1);
+						portPos = at + 2;
+					}
+				}
+				else
+				{
+					// domain or ipv4 address
+					int at = val.indexOf(':');
+					if(at >= 0)
+					{
+						host = val.mid(0, at);
+						portPos = at + 1;
+					}
+				}
+
+				if(portPos < 0)
 				{
 					log_warning("%s:%d: target bad format", qPrintable(fileName), lineNum);
 					ok = false;
 					break;
 				}
 
-				QString sport = val.mid(at + 1);
+				QString sport = val.mid(portPos);
 				int port = sport.toInt(&ok);
 				if(!ok || port < 1 || port > 65535)
 				{
@@ -598,7 +619,8 @@ private:
 					break;
 				}
 
-				target.connectHost = val.mid(0, at);
+				target.type = Target::Default;
+				target.connectHost = host;
 				target.connectPort = port;
 			}
 

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -281,11 +281,23 @@ void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers, con
 QString targetToString(const DomainMap::Target &target)
 {
 	if(target.type == DomainMap::Target::Test)
+	{
 		return "test";
+	}
 	else if(target.type == DomainMap::Target::Custom)
+	{
 		return(target.zhttpRoute.req ? "zhttpreq/" : "zhttp/") + target.zhttpRoute.baseSpec;
+	}
 	else // Default
-		return target.connectHost + ':' + QString::number(target.connectPort);
+	{
+		QString host;
+		if(QHostAddress(target.connectHost).protocol() == QAbstractSocket::IPv6Protocol)
+			host = '[' + target.connectHost + ']';
+		else
+			host = target.connectHost;
+
+		return host + ':' + QString::number(target.connectPort);
+	}
 }
 
 QHostAddress getLogicalAddress(const HttpHeaders &headers, const XffRule &xffRule, const QHostAddress &peerAddress)


### PR DESCRIPTION
This enables route targets to specify IPv6 addresses, using bracket notation:

```
example.com [::1]:80
```

Note that IPv6 connectivity is already supported when using domains that resolve to IPv6 addresses. This change is just making it so IPv6 addresses can be specified directly.