### PR TITLE
proxy: remove most uses of QObject

### DIFF
--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -340,10 +340,8 @@ private:
 	}
 };
 
-class App::Private : public QObject
+class App::Private
 {
-	Q_OBJECT
-
 public:
 	App *q;
 	ArgsData args;
@@ -675,7 +673,6 @@ private:
 			t->routesChanged();
 	}
 
-private slots:
 	void reload()
 	{
 		log_info("reloading");

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -60,10 +60,8 @@
 
 #define DEFAULT_HWM 1000
 
-class Engine::Private : public QObject
+class Engine::Private
 {
-	Q_OBJECT
-
 public:
 	class ProxyItem
 	{
@@ -1082,5 +1080,3 @@ void Engine::routesChanged()
 {
 	d->routesChanged();
 }
-
-#include "engine.moc"

--- a/src/proxy/inspectrequest.cpp
+++ b/src/proxy/inspectrequest.cpp
@@ -103,10 +103,8 @@ static InspectData resultToData(const QVariant &in, bool *ok)
 	return out;
 }
 
-class InspectRequest::Private : public QObject
+class InspectRequest::Private
 {
-	Q_OBJECT
-
 public:
 	InspectRequest *q;
 	InspectData idata;
@@ -174,5 +172,3 @@ void InspectRequest::onSuccess()
 		return;
 	}
 }
-
-#include "inspectrequest.moc"

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -57,10 +57,8 @@ using std::map;
 #define MAX_INITIAL_BUFFER 100000
 #define MAX_STREAM_BUFFER 100000
 
-class ProxySession::Private : public QObject
+class ProxySession::Private
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -1544,5 +1542,3 @@ void ProxySession::add(RequestSession *rs)
 {
 	d->add(rs);
 }
-
-#include "proxysession.moc"

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -128,10 +128,8 @@ static QByteArray ridToString(const QPair<QByteArray, QByteArray> &rid)
 	return rid.first + ':' + rid.second;
 }
 
-class RequestSession::Private : public QObject
+class RequestSession::Private
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -1414,5 +1412,3 @@ int RequestSession::unregisterConnection()
 	QByteArray cid = ridToString(d->rid);
 	return d->stats->removeConnection(cid, false);
 }
-
-#include "requestsession.moc"

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -72,10 +72,8 @@ static QByteArray serializeJsonString(const QString &s)
 	return tmp.mid(1, tmp.length() - 2);
 }
 
-class SockJsManager::Private : public QObject
+class SockJsManager::Private
 {
-	Q_OBJECT
-
 public:
 	class Session
 	{
@@ -737,5 +735,3 @@ void SockJsManager::respond(ZhttpRequest *req, int code, const QByteArray &reaso
 {
 	d->respond(req, code, reason, headers, body);
 }
-
-#include "sockjsmanager.moc"

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -44,10 +44,8 @@ using std::map;
 #define KEEPALIVE_TIMEOUT 25
 #define UNCONNECTED_TIMEOUT 5
 
-class SockJsSession::Private : public QObject
+class SockJsSession::Private
 {
-	Q_OBJECT
-
 public:
 	enum Mode
 	{
@@ -1355,5 +1353,3 @@ void SockJsSession::handleRequest(ZhttpRequest *req, const QByteArray &jsonpCall
 {
 	d->handleRequest(req, jsonpCallback, lastPart, body);
 }
-
-#include "sockjssession.moc"

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -34,10 +34,8 @@
 
 #define MAX_REQUEST_SIZE 100000
 
-class TestHttpRequest::Private : public QObject
+class TestHttpRequest::Private
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -311,5 +309,3 @@ QByteArray TestHttpRequest::readBody(int size)
 {
 	return d->responseBody.take(size);
 }
-
-#include "testhttprequest.moc"

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -34,10 +34,8 @@
 
 #define BUFFER_SIZE 200000
 
-class TestWebSocket::Private : public QObject
+class TestWebSocket::Private
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -330,5 +328,3 @@ void TestWebSocket::close(int code, const QString &reason)
 
 	d->deferCall.defer([=] { d->handleClose(); });
 }
-
-#include "testwebsocket.moc"

--- a/src/proxy/updater.cpp
+++ b/src/proxy/updater.cpp
@@ -67,10 +67,8 @@ static QString getArch()
 	return QString::number(sizeof(void *) * 8);
 }
 
-class Updater::Private : public QObject
+class Updater::Private
 {
-	Q_OBJECT
-
 public:
 	struct ReqConnections {
 		Connection readyReadConnection;
@@ -263,5 +261,3 @@ void Updater::setReport(const Report &report)
 	d->report.messagesSent += report.messagesSent;
 	d->report.ops += report.ops;
 }
-
-#include "updater.moc"

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -177,10 +177,8 @@ static QByteArray encodeEvents(const QList<WebSocketOverHttp::Event> &events)
 	return out;
 }
 
-class WebSocketOverHttp::Private : public QObject
+class WebSocketOverHttp::Private
 {
-	Q_OBJECT
-
 public:
 	struct ReqConnections {
 		Connection readyReadConnection;
@@ -1344,5 +1342,3 @@ int WebSocketOverHttp::removeContentFromFrames(QList<WebSocket::Frame> *frames, 
 
 	return (count - left);
 }
-
-#include "websocketoverhttp.moc"

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -49,10 +49,8 @@
 
 using Connection = boost::signals2::scoped_connection;
 
-class WsControlManager::Private : public QObject
+class WsControlManager::Private
 {
-	Q_OBJECT
-
 public:
 	class KeepAliveRegistration
 	{
@@ -483,5 +481,3 @@ void WsControlManager::unregisterKeepAlive(WsControlSession *s)
 {
 	d->unregisterKeepAlive(s);
 }
-
-#include "wscontrolmanager.moc"

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -35,10 +35,8 @@
 
 using Connection = boost::signals2::scoped_connection;
 
-class WsControlSession::Private : public QObject
+class WsControlSession::Private
 {
-	Q_OBJECT
-
 public:
 	WsControlSession *q;
 	WsControlManager *manager;
@@ -375,5 +373,3 @@ void WsControlSession::handle(const QByteArray &from, const WsControlPacket::Ite
 
 	d->handle(from, item);
 }
-
-#include "wscontrolsession.moc"

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -219,10 +219,8 @@ static HttpExtension getExtension(const QList<QByteArray> &extStrings, const QBy
 	return e;
 }
 
-class WsProxySession::Private : public QObject
+class WsProxySession::Private
 {
-	Q_OBJECT
-
 public:
 	enum State
 	{
@@ -1253,5 +1251,3 @@ Callback<std::tuple<WsProxySession *>> & WsProxySession::finishedByPassthroughCa
 {
 	return d->finishedByPassthroughCallback;
 }
-
-#include "wsproxysession.moc"

--- a/src/proxy/zroutes.cpp
+++ b/src/proxy/zroutes.cpp
@@ -62,10 +62,8 @@ static QStringList baseSpecToSpecs(const QString &baseSpec)
 	}
 }
 
-class ZRoutes::Private : public QObject
+class ZRoutes::Private
 {
-	Q_OBJECT
-
 public:
 	class Item
 	{
@@ -293,5 +291,3 @@ void ZRoutes::removeRef(ZhttpManager *zhttpManager)
 	assert(i->refs > 0);
 	--(i->refs);
 }
-
-#include "zroutes.moc"

--- a/src/proxy/zrpcchecker.cpp
+++ b/src/proxy/zrpcchecker.cpp
@@ -32,10 +32,8 @@
 
 using std::map;
 
-class ZrpcChecker::Private : public QObject
+class ZrpcChecker::Private
 {
-	Q_OBJECT
-
 public:
 	class Item
 	{
@@ -246,5 +244,3 @@ void ZrpcChecker::give(ZrpcRequest *req)
 {
 	d->give(req);
 }
-
-#include "zrpcchecker.moc"


### PR DESCRIPTION
This removes almost all remaining uses of `QObject` from proxy, except for a few related to `QFileSystemWatcher`, `QThread`, and cross-thread deferred calls.