### PR TITLE
replace qzmq namespace with zmq prefix

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -3,17 +3,17 @@ HEADERS += \
 	$$PWD/cowstring.h
 
 HEADERS += \
-	$$PWD/qzmqcontext.h \
-	$$PWD/qzmqsocket.h \
-	$$PWD/qzmqvalve.h \
-	$$PWD/qzmqreqmessage.h \
-	$$PWD/qzmqreprouter.h
+	$$PWD/zmqcontext.h \
+	$$PWD/zmqsocket.h \
+	$$PWD/zmqvalve.h \
+	$$PWD/zmqreqmessage.h \
+	$$PWD/zmqreprouter.h
 
 SOURCES += \
-	$$PWD/qzmqcontext.cpp \
-	$$PWD/qzmqsocket.cpp \
-	$$PWD/qzmqvalve.cpp \
-	$$PWD/qzmqreprouter.cpp
+	$$PWD/zmqcontext.cpp \
+	$$PWD/zmqsocket.cpp \
+	$$PWD/zmqvalve.cpp \
+	$$PWD/zmqreprouter.cpp
 
 HEADERS += $$PWD/processquit.h
 SOURCES += $$PWD/processquit.cpp

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -28,7 +28,7 @@
 #include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include "qzmqsocket.h"
+#include "zmqsocket.h"
 #include "timerwheel.h"
 #include "log.h"
 #include "defercall.h"
@@ -401,7 +401,7 @@ public:
 	int subscriptionTtl;
 	int subscriptionLinger;
 	int reportInterval;
-	std::unique_ptr<QZmq::Socket> sock;
+	std::unique_ptr<ZmqSocket> sock;
 	std::unique_ptr<SimpleHttpServer> prometheusServer;
 	int prometheusConnectionsMax;
 	QString prometheusPrefix;
@@ -499,7 +499,7 @@ public:
 	{
 		sock.reset();
 
-		sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pub);
+		sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
 
 		sock->setHwm(OUT_HWM);
 		sock->setWriteQueueEnabled(false);

--- a/src/core/zmqcontext.cpp
+++ b/src/core/zmqcontext.cpp
@@ -21,49 +21,18 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef QZMQREPROUTER_H
-#define QZMQREPROUTER_H
+#include "zmqcontext.h"
 
-#include <boost/signals2.hpp>
+#include <assert.h>
+#include "rust/bindings.h"
 
-class CowString;
-
-using Signal = boost::signals2::signal<void()>;
-using SignalInt = boost::signals2::signal<void(int)>;
-using Connection = boost::signals2::scoped_connection;
-
-namespace QZmq {
-
-class ReqMessage;
-
-class RepRouter
+ZmqContext::ZmqContext(int ioThreads)
 {
-public:
-	RepRouter();
-	~RepRouter();
-
-	void setShutdownWaitTime(int msecs);
-
-	void connectToAddress(const CowString &addr);
-	bool bind(const CowString &addr);
-
-	bool canRead() const;
-
-	ReqMessage read();
-	void write(const ReqMessage &message);
-
-	Signal readyRead;
-	SignalInt messagesWritten;
-
-private:
-	RepRouter(const RepRouter &) = delete;
-	RepRouter &operator=(const RepRouter &) = delete;
-
-	class Private;
-	friend class Private;
-	std::unique_ptr<Private> d;
-};
-
+	context_ = ffi::wzmq_init(ioThreads);
+	assert(context_);
 }
 
-#endif
+ZmqContext::~ZmqContext()
+{
+	ffi::wzmq_term(context_);
+}

--- a/src/core/zmqcontext.h
+++ b/src/core/zmqcontext.h
@@ -21,16 +21,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef QZMQCONTEXT_H
-#define QZMQCONTEXT_H
+#ifndef ZMQCONTEXT_H
+#define ZMQCONTEXT_H
 
-namespace QZmq {
-
-class Context
+class ZmqContext
 {
 public:
-	Context(int ioThreads = 1);
-	~Context();
+	ZmqContext(int ioThreads = 1);
+	~ZmqContext();
 
 	// the zmq context
 	void *context() { return context_; }
@@ -38,7 +36,5 @@ public:
 private:
 	void *context_;
 };
-
-}
 
 #endif

--- a/src/core/zmqreprouter.cpp
+++ b/src/core/zmqreprouter.cpp
@@ -21,26 +21,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "qzmqreprouter.h"
+#include "zmqreprouter.h"
 
 #include "cowstring.h"
-#include "qzmqsocket.h"
-#include "qzmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqreqmessage.h"
 
-namespace QZmq {
-
-class RepRouter::Private
+class ZmqRepRouter::Private
 {
 public:
-	RepRouter *q;
-	std::unique_ptr<Socket> sock;
+	ZmqRepRouter *q;
+	std::unique_ptr<ZmqSocket> sock;
 	Connection mWConnection;
 	Connection rrConnection;
 
-	Private(RepRouter *_q) :
+	Private(ZmqRepRouter *_q) :
 		q(_q)
 	{
-		sock = std::make_unique<Socket>(Socket::Router);
+		sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 		rrConnection = sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this));
 		mWConnection = sock->messagesWritten.connect(boost::bind(&Private::sock_messagesWritten, this,  boost::placeholders::_1));
 	}
@@ -56,42 +54,39 @@ public:
 	}
 };
 
-RepRouter::RepRouter()
+ZmqRepRouter::ZmqRepRouter()
 {
 	d = std::make_unique<Private>(this);
 }
 
-RepRouter::~RepRouter() = default;
+ZmqRepRouter::~ZmqRepRouter() = default;
 
-void RepRouter::setShutdownWaitTime(int msecs)
+void ZmqRepRouter::setShutdownWaitTime(int msecs)
 {
 	d->sock->setShutdownWaitTime(msecs);
 }
 
-void RepRouter::connectToAddress(const CowString &addr)
+void ZmqRepRouter::connectToAddress(const CowString &addr)
 {
 	d->sock->connectToAddress(addr);
 }
 
-bool RepRouter::bind(const CowString &addr)
+bool ZmqRepRouter::bind(const CowString &addr)
 {
 	return d->sock->bind(addr);
 }
 
-bool RepRouter::canRead() const
+bool ZmqRepRouter::canRead() const
 {
 	return d->sock->canRead();
 }
 
-ReqMessage RepRouter::read()
+ZmqReqMessage ZmqRepRouter::read()
 {
-	return ReqMessage(d->sock->read());
+	return ZmqReqMessage(d->sock->read());
 }
 
-void RepRouter::write(const ReqMessage &message)
+void ZmqRepRouter::write(const ZmqReqMessage &message)
 {
 	d->sock->write(message.toRawMessage());
 }
-
-}
-

--- a/src/core/zmqsocket.h
+++ b/src/core/zmqsocket.h
@@ -22,8 +22,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef QZMQSOCKET_H
-#define QZMQSOCKET_H
+#ifndef ZMQSOCKET_H
+#define ZMQSOCKET_H
 
 #include <boost/signals2.hpp>
 #include "cowbytearray.h"
@@ -34,11 +34,9 @@ using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
 using Connection = boost::signals2::scoped_connection;
 
-namespace QZmq {
+class ZmqContext;
 
-class Context;
-
-class Socket
+class ZmqSocket
 {
 public:
 	enum Type
@@ -54,9 +52,9 @@ public:
 		Sub
 	};
 
-	Socket(Type type);
-	Socket(Type type, Context *context);
-	~Socket();
+	ZmqSocket(Type type);
+	ZmqSocket(Type type, ZmqContext *context);
+	~ZmqSocket();
 
 	// 0 means drop queue and don't block, -1 means infinite (default = -1)
 	void setShutdownWaitTime(int msecs);
@@ -110,14 +108,12 @@ public:
 	SignalInt messagesWritten;
 
 private:
-	Socket(const Socket &) = delete;
-	Socket &operator=(const Socket &) = delete;
+	ZmqSocket(const ZmqSocket &) = delete;
+	ZmqSocket &operator=(const ZmqSocket &) = delete;
 
 	class Private;
 	friend class Private;
 	std::shared_ptr<Private> d;
 };
-
-}
 
 #endif

--- a/src/core/zmqvalve.cpp
+++ b/src/core/zmqvalve.cpp
@@ -22,25 +22,23 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "qzmqvalve.h"
+#include "zmqvalve.h"
 
-#include "qzmqsocket.h"
+#include "zmqsocket.h"
 #include "defercall.h"
 
-namespace QZmq {
-
-class Valve::Private
+class ZmqValve::Private
 {
 public:
-	Valve *q;
-	QZmq::Socket *sock;
+	ZmqValve *q;
+	ZmqSocket *sock;
 	bool isOpen;
 	bool pendingRead;
 	int maxReadsPerEvent;
 	boost::signals2::scoped_connection rrConnection;
 	DeferCall deferCall;
 
-	Private(Valve *_q) :
+	Private(ZmqValve *_q) :
 		q(_q),
 		sock(0),
 		isOpen(false),
@@ -49,7 +47,7 @@ public:
 	{
 	}
 
-	void setup(QZmq::Socket *_sock)
+	void setup(ZmqSocket *_sock)
 	{
 		sock = _sock;
 		rrConnection = sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this));
@@ -105,25 +103,25 @@ public:
 	}
 };
 
-Valve::Valve(QZmq::Socket *sock)
+ZmqValve::ZmqValve(ZmqSocket *sock)
 {
 	d = std::make_shared<Private>(this);
 	d->setup(sock);
 }
 
-Valve::~Valve() = default;
+ZmqValve::~ZmqValve() = default;
 
-bool Valve::isOpen() const
+bool ZmqValve::isOpen() const
 {
 	return d->isOpen;
 }
 
-void Valve::setMaxReadsPerEvent(int max)
+void ZmqValve::setMaxReadsPerEvent(int max)
 {
 	d->maxReadsPerEvent = max;
 }
 
-void Valve::open()
+void ZmqValve::open()
 {
 	if(!d->isOpen)
 	{
@@ -133,9 +131,7 @@ void Valve::open()
 	}
 }
 
-void Valve::close()
+void ZmqValve::close()
 {
 	d->isOpen = false;
-}
-
 }

--- a/src/core/zmqvalve.h
+++ b/src/core/zmqvalve.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Justin Karneges
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
@@ -21,22 +22,36 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "qzmqcontext.h"
+#ifndef ZMQVALVE_H
+#define ZMQVALVE_H
 
-#include <assert.h>
-#include "rust/bindings.h"
+#include <boost/signals2.hpp>
+#include "cowbytearray.h"
 
-namespace QZmq {
+using SignalList = boost::signals2::signal<void(const CowByteArrayList&)>;
+using Connection = boost::signals2::scoped_connection;
 
-Context::Context(int ioThreads)
+class ZmqSocket;
+
+class ZmqValve
 {
-	context_ = ffi::wzmq_init(ioThreads);
-	assert(context_);
-}
+public:
+	ZmqValve(ZmqSocket *sock);
+	~ZmqValve();
 
-Context::~Context()
-{
-	ffi::wzmq_term(context_);
-}
+	bool isOpen() const;
 
-}
+	void setMaxReadsPerEvent(int max);
+
+	void open();
+	void close();
+
+	SignalList readyRead;
+
+private:
+	class Private;
+	friend class Private;
+	std::shared_ptr<Private> d;
+};
+
+#endif

--- a/src/core/zrpcmanager.cpp
+++ b/src/core/zrpcmanager.cpp
@@ -26,9 +26,9 @@
 #include <assert.h>
 #include <QStringList>
 #include <QFile>
-#include "qzmqsocket.h"
-#include "qzmqvalve.h"
-#include "qzmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zmqreqmessage.h"
 #include "log.h"
 #include "tnetstring.h"
 #include "packet/zrpcrequestpacket.h"
@@ -61,10 +61,10 @@ public:
 	int timeout;
 	QStringList clientSpecs;
 	QStringList serverSpecs;
-	std::unique_ptr<QZmq::Socket> clientSock;
-	std::unique_ptr<QZmq::Socket> serverSock;
-	std::unique_ptr<QZmq::Valve> clientValve;
-	std::unique_ptr<QZmq::Valve> serverValve;
+	std::unique_ptr<ZmqSocket> clientSock;
+	std::unique_ptr<ZmqSocket> serverSock;
+	std::unique_ptr<ZmqValve> clientValve;
+	std::unique_ptr<ZmqValve> serverValve;
 	QHash<QByteArray, ZrpcRequest*> clientReqsById;
 	QList<PendingItem> pending;
 	Connection clientValveConnection;
@@ -89,7 +89,7 @@ public:
 		clientValve.reset();
 		clientSock.reset();
 
-		clientSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Dealer);
+		clientSock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
 
 		clientSock->setSendHwm(OUT_HWM);
 		clientSock->setShutdownWaitTime(REQ_WAIT_TIME);
@@ -101,7 +101,7 @@ public:
 			return false;
 		}
 
-		clientValve = std::make_unique<QZmq::Valve>(clientSock.get());
+		clientValve = std::make_unique<ZmqValve>(clientSock.get());
 		clientValveConnection = clientValve->readyRead.connect(boost::bind(&Private::client_readyRead, this, boost::placeholders::_1));
 
 		clientValve->open();
@@ -115,7 +115,7 @@ public:
 		serverValve.reset();
 		serverSock.reset();
 
-		serverSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
+		serverSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 
 		serverSock->setReceiveHwm(IN_HWM);
 		serverSock->setShutdownWaitTime(REP_WAIT_TIME);
@@ -127,7 +127,7 @@ public:
 			return false;
 		}
 
-		serverValve = std::make_unique<QZmq::Valve>(serverSock.get());
+		serverValve = std::make_unique<ZmqValve>(serverSock.get());
 		serverValveConnection = serverValve->readyRead.connect(boost::bind(&Private::server_readyRead, this, boost::placeholders::_1));
 
 		serverValve->open();
@@ -211,7 +211,7 @@ public:
 
 	void server_readyRead(const CowByteArrayList &message)
 	{
-		QZmq::ReqMessage req(message);
+		ZmqReqMessage req(message);
 
 		if(req.content().count() != 1)
 		{

--- a/src/core/zutil.cpp
+++ b/src/core/zutil.cpp
@@ -23,12 +23,12 @@
 #include "zutil.h"
 
 #include <QFile>
-#include "qzmqsocket.h"
+#include "zmqsocket.h"
 #include "cowstring.h"
 
 namespace ZUtil {
 
-bool bindSpec(QZmq::Socket *sock, const QString &spec, int ipcFileMode, QString *errorMessage)
+bool bindSpec(ZmqSocket *sock, const QString &spec, int ipcFileMode, QString *errorMessage)
 {
 	if(!sock->bind(spec))
 	{
@@ -72,7 +72,7 @@ bool bindSpec(QZmq::Socket *sock, const QString &spec, int ipcFileMode, QString 
 	return true;
 }
 
-bool setupSocket(QZmq::Socket *sock, const QStringList &specs, bool bind, int ipcFileMode, QString *errorMessage)
+bool setupSocket(ZmqSocket *sock, const QStringList &specs, bool bind, int ipcFileMode, QString *errorMessage)
 {
 	if(bind)
 	{
@@ -91,7 +91,7 @@ bool setupSocket(QZmq::Socket *sock, const QStringList &specs, bool bind, int ip
 	return true;
 }
 
-bool setupSocket(QZmq::Socket *sock, const QString &spec, bool bind, int ipcFileMode, QString *errorMessage)
+bool setupSocket(ZmqSocket *sock, const QString &spec, bool bind, int ipcFileMode, QString *errorMessage)
 {
 	return setupSocket(sock, QStringList() << spec, bind, ipcFileMode, errorMessage);
 }

--- a/src/core/zutil.h
+++ b/src/core/zutil.h
@@ -26,19 +26,15 @@
 #include <QString>
 #include <QStringList>
 
-namespace QZmq {
-
-class Socket;
-
-}
+class ZmqSocket;
 
 namespace ZUtil {
 
-bool bindSpec(QZmq::Socket *sock, const QString &spec, int ipcFileMode, QString *errorMessage = 0);
+bool bindSpec(ZmqSocket *sock, const QString &spec, int ipcFileMode, QString *errorMessage = 0);
 
-bool setupSocket(QZmq::Socket *sock, const QStringList &specs, bool bind, int ipcFileMode, QString *errorMessage = 0);
+bool setupSocket(ZmqSocket *sock, const QStringList &specs, bool bind, int ipcFileMode, QString *errorMessage = 0);
 
-bool setupSocket(QZmq::Socket *sock, const QString &spec, bool bind, int ipcFileMode, QString *errorMessage = 0);
+bool setupSocket(ZmqSocket *sock, const QString &spec, bool bind, int ipcFileMode, QString *errorMessage = 0);
 
 }
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -26,9 +26,9 @@
 #include <QDir>
 #include "test.h"
 #include "cowstring.h"
-#include "qzmqsocket.h"
-#include "qzmqvalve.h"
-#include "qzmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zmqreqmessage.h"
 #include "qtcompat.h"
 #include "log.h"
 #include "tnetstring.h"
@@ -45,18 +45,18 @@ namespace {
 class Wrapper
 {
 public:
-	std::unique_ptr<QZmq::Socket> zhttpClientOutStreamSock;
-	std::unique_ptr<QZmq::Valve> zhttpClientOutStreamValve;
-	std::unique_ptr<QZmq::Socket> zhttpClientInSock;
-	std::unique_ptr<QZmq::Valve> zhttpClientInValve;
-	std::unique_ptr<QZmq::Socket> zhttpServerInSock;
-	std::unique_ptr<QZmq::Valve> zhttpServerInValve;
-	std::unique_ptr<QZmq::Socket> zhttpServerInStreamSock;
-	std::unique_ptr<QZmq::Valve> zhttpServerInStreamValve;
-	std::unique_ptr<QZmq::Socket> zhttpServerOutSock;
-	std::unique_ptr<QZmq::Socket> proxyAcceptSock;
-	std::unique_ptr<QZmq::Valve> proxyAcceptValve;
-	std::unique_ptr<QZmq::Socket> publishPushSock;
+	std::unique_ptr<ZmqSocket> zhttpClientOutStreamSock;
+	std::unique_ptr<ZmqValve> zhttpClientOutStreamValve;
+	std::unique_ptr<ZmqSocket> zhttpClientInSock;
+	std::unique_ptr<ZmqValve> zhttpClientInValve;
+	std::unique_ptr<ZmqSocket> zhttpServerInSock;
+	std::unique_ptr<ZmqValve> zhttpServerInValve;
+	std::unique_ptr<ZmqSocket> zhttpServerInStreamSock;
+	std::unique_ptr<ZmqValve> zhttpServerInStreamValve;
+	std::unique_ptr<ZmqSocket> zhttpServerOutSock;
+	std::unique_ptr<ZmqSocket> proxyAcceptSock;
+	std::unique_ptr<ZmqValve> proxyAcceptValve;
+	std::unique_ptr<ZmqSocket> publishPushSock;
 
 	QDir workDir;
 	bool acceptSuccess;
@@ -85,34 +85,34 @@ public:
 	{
 		// http sockets
 
-		zhttpClientOutStreamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
-		zhttpClientOutStreamValve = std::make_unique<QZmq::Valve>(zhttpClientOutStreamSock.get());
+		zhttpClientOutStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+		zhttpClientOutStreamValve = std::make_unique<ZmqValve>(zhttpClientOutStreamSock.get());
 		zhttpClientOutStreamValveConnection = zhttpClientOutStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientOutStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpClientInSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Sub);
-		zhttpClientInValve = std::make_unique<QZmq::Valve>(zhttpClientInSock.get());
+		zhttpClientInSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+		zhttpClientInValve = std::make_unique<ZmqValve>(zhttpClientInSock.get());
 		zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pull);
-		zhttpServerInValve = std::make_unique<QZmq::Valve>(zhttpServerInSock.get());
+		zhttpServerInSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+		zhttpServerInValve = std::make_unique<ZmqValve>(zhttpServerInSock.get());
 		zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInStreamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
+		zhttpServerInStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 		zhttpServerInStreamSock->setIdentity("test-server");
-		zhttpServerInStreamValve = std::make_unique<QZmq::Valve>(zhttpServerInStreamSock.get());
+		zhttpServerInStreamValve = std::make_unique<ZmqValve>(zhttpServerInStreamSock.get());
 		zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerOutSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Pub);
+		zhttpServerOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
 
 		// proxy sockets
 
-		proxyAcceptSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Dealer);
-		proxyAcceptValve = std::make_unique<QZmq::Valve>(proxyAcceptSock.get());
+		proxyAcceptSock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
+		proxyAcceptValve = std::make_unique<ZmqValve>(proxyAcceptSock.get());
 		proxyAcceptValveConnection = proxyAcceptValve->readyRead.connect(boost::bind(&Wrapper::proxyAccept_readyRead, this, boost::placeholders::_1));
 
 		// publish sockets
 
-		publishPushSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
+		publishPushSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
 	}
 
 	void startHttp()
@@ -272,7 +272,7 @@ public:
 
 	void proxyAccept_readyRead(const CowByteArrayList &_message)
 	{
-		QZmq::ReqMessage message(_message);
+		ZmqReqMessage message(_message);
 		QVariant v = TnetString::toVariant(message.content()[0]);
 
 		TEST_ASSERT(typeId(v) == QMetaType::QVariantHash);

--- a/src/proxy/engine.cpp
+++ b/src/proxy/engine.cpp
@@ -24,9 +24,9 @@
 #include "engine.h"
 
 #include <assert.h>
-#include "qzmqsocket.h"
-#include "qzmqvalve.h"
-#include "qzmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zmqreqmessage.h"
 #include "tnetstring.h"
 #include "packet/httpresponsedata.h"
 #include "packet/retryrequestpacket.h"
@@ -113,8 +113,8 @@ public:
 	std::unique_ptr<StatsManager> stats;
 	std::unique_ptr<ZrpcManager> command;
 	std::unique_ptr<ZrpcManager> accept;
-	std::unique_ptr<QZmq::Socket> handler_retry_in_sock;
-	std::unique_ptr<QZmq::Valve> handler_retry_in_valve;
+	std::unique_ptr<ZmqSocket> handler_retry_in_sock;
+	std::unique_ptr<ZmqValve> handler_retry_in_valve;
 	QSet<RequestSession*> requestSessions;
 	QHash<QByteArray, ProxyItem*> proxyItemsByKey;
 	QHash<ProxySession*, ProxyItem*> proxyItemsBySession;
@@ -256,7 +256,7 @@ public:
 
 		if(!config.retryInSpec.isEmpty())
 		{
-			handler_retry_in_sock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
+			handler_retry_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 
 			handler_retry_in_sock->setIdentity(config.clientId);
 			handler_retry_in_sock->setHwm(DEFAULT_HWM);
@@ -268,7 +268,7 @@ public:
 				return false;
 			}
 
-			handler_retry_in_valve = std::make_unique<QZmq::Valve>(handler_retry_in_sock.get());
+			handler_retry_in_valve = std::make_unique<ZmqValve>(handler_retry_in_sock.get());
 			rrConnection = handler_retry_in_valve->readyRead.connect(boost::bind(&Private::handler_retry_in_readyRead, this, boost::placeholders::_1));
 		}
 
@@ -829,7 +829,7 @@ private:
 private:
 	void handler_retry_in_readyRead(const CowByteArrayList &message)
 	{
-		QZmq::ReqMessage req(message);
+		ZmqReqMessage req(message);
 
 		if(req.content().count() != 1)
 		{

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -26,9 +26,9 @@
 #include <assert.h>
 #include <QDateTime>
 #include <boost/signals2.hpp>
-#include "qzmqsocket.h"
-#include "qzmqvalve.h"
-#include "qzmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zmqreqmessage.h"
 #include "log.h"
 #include "timer.h"
 #include "tnetstring.h"
@@ -65,9 +65,9 @@ public:
 	int ipcFileMode;
 	QStringList initSpecs;
 	QStringList streamSpecs;
-	std::unique_ptr<QZmq::Socket> initSock;
-	std::unique_ptr<QZmq::Socket> streamSock;
-	std::unique_ptr<QZmq::Valve> streamValve;
+	std::unique_ptr<ZmqSocket> initSock;
+	std::unique_ptr<ZmqSocket> streamSock;
+	std::unique_ptr<ZmqValve> streamValve;
 	QHash<QByteArray, WsControlSession*> sessionsByCid;
 	std::unique_ptr<Timer> refreshTimer;
 	QHash<WsControlSession*, KeepAliveRegistration*> keepAliveRegistrations;
@@ -96,7 +96,7 @@ public:
 	{
 		initSock.reset();
 
-		initSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Push);
+		initSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
 
 		initSock->setHwm(DEFAULT_HWM);
 		initSock->setShutdownWaitTime(0);
@@ -119,7 +119,7 @@ public:
 		streamValve.reset();
 		streamSock.reset();
 
-		streamSock = std::make_unique<QZmq::Socket>(QZmq::Socket::Router);
+		streamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 
 		streamSock->setIdentity(identity);
 		streamSock->setHwm(DEFAULT_HWM);
@@ -135,7 +135,7 @@ public:
 			}
 		}
 
-		streamValve = std::make_unique<QZmq::Valve>(streamSock.get());
+		streamValve = std::make_unique<ZmqValve>(streamSock.get());
 		streamValveConnection = streamValve->readyRead.connect(boost::bind(&Private::stream_readyRead, this, boost::placeholders::_1));
 
 		streamValve->open();
@@ -254,7 +254,7 @@ public:
 private:
 	void stream_readyRead(const CowByteArrayList &message)
 	{
-		QZmq::ReqMessage req(message);
+		ZmqReqMessage req(message);
 
 		if(req.content().count() != 1)
 		{


### PR DESCRIPTION
Now that the classes in the QZmq namespace no longer use Qt, we should drop the "Q" from the name. Since Pushpin doesn't normally use namespaces around classes, this PR removes the namespace instead of renaming it, and prefixes all its classes with `Zmq`. This flat approach is more consistent with the rest of the C++ code. The reason there was a namespace to begin with is QZmq was originally a separate library.

Despite this change, I'm not against developing a namespace structure for the C++ code, especially since our Rust code is organized into modules. This PR is just to make things consistent in the meantime.