### PR TITLE
connmgr: use client cert/key if provided

### DIFF
--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -4432,12 +4432,19 @@ async fn client_connect<'a>(
                 VerifyMode::Full
             };
 
+            let client_cert = if !rdata.client_cert.is_empty() {
+                Some((rdata.client_cert, rdata.client_key))
+            } else {
+                None
+            };
+
             let stream = match AsyncTlsStream::connect(
                 host,
                 stream,
                 verify_mode,
                 tls_waker_data,
                 tls_config_cache,
+                client_cert,
             ) {
                 Ok(stream) => stream,
                 Err(e) => {

--- a/src/connmgr/zhttppacket.rs
+++ b/src/connmgr/zhttppacket.rs
@@ -340,6 +340,8 @@ pub struct RequestData<'buf, 'headers> {
     pub ignore_policies: bool,
     pub trust_connect_host: bool,
     pub ignore_tls_errors: bool,
+    pub client_cert: &'buf str,
+    pub client_key: &'buf str,
     pub follow_redirects: bool,
 }
 
@@ -365,6 +367,8 @@ impl RequestData<'_, '_> {
             ignore_policies: false,
             trust_connect_host: false,
             ignore_tls_errors: false,
+            client_cert: "",
+            client_key: "",
             follow_redirects: false,
         }
     }
@@ -478,6 +482,8 @@ impl<'buf: 'scratch, 'scratch> Parse<'buf, 'scratch> for RequestData<'buf, 'scra
         let mut ignore_policies = false;
         let mut trust_connect_host = false;
         let mut ignore_tls_errors = false;
+        let mut client_cert = "";
+        let mut client_key = "";
         let mut follow_redirects = false;
 
         for e in root {
@@ -641,6 +647,20 @@ impl<'buf: 'scratch, 'scratch> Parse<'buf, 'scratch> for RequestData<'buf, 'scra
 
                     ignore_tls_errors = b;
                 }
+                "client-cert" => {
+                    let s = tnetstring::parse_string(e.data).field("client-cert")?;
+
+                    let s = str::from_utf8(s).field("client-cert")?;
+
+                    client_cert = s;
+                }
+                "client-key" => {
+                    let s = tnetstring::parse_string(e.data).field("client-key")?;
+
+                    let s = str::from_utf8(s).field("client-key")?;
+
+                    client_key = s;
+                }
                 "follow-redirects" => {
                     let b = tnetstring::parse_bool(e.data).field("follow-redirects")?;
 
@@ -669,6 +689,8 @@ impl<'buf: 'scratch, 'scratch> Parse<'buf, 'scratch> for RequestData<'buf, 'scra
             ignore_policies,
             trust_connect_host,
             ignore_tls_errors,
+            client_cert,
+            client_key,
             follow_redirects,
         })
     }
@@ -1815,6 +1837,8 @@ mod tests {
                         ignore_policies: false,
                         trust_connect_host: false,
                         ignore_tls_errors: false,
+                        client_cert: "",
+                        client_key: "",
                         follow_redirects: false,
                     }),
                     ptype_str: "",


### PR DESCRIPTION
This reads `client_cert` and `client_key` fields from the request packet, treating the values as PEM data for passing along to the openssl connector in order to enable mutual TLS authentication. The fields are not set anywhere yet. Next we'll update the proxy to populate the fields when applicable.