### PR TITLE
proxy: add option to use new event loop for main thread

### DIFF
--- a/src/handler/handlerapp.h
+++ b/src/handler/handlerapp.h
@@ -24,8 +24,6 @@
 #ifndef HANDLERAPP_H
 #define HANDLERAPP_H
 
-#include <memory>
-
 class HandlerApp
 {
 public:

--- a/src/proxy/app.h
+++ b/src/proxy/app.h
@@ -24,25 +24,16 @@
 #ifndef APP_H
 #define APP_H
 
-#include <boost/signals2.hpp>
-
-using SignalInt = boost::signals2::signal<void(int)>;
-using Connection = boost::signals2::scoped_connection;
-
 class App
 {
 public:
 	App();
 	~App();
 
-	void start();
-
-	SignalInt quit;
+	int run();
 
 private:
 	class Private;
-	friend class Private;
-	Private *d;
 };
 
 #endif

--- a/src/proxy/main.cpp
+++ b/src/proxy/main.cpp
@@ -23,28 +23,6 @@
 
 #include <QCoreApplication>
 #include "app.h"
-#include "timer.h"
-#include "defercall.h"
-
-class AppMain
-{
-public:
-	App *app;
-
-	void start()
-	{
-		app = new App;
-		app->quit.connect(boost::bind(&AppMain::app_quit, this, boost::placeholders::_1));
-		app->start();
-	}
-
-private:
-	void app_quit(int returnCode)
-	{
-		delete app;
-		QCoreApplication::exit(returnCode);
-	}
-};
 
 extern "C" {
 
@@ -52,22 +30,8 @@ int proxy_main(int argc, char **argv)
 {
 	QCoreApplication qapp(argc, argv);
 
-	// plenty for the main thread
-	Timer::init(100);
-
-	AppMain appMain;
-	DeferCall deferCall;
-	deferCall.defer([&] { appMain.start(); });
-	int ret = qapp.exec();
-
-	// ensure deferred deletes are processed
-	QCoreApplication::instance()->sendPostedEvents();
-
-	// deinit here, after all event loop activity has completed
-	DeferCall::cleanup();
-	Timer::deinit();
-
-	return ret;
+	App app;
+	return app.run();
 }
 
 }


### PR DESCRIPTION
This reworks the proxy similar to what was done to the handler in #48137 and #48138, to make it possible to try out the new event loop without fully committing to it yet.

I've done some basic testing of common flows (start/stop/reload) and things look ok so far.

Note that unlike the handler which is single-threaded and runs everything in the main/only thread, the proxy is multithreaded and this PR only updates its main thread to be able to use the new event loop. The proxy's other threads (for domainmap and engine workers) still always use the Qt event loop.