### PR TITLE
eventloop: fix panic during dispatch

### DIFF
--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -164,26 +164,14 @@ impl<C: Callback> Registrations<C> {
     }
 
     fn dispatch_activated(&self) {
-        // move the current list aside so we only process registrations that
-        // have been activated up to this point, and not registrations that
-        // might get activated during the course of calling callbacks
-        let mut activated = {
-            let data = &mut *self.data.borrow_mut();
-
-            let mut l = list::List::default();
-            l.concat(&mut data.nodes, &mut data.activated);
-
-            l
-        };
-
         // call the callback of each activated registration, ensuring we
         // release borrows before each call. this way, callbacks can access
-        // the eventloop, for example to add registrations
+        // the eventloop, for example to add or remove registrations
         loop {
             let (nkey, mut callback, readiness) = {
                 let data = &mut *self.data.borrow_mut();
 
-                let nkey = match activated.pop_front(&mut data.nodes) {
+                let nkey = match data.activated.pop_front(&mut data.nodes) {
                     Some(nkey) => nkey,
                     None => break,
                 };


### PR DESCRIPTION
This fixes a panic in `dispatch_activated()` when an activated registration is removed while processing registrations. The problem is the content of the `activated` list is moved into a temporary, which `Registrations::remove()` doesn't take into consideration. We can fix this by simply not moving the content of `activated` and instead processing it directly. The original reason for moving it aside is so it can't be appended to while we are processing it, but this can't happen anyway: the `activated` list is only appended to during `reactor.poll()`, which is called outside of `dispatch_activated()`.