### PR TITLE
zhttpmanager: send messages via router if asked

### DIFF
--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -70,6 +70,9 @@ QVariant RetryRequestPacket::toVariant() const
 		vrequest["in-seq"] = r.inSeq;
 		vrequest["out-seq"] = r.outSeq;
 		vrequest["out-credits"] = r.outCredits;
+
+		if(r.routerResp)
+			vrequest["router-resp"] = r.routerResp;
 
 		if(r.userData.isValid())
 			vrequest["user-data"] = r.userData;
@@ -246,6 +249,14 @@ bool RetryRequestPacket::fromVariant(const QVariant &in)
 		if(!vrequest.contains("out-credits") || !canConvert(vrequest["out-credits"], QMetaType::Int))
 			return false;
 		r.outCredits = vrequest["out-credits"].toInt();
+
+		if(vrequest.contains("router-resp"))
+		{
+			if(typeId(vrequest["router-resp"]) != QMetaType::Bool)
+				return false;
+
+			r.routerResp = vrequest["router-resp"].toBool();
+		}
 
 		if(vrequest.contains("user-data"))
 			r.userData = vrequest["user-data"];

--- a/src/core/packet/retryrequestpacket.h
+++ b/src/core/packet/retryrequestpacket.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -49,6 +49,7 @@ public:
 		int inSeq;
 		int outSeq;
 		int outCredits;
+		bool routerResp;
 		QVariant userData;
 
 		Request() :
@@ -59,7 +60,8 @@ public:
 			unreportedTime(-1),
 			inSeq(-1),
 			outSeq(-1),
-			outCredits(-1)
+			outCredits(-1),
+			routerResp(false)
 		{
 		}
 	};

--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -88,10 +88,10 @@ private:
 	bool canWriteImmediately() const;
 	void writeHttp(const ZhttpRequestPacket &packet);
 	void writeHttp(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress);
-	void writeHttp(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress);
+	void writeHttp(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp);
 	void writeWs(const ZhttpRequestPacket &packet);
 	void writeWs(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress);
-	void writeWs(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress);
+	void writeWs(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp);
 
 	void registerKeepAlive(ZhttpRequest *req);
 	void unregisterKeepAlive(ZhttpRequest *req);

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -102,6 +102,7 @@ public:
 	std::unique_ptr<Timer> keepAliveTimer;
 	std::unique_ptr<Timer> finishTimer;
 	bool multi;
+	bool routerResp;
 	bool quiet;
 	DeferCall deferCall;
 
@@ -132,6 +133,7 @@ public:
 		writableChanged(false),
 		errored(false),
 		multi(false),
+		routerResp(false),
 		quiet(false)
 	{
 		expireTimer = std::make_unique<Timer>();
@@ -220,6 +222,9 @@ public:
 		if(packet.multi)
 			multi = true;
 
+		if(packet.routerResp)
+			routerResp = true;
+
 		if(!packet.more)
 			haveRequestBody = true;
 
@@ -239,6 +244,7 @@ public:
 			outSeq = ss.outSeq;
 		if(ss.outCredits >= 0)
 			outCredits = ss.outCredits;
+		routerResp = ss.routerResp;
 		userData = ss.userData;
 
 		if(ss.responseCode != -1)
@@ -853,7 +859,7 @@ public:
 		out.ids += ZhttpResponsePacket::Id(rid.second, outSeq++);
 		out.userData = userData;
 		
-		manager->writeHttp(out, rid.first);
+		manager->writeHttp(out, rid.first, routerResp);
 	}
 
 	void writeCancel()
@@ -1302,6 +1308,7 @@ ZhttpRequest::ServerState ZhttpRequest::serverState() const
 	ss.inSeq = d->inSeq;
 	ss.outSeq = d->outSeq;
 	ss.outCredits = d->outCredits;
+	ss.routerResp = d->routerResp;
 	ss.userData = d->userData;
 	return ss;
 }
@@ -1428,6 +1435,11 @@ bool ZhttpRequest::isServer() const
 QByteArray ZhttpRequest::toAddress() const
 {
 	return d->toAddress;
+}
+
+bool ZhttpRequest::routerResp() const
+{
+	return d->routerResp;
 }
 
 int ZhttpRequest::outSeqInc()

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -55,13 +55,15 @@ public:
 		int inSeq;
 		int outSeq;
 		int outCredits;
+		bool routerResp;
 		QVariant userData;
 
 		ServerState() :
 			responseCode(-1),
 			inSeq(-1),
 			outSeq(-1),
-			outCredits(-1)
+			outCredits(-1),
+			routerResp(false)
 		{
 		}
 	};
@@ -129,6 +131,7 @@ private:
 	void startServer();
 	bool isServer() const;
 	QByteArray toAddress() const;
+	bool routerResp() const;
 	int outSeqInc();
 	void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
 	void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet);

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -91,6 +91,7 @@ public:
 	int inContentType;
 	int outContentType;
 	bool multi;
+	bool routerResp;
 	DeferCall deferCall;
 
 	Private(ZWebSocket *_q) :
@@ -118,7 +119,8 @@ public:
 		outSize(0),
 		inContentType(-1),
 		outContentType((int)Frame::Text),
-		multi(false)
+		multi(false),
+		routerResp(false)
 	{
 		expireTimer = std::make_unique<Timer>();
 		expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
@@ -183,6 +185,9 @@ public:
 
 		if(packet.multi)
 			multi = true;
+
+		if(packet.routerResp)
+			routerResp = true;
 
 		return true;
 	}
@@ -762,7 +767,7 @@ public:
 		out.ids += ZhttpResponsePacket::Id(rid.second, outSeq++);
 		out.userData = userData;
 
-		manager->writeWs(out, rid.first);
+		manager->writeWs(out, rid.first, routerResp);
 	}
 
 	void writeFrameInternal(const Frame &frame, int credits = -1)
@@ -1274,6 +1279,11 @@ bool ZWebSocket::isServer() const
 QByteArray ZWebSocket::toAddress() const
 {
 	return d->toAddress;
+}
+
+bool ZWebSocket::routerResp() const
+{
+	return d->routerResp;
 }
 
 int ZWebSocket::outSeqInc()

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -88,6 +88,7 @@ private:
 	void startServer();
 	bool isServer() const;
 	QByteArray toAddress() const;
+	bool routerResp() const;
 	int outSeqInc();
 	void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
 	void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet);

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1036,6 +1036,7 @@ private:
 					rpreq.inSeq = rs.inSeq;
 					rpreq.outSeq = rs.outSeq;
 					rpreq.outCredits = rs.outCredits;
+					rpreq.routerResp = rs.routerResp;
 					rpreq.userData = rs.userData;
 
 					rp.requests += rpreq;
@@ -1101,6 +1102,7 @@ private:
 			ss.inSeq = rs.inSeq;
 			ss.outSeq = rs.outSeq;
 			ss.outCredits = rs.outCredits;
+			ss.routerResp = rs.routerResp;
 			ss.userData = rs.userData;
 
 			// take over responsibility for request

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -1062,6 +1062,7 @@ private:
 			rpreq.inSeq = ss.inSeq;
 			rpreq.outSeq = ss.outSeq;
 			rpreq.outCredits = ss.outCredits;
+			rpreq.routerResp = ss.routerResp;
 			rpreq.userData = ss.userData;
 
 			rp.requests += rpreq;

--- a/src/handler/requeststate.cpp
+++ b/src/handler/requeststate.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016-2023 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -60,6 +60,14 @@ RequestState RequestState::fromVariant(const QVariant &in)
 		return RequestState();
 
 	rs.outCredits = r["out-credits"].toInt();
+
+	if(r.contains("router-resp"))
+	{
+		if(typeId(r["router-resp"]) != QMetaType::Bool)
+			return RequestState();
+
+		rs.routerResp = r["router-resp"].toBool();
+	}
 
 	if(r.contains("response-code"))
 	{

--- a/src/handler/requeststate.h
+++ b/src/handler/requeststate.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2023 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -36,6 +37,7 @@ public:
 	int inSeq;
 	int outSeq;
 	int outCredits;
+	bool routerResp;
 	QHostAddress peerAddress;
 	QHostAddress logicalPeerAddress;
 	bool isHttps;
@@ -52,6 +54,7 @@ public:
 		inSeq(0),
 		outSeq(0),
 		outCredits(0),
+		routerResp(false),
 		isHttps(false),
 		debug(false),
 		isRetry(false),

--- a/src/proxy/acceptdata.h
+++ b/src/proxy/acceptdata.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -53,6 +53,7 @@ public:
 		int inSeq;
 		int outSeq;
 		int outCredits;
+		bool routerResp;
 		QVariant userData;
 
 		Request() :
@@ -65,7 +66,8 @@ public:
 			responseCode(-1),
 			inSeq(-1),
 			outSeq(-1),
-			outCredits(-1)
+			outCredits(-1),
+			routerResp(false)
 		{
 		}
 	};

--- a/src/proxy/acceptrequest.cpp
+++ b/src/proxy/acceptrequest.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2023 Fanout, Inc.
- * Copyright (C) 2023-2024 Fastly, Inc.
+ * Copyright (C) 2023-2025 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -77,6 +77,10 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 			vrequest["in-seq"] = r.inSeq;
 			vrequest["out-seq"] = r.outSeq;
 			vrequest["out-credits"] = r.outCredits;
+
+			if(r.routerResp)
+				vrequest["router-resp"] = true;
+
 			if(r.userData.isValid())
 				vrequest["user-data"] = r.userData;
 

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -890,6 +890,7 @@ private:
 			ss.inSeq = req.inSeq;
 			ss.outSeq = req.outSeq;
 			ss.outCredits = req.outCredits;
+			ss.routerResp = req.routerResp;
 			ss.userData = req.userData;
 
 			ZhttpRequest *zhttpRequest = zhttpIn->createRequestFromState(ss);

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -1300,6 +1300,7 @@ public:
 				areq.inSeq = ss.inSeq;
 				areq.outSeq = ss.outSeq;
 				areq.outCredits = ss.outCredits;
+				areq.routerResp = ss.routerResp;
 				areq.userData = ss.userData;
 				adata.requests += areq;
 			}


### PR DESCRIPTION
Related to #48222, this adds support in the proxy and handler for responding via router if requested to do so. The mode is also persisted across handoffs between the two.

Connmgr logs below of a long poll flow, flipping between proxy and handler multiple times, and always receiving via router:

```
[TRACE] 2025-05-05 11:26:59.728 [connmgr] [pushpin::connmgr::zhttpsocket] OUT stream { "from": "connmgr", "id": "0-0-0", "seq": 0, "ext": { "multi": true }, "method": "GET", "uri": "http://localhost:7999/response", "headers": [ [ "Host", "localhost:7999" ], [ "User-Agent", "curl/8.4.0" ], [ "Accept", "*/*" ] ], "credits": 8192, "stream": true, "router-resp": true, "peer-address": "127.0.0.1", "peer-port": 64626 } 0 
[TRACE] 2025-05-05 11:26:59.730 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "type": "keep-alive", "ext": { "multi": true }, "from": "proxy_8808", "seq": 0 }
[TRACE] 2025-05-05 11:26:59.733 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "type": "handoff-start", "from": "proxy_8808", "seq": 1 }
[TRACE] 2025-05-05 11:26:59.733 [connmgr] [pushpin::connmgr::zhttpsocket] OUT stream to=proxy_8808 { "from": "connmgr", "id": "0-0-0", "seq": 1, "ext": { "multi": true }, "type": "handoff-proceed" }
[TRACE] 2025-05-05 11:26:59.736 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "from": "handler_8809", "ext": { "multi": true }, "seq": 2, "type": "keep-alive" }
[TRACE] 2025-05-05 11:27:00.867 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "from": "handler_8809", "seq": 3, "type": "handoff-start" }
[TRACE] 2025-05-05 11:27:00.868 [connmgr] [pushpin::connmgr::zhttpsocket] OUT stream to=handler_8809 { "from": "connmgr", "id": "0-0-0", "seq": 2, "ext": { "multi": true }, "type": "handoff-proceed" }
[TRACE] 2025-05-05 11:27:00.871 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "type": "keep-alive", "ext": { "multi": true }, "from": "proxy_8808", "seq": 4 }
[TRACE] 2025-05-05 11:27:00.872 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "type": "handoff-start", "from": "proxy_8808", "seq": 5 }
[TRACE] 2025-05-05 11:27:00.872 [connmgr] [pushpin::connmgr::zhttpsocket] OUT stream to=proxy_8808 { "from": "connmgr", "id": "0-0-0", "seq": 3, "ext": { "multi": true }, "type": "handoff-proceed" }
[TRACE] 2025-05-05 11:27:00.875 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "from": "handler_8809", "ext": { "multi": true }, "seq": 6, "type": "keep-alive" }
[TRACE] 2025-05-05 11:27:02.853 [connmgr] [pushpin::connmgr::zhttpsocket] IN stream (router) { "id": "0-0-0", "from": "handler_8809", "headers": [ [ "Content-Type", "text/plain" ] ], "code": 200, "reason": "OK", "seq": 7 } 3 "yo\n"
```