### PR TITLE
make retry/recovery optional on first subscriptions

### DIFF
--- a/examples/config/pushpin.conf
+++ b/examples/config/pushpin.conf
@@ -157,6 +157,9 @@ message_wait=5000
 # time (seconds) to cache message ids
 id_cache_ttl=60
 
+# retry/recover sessions soon after the first subscription to a channel
+update_on_first_subscription=true
+
 # max subscriptions per connection
 connection_subscription_max=20
 

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -314,6 +314,7 @@ public:
 		int messageBlockSize = settings.value("handler/message_block_size", -1).toInt();
 		int messageWait = settings.value("handler/message_wait", 5000).toInt();
 		int idCacheTtl = settings.value("handler/id_cache_ttl", 0).toInt();
+		bool updateOnFirstSubscription = settings.value("handler/update_on_first_subscription", true).toBool();
 		int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
 		int connectionSubscriptionMax = settings.value("handler/connection_subscription_max", 20).toInt();
 		int subscriptionLinger = settings.value("handler/subscription_linger", 60).toInt();
@@ -378,6 +379,7 @@ public:
 		config.messageBlockSize = messageBlockSize;
 		config.messageWait = messageWait;
 		config.idCacheTtl = idCacheTtl;
+		config.updateOnFirstSubscription = updateOnFirstSubscription;
 		config.connectionsMax = clientMaxconn;
 		config.connectionSubscriptionMax = connectionSubscriptionMax;
 		config.subscriptionLinger = subscriptionLinger;

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -2316,7 +2316,8 @@ private:
 	
 	void sub_subscribed(Subscription *sub)
 	{
-		updateSessions(sub->channel());
+		if(config.updateOnFirstSubscription)
+			updateSessions(sub->channel());
 	}
 
 	void acceptWorker_sessionsReady(AcceptWorker *w)

--- a/src/handler/handlerengine.h
+++ b/src/handler/handlerengine.h
@@ -75,6 +75,7 @@ public:
 		int messageBlockSize;
 		int messageWait;
 		int idCacheTtl;
+		bool updateOnFirstSubscription;
 		int connectionsMax;
 		int connectionSubscriptionMax;
 		int subscriptionLinger;
@@ -98,6 +99,7 @@ public:
 			messageBlockSize(-1),
 			messageWait(-1),
 			idCacheTtl(-1),
+			updateOnFirstSubscription(false),
 			connectionsMax(-1),
 			connectionSubscriptionMax(-1),
 			subscriptionLinger(-1),


### PR DESCRIPTION
Normally, whenever a channel gains its first subscribing session, a short moment later every session subscribed to that channel will have its retry or recovery mechanism invoked. (Note: often this is not many sessions since it is only triggered when the number of sessions for the channel goes from zero to one.)

This behavior exists to work around a race between subscription notifications and the next message being published to the channel, in environments where messages are only relayed to Pushpin for known subscriptions. However, this behavior may not be desirable in all environments, for example where messages are sent to Pushpin unconditionally, or where the side effects of the race are tolerable. This PR makes it optional.