### PR TITLE
use router probe to reduce wait times in tests

### DIFF
--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -48,6 +48,7 @@ public:
 
 	void setIpcFileMode(int mode);
 	void setBind(bool enable);
+	void setProbe(bool enable);
 
 	bool setClientOutSpecs(const QStringList &specs);
 	bool setClientOutStreamSpecs(const QStringList &specs);
@@ -73,6 +74,7 @@ public:
 
 	Signal requestReady;
 	Signal socketReady;
+	Signal probeAcked;
 
 private:
 	class Private;

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -171,14 +171,22 @@ public:
 		filterServer = std::make_unique<HttpFilterServer>(workDir);
 
 		zhttpOut = std::make_unique<ZhttpManager>();
+
+		limiter = std::make_shared<RateLimiter>();
+
+		bool connected = false;
+		zhttpOut->probeAcked.connect([&] {
+			connected = true;
+		});
+
 		zhttpOut->setInstanceId("filter-test-client");
+		zhttpOut->setProbe(true);
 		zhttpOut->setClientOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in")));
 		zhttpOut->setClientOutStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in-stream")));
 		zhttpOut->setClientInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-out")));
 
-		limiter = std::make_shared<RateLimiter>();
-
-		loop_wait(500);
+		while(!connected)
+			loop_wait(10);
 	}
 
 	~TestState()

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -171,12 +171,20 @@ public:
 		wohServer = std::make_unique<WohServer>(workDir);
 
 		zhttpOut = std::make_unique<ZhttpManager>();
+
+		bool connected = false;
+		zhttpOut->probeAcked.connect([&] {
+			connected = true;
+		});
+
 		zhttpOut->setInstanceId("woh-test-client");
+		zhttpOut->setProbe(true);
 		zhttpOut->setClientOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in")));
 		zhttpOut->setClientOutStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in-stream")));
 		zhttpOut->setClientInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-out")));
 
-		loop_wait(500);
+		while(!connected)
+			loop_wait(10);
 	}
 
 	~TestState()


### PR DESCRIPTION
Currently, many tests sleep for 500ms during initialization to ensure asynchronous ZeroMQ connections are established before proceeding. Such sleeping adds a lot of delay to the tests.

This PR updates the tests to detect when peers become available in order to proceed quickly. It does this by adding a "probe" ability to `ZhttpManager`, which enables ZeroMQ's router probe mode on the client side and responds with an ack on the server side. Then the tests are updated to use it. Probing is not used outside of tests.

On my machine this reduces test time by over 50%.

Before:
```
cargo test  1.75s user 1.19s system 10% cpu 27.562 total
```

After:
```
cargo test  1.58s user 0.97s system 20% cpu 12.249 total
```