### PR TITLE
filewatcher: return error if watch fails and fix init race

### DIFF
--- a/src/core/filewatcher.h
+++ b/src/core/filewatcher.h
@@ -19,6 +19,7 @@
 
 #include <boost/signals2.hpp>
 #include "socketnotifier.h"
+#include "defercall.h"
 #include "rust/bindings.h"
 
 class QString;
@@ -29,13 +30,14 @@ public:
 	FileWatcher();
 	~FileWatcher();
 
-	void start(const QString &filePath);
+	bool start(const QString &filePath);
 
 	boost::signals2::signal<void()> fileChanged;
 
 private:
 	ffi::FileWatcher *inner_;
 	std::unique_ptr<SocketNotifier> sn_;
+	DeferCall deferCall_;
 
 	void sn_activated(int socket, uint8_t readiness);
 };

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -317,7 +317,10 @@ public slots:
 		if(!fileName.isEmpty())
 		{
 			watcher.fileChanged.connect(boost::bind(&Worker::fileChanged, this));
-			watcher.start(fileName);
+
+			if(!watcher.start(fileName)) {
+				log_error("failed to watch %s", qPrintable(fileName));
+			}
 
 			reload();
 		}


### PR DESCRIPTION
A few tweaks around `FileWatcher`:

* Support relative input paths.
* If watch fails, return error instead of logging and returning success.
* Instead of asserting watch success in the C++ code, log error.
* Fix race between watcher starting notifications and socket notifier registration.