### PR TITLE
Cargo.toml: update authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pushpin"
 version = "1.42.0-dev"
-authors = ["Justin Karneges <jkarneges@fastly.com>"]
+authors = ["Fastly <oss@fastly.com>"]
 description = "Reverse proxy for realtime web services"
 repository = "https://github.com/fastly/pushpin"
 readme = "README.md"


### PR DESCRIPTION
Making this the same as other Fastly projects, for example [the fastly-api crate](https://github.com/fastly/fastly-rust/blob/main/Cargo.toml).