### PR TITLE
processquit: fix processing of more than one signal call

### DIFF
--- a/src/core/processquit.cpp
+++ b/src/core/processquit.cpp
@@ -114,6 +114,8 @@ public:
 
 	void sig_activated(int)
 	{
+		sig_notifier->clearReadiness(SocketNotifier::Read);
+
 		unsigned char c;
 		if(::read(sig_pipe[0], &c, 1) == -1)
 		{


### PR DESCRIPTION
This fixes a regression in `ProcessQuit` after we moved to `SocketNotifier`, which prevents processing more than one signal call. Mainly it affects the use of `SIGHUP`.