### PR TITLE
runner: convert tests to new style

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,6 @@ pub mod ffi {
         pub fn publishformat_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn publishitem_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn handlerengine_test(out_ex: *mut TestException) -> libc::c_int;
-        pub fn template_test(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
+        pub fn template_test(out_ex: *mut TestException) -> libc::c_int;
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -545,11 +545,11 @@ fn parse_log_levels(log_levels: Vec<String>) -> Result<HashMap<String, u8>, Box<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{call_c_main, ensure_example_config, qtest, test_dir};
+    use crate::core::test::TestException;
+    use crate::core::{ensure_example_config, qtest, test_dir};
     use crate::ffi;
     use std::collections::HashMap;
     use std::error::Error;
-    use std::ffi::OsStr;
     use std::net::SocketAddr;
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::PathBuf;
@@ -906,14 +906,14 @@ mod tests {
         }
     }
 
-    fn template_test(args: &[&OsStr]) -> u8 {
+    fn template_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
-        unsafe { call_c_main(ffi::template_test, args) as u8 }
+        unsafe { ffi::template_test(out_ex) == 0 }
     }
 
     #[test]
     fn template() {
-        assert!(qtest::run(template_test));
+        qtest::run_no_main(template_test);
     }
 }
 

--- a/src/runner/templatetest.cpp
+++ b/src/runner/templatetest.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -20,59 +21,43 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <QtTest/QtTest>
+#include "test.h"
 #include "template.h"
 
-class TemplateTest : public QObject
+void render()
 {
-	Q_OBJECT
+	QVariantMap context;
+	context["place"] = "world";
 
-private slots:
-	void render()
-	{
-		QVariantMap context;
-		context["place"] = "world";
+	QVariantMap user;
+	user["first"] = "john";
+	user["last"] = "smith";
+	context["user"] = user;
 
-		QVariantMap user;
-		user["first"] = "john";
-		user["last"] = "smith";
-		context["user"] = user;
+	QVariantList fruits;
+	fruits.append("apple");
+	fruits.append("banana");
+	context["fruits"] = fruits;
 
-		QVariantList fruits;
-		fruits.append("apple");
-		fruits.append("banana");
-		context["fruits"] = fruits;
+	QString content("hello {{ place }}!");
+	QString output = Template::render(content, context);
+	TEST_ASSERT_EQ(output, QString("hello world!"));
 
-		QString content("hello {{ place }}!");
-		QString output = Template::render(content, context);
-		QCOMPARE(output, QString("hello world!"));
+	content = QString("hello {% if formal %}{{ user.last }}{% endif %}{% if not formal %}{{ user.first }}{% endif %}!");
+	output = Template::render(content, context);
+	TEST_ASSERT_EQ(output, QString("hello john!"));
+	context["formal"] = true;
+	output = Template::render(content, context);
+	TEST_ASSERT_EQ(output, QString("hello smith!"));
 
-		content = QString("hello {% if formal %}{{ user.last }}{% endif %}{% if not formal %}{{ user.first }}{% endif %}!");
-		output = Template::render(content, context);
-		QCOMPARE(output, QString("hello john!"));
-		context["formal"] = true;
-		output = Template::render(content, context);
-		QCOMPARE(output, QString("hello smith!"));
-
-		content = QString("please eat {% for f in fruits %}{% if not loop.first %} and {% endif %}fresh {{ f }}s{% endfor %}.");
-		output = Template::render(content, context);
-		QCOMPARE(output, QString("please eat fresh apples and fresh bananas."));
-	}
-};
-
-namespace {
-namespace Main {
-QTEST_MAIN(TemplateTest)
-}
+	content = QString("please eat {% for f in fruits %}{% if not loop.first %} and {% endif %}fresh {{ f }}s{% endfor %}.");
+	output = Template::render(content, context);
+	TEST_ASSERT_EQ(output, QString("please eat fresh apples and fresh bananas."));
 }
 
-extern "C" {
-
-int template_test(int argc, char **argv)
+extern "C" int template_test(ffi::TestException *out_ex)
 {
-	return Main::main(argc, argv);
-}
+	TEST_CATCH(render());
 
+	return 0;
 }
-
-#include "templatetest.moc"

--- a/src/runner/templatetest.cpp
+++ b/src/runner/templatetest.cpp
@@ -24,7 +24,7 @@
 #include "test.h"
 #include "template.h"
 
-void render()
+static void render()
 {
 	QVariantMap context;
 	context["place"] = "world";


### PR DESCRIPTION
This converts the last test that was using the Qt test harness. After this, we'll be able to remove any related support code.