### PR TITLE
proxy: remove parenting from all public interfaces

### DIFF
--- a/src/proxy/acceptrequest.h
+++ b/src/proxy/acceptrequest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,7 +24,6 @@
 #ifndef ACCEPTREQUEST_H
 #define ACCEPTREQUEST_H
 
-#include <QObject>
 #include "packet/httpresponsedata.h"
 #include "zrpcrequest.h"
 

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -354,7 +354,6 @@ public:
 	Connection changedConnection;
 
 	Private(App *_q) :
-		QObject(_q),
 		q(_q)
 	{
 		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::doQuit, this));
@@ -705,8 +704,7 @@ private slots:
 	}
 };
 
-App::App(QObject *parent) :
-	QObject(parent)
+App::App()
 {
 	d = new Private(this);
 }

--- a/src/proxy/app.h
+++ b/src/proxy/app.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,18 +24,15 @@
 #ifndef APP_H
 #define APP_H
 
-#include <QObject>
 #include <boost/signals2.hpp>
 
 using SignalInt = boost::signals2::signal<void(int)>;
 using Connection = boost::signals2::scoped_connection;
 
-class App : public QObject
+class App
 {
-	Q_OBJECT
-
 public:
-	App(QObject *parent = 0);
+	App();
 	~App();
 
 	void start();

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -803,7 +803,6 @@ public:
 	Connection changedConnection;
 
 	Private(DomainMap *_q) :
-		QObject(_q),
 		q(_q),
 		thread(0)
 	{
@@ -839,15 +838,13 @@ private slots:
 	}
 };
 
-DomainMap::DomainMap(QObject *parent) :
-	QObject(parent)
+DomainMap::DomainMap()
 {
 	d = new Private(this);
 	d->start();
 }
 
-DomainMap::DomainMap(const QString &fileName, QObject *parent) :
-	QObject(parent)
+DomainMap::DomainMap(const QString &fileName)
 {
 	d = new Private(this);
 	d->start(fileName);

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -24,7 +24,6 @@
 #ifndef DOMAINMAP_H
 #define DOMAINMAP_H
 
-#include <QObject>
 #include <QPair>
 #include <QString>
 #include <QStringList>
@@ -39,10 +38,8 @@ using Connection = boost::signals2::scoped_connection;
 // this class offers fast access to the routes file. the table is maintained
 //   by a background thread so that file access doesn't cause blocking.
 
-class DomainMap : public QObject
+class DomainMap
 {
-	Q_OBJECT
-
 public:
 	class JsonpConfig
 	{
@@ -182,8 +179,8 @@ public:
 		}
 	};
 
-	DomainMap(QObject *parent = 0);
-	DomainMap(const QString &fileName, QObject *parent = 0);
+	DomainMap();
+	DomainMap(const QString &fileName);
 	~DomainMap();
 
 	// shouldn't really ever need to call this, but it's here in case the

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -137,7 +137,6 @@ public:
 	Connection rrConnection;
 
 	Private(Engine *_q, DomainMap *_domainMap) :
-		QObject(_q),
 		q(_q),
 		destroying(false),
 		domainMap(_domainMap)
@@ -1059,8 +1058,7 @@ private:
 	}
 };
 
-Engine::Engine(DomainMap *domainMap, QObject *parent) :
-	QObject(parent)
+Engine::Engine(DomainMap *domainMap)
 {
 	d = new Private(this, domainMap);
 }

--- a/src/proxy/engine.h
+++ b/src/proxy/engine.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -24,13 +24,12 @@
 #ifndef ENGINE_H
 #define ENGINE_H
 
-#include <QObject>
 #include <QStringList>
 #include <QHostAddress>
-#include "jwt.h"
-#include "xffrule.h"
 #include <boost/signals2.hpp>
 #include <map>
+#include "jwt.h"
+#include "xffrule.h"
 
 // each session can have a bunch of timers:
 // 2 per incoming zhttprequest/zwebsocket
@@ -52,10 +51,8 @@ using Connection = boost::signals2::scoped_connection;
 class StatsManager;
 class DomainMap;
 
-class Engine : public QObject
+class Engine
 {
-	Q_OBJECT
-
 public:
 	class Configuration
 	{
@@ -133,7 +130,7 @@ public:
 		}
 	};
 
-	Engine(DomainMap *domainMap, QObject *parent = 0);
+	Engine(DomainMap *domainMap);
 	~Engine();
 
 	StatsManager *statsManager() const;

--- a/src/proxy/inspectrequest.h
+++ b/src/proxy/inspectrequest.h
@@ -24,7 +24,6 @@
 #ifndef INSPECTREQUEST_H
 #define INSPECTREQUEST_H
 
-#include <QObject>
 #include "zrpcrequest.h"
 
 class HttpRequestData;

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -173,7 +173,6 @@ public:
 	map<RequestSession*, RequestSessionConnections> reqSessionConnectionMap;
 
 	Private(ProxySession *_q, ZRoutes *_zroutes, ZrpcManager *_acceptManager, const LogUtil::Config &_logConfig, StatsManager *_statsManager) :
-		QObject(_q),
 		q(_q),
 		state(Stopped),
 		zroutes(_zroutes),
@@ -1480,8 +1479,7 @@ public:
 	}
 };
 
-ProxySession::ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig, StatsManager *statsManager, QObject *parent) :
-	QObject(parent)
+ProxySession::ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig, StatsManager *statsManager)
 {
 	d = std::make_shared<Private>(this, zroutes, acceptManager, logConfig, statsManager);
 }

--- a/src/proxy/proxysession.h
+++ b/src/proxy/proxysession.h
@@ -24,7 +24,7 @@
 #ifndef PROXYSESSION_H
 #define PROXYSESSION_H
 
-#include <QObject>
+#include <boost/signals2.hpp>
 #include "logutil.h"
 #include "domainmap.h"
 
@@ -39,17 +39,14 @@ class ZRoutes;
 class StatsManager;
 class XffRule;
 class RequestSession;
-#include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
-class ProxySession : public QObject
+class ProxySession
 {
-	Q_OBJECT
-
 public:
-	ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig, StatsManager *stats = 0, QObject *parent = 0);
+	ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig, StatsManager *stats = 0);
 	~ProxySession();
 
 	void setRoute(const DomainMap::Entry &route);

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -203,7 +203,6 @@ public:
 	DeferCall deferCall;
 
 	Private(RequestSession *_q, int _workerId, DomainMap *_domainMap = 0, SockJsManager *_sockJsManager = 0, ZrpcManager *_inspectManager = 0, ZrpcChecker *_inspectChecker = 0, ZrpcManager *_acceptManager = 0, StatsManager *_stats = 0) :
-		QObject(_q),
 		q(_q),
 		workerId(_workerId),
 		state(Stopped),
@@ -1183,8 +1182,7 @@ public:
 	}
 };
 
-RequestSession::RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *acceptManager, StatsManager *stats, QObject *parent) :
-	QObject(parent)
+RequestSession::RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *acceptManager, StatsManager *stats)
 {
 	d = std::make_shared<Private>(this, workerId, domainMap, sockJsManager, inspectManager, inspectChecker, acceptManager, stats);
 }

--- a/src/proxy/requestsession.h
+++ b/src/proxy/requestsession.h
@@ -24,10 +24,9 @@
 #ifndef REQUESTSESSION_H
 #define REQUESTSESSION_H
 
-#include <QObject>
+#include <boost/signals2.hpp>
 #include "zhttprequest.h"
 #include "domainmap.h"
-#include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
@@ -49,12 +48,10 @@ class ZrpcChecker;
 class StatsManager;
 class XffRule;
 
-class RequestSession : public QObject
+class RequestSession
 {
-	Q_OBJECT
-
 public:
-	RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats, QObject *parent = 0);
+	RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats);
 	~RequestSession();
 
 	bool isRetry() const;

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -150,7 +150,6 @@ public:
 	map<ZWebSocket*, WSConnections> wsConnectionMap;
 
 	Private(SockJsManager *_q, const QString &sockJsUrl) :
-		QObject(_q),
 		q(_q)
 	{
 		iframeHtml = QString(iframeHtmlTemplate).arg(sockJsUrl).toUtf8();
@@ -684,8 +683,7 @@ private:
 	}
 };
 
-SockJsManager::SockJsManager(const QString &sockJsUrl, QObject *parent) :
-	QObject(parent)
+SockJsManager::SockJsManager(const QString &sockJsUrl)
 {
 	d = new Private(this, sockJsUrl);
 }

--- a/src/proxy/sockjsmanager.h
+++ b/src/proxy/sockjsmanager.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2017 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,7 +24,6 @@
 #ifndef SOCKJSMANAGER_H
 #define SOCKJSMANAGER_H
 
-#include <QObject>
 #include "domainmap.h"
 #include <boost/signals2.hpp>
 #include <boost/signals2.hpp>
@@ -36,12 +36,10 @@ class ZhttpRequest;
 class ZWebSocket;
 class SockJsSession;
 
-class SockJsManager : public QObject
+class SockJsManager
 {
-	Q_OBJECT
-
 public:
-	SockJsManager(const QString &sockJsUrl, QObject *parent = 0);
+	SockJsManager(const QString &sockJsUrl);
 	~SockJsManager();
 
 	void giveRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath = QByteArray(), const DomainMap::Entry &route = DomainMap::Entry());

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -24,7 +24,6 @@
 #ifndef SOCKJSSESSION_H
 #define SOCKJSSESSION_H
 
-#include <QObject>
 #include <QUrl>
 #include <QHostAddress>
 #include "httpheaders.h"

--- a/src/proxy/updater.cpp
+++ b/src/proxy/updater.cpp
@@ -91,7 +91,6 @@ public:
 	Connection timerConnection;
 
 	Private(Updater *_q, Mode _mode, bool _quiet, const QString &_currentVersion, const QString &_org, ZhttpManager *zhttp) :
-		QObject(_q),
 		q(_q),
 		mode(_mode),
 		quiet(_quiet),
@@ -242,8 +241,7 @@ private:
 	}
 };
 
-Updater::Updater(Mode mode, bool quiet, const QString &currentVersion, const QString &org, ZhttpManager *zhttp, QObject *parent) :
-	QObject(parent)
+Updater::Updater(Mode mode, bool quiet, const QString &currentVersion, const QString &org, ZhttpManager *zhttp)
 {
 	d = new Private(this, mode, quiet, currentVersion, org, zhttp);
 }

--- a/src/proxy/updater.h
+++ b/src/proxy/updater.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,17 +24,16 @@
 #ifndef UPDATER_H
 #define UPDATER_H
 
-#include <QObject>
 #include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
 
+class QString;
+
 class ZhttpManager;
 
-class Updater : public QObject
+class Updater
 {
-	Q_OBJECT
-
 public:
 	enum Mode
 	{
@@ -60,7 +60,7 @@ public:
 		}
 	};
 
-	Updater(Mode mode, bool quiet, const QString &currentVersion, const QString &org, ZhttpManager *zhttp, QObject *parent = 0);
+	Updater(Mode mode, bool quiet, const QString &currentVersion, const QString &org, ZhttpManager *zhttp);
 	~Updater();
 
 	void setReport(const Report &report);

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -80,7 +80,6 @@ public:
 	Connection refreshTimerConnection;
 
 	Private(WsControlManager *_q) :
-		QObject(_q),
 		q(_q),
 		ipcFileMode(-1),
 		currentSessionRefreshBucket(0)

--- a/src/proxy/wscontrolmanager.h
+++ b/src/proxy/wscontrolmanager.h
@@ -25,15 +25,12 @@
 #define WSCONTROLMANAGER_H
 
 #include <memory>
-#include <QObject>
 #include "packet/wscontrolpacket.h"
 
 class WsControlSession;
 
-class WsControlManager : public QObject
+class WsControlManager
 {
-	Q_OBJECT
-
 public:
 	WsControlManager();
 	~WsControlManager();

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -59,7 +59,6 @@ public:
 	Connection requestTimerConnection;
 
 	Private(WsControlSession *_q) :
-		QObject(_q),
 		q(_q),
 		manager(0),
 		nextReqId(0),

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -25,20 +25,17 @@
 #define WSCONTROLSESSION_H
 
 #include <QByteArray>
-#include <QObject>
+#include <boost/signals2.hpp>
 #include "websocket.h"
 #include "wscontrol.h"
 #include "packet/wscontrolpacket.h"
-#include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 
 class WsControlManager;
 
-class WsControlSession : public QObject
+class WsControlSession
 {
-	Q_OBJECT
-
 public:
 	~WsControlSession();
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -316,7 +316,6 @@ public:
 	InWSConnections inWSConnection;
 
 	Private(WsProxySession *_q, ZRoutes *_zroutes, ConnectionManager *_connectionManager, const LogUtil::Config &_logConfig, StatsManager *_statsManager, WsControlManager *_wsControlManager) :
-		QObject(_q),
 		q(_q),
 		state(Idle),
 		zroutes(_zroutes),
@@ -1162,8 +1161,7 @@ private:
 	}
 };
 
-WsProxySession::WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager, const LogUtil::Config &logConfig, StatsManager *statsManager, WsControlManager *wsControlManager, QObject *parent) :
-	QObject(parent)
+WsProxySession::WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager, const LogUtil::Config &logConfig, StatsManager *statsManager, WsControlManager *wsControlManager)
 {
 	d = new Private(this, zroutes, connectionManager, logConfig, statsManager, wsControlManager);
 }

--- a/src/proxy/wsproxysession.h
+++ b/src/proxy/wsproxysession.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2022 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,7 +24,6 @@
 #ifndef WSPROXYSESSION_H
 #define WSPROXYSESSION_H
 
-#include <QObject>
 #include "callback.h"
 #include "logutil.h"
 #include "domainmap.h"
@@ -44,12 +44,10 @@ class StatsManager;
 class ConnectionManager;
 class XffRule;
 
-class WsProxySession : public QObject
+class WsProxySession
 {
-	Q_OBJECT
-
 public:
-	WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager, const LogUtil::Config &logConfig, StatsManager *stats = 0, WsControlManager *wsControlManager = 0, QObject *parent = 0);
+	WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager, const LogUtil::Config &logConfig, StatsManager *stats = 0, WsControlManager *wsControlManager = 0);
 	~WsProxySession();
 
 	QHostAddress logicalClientAddress() const;

--- a/src/proxy/zroutes.cpp
+++ b/src/proxy/zroutes.cpp
@@ -96,7 +96,6 @@ public:
 	Connection cleanupTimerConnection;
 
 	Private(ZRoutes *_q) :
-		QObject(_q),
 		q(_q),
 		defaultItem(0)
 	{
@@ -194,8 +193,7 @@ public:
 	}
 };
 
-ZRoutes::ZRoutes(QObject *parent) :
-	QObject(parent)
+ZRoutes::ZRoutes()
 {
 	d = new Private(this);
 }

--- a/src/proxy/zroutes.h
+++ b/src/proxy/zroutes.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,16 +24,13 @@
 #ifndef ZROUTES_H
 #define ZROUTES_H
 
-#include <QObject>
 #include "zhttpmanager.h"
 #include "domainmap.h"
 
-class ZRoutes : public QObject
+class ZRoutes
 {
-	Q_OBJECT
-
 public:
-	ZRoutes(QObject *parent = 0);
+	ZRoutes();
 	~ZRoutes();
 
 	void setInstanceId(const QByteArray &id);

--- a/src/proxy/zrpcchecker.cpp
+++ b/src/proxy/zrpcchecker.cpp
@@ -69,7 +69,6 @@ public:
 	Connection timerConnection;
 
 	Private(ZrpcChecker *_q) :
-		QObject(_q),
 		q(_q),
 		avail(true)
 	{
@@ -218,8 +217,7 @@ public:
 	}
 };
 
-ZrpcChecker::ZrpcChecker(QObject *parent) :
-	QObject(parent)
+ZrpcChecker::ZrpcChecker()
 {
 	d = new Private(this);
 }

--- a/src/proxy/zrpcchecker.h
+++ b/src/proxy/zrpcchecker.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -23,7 +24,6 @@
 #ifndef ZRPCCHECKER_H
 #define ZRPCCHECKER_H
 
-#include <QObject>
 #include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
@@ -34,12 +34,10 @@ class ZrpcRequest;
 //   watch() to have it monitor a request, but not own it. use give() to have
 //   this class take ownership of an already-watched request.
 
-class ZrpcChecker : public QObject
+class ZrpcChecker
 {
-	Q_OBJECT
-
 public:
-	ZrpcChecker(QObject *parent = 0);
+	ZrpcChecker();
 	~ZrpcChecker();
 
 	bool isInterfaceAvailable() const;


### PR DESCRIPTION
After #48184 we are no longer using parenting, so we can remove the ability.