### PR TITLE
clippy: allow uninlined format args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,5 +101,7 @@ test = false
 bench = false
 
 [lints.rust]
-
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(qt_lib_prefix, values("Qt", "Qt6", "Qt5"))'] }
+
+[lints.clippy]
+uninlined_format_args = "allow"


### PR DESCRIPTION
Quieting this thing for now.

Also updated the `fanout/build-base` image with the latest Rust, which the jobs on this PR ran against.