### PR TITLE
connmgr: add ability to handle responses via router instead of sub

### DIFF
--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -286,6 +286,10 @@ fn make_zhttp_request(
         data.stream = true;
     }
 
+    if mode == Mode::HttpStream || mode == Mode::WebSocket {
+        data.router_resp = true;
+    }
+
     data.credits = credits;
 
     let mut addr = [0; 128];
@@ -7684,10 +7688,10 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T179:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T201:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,23:http://example.com/path,7:hea",
             "ders,26:22:4:Host,11:example.com,]]7:credits,4:1024#6:stre",
-            "am,4:true!}",
+            "am,4:true!11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -7812,10 +7816,11 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T220:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T242:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,4:POST,3:uri,23:http://example.com/path,7:he",
             "aders,52:22:4:Host,11:example.com,]22:14:Content-Length,1:",
-            "6,]]7:credits,4:1024#4:more,4:true!6:stream,4:true!}",
+            "6,]]7:credits,4:1024#4:more,4:true!6:stream,4:true!11:rout",
+            "er-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -7967,10 +7972,10 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T179:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T201:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,23:http://example.com/path,7:hea",
             "ders,26:22:4:Host,11:example.com,]]7:credits,4:1024#6:stre",
-            "am,4:true!}",
+            "am,4:true!11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -8114,10 +8119,11 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T220:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T242:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,4:POST,3:uri,23:http://example.com/path,7:he",
             "aders,52:22:4:Host,11:example.com,]22:14:Content-Length,1:",
-            "6,]]7:credits,4:1024#4:more,4:true!6:stream,4:true!}",
+            "6,]]7:credits,4:1024#4:more,4:true!6:stream,4:true!11:rout",
+            "er-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -8214,10 +8220,10 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T179:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T201:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,23:http://example.com/path,7:hea",
             "ders,26:22:4:Host,11:example.com,]]7:credits,4:1024#6:stre",
-            "am,4:true!}",
+            "am,4:true!11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -8381,10 +8387,10 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T179:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T201:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,23:http://example.com/path,7:hea",
             "ders,26:22:4:Host,11:example.com,]]7:credits,4:1024#6:stre",
-            "am,4:true!}",
+            "am,4:true!11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -8497,11 +8503,11 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T255:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T277:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,21:ws://example.com/path,7:heade",
             "rs,119:22:4:Host,11:example.com,]22:7:Upgrade,9:websocket,",
             "]30:21:Sec-WebSocket-Version,2:13,]29:17:Sec-WebSocket-Key",
-            ",5:abcde,]]7:credits,4:1024#}",
+            ",5:abcde,]]7:credits,4:1024#11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -8669,12 +8675,12 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T309:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T331:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,21:ws://example.com/path,7:heade",
             "rs,173:22:4:Host,11:example.com,]22:7:Upgrade,9:websocket,",
             "]30:21:Sec-WebSocket-Version,2:13,]29:17:Sec-WebSocket-Key",
             ",5:abcde,]50:24:Sec-WebSocket-Extensions,18:permessage-def",
-            "late,]]7:credits,4:1024#}",
+            "late,]]7:credits,4:1024#11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);
@@ -8862,11 +8868,11 @@ mod tests {
         let buf = &msg[..];
 
         let expected = concat!(
-            "T255:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
+            "T277:4:from,4:test,2:id,1:1,3:seq,1:0#3:ext,15:5:multi,4:t",
             "rue!}6:method,3:GET,3:uri,21:ws://example.com/path,7:heade",
             "rs,119:22:4:Host,11:example.com,]22:7:Upgrade,9:websocket,",
             "]30:21:Sec-WebSocket-Version,2:13,]29:17:Sec-WebSocket-Key",
-            ",5:abcde,]]7:credits,4:1024#}",
+            ",5:abcde,]]7:credits,4:1024#11:router-resp,4:true!}",
         );
 
         assert_eq!(str::from_utf8(buf).unwrap(), expected);

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -2408,6 +2408,13 @@ impl TestServer {
 
         w.start_array()?;
 
+        if !prefix_addr {
+            w.start_array()?;
+            w.write_string(b"Response-Path")?;
+            w.write_string(b"router")?;
+            w.end_array()?;
+        }
+
         w.start_array()?;
         w.write_string(b"Content-Length")?;
         w.write_string(b"6")?;
@@ -2900,7 +2907,7 @@ pub mod tests {
 
         assert_eq!(
             str::from_utf8(&buf).unwrap(),
-            "HTTP/1.0 200 OK\r\nContent-Length: 6\r\n\r\nworld\n"
+            "HTTP/1.0 200 OK\r\nResponse-Path: router\r\nContent-Length: 6\r\n\r\nworld\n"
         );
 
         // stream (ws)

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -1513,21 +1513,27 @@ impl Worker {
                     }
                     // stream_handle.recv
                     Select8::R8(result) => match result {
-                        Ok((msg, _from_router)) => {
+                        Ok((msg, from_router)) => {
                             let msg_data = &msg.get()[..];
 
-                            let (addr, offset) = match get_addr_and_offset(msg_data) {
-                                Ok(ret) => ret,
-                                Err(_) => {
-                                    warn!("server-worker {}: packet has unexpected format", id);
+                            let offset = if from_router {
+                                0
+                            } else {
+                                let (addr, offset) = match get_addr_and_offset(msg_data) {
+                                    Ok(ret) => ret,
+                                    Err(_) => {
+                                        warn!("server-worker {}: packet has unexpected format", id);
+                                        continue;
+                                    }
+                                };
+
+                                if addr != *instance_id {
+                                    warn!("server-worker {}: packet not for us", id);
                                     continue;
                                 }
-                            };
 
-                            if addr != *instance_id {
-                                warn!("server-worker {}: packet not for us", id);
-                                continue;
-                            }
+                                offset
+                            };
 
                             let scratch = arena::Rc::new(
                                 RefCell::new(zhttppacket::ParseScratch::new()),
@@ -2368,12 +2374,16 @@ impl TestServer {
         Ok(zmq::Message::from(&dest[..size]))
     }
 
-    fn respond_stream(id: &[u8]) -> Result<zmq::Message, io::Error> {
+    fn respond_stream(prefix_addr: bool, id: &[u8]) -> Result<zmq::Message, io::Error> {
         let mut dest = [0; 1024];
 
         let mut cursor = io::Cursor::new(&mut dest[..]);
 
-        cursor.write_all(b"test T")?;
+        if prefix_addr {
+            cursor.write_all(b"test ")?;
+        }
+
+        cursor.write_all(b"T")?;
 
         let mut w = tnetstring::Writer::new(&mut cursor);
 
@@ -2634,6 +2644,7 @@ impl TestServer {
                 let mut id = "";
                 let mut method = "";
                 let mut uri = "";
+                let mut router_resp = false;
 
                 for f in tnetstring::parse_map(&msg[1..]).unwrap() {
                     let f = f.unwrap();
@@ -2651,8 +2662,15 @@ impl TestServer {
                             let s = tnetstring::parse_string(f.data).unwrap();
                             uri = str::from_utf8(s).unwrap();
                         }
+                        "router-resp" => {
+                            router_resp = tnetstring::parse_bool(f.data).unwrap();
+                        }
                         _ => {}
                     }
+                }
+
+                if !uri.contains("router-resp") {
+                    router_resp = false;
                 }
 
                 assert_eq!(method, "GET");
@@ -2661,8 +2679,15 @@ impl TestServer {
                     let msg = Self::respond_ws(id.as_bytes()).unwrap();
                     out_sock.send(msg, 0).unwrap();
                 } else {
-                    let msg = Self::respond_stream(id.as_bytes()).unwrap();
-                    out_sock.send(msg, 0).unwrap();
+                    let msg = Self::respond_stream(!router_resp, id.as_bytes()).unwrap();
+
+                    if router_resp {
+                        in_stream_sock
+                            .send_multipart([b"test".as_slice(), &[], &msg], 0)
+                            .unwrap();
+                    } else {
+                        out_sock.send(msg, 0).unwrap();
+                    }
                 }
             }
 
@@ -2853,6 +2878,21 @@ pub mod tests {
         let mut client = std::net::TcpStream::connect(&server.stream_addr()).unwrap();
         client
             .write(b"GET /hello HTTP/1.0\r\nHost: example.com\r\n\r\n")
+            .unwrap();
+
+        let mut buf = Vec::new();
+        client.read_to_end(&mut buf).unwrap();
+
+        assert_eq!(
+            str::from_utf8(&buf).unwrap(),
+            "HTTP/1.0 200 OK\r\nContent-Length: 6\r\n\r\nworld\n"
+        );
+
+        // stream (http) with responses via router
+
+        let mut client = std::net::TcpStream::connect(&server.stream_addr()).unwrap();
+        client
+            .write(b"GET /hello?router-resp HTTP/1.0\r\nHost: example.com\r\n\r\n")
             .unwrap();
 
         let mut buf = Vec::new();


### PR DESCRIPTION
Related to #48222, this completes the implementation in connmgr for receiving response data via router. After this, the proxy and handler will need to be updated to support sending response data this way.

Notably, the following changes are made:

1. All requests set the `router-resp` flag in the first packet to ask the peer to reply via the router socket.
2. If a received message is flagged as having come from the router socket, it is parsed as such (no address prefix) and then handled like any other message.
3. `TestServer` (used by the tests) is updated to be able to reply via router if the `router-resp` flag is set in the request and if the request also contains the string "router-resp" somewhere in the URI. Since the `router-resp` is flag is set in all requests, the tests can use different URIs to control whether `TestServer` honors the ask or not.