### PR TITLE
proxy: add support for new event loop in engine and domainmap threads

### DIFF
--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -409,9 +409,9 @@ private:
 		{
 			log_debug("using new event loop");
 
-			// enough for control requests and prometheus requests. client
-			// sessions don't use socket notifiers
-			int socketNotifiersMax = SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX);
+			// enough for control requests and prometheus requests, plus an
+			// extra 100 for misc. client sessions don't use socket notifiers
+			int socketNotifiersMax = (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX)) + 100;
 
 			int registrationsMax = timersMax + socketNotifiersMax;
 			loop = std::make_unique<EventLoop>(registrationsMax);

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -179,8 +179,8 @@ public:
 		}
 	};
 
-	DomainMap();
-	DomainMap(const QString &fileName);
+	DomainMap(bool newEventLoop);
+	DomainMap(const QString &fileName, bool newEventLoop);
 	~DomainMap();
 
 	// shouldn't really ever need to call this, but it's here in case the

--- a/src/proxy/engine.h
+++ b/src/proxy/engine.h
@@ -42,6 +42,9 @@
 // each zroute has a zhttpmanager, which has up to 8 timers
 #define TIMERS_PER_ZROUTE 10
 
+// each zroute has a zhttpmanager, which has up to 8 socket notifiers
+#define SOCKETNOTIFIERS_PER_ZROUTE 10
+
 #define PROMETHEUS_CONNECTIONS_MAX 16
 #define ZROUTES_MAX 100
 

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -580,7 +580,7 @@ public:
 		wrapper = new Wrapper(workDir);
 		wrapper->startHttp();
 
-		domainMap = new DomainMap(configDir.filePath("routes.test"));
+		domainMap = new DomainMap(configDir.filePath("routes.test"), false);
 
 		engine = new Engine(domainMap);
 


### PR DESCRIPTION
Following #48207, this makes the `new_event_loop=true` setting cause the new event loop to be used in the proxy's other threads too, not only the main thread.

I've done some basic testing of common flows (start/stop, passthrough, websocket-over-http, accept/retry) and things look ok so far.