### PR TITLE
filewatcher: only act on change events

### DIFF
--- a/src/core/fs.rs
+++ b/src/core/fs.rs
@@ -234,6 +234,13 @@ impl FileWatcher {
                     return;
                 }
 
+                match event.kind {
+                    notify::EventKind::Create(_)
+                    | notify::EventKind::Modify(_)
+                    | notify::EventKind::Remove(_) => {}
+                    _ => return, // skip non-change events
+                }
+
                 let mut state = data
                     .state
                     .lock()


### PR DESCRIPTION
On Linux, I'm seeing [`Access`](https://docs.rs/notify/latest/notify/enum.EventKind.html#variant.Access) events (e.g. the watched file was opened), which we should ignore.