### PR TITLE
in tests, use new event loop only

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -25,6 +25,7 @@ HEADERS += \
 	$$PWD/layertracker.h
 
 SOURCES += \
+	$$PWD/test.cpp \
 	$$PWD/tnetstring.cpp \
 	$$PWD/httpheaders.cpp \
 	$$PWD/zhttprequestpacket.cpp \

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -24,8 +24,6 @@
 #include <thread>
 #include <QHostAddress>
 #include "test.h"
-#include "timer.h"
-#include "defercall.h"
 #include "eventloop.h"
 #include "tcplistener.h"
 #include "tcpstream.h"
@@ -276,17 +274,6 @@ static void accept()
 	});
 }
 
-static void acceptQt()
-{
-	TestQCoreApplication qapp;
-	Timer::init(100);
-
-	runAccept([] { QTest::qWait(10); });
-
-	DeferCall::cleanup();
-	Timer::deinit();
-}
-
 static void io()
 {
 	EventLoop loop(100);
@@ -297,23 +284,10 @@ static void io()
 	});
 }
 
-static void ioQt()
-{
-	TestQCoreApplication qapp;
-	Timer::init(100);
-
-	runIo([] { QTest::qWait(10); });
-
-	DeferCall::cleanup();
-	Timer::deinit();
-}
-
 extern "C" int tcpstream_test(ffi::TestException *out_ex)
 {
 	TEST_CATCH(accept());
-	TEST_CATCH(acceptQt());
 	TEST_CATCH(io());
-	TEST_CATCH(ioQt());
 
 	return 0;
 }

--- a/src/core/test.cpp
+++ b/src/core/test.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ *
+ */
+
+#include "test.h"
+
+#include <chrono>
+#include "eventloop.h"
+
+using namespace std::chrono_literals;
+
+void test_with_event_loop(std::function<void (std::function<void (int)>)> f)
+{
+	EventLoop loop(100);
+
+	auto loop_wait = [&](int ms) {
+		for(int i = ms; i > 0; i -= 10)
+		{
+			std::this_thread::sleep_for(10ms);
+			loop.step();
+		}
+	};
+
+	f(loop_wait);
+}

--- a/src/core/test.cpp
+++ b/src/core/test.cpp
@@ -22,6 +22,7 @@
 #include "test.h"
 
 #include <chrono>
+#include <thread>
 #include "eventloop.h"
 
 using namespace std::chrono_literals;

--- a/src/core/test.h
+++ b/src/core/test.h
@@ -19,12 +19,14 @@
  *
  */
 
+#ifndef PUSHPIN_TEST_H
+#define PUSHPIN_TEST_H
+
 #include "string.h"
 #include <QtTest/QtTest>
 #include "rust/bindings.h"
 
-#ifndef PUSHPIN_TEST_H
-#define PUSHPIN_TEST_H
+using namespace std::chrono_literals;
 
 class TestException
 {
@@ -75,26 +77,9 @@ do {\
 // for running a test and catching an exception if any. expects local variable ffi::TestException* out_ex to exist
 #define TEST_CATCH(statement) try { statement; } catch(const TestException &ex) { ex.toFfi(out_ex); return 1; }
 
-class TestQCoreApplication
-{
-public:
-    TestQCoreApplication()
-    {
-        argc_ = 1;
-        argv_[0] = strdup("qt-test");
-        qapp_ = new QCoreApplication(argc_, argv_);
-    }
-
-    ~TestQCoreApplication()
-    {
-        delete qapp_;
-        free(argv_[0]);
-    }
-
-private:
-    int argc_;
-    char *argv_[1];
-    QCoreApplication *qapp_;
-};
+// expects a test function that takes a wait function as an argument. the wait
+// function can be used by the test to wait for a number of milliseconds while
+// the event loop runs.
+void test_with_event_loop(std::function<void (std::function<void (int)>)> f);
 
 #endif

--- a/src/core/test.h
+++ b/src/core/test.h
@@ -26,8 +26,6 @@
 #include <QtTest/QtTest>
 #include "rust/bindings.h"
 
-using namespace std::chrono_literals;
-
 class TestException
 {
 public:

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -62,28 +62,9 @@ static void zeroTimeout()
 	TEST_ASSERT_EQ(count, 2);
 }
 
-static void zeroTimeoutQt()
-{
-	TestQCoreApplication qapp;
-	Timer::init(1);
-
-	int count = runZeroTimeout([] {
-		// the timer's qt-based implementation will process both timeouts
-		// during a single timer processing pass. therefore, both
-		// timeouts should get processed within a single event loop pass
-		QCoreApplication::processEvents(QEventLoop::AllEvents);
-	});
-
-	TEST_ASSERT_EQ(count, 2);
-
-	Timer::deinit();
-}
-
-
 extern "C" int timer_test(ffi::TestException *out_ex)
 {
 	TEST_CATCH(zeroTimeout());
-	TEST_CATCH(zeroTimeoutQt());
 
 	return 0;
 }

--- a/src/core/unixstreamtest.cpp
+++ b/src/core/unixstreamtest.cpp
@@ -24,8 +24,6 @@
 #include <thread>
 #include <QHostAddress>
 #include "test.h"
-#include "timer.h"
-#include "defercall.h"
 #include "eventloop.h"
 #include "unixlistener.h"
 #include "unixstream.h"
@@ -284,17 +282,6 @@ static void accept()
 	});
 }
 
-static void acceptQt()
-{
-	TestQCoreApplication qapp;
-	Timer::init(100);
-
-	runAccept([] { QTest::qWait(10); });
-
-	DeferCall::cleanup();
-	Timer::deinit();
-}
-
 static void io()
 {
 	EventLoop loop(100);
@@ -305,23 +292,10 @@ static void io()
 	});
 }
 
-static void ioQt()
-{
-	TestQCoreApplication qapp;
-	Timer::init(100);
-
-	runIo([] { QTest::qWait(10); });
-
-	DeferCall::cleanup();
-	Timer::deinit();
-}
-
 extern "C" int unixstream_test(ffi::TestException *out_ex)
 {
 	TEST_CATCH(accept());
-	TEST_CATCH(acceptQt());
 	TEST_CATCH(io());
-	TEST_CATCH(ioQt());
 
 	return 0;
 }

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -24,12 +24,9 @@
 #include <QDir>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <qtestsupport_core.h>
 #include <boost/signals2.hpp>
 #include "test.h"
 #include "log.h"
-#include "timer.h"
-#include "defercall.h"
 #include "zhttpmanager.h"
 #include "ratelimiter.h"
 #include "filter.h"
@@ -164,14 +161,12 @@ public:
 	std::unique_ptr<ZhttpManager> zhttpOut;
 	std::shared_ptr<RateLimiter> limiter;
 
-	TestState()
+	TestState(std::function<void (int)> loop_wait)
 	{
 		log_setOutputLevel(LOG_LEVEL_WARNING);
 
 		QDir outDir(qgetenv("OUT_DIR"));
 		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
-
-		Timer::init(100);
 
 		filterServer = std::make_unique<HttpFilterServer>(workDir);
 
@@ -183,7 +178,7 @@ public:
 
 		limiter = std::make_shared<RateLimiter>();
 
-		QTest::qWait(500);
+		loop_wait(500);
 	}
 
 	~TestState()
@@ -191,18 +186,12 @@ public:
 		limiter.reset();
 		zhttpOut.reset();
 		filterServer.reset();
-
-		// ensure deferred deletes are processed
-		QCoreApplication::instance()->sendPostedEvents();
-
-		DeferCall::cleanup();
-		Timer::deinit();
 	}
 };
 
 }
 
-static Filter::MessageFilter::Result runMessageFilters(const QStringList &filterNames, const Filter::Context &context, const QByteArray &content)
+static Filter::MessageFilter::Result runMessageFilters(const QStringList &filterNames, const Filter::Context &context, const QByteArray &content, std::function<void (int)> loop_wait)
 {
 	Filter::MessageFilterStack fs(filterNames);
 
@@ -217,15 +206,13 @@ static Filter::MessageFilter::Result runMessageFilters(const QStringList &filter
 	fs.start(context, content);
 
 	while(!finished)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	return r;
 }
 
-static void messageFilters()
+static void messageFilters(std::function<void (int)> loop_wait)
 {
-	TestQCoreApplication qapp;
-
 	QStringList filterNames = QStringList() << "skip-self" << "var-subst";
 
 	Filter::Context context;
@@ -234,7 +221,7 @@ static void messageFilters()
 	QByteArray content = "hello %(user)s";
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT(r.errorMessage.isNull());
 		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
 		TEST_ASSERT_EQ(r.content, "hello alice");
@@ -242,16 +229,15 @@ static void messageFilters()
 
 	{
 		context.publishMeta["sender"] = "alice";
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT(r.errorMessage.isNull());
 		TEST_ASSERT_EQ(r.sendAction, Filter::Drop);
 	}
 }
 
-static void httpCheck()
+static void httpCheck(std::function<void (int)> loop_wait)
 {
-	TestQCoreApplication qapp;
-	TestState state;
+	TestState state(loop_wait);
 
 	QStringList filterNames = QStringList() << "http-check";
 
@@ -264,7 +250,7 @@ static void httpCheck()
 	QByteArray content = "hello world";
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT(r.errorMessage.isNull());
 		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
 		TEST_ASSERT_EQ(r.content, "hello world");
@@ -273,7 +259,7 @@ static void httpCheck()
 	context.subscriptionMeta["url"] = "/filter/drop";
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT(r.errorMessage.isNull());
 		TEST_ASSERT_EQ(r.sendAction, Filter::Drop);
 	}
@@ -281,15 +267,14 @@ static void httpCheck()
 	context.subscriptionMeta["url"] = "/filter/error";
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT_EQ(r.errorMessage, "unexpected network request status: code=400");
 	}
 }
 
-static void httpModify()
+static void httpModify(std::function<void (int)> loop_wait)
 {
-	TestQCoreApplication qapp;
-	TestState state;
+	TestState state(loop_wait);
 
 	QStringList filterNames = QStringList() << "http-modify";
 
@@ -303,7 +288,7 @@ static void httpModify()
 	QByteArray content = "hello world";
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT(r.errorMessage.isNull());
 		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
 		TEST_ASSERT_EQ(r.content, "hello world");
@@ -313,7 +298,7 @@ static void httpModify()
 	context.publishMeta["append"] = ">>>";
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT(r.errorMessage.isNull());
 		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
 		TEST_ASSERT_EQ(r.content, "<<<hello world>>>");
@@ -325,16 +310,16 @@ static void httpModify()
 	context.responseSizeMax = 1000;
 
 	{
-		auto r = runMessageFilters(filterNames, context, content);
+		auto r = runMessageFilters(filterNames, context, content, loop_wait);
 		TEST_ASSERT_EQ(r.errorMessage, "network response exceeded 1000 bytes");
 	}
 }
 
 extern "C" int filter_test(ffi::TestException *out_ex)
 {
-	TEST_CATCH(messageFilters());
-	TEST_CATCH(httpCheck());
-	TEST_CATCH(httpModify());
+	TEST_CATCH(test_with_event_loop(messageFilters));
+	TEST_CATCH(test_with_event_loop(httpCheck));
+	TEST_CATCH(test_with_event_loop(httpModify));
 
 	return 0;
 }

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -39,8 +39,6 @@
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "packet/statspacket.h"
-#include "timer.h"
-#include "defercall.h"
 #include "eventloop.h"
 #include "zhttpmanager.h"
 #include "statsmanager.h"

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -22,12 +22,9 @@
 
 #include <unordered_map>
 #include <QDir>
-#include <qtestsupport_core.h>
 #include <boost/signals2.hpp>
 #include "test.h"
 #include "log.h"
-#include "timer.h"
-#include "defercall.h"
 #include "zhttpmanager.h"
 #include "websocketoverhttp.h"
 
@@ -164,14 +161,12 @@ public:
 	std::unique_ptr<WohServer> wohServer;
 	std::unique_ptr<ZhttpManager> zhttpOut;
 
-	TestState()
+	TestState(std::function<void (int)> loop_wait)
 	{
 		log_setOutputLevel(LOG_LEVEL_WARNING);
 
 		QDir outDir(qgetenv("OUT_DIR"));
 		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
-
-		Timer::init(100);
 
 		wohServer = std::make_unique<WohServer>(workDir);
 
@@ -181,7 +176,7 @@ public:
 		zhttpOut->setClientOutStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in-stream")));
 		zhttpOut->setClientInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-out")));
 
-		QTest::qWait(500);
+		loop_wait(500);
 	}
 
 	~TestState()
@@ -190,12 +185,6 @@ public:
 
 		zhttpOut.reset();
 		wohServer.reset();
-
-		// ensure deferred deletes are processed
-		QCoreApplication::instance()->sendPostedEvents();
-
-		DeferCall::cleanup();
-		Timer::deinit();
 	}
 };
 
@@ -252,10 +241,9 @@ static void removePartial()
 	TEST_ASSERT(frames.isEmpty());
 }
 
-static void io()
+static void io(std::function<void (int)> loop_wait)
 {
-	TestQCoreApplication qapp;
-	TestState state;
+	TestState state(loop_wait);
 
 	WebSocketOverHttp client(state.zhttpOut.get());
 
@@ -289,7 +277,7 @@ static void io()
 	client.start(QUrl("ws://localhost/ws"), HttpHeaders());
 
 	while(!clientConnected && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	TEST_ASSERT(!clientError);
 	TEST_ASSERT(clientConnected);
@@ -297,7 +285,7 @@ static void io()
 	client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, "hello", false));
 
 	while(!clientReadyRead && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	TEST_ASSERT(!clientError);
 	TEST_ASSERT(clientReadyRead);
@@ -312,16 +300,15 @@ static void io()
 	client.close();
 
 	while(!clientClosed && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	TEST_ASSERT(!clientError);
 	TEST_ASSERT(clientClosed);
 }
 
-static void replay()
+static void replay(std::function<void (int)> loop_wait)
 {
-	TestQCoreApplication qapp;
-	TestState state;
+	TestState state(loop_wait);
 
 	WebSocketOverHttp client(state.zhttpOut.get());
 
@@ -360,7 +347,7 @@ static void replay()
 	client.start(QUrl("ws://localhost/ws"), HttpHeaders());
 
 	while(!clientConnected && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	TEST_ASSERT(!clientError);
 	TEST_ASSERT(clientConnected);
@@ -370,7 +357,7 @@ static void replay()
 	TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail - 11);
 
 	while(!clientWriteBytesChanged && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	TEST_ASSERT(!clientError);
 	TEST_ASSERT(clientWriteBytesChanged);
@@ -381,7 +368,7 @@ static void replay()
 	client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, " world]", false));
 
 	while(!clientReadyRead && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	WebSocket::Frame f = client.readFrame();
 	TEST_ASSERT_EQ(f.type, WebSocket::Frame::Text);
@@ -394,7 +381,7 @@ static void replay()
 	client.close();
 
 	while(!clientClosed && !clientError)
-		QTest::qWait(10);
+		loop_wait(10);
 
 	TEST_ASSERT(!clientError);
 	TEST_ASSERT(clientClosed);
@@ -404,8 +391,8 @@ extern "C" int websocketoverhttp_test(ffi::TestException *out_ex)
 {
 	TEST_CATCH(convertFrames());
 	TEST_CATCH(removePartial());
-	TEST_CATCH(io());
-	TEST_CATCH(replay());
+	TEST_CATCH(test_with_event_loop(io));
+	TEST_CATCH(test_with_event_loop(replay));
 
 	return 0;
 }


### PR DESCRIPTION
This removes any tests that were using the Qt event loop for which we already had an equivalent test using the new event loop, and converts any tests that were only using the Qt event loop to use the new event loop instead. As a result, the tests no longer depend on `QCoreApplication`, which opens the door to allowing parallelization of C++ tests.