### PR TITLE
qzmq: use cow types everywhere

### DIFF
--- a/src/core/qzmqreprouter.cpp
+++ b/src/core/qzmqreprouter.cpp
@@ -68,12 +68,12 @@ void RepRouter::setShutdownWaitTime(int msecs)
 	d->sock->setShutdownWaitTime(msecs);
 }
 
-void RepRouter::connectToAddress(const QString &addr)
+void RepRouter::connectToAddress(const CowString &addr)
 {
 	d->sock->connectToAddress(addr);
 }
 
-bool RepRouter::bind(const QString &addr)
+bool RepRouter::bind(const CowString &addr)
 {
 	return d->sock->bind(addr);
 }

--- a/src/core/qzmqreprouter.h
+++ b/src/core/qzmqreprouter.h
@@ -26,7 +26,7 @@
 
 #include <boost/signals2.hpp>
 
-class QString;
+class CowString;
 
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
@@ -44,8 +44,8 @@ public:
 
 	void setShutdownWaitTime(int msecs);
 
-	void connectToAddress(const QString &addr);
-	bool bind(const QString &addr);
+	void connectToAddress(const CowString &addr);
+	bool bind(const CowString &addr);
 
 	bool canRead() const;
 

--- a/src/core/qzmqreqmessage.h
+++ b/src/core/qzmqreqmessage.h
@@ -24,6 +24,8 @@
 #ifndef QZMQREQMESSAGE_H
 #define QZMQREQMESSAGE_H
 
+class CowByteArrayList;
+
 namespace QZmq {
 
 class ReqMessage
@@ -33,16 +35,16 @@ public:
 	{
 	}
 
-	ReqMessage(const QList<QByteArray> &headers, const QList<QByteArray> &content) :
+	ReqMessage(const CowByteArrayList &headers, const CowByteArrayList &content) :
 		headers_(headers),
 		content_(content)
 	{
 	}
 
-	ReqMessage(const QList<QByteArray> &rawMessage)
+	ReqMessage(const CowByteArrayList &rawMessage)
 	{
 		bool collectHeaders = true;
-		foreach(const QByteArray &part, rawMessage)
+		for(CowByteArrayConstRef part : std::as_const(rawMessage))
 		{
 			if(part.isEmpty())
 			{
@@ -59,26 +61,26 @@ public:
 
 	bool isNull() const { return headers_.isEmpty() && content_.isEmpty(); }
 
-	QList<QByteArray> headers() const { return headers_; }
-	QList<QByteArray> content() const { return content_; }
+	CowByteArrayList headers() const { return headers_; }
+	CowByteArrayList content() const { return content_; }
 
-	ReqMessage createReply(const QList<QByteArray> &content)
+	ReqMessage createReply(const CowByteArrayList &content)
 	{
 		return ReqMessage(headers_, content);
 	}
 
-	QList<QByteArray> toRawMessage() const
+	CowByteArrayList toRawMessage() const
 	{
-		QList<QByteArray> out;
+		CowByteArrayList out;
 		out += headers_;
-		out += QByteArray();
+		out += CowByteArray();
 		out += content_;
 		return out;
 	}
 
 private:
-	QList<QByteArray> headers_;
-	QList<QByteArray> content_;
+	CowByteArrayList headers_;
+	CowByteArrayList content_;
 };
 
 }

--- a/src/core/qzmqvalve.cpp
+++ b/src/core/qzmqvalve.cpp
@@ -81,7 +81,7 @@ public:
 
 			if(!msg.isEmpty())
 			{
-				q->readyRead(msg.asQByteArrayList());
+				q->readyRead(msg);
 				if(self.expired())
 					return;
 			}

--- a/src/core/qzmqvalve.h
+++ b/src/core/qzmqvalve.h
@@ -25,11 +25,10 @@
 #ifndef QZMQVALVE_H
 #define QZMQVALVE_H
 
-#include <QByteArray>
-#include <QList>
 #include <boost/signals2.hpp>
+#include "cowbytearray.h"
 
-using SignalList = boost::signals2::signal<void(const QList<QByteArray>&)>;
+using SignalList = boost::signals2::signal<void(const CowByteArrayList&)>;
 using Connection = boost::signals2::scoped_connection;
 
 namespace QZmq {

--- a/src/core/tnetstring.cpp
+++ b/src/core/tnetstring.cpp
@@ -22,6 +22,7 @@
 #include "tnetstring.h"
 
 #include <assert.h>
+#include "cowbytearray.h"
 #include "qtcompat.h"
 
 namespace TnetString {
@@ -251,6 +252,11 @@ QVariant toVariant(const QByteArray &in, int offset, bool *ok)
 	}
 
 	return toVariant(in, offset, type, dataOffset, dataSize, ok);
+}
+
+QVariant toVariant(const CowByteArray &in, int offset, bool *ok)
+{
+	return toVariant(in.asQByteArray(), offset, ok);
 }
 
 QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)

--- a/src/core/tnetstring.h
+++ b/src/core/tnetstring.h
@@ -23,6 +23,8 @@
 
 #include <QVariant>
 
+class CowByteArray;
+
 namespace TnetString {
 
 enum Type
@@ -55,6 +57,7 @@ QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSi
 QVariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 QVariant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok = 0);
 QVariant toVariant(const QByteArray &in, int offset = 0, bool *ok = 0);
+QVariant toVariant(const CowByteArray &in, int offset = 0, bool *ok = 0);
 
 QString byteArrayToEscapedString(const QByteArray &in);
 

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -436,11 +436,11 @@ public:
 		}
 	}
 
-	void writeProbeAck(const QByteArray &toAddress)
+	void writeProbeAck(const CowByteArray &toAddress)
 	{
-		QList<QByteArray> msg;
+		CowByteArrayList msg;
 		msg += toAddress;
-		msg += QByteArray();
+		msg += CowByteArray();
 		msg += "probe-ack";
 		server_in_stream_sock->write(msg);
 	}
@@ -538,14 +538,14 @@ public:
 
 		while(client_req_sock->canRead())
 		{
-			QList<QByteArray> msg = client_req_sock->read().asQByteArrayList();
+			CowByteArrayList msg = client_req_sock->read();
 			if(msg.count() != 2)
 			{
 				log_warning("zhttp/zws client req: received message with parts != 2, skipping");
 				continue;
 			}
 
-			QByteArray dataRaw = msg[1];
+			CowByteArray dataRaw = msg[1];
 			if(dataRaw.length() < 1 || dataRaw[0] != 'T')
 			{
 				log_warning("zhttp/zws client req: received message with invalid format (missing type), skipping");
@@ -593,7 +593,7 @@ public:
 		}
 	}
 
-	void processClientIn(const QByteArray &receiver, const QByteArray &msg)
+	void processClientIn(const CowByteArray &receiver, const CowByteArray &msg)
 	{
 		if(msg.length() < 1 || msg[0] != 'T')
 		{
@@ -653,7 +653,7 @@ public:
 		}
 	}
 
-	void client_out_stream_readyRead(const QList<QByteArray> &msg)
+	void client_out_stream_readyRead(const CowByteArrayList &msg)
 	{
 		if(msg.count() != 3)
 		{
@@ -667,10 +667,10 @@ public:
 			return;
 		}
 
-		processClientIn(QByteArray(), msg[2]);
+		processClientIn(CowByteArray(), msg[2]);
 	}
 
-	void client_in_readyRead(const QList<QByteArray> &msg)
+	void client_in_readyRead(const CowByteArrayList &msg)
 	{
 		if(msg.count() != 1)
 		{
@@ -685,13 +685,13 @@ public:
 			return;
 		}
 
-		QByteArray receiver = msg[0].mid(0, at);
-		QByteArray dataRaw = msg[0].mid(at + 1);
+		CowByteArray receiver = msg[0].mid(0, at);
+		CowByteArray dataRaw = msg[0].mid(at + 1);
 
 		processClientIn(receiver, dataRaw);
 	}
 
-	void server_in_readyRead(const QList<QByteArray> &msg)
+	void server_in_readyRead(const CowByteArrayList &msg)
 	{
 		if(msg.count() != 1)
 		{
@@ -798,7 +798,7 @@ public:
 		}
 	}
 
-	void server_in_stream_readyRead(const QList<QByteArray> &msg)
+	void server_in_stream_readyRead(const CowByteArrayList &msg)
 	{
 		if(msg.count() < 2 || msg.count() > 3)
 		{

--- a/src/core/zrpcmanager.cpp
+++ b/src/core/zrpcmanager.cpp
@@ -168,7 +168,7 @@ public:
 		serverSock->write(message);
 	}
 
-	void client_readyRead(const QList<QByteArray> &message)
+	void client_readyRead(const CowByteArrayList &message)
 	{
 		if(message.count() != 2)
 		{
@@ -209,7 +209,7 @@ public:
 		req->handle(p);
 	}
 
-	void server_readyRead(const QList<QByteArray> &message)
+	void server_readyRead(const CowByteArrayList &message)
 	{
 		QZmq::ReqMessage req(message);
 
@@ -237,7 +237,7 @@ public:
 		}
 
 		PendingItem i;
-		i.headers = req.headers();
+		i.headers = req.headers().asQByteArrayList();
 		i.packet = p;
 		pending += i;
 

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -2383,12 +2383,13 @@ private:
 			removeSub(channel);
 	}
 
-	QVariant parseJsonOrTnetstring(const QByteArray &message, bool *ok = 0, QString *errorMessage = 0) {
+	QVariant parseJsonOrTnetstring(const CowByteArray &message, bool *ok = 0, QString *errorMessage = 0)
+	{
 		QVariant data;
 		bool ok_;
 		if(message.length() > 0 && message[0] == 'J') {
 			QJsonParseError e;
-			QJsonDocument doc = QJsonDocument::fromJson(message.mid(1), &e);
+			QJsonDocument doc = QJsonDocument::fromJson(message.mid(1).asQByteArray(), &e);
 			if(e.error != QJsonParseError::NoError)
 			{
 				if(errorMessage)
@@ -2433,7 +2434,7 @@ private:
 		return data;
 	}
 
-	void inPull_readyRead(const QList<QByteArray> &message)
+	void inPull_readyRead(const CowByteArrayList &message)
 	{
 		if(message.count() != 1)
 		{
@@ -2463,7 +2464,7 @@ private:
 		handlePublishItem(item);
 	}
 
-	void inSub_readyRead(const QList<QByteArray> &message)
+	void inSub_readyRead(const CowByteArrayList &message)
 	{
 		if(message.count() != 2)
 		{
@@ -2479,7 +2480,7 @@ private:
 			return;
 		}
 
-		QString channel = QString::fromUtf8(message[0]);
+		QString channel = QString::fromUtf8(message[0].asQByteArray());
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
 			log_debug("IN sub: channel=%s %s", qPrintable(channel), qPrintable(TnetString::variantToString(data, -1)));
@@ -2494,7 +2495,7 @@ private:
 		handlePublishItem(item);
 	}
 
-	void wsControlInit_readyRead(const QList<QByteArray> &message)
+	void wsControlInit_readyRead(const CowByteArrayList &message)
 	{
 		if(message.count() != 1)
 		{
@@ -2505,7 +2506,7 @@ private:
 		wsControlIn_readyRead(message[0]);
 	}
 
-	void wsControlStream_readyRead(const QList<QByteArray> &message)
+	void wsControlStream_readyRead(const CowByteArrayList &message)
 	{
 		QZmq::ReqMessage req(message);
 
@@ -2518,7 +2519,7 @@ private:
 		wsControlIn_readyRead(req.content()[0]);
 	}
 
-	void wsControlIn_readyRead(const QByteArray &message)
+	void wsControlIn_readyRead(const CowByteArray &message)
 	{
 		bool ok;
 		QVariant data = TnetString::toVariant(message, 0, &ok);
@@ -2830,7 +2831,7 @@ private:
 		}
 	}
 
-	void proxyStats_readyRead(const QList<QByteArray> &message)
+	void proxyStats_readyRead(const CowByteArrayList &message)
 	{
 		if(message.count() != 1)
 		{
@@ -2845,7 +2846,7 @@ private:
 			return;
 		}
 
-		QByteArray type = message[0].mid(0, at);
+		QByteArray type = message[0].mid(0, at).asQByteArray();
 
 		if(at + 1 >= message[0].length() || message[0][at + 1] != 'T')
 		{

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -158,7 +158,7 @@ public:
 		requestBody.clear();
 	}
 
-	void processClientIn(const QByteArray &message)
+	void processClientIn(const CowByteArray &message)
 	{
 		log_debug("client in");
 
@@ -183,14 +183,14 @@ public:
 		}
 	}
 
-	void zhttpClientIn_readyRead(const QList<QByteArray> &message)
+	void zhttpClientIn_readyRead(const CowByteArrayList &message)
 	{
 		int at = message[0].indexOf(' ');
 
 		processClientIn(message[0].mid(at + 2));
 	}
 
-	void zhttpClientOutStream_readyRead(const QList<QByteArray> &message)
+	void zhttpClientOutStream_readyRead(const CowByteArrayList &message)
 	{
 		if(message[2] == "probe-ack")
 		{
@@ -201,7 +201,7 @@ public:
 		processClientIn(message[2].mid(1));
 	}
 
-	void zhttpServerIn_readyRead(const QList<QByteArray> &message)
+	void zhttpServerIn_readyRead(const CowByteArrayList &message)
 	{
 		++serverReqs;
 		log_debug("server in");
@@ -212,7 +212,7 @@ public:
 		handleServerIn(zreq);
 	}
 
-	void zhttpServerInStream_readyRead(const QList<QByteArray> &message)
+	void zhttpServerInStream_readyRead(const CowByteArrayList &message)
 	{
 		log_debug("server stream in");
 		QVariant v = TnetString::toVariant(message[2].mid(1));
@@ -270,7 +270,7 @@ public:
 		serverOutSeq = 0;
 	}
 
-	void proxyAccept_readyRead(const QList<QByteArray> &_message)
+	void proxyAccept_readyRead(const CowByteArrayList &_message)
 	{
 		QZmq::ReqMessage message(_message);
 		QVariant v = TnetString::toVariant(message.content()[0]);

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -1438,7 +1438,7 @@ public:
 		}
 	}
 
-	void handleZhttpIn(Mode mode, const QList<QByteArray> &message)
+	void handleZhttpIn(Mode mode, const CowByteArrayList &message)
 	{
 		const char *logprefix = (mode == Http ? "zhttp" : "zws");
 
@@ -1455,7 +1455,7 @@ public:
 			return;
 		}
 
-		QByteArray dataRaw = message[0].mid(at + 1);
+		CowByteArray dataRaw = message[0].mid(at + 1);
 		if(dataRaw.length() < 1 || dataRaw[0] != 'T')
 		{
 			log_warning("%s: received message with invalid format (missing type), skipping", logprefix);
@@ -2319,7 +2319,7 @@ public:
 		}
 	}
 
-	void m2_in_readyRead(const QList<QByteArray> &message)
+	void m2_in_readyRead(const CowByteArrayList &message)
 	{
 		if(message.count() != 1)
 		{
@@ -2328,10 +2328,10 @@ public:
 		}
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logByteArray(LOG_LEVEL_DEBUG, message[0], "m2: IN");
+			LogUtil::logByteArray(LOG_LEVEL_DEBUG, message[0].asQByteArray(), "m2: IN");
 
 		M2RequestPacket mreq;
-		if(!mreq.fromByteArray(message[0]))
+		if(!mreq.fromByteArray(message[0].asQByteArray()))
 		{
 			log_warning("m2: received message with invalid format, skipping");
 			return;
@@ -2755,7 +2755,7 @@ public:
 
 		while(sock->canRead())
 		{
-			QList<QByteArray> message = sock->read().asQByteArrayList();
+			CowByteArrayList message = sock->read();
 
 			if(message.count() != 2)
 			{
@@ -2814,12 +2814,12 @@ public:
 		}
 	}
 
-	void zhttp_in_readyRead(const QList<QByteArray> &message)
+	void zhttp_in_readyRead(const CowByteArrayList &message)
 	{
 		handleZhttpIn(Http, message);
 	}
 
-	void zws_in_readyRead(const QList<QByteArray> &message)
+	void zws_in_readyRead(const CowByteArrayList &message)
 	{
 		handleZhttpIn(WebSocket, message);
 	}

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -827,7 +827,7 @@ private:
 	}
 
 private:
-	void handler_retry_in_readyRead(const QList<QByteArray> &message)
+	void handler_retry_in_readyRead(const CowByteArrayList &message)
 	{
 		QZmq::ReqMessage req(message);
 

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -198,7 +198,7 @@ public:
 	}
 
 private:
-	void processClientIn(const QByteArray &message)
+	void processClientIn(const CowByteArray &message)
 	{
 		log_debug("client in");
 		QVariant v = TnetString::toVariant(message);
@@ -245,14 +245,14 @@ private:
 		}
 	}
 
-	void zhttpClientIn_readyRead(const QList<QByteArray> &message)
+	void zhttpClientIn_readyRead(const CowByteArrayList &message)
 	{
 		int at = message[0].indexOf(' ');
 
 		processClientIn(message[0].mid(at + 2));
 	}
 
-	void zhttpClientOutStream_readyRead(const QList<QByteArray> &message)
+	void zhttpClientOutStream_readyRead(const CowByteArrayList &message)
 	{
 		if(message[2] == "probe-ack")
 		{
@@ -263,7 +263,7 @@ private:
 		processClientIn(message[2].mid(1));
 	}
 
-	void zhttpServerIn_readyRead(const QList<QByteArray> &message)
+	void zhttpServerIn_readyRead(const CowByteArrayList &message)
 	{
 		log_debug("server in");
 		QVariant v = TnetString::toVariant(message[0].mid(1));
@@ -279,7 +279,7 @@ private:
 		handleServerIn(zreq);
 	}
 
-	void zhttpServerInStream_readyRead(const QList<QByteArray> &message)
+	void zhttpServerInStream_readyRead(const CowByteArrayList &message)
 	{
 		log_debug("server stream in");
 		QVariant v = TnetString::toVariant(message[2].mid(1));
@@ -468,7 +468,7 @@ private:
 		serverOutSeq = 0;
 	}
 
-	void handlerInspect_readyRead(const QList<QByteArray> &_message)
+	void handlerInspect_readyRead(const CowByteArrayList &_message)
 	{
 		QZmq::ReqMessage message(_message);
 		QVariant v = TnetString::toVariant(message.content()[0]);
@@ -493,7 +493,7 @@ private:
 		}
 	}
 
-	void handlerAccept_readyRead(const QList<QByteArray> &_message)
+	void handlerAccept_readyRead(const CowByteArrayList &_message)
 	{
 		QZmq::ReqMessage message(_message);
 		QVariant v = TnetString::toVariant(message.content()[0]);

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -252,7 +252,7 @@ public:
 	}
 
 private:
-	void stream_readyRead(const QList<QByteArray> &message)
+	void stream_readyRead(const CowByteArrayList &message)
 	{
 		QZmq::ReqMessage req(message);
 


### PR DESCRIPTION
This updates the rest of the QZmq* classes to use the COW types. All the places that use these classes had to be updated to match, but only minimally.