### PR TITLE
fix clippy warnings on latest rust

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -158,5 +158,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
+    - name: cargo fetch
+      run: cargo +${{ matrix.rust-version }} fetch
     - name: build release
       run: TOOLCHAIN=${{ matrix.rust-version }} RELEASE=1 RUSTFLAGS="-D warnings" make build

--- a/src/connmgr/resolver.rs
+++ b/src/connmgr/resolver.rs
@@ -332,10 +332,7 @@ impl<'a> AsyncResolver<'a> {
     }
 
     pub fn resolve(&self, host: &str) -> QueryFuture {
-        let query = match self.resolver.resolve(host) {
-            Ok(q) => Some(q),
-            Err(()) => None,
-        };
+        let query = self.resolver.resolve(host).ok();
 
         QueryFuture {
             evented: None,


### PR DESCRIPTION
`fanout/build-base:latest` has been updated to 1.86.0.