### PR TITLE
update build image to use qt 6

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 ubuntu:24.04
 ENV TZ=US \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get install -y zstd git pkg-config curl make g++ libssl-dev libzmq3-dev qtbase5-dev libboost-dev black
+RUN apt-get -qq update && apt-get install -y zstd git pkg-config curl make g++ libssl-dev libzmq3-dev qt6-base-dev libboost-dev black
 
 # install toolchain
 RUN curl https://sh.rustup.rs -sSf | \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,8 @@ jobs:
     - if: matrix.build-mode == 'manual'
       shell: bash
       env:
-        CPP_BUILD_DIR: /cppbuild
-      run: cargo check --no-default-features --features do-qmake
+        CPP_BUILD_DIR: ${{ github.workspace }}/cppbuild
+      run: echo "${{ env.CPP_BUILD_DIR }}" && cargo check --no-default-features --features do-qmake
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -54,7 +54,7 @@ jobs:
     - if: matrix.build-mode == 'manual'
       shell: bash
       env:
-        CPP_BUILD_DIR: /cppbuild
+        CPP_BUILD_DIR: ${{ github.workspace }}/cppbuild
       run: cargo build --no-default-features --features do-cpp-build
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash
       env:
         CPP_BUILD_DIR: /cppbuild
-      run: cargo check --features skip-cpp-build
+      run: cargo check --no-default-features --features do-qmake
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -55,7 +55,7 @@ jobs:
       shell: bash
       env:
         CPP_BUILD_DIR: /cppbuild
-      run: cargo build --features skip-qmake
+      run: cargo build --no-default-features --features do-cpp-build
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,11 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "codeql"
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      env:
+        CPP_BUILD_DIR: /cppbuild
+      run: cargo check --features skip-cpp-build
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -48,7 +53,9 @@ jobs:
         build-mode: ${{ matrix.build-mode }}
     - if: matrix.build-mode == 'manual'
       shell: bash
-      run: make build
+      env:
+        CPP_BUILD_DIR: /cppbuild
+      run: cargo build --features skip-qmake
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash
       env:
         CPP_BUILD_DIR: ${{ github.workspace }}/cppbuild
-      run: echo "${{ env.CPP_BUILD_DIR }}" && cargo check --no-default-features --features do-qmake
+      run: cargo check --no-default-features --features do-qmake
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ rust-version = "1.75"
 default-run = "pushpin"
 
 [features]
-skip-qmake = []
-skip-cpp-build = []
+default = ["do-qmake", "do-cpp-build"]
+do-qmake = []
+do-cpp-build = []
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2018"
 rust-version = "1.75"
 default-run = "pushpin"
 
+[features]
+skip-qmake = []
+skip-cpp-build = []
+
 [profile.dev]
 panic = "abort"
 

--- a/build.rs
+++ b/build.rs
@@ -525,7 +525,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         &log_dir,
     )?;
 
-    if cfg!(not(feature = "skip-qmake")) {
+    if cfg!(feature = "do-qmake") {
         check_command(Command::new(&qmake_path).args([
             OsStr::new("-o"),
             cpp_build_dir.join("Makefile").as_os_str(),
@@ -545,7 +545,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         )?;
     }
 
-    if cfg!(not(feature = "skip-cpp-build")) {
+    if cfg!(feature = "do-cpp-build") {
         check_command(
             Command::new("make")
                 .env("MAKEFLAGS", env::var("CARGO_MAKEFLAGS")?)


### PR DESCRIPTION
This includes a workaround for CodeQL and Qt 6. Apparently `qmake` can crash when running under CodeQL instrumentation, and [a recommendation](https://github.com/orgs/community/discussions/67835) is to run non-build steps before initializing CodeQL. This PR introduces two cargo feature flags, `do-qmake` and `do-cpp-build`, both enabled by default, along with an environment variable `CPP_BUILD_DIR`, and then uses them from the github action to ensure `qmake` is run before CodeQL initialization and not after.

`CPP_BUILD_DIR` is needed because changing cargo feature flags causes cargo to use a different build dir within `target`, and so if we want to invoke cargo twice with different flags while sharing intermediate build files, a solution is for the files to live outside of `target`.

The jobs on this PR ran against the new image.