### PR TITLE
chore: Remove new http filters

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -1,8 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches: 
+    branches:
       - main
+      - v1
 defaults:
   run:
      shell: bash -leo pipefail {0}
@@ -138,7 +139,7 @@ jobs:
     - name: Cache
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: "CI-Suite"      
+        shared-key: "CI-Suite"
     - name: bench
       run: RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} bench --no-run
   build-full:

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -699,10 +699,11 @@ Filter::MessageFilter *Filter::createMessageFilter(const QString &name)
 		return new BuildIdFilter;
 	else if(name == "var-subst")
 		return new VarSubstFilter;
-	else if(name == "http-check")
-		return new HttpFilter(HttpFilter::Check);
-	else if(name == "http-modify")
-		return new HttpFilter(HttpFilter::Modify);
+	// NOTE(clintjedwards): Not release ready [08-12-2025]
+	// else if(name == "http-check")
+	// 	return new HttpFilter(HttpFilter::Check);
+	// else if(name == "http-modify")
+	// 	return new HttpFilter(HttpFilter::Modify);
 	else
 		return 0;
 }
@@ -714,9 +715,10 @@ QStringList Filter::names()
 		<< "skip-users"
 		<< "require-sub"
 		<< "build-id"
-		<< "var-subst"
-		<< "http-check"
-		<< "http-modify");
+		<< "var-subst");
+	  // NOTE(clintjedwards): Not release ready [08-12-2025]
+	  // << "http-check"
+	  // << "http-modify");
 }
 
 Filter::Targets Filter::targets(const QString &name)
@@ -731,10 +733,11 @@ Filter::Targets Filter::targets(const QString &name)
 		return Filter::Targets(Filter::MessageContent | Filter::ResponseContent);
 	else if(name == "var-subst")
 		return Filter::MessageContent;
-	else if(name == "http-check")
-		return Filter::MessageDelivery;
-	else if(name == "http-modify")
-		return Filter::Targets(Filter::MessageDelivery | Filter::MessageContent);
+	// NOTE(clintjedwards): Not release ready [08-12-2025]
+	// else if(name == "http-check")
+	// 	return Filter::MessageDelivery;
+	// else if(name == "http-modify")
+	// 	return Filter::Targets(Filter::MessageDelivery | Filter::MessageContent);
 	else
 		return Filter::Targets(0);
 }

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -518,7 +518,7 @@ bool HttpFilter::RequestAction::execute()
 	return true;
 }
 
-HttpFilter::HttpFilter(Mode mode)
+[[maybe_unused]] HttpFilter::HttpFilter(Mode mode)
 {
 	inner = std::make_shared<HttpFilterInner>(mode);
 

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -243,7 +243,7 @@ static void messageFilters(std::function<void (int)> loop_wait)
 	}
 }
 
-static void httpCheck(std::function<void (int)> loop_wait)
+[[maybe_unused]] static void httpCheck(std::function<void (int)> loop_wait)
 {
 	TestState state(loop_wait);
 
@@ -280,7 +280,7 @@ static void httpCheck(std::function<void (int)> loop_wait)
 	}
 }
 
-static void httpModify(std::function<void (int)> loop_wait)
+[[maybe_unused]] static void httpModify(std::function<void (int)> loop_wait)
 {
 	TestState state(loop_wait);
 

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -326,8 +326,9 @@ static void httpModify(std::function<void (int)> loop_wait)
 extern "C" int filter_test(ffi::TestException *out_ex)
 {
 	TEST_CATCH(test_with_event_loop(messageFilters));
-	TEST_CATCH(test_with_event_loop(httpCheck));
-	TEST_CATCH(test_with_event_loop(httpModify));
+	// NOTE(clintjedwards): Not release ready [08-12-2025]
+	// TEST_CATCH(test_with_event_loop(httpCheck));
+	// TEST_CATCH(test_with_event_loop(httpModify));
 
 	return 0;
 }

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -177,7 +177,9 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
 
 		requestData->headers.removeAll("Grip-Feature");
 		requestData->headers += HttpHeader("Grip-Feature",
-			"status, session, link:next, link:gone, filter:skip-self, filter:skip-users, filter:require-sub, filter:build-id, filter:var-subst, filter:http-check, filter:http-modify");
+			"status, session, link:next, link:gone, filter:skip-self, filter:skip-users, filter:require-sub, filter:build-id, filter:var-subst");
+			// NOTE(clintjedwards): Not release ready [08-12-2025]
+			//, filter:http-check, filter:http-modify");
 
 		if(!idata.sid.isEmpty())
 		{


### PR DESCRIPTION
These are added as part of main but not quite yet ready for a full release. Remove the temporarily until they're fully baked.