### PR TITLE
qzmq: add ability to set router probe

### DIFF
--- a/src/core/qzmqsocket.cpp
+++ b/src/core/qzmqsocket.cpp
@@ -105,6 +105,14 @@ static void set_router_mandatory(void *sock, bool on)
 	assert(ret == 0);
 }
 
+static void set_probe_router(void *sock, bool on)
+{
+	int v = on ? 1 : 0;
+	size_t opt_len = sizeof(v);
+	int ret = wzmq_setsockopt(sock, WZMQ_PROBE_ROUTER, &v, opt_len);
+	assert(ret == 0);
+}
+
 #else
 
 static void set_immediate(void *sock, bool on)
@@ -723,6 +731,11 @@ void Socket::setImmediateEnabled(bool on)
 void Socket::setRouterMandatoryEnabled(bool on)
 {
 	set_router_mandatory(d->sock, on);
+}
+
+void Socket::setProbeRouterEnabled(bool on)
+{
+	set_probe_router(d->sock, on);
 }
 
 void Socket::setTcpKeepAliveEnabled(bool on)

--- a/src/core/qzmqsocket.h
+++ b/src/core/qzmqsocket.h
@@ -88,6 +88,7 @@ public:
 
 	void setImmediateEnabled(bool on);
 	void setRouterMandatoryEnabled(bool on);
+	void setProbeRouterEnabled(bool on);
 
 	void setTcpKeepAliveEnabled(bool on);
 	void setTcpKeepAliveParameters(int idle = -1, int count = -1, int interval = -1);

--- a/src/core/zmq.rs
+++ b/src/core/zmq.rs
@@ -746,6 +746,7 @@ mod ffi {
     pub const WZMQ_TCP_KEEPALIVE_CNT: libc::c_int = 12;
     pub const WZMQ_TCP_KEEPALIVE_INTVL: libc::c_int = 13;
     pub const WZMQ_ROUTER_MANDATORY: libc::c_int = 14;
+    pub const WZMQ_PROBE_ROUTER: libc::c_int = 15;
 
     pub const WZMQ_DONTWAIT: libc::c_int = 0x01;
     pub const WZMQ_SNDMORE: libc::c_int = 0x02;
@@ -1094,6 +1095,21 @@ mod ffi {
                 };
 
                 if let Err(e) = sock.set_router_mandatory(*x != 0) {
+                    set_errno(e.to_raw());
+                    return -1;
+                }
+            }
+            WZMQ_PROBE_ROUTER => {
+                if option_len as u32 != libc::c_int::BITS / 8 {
+                    return -1;
+                }
+
+                let x = match (option_value as *const libc::c_int).as_ref() {
+                    Some(x) => x,
+                    None => return -1,
+                };
+
+                if let Err(e) = sock.set_probe_router(*x != 0) {
                     set_errno(e.to_raw());
                     return -1;
                 }


### PR DESCRIPTION
This adds method `QZmqSocket::setProbeRouterEnabled()` but doesn't use it anywhere yet. The plan is to use it in tests to do fast peer detection and avoid excess sleeping.