### PR TITLE
use c++ std::thread instead of QThread

### DIFF
--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -27,9 +27,8 @@
 #include <memory>
 #include <list>
 #include <unordered_map>
+#include <thread>
 #include <mutex>
-
-class QThread;
 
 // queues calls to be run after returning to the event loop
 class DeferCall
@@ -84,13 +83,13 @@ private:
 	class Manager;
 	friend class Manager;
 
-	QThread *thread_;
+	std::thread::id thread_;
 	std::shared_ptr<CallsList> deferredCalls_;
 
 	static thread_local std::shared_ptr<Manager> localManager;
 	static thread_local std::unique_ptr<DeferCall> localInstance;
 
-	static std::unordered_map<QThread*, std::shared_ptr<Manager>> managerByThread;
+	static std::unordered_map<std::thread::id, std::shared_ptr<Manager>> managerByThread;
 	static std::mutex managerByThreadMutex;
 };
 

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -20,6 +20,8 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include <chrono>
+#include <thread>
 #include <QHostAddress>
 #include "test.h"
 #include "timer.h"
@@ -27,6 +29,8 @@
 #include "eventloop.h"
 #include "tcplistener.h"
 #include "tcpstream.h"
+
+using namespace std::chrono_literals;
 
 static void runAccept(std::function<void ()> loop_wait)
 {
@@ -267,7 +271,7 @@ static void accept()
 	EventLoop loop(100);
 
 	runAccept([&] {
-		QThread::msleep(10);
+		std::this_thread::sleep_for(10ms);
 		loop.step();
 	});
 
@@ -290,7 +294,7 @@ static void io()
 	EventLoop loop(100);
 
 	runIo([&] {
-		QThread::msleep(10);
+		std::this_thread::sleep_for(10ms);
 		loop.step();
 	});
 

--- a/src/core/unixstreamtest.cpp
+++ b/src/core/unixstreamtest.cpp
@@ -20,6 +20,8 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include <chrono>
+#include <thread>
 #include <QHostAddress>
 #include "test.h"
 #include "timer.h"
@@ -27,6 +29,8 @@
 #include "eventloop.h"
 #include "unixlistener.h"
 #include "unixstream.h"
+
+using namespace std::chrono_literals;
 
 static void runAccept(std::function<void ()> loop_wait)
 {
@@ -275,7 +279,7 @@ static void accept()
 	EventLoop loop(100);
 
 	runAccept([&] {
-		QThread::msleep(10);
+		std::this_thread::sleep_for(10ms);
 		loop.step();
 	});
 
@@ -298,7 +302,7 @@ static void io()
 	EventLoop loop(100);
 
 	runIo([&] {
-		QThread::msleep(10);
+		std::this_thread::sleep_for(10ms);
 		loop.step();
 	});
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -21,6 +21,8 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include <chrono>
+#include <thread>
 #include <QDir>
 #include "test.h"
 #include "qzmqsocket.h"
@@ -36,6 +38,8 @@
 #include "defercall.h"
 #include "eventloop.h"
 #include "handlerengine.h"
+
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -313,7 +317,7 @@ static void runWithEventLoops(std::function<void (Wrapper *, std::function<void 
 		auto loop_wait = [&](int ms) {
 			for(int i = ms; i > 0; i -= 10)
 			{
-				QThread::msleep(10);
+				std::this_thread::sleep_for(10ms);
 				loop.step();
 			}
 		};


### PR DESCRIPTION
This removes the need to subclass `QThread` and thus avoids some remaining uses of `moc` (Qt Meta Object Compiler).