### PR TITLE
runner: look for bins in target dir instead of bin dir

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -47,6 +47,10 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(test)]
 use std::path::{Path, PathBuf};
 
+pub fn is_debug_build() -> bool {
+    cfg!(debug_assertions)
+}
+
 pub fn version() -> &'static str {
     env!("APP_VERSION")
 }
@@ -94,6 +98,19 @@ pub fn ensure_example_config(dest: &Path) {
         fs::copy(src_dir.join("pushpin.conf"), dest_dir.join("pushpin.conf")).unwrap();
         fs::copy(src_dir.join("routes"), dest_dir.join("routes")).unwrap();
     });
+}
+
+mod ffi {
+    use std::os::raw::c_int;
+
+    #[no_mangle]
+    pub extern "C" fn is_debug_build() -> c_int {
+        if super::is_debug_build() {
+            1
+        } else {
+            0
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Fanout, Inc.
+ * Copyright (C) 2016-2025 Fanout, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -30,6 +30,7 @@
 #include <QDir>
 #include <QUrl>
 #include <QUrlQuery>
+#include "rust/bindings.h"
 #include "processquit.h"
 #include "log.h"
 #include "settings.h"
@@ -458,23 +459,29 @@ public:
 
 		bool allowCompression = settings.value("runner/allow_compression").toBool();
 
+		QString targetDir;
+		if(ffi::is_debug_build())
+			targetDir = QDir(exeDir).filePath("target/debug");
+		else
+			targetDir = QDir(exeDir).filePath("target/release");
+
 		QString m2aBin = "m2adapter";
-		QFileInfo fi(QDir(exeDir).filePath("bin/m2adapter"));
+		QFileInfo fi(QDir(targetDir).filePath("m2adapter"));
 		if(fi.isFile())
 			m2aBin = fi.canonicalFilePath();
 
 		QString connmgrBin = "pushpin-connmgr";
-		fi = QFileInfo(QDir(exeDir).filePath("bin/pushpin-connmgr"));
+		fi = QFileInfo(QDir(targetDir).filePath("pushpin-connmgr"));
 		if(fi.isFile())
 			connmgrBin = fi.canonicalFilePath();
 
 		QString proxyBin = "pushpin-proxy";
-		fi = QFileInfo(QDir(exeDir).filePath("bin/pushpin-proxy"));
+		fi = QFileInfo(QDir(targetDir).filePath("pushpin-proxy"));
 		if(fi.isFile())
 			proxyBin = fi.canonicalFilePath();
 
 		QString handlerBin = "pushpin-handler";
-		fi = QFileInfo(QDir(exeDir).filePath("bin/pushpin-handler"));
+		fi = QFileInfo(QDir(targetDir).filePath("pushpin-handler"));
 		if(fi.isFile())
 			handlerBin = fi.canonicalFilePath();
 


### PR DESCRIPTION
Currently, the runner looks for component programs in a relative `bin` dir, to support running Pushpin within the source tree. However, the programs are placed there by `make` and not `cargo`, which means if you prefer developing using cargo you have to remember to run `make` before running Pushpin to ensure the latest bins actually get used.

This PR changes the runner to instead look in the `target/{buildmode}` dir for programs. That way, the runner will always use the latest programs without needing to run `make` first. This helps reduce the difference between using `make` and `cargo`, though it's still not perfect (see notes below).

With this change, the following build & run flows are possible from a clean tree:

* `cargo build` followed by `cargo run`
* `make` followed by `./pushpin`

Notes:

* `make` not only copies the component programs to the `bin` dir but it also copies the runner to the base dir as `./pushpin`. This means running `cargo build` followed by `./pushpin` will either run an old build from an earlier `make` invocation or fail due to the program not existing. Running `make` followed by `cargo run` is okay though.
* `cargo run` only builds the default executable before running it, so unfortunately that command alone is not enough to build & run Pushpin out of the box (since the other components won't have been built), and you also can't iterate with it (since it won't build the other components). Use `cargo build && cargo run` instead.

It would be great if someday `cargo build` could place the default executable in the base dir and `cargo run` could build all dependent executables, but as far as I can tell this is not possible to do yet.