### PR TITLE
run c++ tests in parallel

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -115,7 +115,7 @@ mod ffi {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::test::{run_serial, TestException};
+    use crate::core::test::{run_cpp, TestException};
     use crate::ffi;
 
     fn httpheaders_test(out_ex: &mut TestException) -> bool {
@@ -155,36 +155,36 @@ mod tests {
 
     #[test]
     fn httpheaders() {
-        run_serial(httpheaders_test);
+        run_cpp(httpheaders_test);
     }
 
     #[test]
     fn jwt() {
-        run_serial(jwt_test);
+        run_cpp(jwt_test);
     }
 
     #[test]
     fn timer() {
-        run_serial(timer_test);
+        run_cpp(timer_test);
     }
 
     #[test]
     fn defercall() {
-        run_serial(defercall_test);
+        run_cpp(defercall_test);
     }
 
     #[test]
     fn tcpstream() {
-        run_serial(tcpstream_test);
+        run_cpp(tcpstream_test);
     }
 
     #[test]
     fn unixstream() {
-        run_serial(unixstream_test);
+        run_cpp(unixstream_test);
     }
 
     #[test]
     fn eventloop() {
-        run_serial(eventloop_test);
+        run_cpp(eventloop_test);
     }
 }

--- a/src/core/test.rs
+++ b/src/core/test.rs
@@ -17,8 +17,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{mpsc, OnceLock};
-use std::thread;
+use std::sync::OnceLock;
 
 #[derive(Default)]
 pub struct TestException {
@@ -38,77 +37,27 @@ fn get_root_dir() -> &'static Path {
     })
 }
 
-fn run_catchable<F>(test_fn: F) -> Option<TestException>
+fn run_catchable<F>(test_fn: F) -> Result<(), TestException>
 where
     F: FnOnce(&mut TestException) -> bool,
 {
     let mut ex = TestException::default();
 
     if !test_fn(&mut ex) {
-        return Some(ex);
+        return Err(ex);
     }
 
-    None
+    Ok(())
 }
 
-struct RunSerial {
-    f: Box<dyn FnOnce(&mut TestException) -> bool + Send>,
-    ret: mpsc::SyncSender<Option<TestException>>,
-}
-
-fn run_serial_inner<F>(test_fn: F) -> Option<TestException>
-where
-    F: FnOnce(&mut TestException) -> bool + Send + 'static,
-{
-    static SENDER: OnceLock<mpsc::Sender<RunSerial>> = OnceLock::new();
-
-    let s_call = SENDER.get_or_init(|| {
-        let (s, r) = mpsc::channel::<RunSerial>();
-
-        // run in the background forever
-        thread::Builder::new()
-            .name("run-serial".to_string())
-            .spawn(move || {
-                for t in r {
-                    let ret = run_catchable(t.f);
-
-                    // if receiver is gone, keep going
-                    let _ = t.ret.send(ret);
-                }
-                unreachable!();
-            })
-            .unwrap();
-
-        s
-    });
-
-    let (s_ret, r_ret) = mpsc::sync_channel(1);
-
-    s_call
-        .send(RunSerial {
-            f: Box::new(test_fn),
-            ret: s_ret,
-        })
-        .expect("call channel should always be writable");
-
-    r_ret
-        .recv()
-        .expect("return channel should always be readable")
-}
-
-// this function is meant for running tests that use QCoreApplication. there
-// can only be one global QCoreApplication instance, and qt doesn't like it
-// when QCoreApplication is recreated in different threads, so this function
-// sets up a background thread to enable running tests serially and all from
-// the same thread
 #[track_caller]
-pub fn run_serial<F>(test_fn: F)
+pub fn run_cpp<F>(test_fn: F)
 where
-    F: FnOnce(&mut TestException) -> bool + Send + 'static,
+    F: FnOnce(&mut TestException) -> bool,
 {
     let root_dir = get_root_dir();
 
-    if let Some(ex) = run_serial_inner(Box::new(test_fn)) {
+    if let Err(ex) = run_catchable(test_fn) {
         let file = Path::new(&ex.file);
         let file = file.strip_prefix(root_dir).unwrap_or(file);
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -119,11 +119,11 @@ public:
 		zhttpClientOutStreamSock->setIdentity("test-client");
 		zhttpClientOutStreamSock->setProbeRouterEnabled(true);
 
-		zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("client-out-stream"));
-		zhttpClientInSock->bind("ipc://" + workDir.filePath("client-in"));
-		zhttpServerInSock->bind("ipc://" + workDir.filePath("server-in"));
-		zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("server-in-stream"));
-		zhttpServerOutSock->bind("ipc://" + workDir.filePath("server-out"));
+		zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("hndtst-client-out-stream"));
+		zhttpClientInSock->bind("ipc://" + workDir.filePath("hndtst-client-in"));
+		zhttpServerInSock->bind("ipc://" + workDir.filePath("hndtst-server-in"));
+		zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("hndtst-server-in-stream"));
+		zhttpServerOutSock->bind("ipc://" + workDir.filePath("hndtst-server-out"));
 
 		zhttpClientInSock->subscribe("test-client ");
 
@@ -135,14 +135,14 @@ public:
 
 	void startProxy()
 	{
-		proxyAcceptSock->bind("ipc://" + workDir.filePath("accept"));
+		proxyAcceptSock->bind("ipc://" + workDir.filePath("hndtst-accept"));
 
 		proxyAcceptValve->open();
 	}
 
 	void startPublish()
 	{
-		publishPushSock->connectToAddress("ipc://" + workDir.filePath("publish-pull"));
+		publishPushSock->connectToAddress("ipc://" + workDir.filePath("hndtst-publish-pull"));
 	}
 
 	void reset()
@@ -315,13 +315,13 @@ public:
 
 		HandlerEngine::Configuration config;
 		config.instanceId = "handler";
-		config.serverInStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("client-out-stream"));
-		config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("client-in"));
-		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("server-in"));
-		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("server-in-stream"));
-		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("server-out"));
-		config.acceptSpecs = QStringList() << ("ipc://" + workDir.filePath("accept"));
-		config.pushInSpec = ("ipc://" + workDir.filePath("publish-pull"));
+		config.serverInStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-client-out-stream"));
+		config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-client-in"));
+		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-in"));
+		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-in-stream"));
+		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-out"));
+		config.acceptSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-accept"));
+		config.pushInSpec = ("ipc://" + workDir.filePath("hndtst-publish-pull"));
 		config.connectionSubscriptionMax = 20;
 		config.connectionsMax = 20;
 		TEST_ASSERT(engine->start(config));

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -16,7 +16,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::core::test::{run_serial, TestException};
+    use crate::core::test::{run_cpp, TestException};
     use crate::ffi;
 
     fn filter_test(out_ex: &mut TestException) -> bool {
@@ -56,36 +56,36 @@ mod tests {
 
     #[test]
     fn filter() {
-        run_serial(filter_test);
+        run_cpp(filter_test);
     }
 
     #[test]
     fn jsonpatch() {
-        run_serial(jsonpatch_test);
+        run_cpp(jsonpatch_test);
     }
 
     #[test]
     fn instruct() {
-        run_serial(instruct_test);
+        run_cpp(instruct_test);
     }
 
     #[test]
     fn idformat() {
-        run_serial(idformat_test);
+        run_cpp(idformat_test);
     }
 
     #[test]
     fn publishformat() {
-        run_serial(publishformat_test);
+        run_cpp(publishformat_test);
     }
 
     #[test]
     fn publishitem() {
-        run_serial(publishitem_test);
+        run_cpp(publishitem_test);
     }
 
     #[test]
     fn handlerengine() {
-        run_serial(handlerengine_test);
+        run_cpp(handlerengine_test);
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -16,7 +16,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::core::test::{run_serial, TestException};
+    use crate::core::test::{run_cpp, TestException};
     use crate::ffi;
 
     fn websocketoverhttp_test(out_ex: &mut TestException) -> bool {
@@ -36,16 +36,16 @@ mod tests {
 
     #[test]
     fn websocketoverhttp() {
-        run_serial(websocketoverhttp_test);
+        run_cpp(websocketoverhttp_test);
     }
 
     #[test]
     fn routesfile() {
-        run_serial(routesfile_test);
+        run_cpp(routesfile_test);
     }
 
     #[test]
     fn proxyengine() {
-        run_serial(proxyengine_test);
+        run_cpp(proxyengine_test);
     }
 }

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -152,12 +152,12 @@ public:
 		zhttpClientOutStreamSock->setIdentity("test-client");
 		zhttpClientOutStreamSock->setProbeRouterEnabled(true);
 
-		zhttpClientOutSock->bind("ipc://" + workDir.filePath("client-out"));
-		zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("client-out-stream"));
-		zhttpClientInSock->bind("ipc://" + workDir.filePath("client-in"));
-		zhttpServerInSock->bind("ipc://" + workDir.filePath("server-in"));
-		zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("server-in-stream"));
-		zhttpServerOutSock->bind("ipc://" + workDir.filePath("server-out"));
+		zhttpClientOutSock->bind("ipc://" + workDir.filePath("prxtst-client-out"));
+		zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("prxtst-client-out-stream"));
+		zhttpClientInSock->bind("ipc://" + workDir.filePath("prxtst-client-in"));
+		zhttpServerInSock->bind("ipc://" + workDir.filePath("prxtst-server-in"));
+		zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("prxtst-server-in-stream"));
+		zhttpServerOutSock->bind("ipc://" + workDir.filePath("prxtst-server-out"));
 
 		zhttpClientInSock->subscribe("test-client ");
 
@@ -169,9 +169,9 @@ public:
 
 	void startHandler()
 	{
-		handlerInspectSock->connectToAddress("ipc://" + workDir.filePath("inspect"));
-		handlerAcceptSock->connectToAddress("ipc://" + workDir.filePath("accept"));
-		handlerRetryOutSock->connectToAddress("ipc://" + workDir.filePath("retry-out"));
+		handlerInspectSock->connectToAddress("ipc://" + workDir.filePath("prxtst-inspect"));
+		handlerAcceptSock->connectToAddress("ipc://" + workDir.filePath("prxtst-accept"));
+		handlerRetryOutSock->connectToAddress("ipc://" + workDir.filePath("prxtst-retry-in"));
 
 		handlerInspectValve->open();
 		handlerAcceptValve->open();
@@ -620,16 +620,16 @@ public:
 
 		Engine::Configuration config;
 		config.clientId = "proxy";
-		config.serverInSpecs = QStringList() << ("ipc://" + workDir.filePath("client-out"));
-		config.serverInStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("client-out-stream"));
-		config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("client-in"));
-		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("server-in"));
-		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("server-in-stream"));
-		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("server-out"));
-		config.inspectSpec = ("ipc://" + workDir.filePath("inspect"));
-		config.acceptSpec = ("ipc://" + workDir.filePath("accept"));
-		config.retryInSpec = ("ipc://" + workDir.filePath("retry-out"));
-		config.statsSpec = ("ipc://" + workDir.filePath("stats"));
+		config.serverInSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-out"));
+		config.serverInStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-out-stream"));
+		config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-in"));
+		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-in"));
+		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-in-stream"));
+		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-out"));
+		config.inspectSpec = ("ipc://" + workDir.filePath("prxtst-inspect"));
+		config.acceptSpec = ("ipc://" + workDir.filePath("prxtst-accept"));
+		config.retryInSpec = ("ipc://" + workDir.filePath("prxtst-retry-in"));
+		config.statsSpec = ("ipc://" + workDir.filePath("prxtst-stats"));
 		config.sessionsMax = 20;
 		config.inspectTimeout = 500;
 		config.inspectPrefetch = 5;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -539,7 +539,7 @@ fn parse_log_levels(log_levels: Vec<String>) -> Result<HashMap<String, u8>, Box<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::test::{run_serial, TestException};
+    use crate::core::test::{run_cpp, TestException};
     use crate::core::{ensure_example_config, test_dir};
     use crate::ffi;
     use std::collections::HashMap;
@@ -907,7 +907,7 @@ mod tests {
 
     #[test]
     fn template() {
-        run_serial(template_test);
+        run_cpp(template_test);
     }
 }
 


### PR DESCRIPTION
Now that the C++ tests no longer use `QCoreApplication`, we have the opportunity to run them in parallel. This PR ensures there isn't anything else that could conflict among the tests (just temp file names it seems) and removes the `run_serial` wrapping.

On my machine I see a 25% reduction.

Before:

```
cargo test  1.42s user 0.89s system 19% cpu 11.760 total
```

After:

```
cargo test  1.36s user 0.83s system 25% cpu 8.770 total
```