### PR TITLE
defercall: automatically clean up when eventloop destructs

### DIFF
--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -91,6 +91,8 @@ private:
 
 	static std::unordered_map<std::thread::id, std::shared_ptr<Manager>> managerByThread;
 	static std::mutex managerByThreadMutex;
+
+	static void eventloop_cleanup_handler(void *ctx);
 };
 
 #endif

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -86,8 +86,6 @@ static void deferCall()
 
 	TEST_ASSERT_EQ(pendingCount, 0);
 	TEST_ASSERT_EQ(count, 2);
-
-	DeferCall::cleanup();
 }
 
 static void deferCallQt()
@@ -121,8 +119,6 @@ static void nonLocal()
 
 	TEST_ASSERT_EQ(pendingCount, 0);
 	TEST_ASSERT_EQ(count, 1);
-
-	DeferCall::cleanup();
 }
 
 static void nonLocalQt()

--- a/src/core/eventloop.h
+++ b/src/core/eventloop.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <optional>
+#include <list>
 #include "event.h"
 #include "rust/bindings.h"
 
@@ -41,10 +42,26 @@ public:
 	std::tuple<int, std::unique_ptr<Event::SetReadiness>> registerCustom(void (*cb)(void *, uint8_t), void *ctx);
 	void deregister(int id);
 
+	void addCleanupHandler(void (*handler)(void *), void *ctx);
+	void removeCleanupHandler(void (*handler)(void *), void *ctx);
+
 	static EventLoop *instance();
 
 private:
+	class CleanupHandler
+	{
+	public:
+		void (*handler)(void *);
+		void *ctx;
+
+		bool operator==(const CleanupHandler &other) const
+		{
+			return (other.handler == handler && other.ctx == ctx);
+		}
+	};
+
 	ffi::EventLoopRaw *inner_;
+	std::list<CleanupHandler> cleanupHandlers_;
 };
 
 #endif


### PR DESCRIPTION
Currently, the `DeferCall` subsystem must be explicitly deinitialized via `DeferCall::cleanup()` after event loop execution ends, in order to ensure any remaining pending calls are processed, and also to deallocate any globals (makes valgrind happy). The need to do this explicitly may have made sense when `DeferCall` was only used in certain places, but we now use it everywhere and these cleanup calls amount to a lot of boilerplate, particularly in the tests.

This PR makes it so the destruction of an `EventLoop` automatically calls `DeferCall::cleanup`. Since `DeferCall` depends on `EventLoop`, a generic cleanup mechanism is added to `EventLoop` in order to avoid a circular dependency, which `DeferCall` then uses. Also, some tests have been updated to remove the explicit cleanup calls (will do the rest in a later PR).

I ran the tests under valgrind to confirm the cleanup still happens.

Note: If the Qt event loop is used, `DeferCall` must still be explicitly deinitialized. Currently this is needed in some older tests, but these tests will be removed soon and/or ported to `EventLoop`.