### PR TITLE
ci: use ubuntu-latest for github actions since focal is deprecated

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     steps:
     - name: Checkout code
@@ -30,7 +30,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: check
     steps:
@@ -49,7 +49,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: check
     steps:
@@ -70,7 +70,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: check
     steps:
@@ -89,7 +89,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: build
     steps:
@@ -108,7 +108,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: build
     steps:
@@ -127,7 +127,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: build
     steps:
@@ -146,7 +146,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [audit, test]
     steps:

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     steps:
     - name: Checkout code
@@ -30,7 +30,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: check
     steps:
@@ -49,7 +49,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: check
     steps:
@@ -70,7 +70,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: check
     steps:
@@ -89,7 +89,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: build
     steps:
@@ -108,7 +108,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: build
     steps:
@@ -127,7 +127,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: build
     steps:
@@ -146,7 +146,7 @@ jobs:
       fail-fast: true
       matrix:
         rust-version: [stable, 1.75.0]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: fanout/build-base:latest
     needs: [audit, test]
     steps:


### PR DESCRIPTION
All of our tests run within a focal docker container, so the OS version used by the actions isn't too important. Let's simply use `ubuntu-latest` for the actions.