### PR TITLE
add client_cert and client_key target params for mtls

### DIFF
--- a/src/core/httprequest.h
+++ b/src/core/httprequest.h
@@ -59,6 +59,7 @@ public:
 	virtual void setTrustConnectHost(bool on) = 0;
 	virtual void setIgnoreTlsErrors(bool on) = 0;
 	virtual void setTimeout(int msecs) = 0;
+	virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
 	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers) = 0;
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) = 0;

--- a/src/core/websocket.h
+++ b/src/core/websocket.h
@@ -87,6 +87,7 @@ public:
 	virtual void setIgnorePolicies(bool on) = 0;
 	virtual void setTrustConnectHost(bool on) = 0;
 	virtual void setIgnoreTlsErrors(bool on) = 0;
+	virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
 	virtual void start(const QUrl &uri, const HttpHeaders &headers) = 0;
 

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -72,6 +72,8 @@ public:
 	bool trustConnectHost;
 	bool ignoreTlsErrors;
 	int timeout;
+	QString clientCert;
+	QString clientKey;
 	bool sendBodyAfterAck;
 	QVariant passthrough;
 	QString requestMethod;
@@ -970,6 +972,8 @@ public:
 						p.trustConnectHost = true;
 					if(ignoreTlsErrors)
 						p.ignoreTlsErrors = true;
+					p.clientCert = clientCert;
+					p.clientKey = clientKey;
 					if(passthrough.isValid())
 						p.passthrough = passthrough;
 					if(quiet)
@@ -1021,6 +1025,8 @@ public:
 					p.trustConnectHost = true;
 				if(ignoreTlsErrors)
 					p.ignoreTlsErrors = true;
+				p.clientCert = clientCert;
+				p.clientKey = clientKey;
 				if(passthrough.isValid())
 					p.passthrough = passthrough;
 				if(quiet)
@@ -1231,6 +1237,12 @@ void ZhttpRequest::setIgnoreTlsErrors(bool on)
 void ZhttpRequest::setTimeout(int msecs)
 {
 	d->timeout = msecs;
+}
+
+void ZhttpRequest::setClientCert(const QString &cert, const QString &key)
+{
+	d->clientCert = cert;
+	d->clientKey = key;
 }
 
 void ZhttpRequest::setIsTls(bool on)

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -92,6 +92,7 @@ public:
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
 	virtual void setTimeout(int msecs);
+	virtual void setClientCert(const QString &cert, const QString &key);
 
 	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers);
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -150,6 +150,12 @@ QVariant ZhttpRequestPacket::toVariant() const
 	if(ignoreTlsErrors)
 		obj["ignore-tls-errors"] = true;
 
+	if(!clientCert.isEmpty())
+		obj["client-cert"] = clientCert.toUtf8();
+
+	if(!clientKey.isEmpty())
+		obj["client-key"] = clientKey.toUtf8();
+
 	if(followRedirects)
 		obj["follow-redirects"] = true;
 
@@ -466,6 +472,24 @@ bool ZhttpRequestPacket::fromVariant(const QVariant &in)
 			return false;
 
 		ignoreTlsErrors = obj["ignore-tls-errors"].toBool();
+	}
+
+	clientCert.clear();
+	if(obj.contains("client-cert"))
+	{
+		if(typeId(obj["client-cert"]) != QMetaType::QByteArray)
+			return false;
+
+		clientCert = QString::fromUtf8(obj["client-cert"].toByteArray());
+	}
+
+	clientKey.clear();
+	if(obj.contains("client-key"))
+	{
+		if(typeId(obj["client-key"]) != QMetaType::QByteArray)
+			return false;
+
+		clientKey = QString::fromUtf8(obj["client-key"].toByteArray());
 	}
 
 	followRedirects = false;

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -93,6 +93,8 @@ public:
 	bool ignorePolicies;
 	bool trustConnectHost;
 	bool ignoreTlsErrors;
+	QString clientCert;
+	QString clientKey;
 	bool followRedirects;
 	QVariant passthrough; // if valid, may contain pushpin-specific passthrough info
 	bool multi;

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -61,6 +61,8 @@ public:
 	bool ignorePolicies;
 	bool trustConnectHost;
 	bool ignoreTlsErrors;
+	QString clientCert;
+	QString clientKey;
 	QUrl requestUri;
 	HttpHeaders requestHeaders;
 	int inSeq;
@@ -1031,6 +1033,8 @@ public:
 				p.trustConnectHost = true;
 			if(ignoreTlsErrors)
 				p.ignoreTlsErrors = true;
+			p.clientCert = clientCert;
+			p.clientKey = clientKey;
 			p.credits = IDEAL_CREDITS;
 			p.multi = true;
 			writePacket(p);
@@ -1121,6 +1125,12 @@ void ZWebSocket::setIgnoreTlsErrors(bool on)
 void ZWebSocket::setIsTls(bool on)
 {
 	d->requestUri.setScheme(on ? "wss" : "ws");
+}
+
+void ZWebSocket::setClientCert(const QString &cert, const QString &key)
+{
+	d->clientCert = cert;
+	d->clientKey = key;
 }
 
 void ZWebSocket::start(const QUrl &uri, const HttpHeaders &headers)

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -53,6 +53,7 @@ public:
 	virtual void setIgnorePolicies(bool on);
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
+	virtual void setClientCert(const QString &cert, const QString &key);
 
 	virtual void start(const QUrl &uri, const HttpHeaders &headers);
 

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -115,6 +115,8 @@ public:
 		QStringList subscriptions; // implicit subscriptions
 		bool overHttp; // use websocket-over-http protocol
 		bool oneEvent; // send one event at a time with overHttp
+		QString clientCert;
+		QString clientKey;
 
 		Target() :
 			type(Default),

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -474,6 +474,9 @@ public:
 			zhttpRequest->setConnectPort(target.connectPort);
 		}
 
+		if(!target.clientCert.isEmpty())
+			zhttpRequest->setClientCert(target.clientCert, target.clientKey);
+
 		ProxyUtil::applyHostHeader(&requestData.headers, uri);
 
 		incCounter(Stats::ServerHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(requestData.method, uri, requestData.headers));

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -1171,6 +1171,15 @@ void SockJsSession::setIgnoreTlsErrors(bool on)
 	assert(0);
 }
 
+void SockJsSession::setClientCert(const QString &cert, const QString &key)
+{
+	Q_UNUSED(cert);
+	Q_UNUSED(key);
+
+	// this class is server only
+	assert(0);
+}
+
 void SockJsSession::start(const QUrl &uri, const HttpHeaders &headers)
 {
 	Q_UNUSED(uri);

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -54,6 +54,7 @@ public:
 	virtual void setIgnorePolicies(bool on);
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
+	virtual void setClientCert(const QString &cert, const QString &key);
 
 	virtual void start(const QUrl &uri, const HttpHeaders &headers);
 

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -185,6 +185,12 @@ void TestHttpRequest::setTimeout(int msecs)
 	Q_UNUSED(msecs);
 }
 
+void TestHttpRequest::setClientCert(const QString &cert, const QString &key)
+{
+	Q_UNUSED(cert);
+	Q_UNUSED(key);
+}
+
 void TestHttpRequest::start(const QString &method, const QUrl &uri, const HttpHeaders &headers)
 {
 	assert(d->state == Private::Idle);

--- a/src/proxy/testhttprequest.h
+++ b/src/proxy/testhttprequest.h
@@ -44,6 +44,7 @@ public:
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
 	virtual void setTimeout(int msecs);
+	virtual void setClientCert(const QString &cert, const QString &key);
 
 	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers);
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -193,6 +193,12 @@ void TestWebSocket::setIgnoreTlsErrors(bool on)
 	Q_UNUSED(on);
 }
 
+void TestWebSocket::setClientCert(const QString &cert, const QString &key)
+{
+	Q_UNUSED(cert);
+	Q_UNUSED(key);
+}
+
 void TestWebSocket::start(const QUrl &uri, const HttpHeaders &headers)
 {
 	d->request.uri = uri;

--- a/src/proxy/testwebsocket.h
+++ b/src/proxy/testwebsocket.h
@@ -43,6 +43,7 @@ public:
 	virtual void setIgnorePolicies(bool on);
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
+	virtual void setClientCert(const QString &cert, const QString &key);
 
 	virtual void start(const QUrl &uri, const HttpHeaders &headers);
 

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -193,6 +193,8 @@ public:
 	bool ignorePolicies;
 	bool trustConnectHost;
 	bool ignoreTlsErrors;
+	QString clientCert;
+	QString clientKey;
 	State state;
 	QByteArray cid;
 	HttpRequestData requestData;
@@ -568,6 +570,8 @@ private:
 		req->setIgnorePolicies(ignorePolicies);
 		req->setTrustConnectHost(trustConnectHost);
 		req->setIgnoreTlsErrors(ignoreTlsErrors);
+		if(!clientCert.isEmpty())
+			req->setClientCert(clientCert, clientKey);
 		req->setSendBodyAfterAcknowledgement(true);
 
 		HttpHeaders headers = requestData.headers;
@@ -1112,6 +1116,12 @@ void WebSocketOverHttp::setTrustConnectHost(bool on)
 void WebSocketOverHttp::setIgnoreTlsErrors(bool on)
 {
 	d->ignoreTlsErrors = on;
+}
+
+void WebSocketOverHttp::setClientCert(const QString &cert, const QString &key)
+{
+	d->clientCert = cert;
+	d->clientKey = key;
 }
 
 void WebSocketOverHttp::start(const QUrl &uri, const HttpHeaders &headers)

--- a/src/proxy/websocketoverhttp.h
+++ b/src/proxy/websocketoverhttp.h
@@ -72,6 +72,7 @@ public:
 	virtual void setIgnorePolicies(bool on);
 	virtual void setTrustConnectHost(bool on);
 	virtual void setIgnoreTlsErrors(bool on);
+	virtual void setClientCert(const QString &cert, const QString &key);
 
 	virtual void start(const QUrl &uri, const HttpHeaders &headers);
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -593,6 +593,9 @@ public:
 			outSock->setConnectPort(target.connectPort);
 		}
 
+		if(!target.clientCert.isEmpty())
+			outSock->setClientCert(target.clientCert, target.clientKey);
+
 		ProxyUtil::applyHostHeader(&requestData.headers, uri);
 
 		incCounter(Stats::ServerHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes("GET", uri, requestData.headers));


### PR DESCRIPTION
This enables mutual TLS authentication by allowing cert & key files to be applied to route targets.

Tested against the following python server code that responds with the client cert's common name in the response:

```py
import socket
import ssl
import time
import traceback

context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
context.load_cert_chain('server.crt', 'server.key')
context.verify_mode = ssl.CERT_OPTIONAL
context.load_verify_locations(cafile='ca.crt')

with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
    sock.bind(('127.0.0.1', 8443))
    sock.listen(5)

    with context.wrap_socket(sock, server_side=True) as ssock:
        while True:
            try:
                conn, addr = ssock.accept()
                with conn:
                    common_name = None
                    cert = conn.getpeercert()
                    if cert:
                        for name in cert['subject']:
                            k, v = name[0]
                            if k == 'commonName':
                                common_name = v
                    print(f'connection from {addr}, peer cert = {cert}')
                    conn.read()
                    body = f'hello, {common_name}\n'.encode('utf-8')
                    conn.write(b'HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n' + body)
                    conn = conn.unwrap()
            except Exception:
                print('connection failed')
                traceback.print_exc()
```

Client cert:

```
% openssl x509 -in client.crt -text | grep Subject:
        Subject: C = US, ST = CA, O = Internet Widgits Pty Ltd, CN = test client
```

Pushpin route:

```
* localhost:8443,ssl,insecure,client_cert=client.crt,client_key=client.key
```

Client request:

```
% curl http://localhost:7999
hello, test client
```