### PR TITLE
always use the new event loop

### DIFF
--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -325,7 +325,6 @@ public:
 		QString statsFormat = settings.value("handler/stats_format").toString();
 		QString prometheusPort = settings.value("handler/prometheus_port").toString();
 		QString prometheusPrefix = settings.value("handler/prometheus_prefix").toString();
-		bool newEventLoop = settings.value("handler/new_event_loop", false).toBool();
 
 		if(m2a_in_stream_specs.isEmpty() || m2a_out_specs.isEmpty())
 		{
@@ -391,7 +390,7 @@ public:
 		config.prometheusPort = prometheusPort;
 		config.prometheusPrefix = prometheusPrefix;
 
-		return runLoop(config, newEventLoop);
+		return runLoop(config, true);
 	}
 
 private:

--- a/src/proxy/app.cpp
+++ b/src/proxy/app.cpp
@@ -545,7 +545,6 @@ public:
 		int statsReportInterval = settings.value("proxy/stats_report_interval", 10).toInt();
 		QString prometheusPort = settings.value("proxy/prometheus_port").toString();
 		QString prometheusPrefix = settings.value("proxy/prometheus_prefix").toString();
-		bool newEventLoop = settings.value("proxy/new_event_loop", false).toBool();
 
 		QList<QByteArray> origHeadersNeedMark;
 		foreach(const QString &s, origHeadersNeedMarkStr)
@@ -642,7 +641,7 @@ public:
 		config.prometheusPort = prometheusPort;
 		config.prometheusPrefix = prometheusPrefix;
 
-		return runLoop(config, args.routeLines, routesFile, workerCount, newEventLoop);
+		return runLoop(config, args.routeLines, routesFile, workerCount, true);
 	}
 
 private:


### PR DESCRIPTION
This simply makes the new event loop the default and removes the option to change it. All the code related to the old event loop is still present, just only used by tests. We can remove that code later on.

By committing to the new event loop we can start building things that rely on it, for example a mechanism to allow mixing async Rust and C++ code in the same thread.