### PR TITLE
wssession: set prevIds on filter context to make require-sub work

### DIFF
--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -139,7 +139,15 @@ void WsSession::processPublishQueue()
 		filters = std::make_unique<Filter::MessageFilterStack>(channelFilters[item.channel]);
 		filtersFinishedConnection = filters->finished.connect(boost::bind(&WsSession::filtersFinished, this, boost::placeholders::_1));
 
+		// websocket sessions currently don't support previous IDs on
+		// subscriptions, but we still need to populate the channel names in
+		// in the filter context even if all the values will be null
+		QHash<QString, QString> prevIds;
+		foreach(const QString &name, channels)
+			prevIds[name] = QString();
+
 		Filter::Context fc;
+		fc.prevIds = prevIds;
 		fc.subscriptionMeta = meta;
 		fc.publishMeta = item.meta;
 		fc.zhttpOut = zhttpOut;


### PR DESCRIPTION
Apparently the `require-sub` filter doesn't work with WebSockets, because the `prevIds` field isn't being populated on the filter context.

Background: The `prevIds` field of the filter context is a hash map where the keys are the session's subscribed channel names and the values are the so-called "previous IDs" of the subscribed channels, if available. The map serves two purposes: 1) to provide the filter a way to look up the previous IDs of subscribed channels, and 2) to provide the filter a way to simply look up the existence of subscribed channels. To support the latter case, we ensure the hash map is populated with all of the session's subscribed channels, whether or not they have previous IDs. In the case of WebSocket sessions, none of the channels have previous IDs.

Tested manually.