### PR TITLE
proxy/handler: tweak arg handling style and format

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -180,6 +180,16 @@ int Settings::adjustedPort(const QString &key, int defaultValue) const
 	return x;
 }
 
+QString Settings::ipcPrefix() const
+{
+	return ipcPrefix_;
+}
+
+int Settings::portOffset() const
+{
+	return portOffset_;
+}
+
 void Settings::setIpcPrefix(const QString &s)
 {
 	ipcPrefix_ = s;
@@ -188,14 +198,4 @@ void Settings::setIpcPrefix(const QString &s)
 void Settings::setPortOffset(int x)
 {
 	portOffset_ = x;
-}
-
-QString Settings::getIpcPrefix() const
-{
-	return ipcPrefix_;
-}
-
-int Settings::getPortOffset() const 
-{
-	return portOffset_;
 }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -31,18 +31,18 @@ class QSettings;
 class Settings
 {
 public:
-
 	Settings(const QString &fileName);
 	~Settings();
+
 	bool contains(const QString &key) const;
 	QVariant valueRaw(const QString &key, const QVariant &defaultValue = QVariant()) const;
 	QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
 	int adjustedPort(const QString &key, int defaultValue = -1) const;
 
+	QString ipcPrefix() const;
+	int portOffset() const;
 	void setIpcPrefix(const QString &s);
 	void setPortOffset(int x);
-	QString getIpcPrefix() const;
-	int getPortOffset() const;
 
 private:
 	QSettings *main_;

--- a/src/handler/cliargs.rs
+++ b/src/handler/cliargs.rs
@@ -169,6 +169,7 @@ mod tests {
             config_file: Some(config_test_file.clone()),
             log_file: Some("pushpin.log".to_string()),
             log_level: 3,
+            verbose: false,
             ipc_prefix: Some("ipc".to_string()),
             port_offset: Some(8080),
         };
@@ -180,6 +181,7 @@ mod tests {
         assert_eq!(verified_args.config_file, Some(config_test_file.clone()));
         assert_eq!(verified_args.log_file, Some("pushpin.log".to_string()));
         assert_eq!(verified_args.log_level, 3);
+        assert_eq!(verified_args.verbose, false);
         assert_eq!(verified_args.ipc_prefix, Some("ipc".to_string()));
         assert_eq!(verified_args.port_offset, Some(8080));
 
@@ -217,6 +219,7 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: 2,
+            verbose: false,
             ipc_prefix: None,
             port_offset: None,
         };
@@ -235,6 +238,7 @@ mod tests {
         );
         assert_eq!(verified_empty_args.log_file, None);
         assert_eq!(verified_empty_args.log_level, 2);
+        assert_eq!(verified_empty_args.verbose, false);
         assert_eq!(verified_empty_args.ipc_prefix, None);
         assert_eq!(verified_empty_args.port_offset, None);
 
@@ -266,5 +270,19 @@ mod tests {
         unsafe {
             destroy_handler_cli_args(empty_args_ffi);
         }
+
+        // Test verbose
+        let args = CliArgs {
+            config_file: None,
+            log_file: None,
+            log_level: 2,
+            verbose: true,
+            ipc_prefix: None,
+            port_offset: None,
+        };
+
+        // Test verify() method
+        let verified_args = args.verify();
+        assert_eq!(verified_args.log_level, 3);
     }
 }

--- a/src/handler/cliargs.rs
+++ b/src/handler/cliargs.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 // Struct to hold the command line arguments
 #[derive(Parser, Debug)]
 #[command(
-    name= "Pushpin Handler",
+    name= "pushpin-handler",
     version = version(),
     about = "Pushpin handler component."
 )]
@@ -41,11 +41,15 @@ pub struct CliArgs {
     #[arg(short = 'L', long = "loglevel", value_name = "x", default_value_t = 2, value_parser = clap::value_parser!(u32).range(1..=4))]
     pub log_level: u32,
 
-    /// Override ipc_prefix config option, which is used to add a prefix to all ZeroMQ IPC filenames
+    /// Set verbose output; same as --loglevel=3
+    #[arg(long = "verbose")]
+    pub verbose: bool,
+
+    /// Add a prefix to all ZeroMQ IPC filenames
     #[arg(long, value_name = "prefix")]
     pub ipc_prefix: Option<String>,
 
-    /// Override port_offset config option, which is used to increment all ZeroMQ TCP ports and the HTTP control server port
+    /// Increment all ZeroMQ TCP ports and the HTTP control server port
     #[arg(long, value_name = "offset", value_parser = clap::value_parser!(u32))]
     pub port_offset: Option<u32>,
 }
@@ -64,6 +68,10 @@ impl CliArgs {
                 std::process::exit(1);
             }
         };
+
+        if self.verbose {
+            self.log_level = 3;
+        }
 
         self
     }

--- a/src/handler/handlerargsdata.cpp
+++ b/src/handler/handlerargsdata.cpp
@@ -22,18 +22,12 @@
  */
 
 #include "handlerargsdata.h"
-#include "settings.h"
-#include "config.h"
-#include "log.h"
-#include "rust/bindings.h"
-#include <QCoreApplication>
-#include <QFile>
 
 HandlerArgsData::HandlerArgsData(const ffi::HandlerCliArgs *argsFfi)
 {
-    configFile  = QString::fromUtf8(argsFfi->config_file);
-    logFile     = QString::fromUtf8(argsFfi->log_file);
-    logLevel 	= argsFfi->log_level;
-    ipcPrefix 	= QString::fromUtf8(argsFfi->ipc_prefix);
-    portOffset  = argsFfi->port_offset;
+	configFile = QString::fromUtf8(argsFfi->config_file);
+	logFile    = QString::fromUtf8(argsFfi->log_file);
+	logLevel   = argsFfi->log_level;
+	ipcPrefix  = QString::fromUtf8(argsFfi->ipc_prefix);
+	portOffset = argsFfi->port_offset;
 }

--- a/src/handler/handlerargsdata.h
+++ b/src/handler/handlerargsdata.h
@@ -25,19 +25,18 @@
 #define HANDLERARGSDATA_H
 
 #include <QString>
-#include <QStringList>
 #include "rust/bindings.h"
 
 class HandlerArgsData
 {
-	public:
-		QString configFile;
-		QString logFile;
-		int logLevel;
-		QString ipcPrefix;
-		int portOffset;
+public:
+	QString configFile;
+	QString logFile;
+	int logLevel;
+	QString ipcPrefix;
+	int portOffset;
 
-		HandlerArgsData(const ffi::HandlerCliArgs *argsFfi);
+	HandlerArgsData(const ffi::HandlerCliArgs *argsFfi);
 };
 
 #endif

--- a/src/handler/handlerargstest.cpp
+++ b/src/handler/handlerargstest.cpp
@@ -20,70 +20,70 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "rust/bindings.h"
+#include "test.h"
+#include "log.h"
 #include "config.h"
 #include "settings.h"
-#include "test.h"
 #include "handlerargsdata.h"
-#include "rust/bindings.h"
-#include "log.h"
 
-void handlerargstest()
+static void handlerargstest()
 {
-    // Get file for example config
-    std::string configFile = "examples/config/pushpin.conf";
+	// Get file for example config
+	std::string configFile = "examples/config/pushpin.conf";
 
-    ffi::HandlerCliArgs argsFfi = {
-        const_cast<char*>(configFile.c_str()),  // config_file
-        const_cast<char*>("handler-log.txt"),           // log_file
-        3,                                      // log_level
-        const_cast<char*>("ipc:prefix"),        // ipc_prefix
-        81                                      // port_offset
-    };
+	ffi::HandlerCliArgs argsFfi = {
+		const_cast<char*>(configFile.c_str()),  // config_file
+		const_cast<char*>("handler-log.txt"),   // log_file
+		3,                                      // log_level
+		const_cast<char*>("ipc:prefix"),        // ipc_prefix
+		81                                      // port_offset
+	};
 
-    // Verify HandlerArgsData parsing
-    HandlerArgsData args(&argsFfi);
-    TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
-    TEST_ASSERT_EQ(args.logFile, QString("handler-log.txt"));
-    TEST_ASSERT_EQ(args.logLevel, 3);
-    TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
-    TEST_ASSERT_EQ(args.portOffset, 81);
+	// Verify HandlerArgsData parsing
+	HandlerArgsData args(&argsFfi);
+	TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
+	TEST_ASSERT_EQ(args.logFile, QString("handler-log.txt"));
+	TEST_ASSERT_EQ(args.logLevel, 3);
+	TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
+	TEST_ASSERT_EQ(args.portOffset, 81);
 
-    Settings settings(args.configFile);
-    if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
-    if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
+	Settings settings(args.configFile);
+	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+	if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
 
-    // Test command-line overrides were applied
-    TEST_ASSERT_EQ(settings.getPortOffset(), 81);
-    TEST_ASSERT_EQ(settings.getIpcPrefix(), QString("ipc:prefix"));
+	// Test command-line overrides were applied
+	TEST_ASSERT_EQ(settings.portOffset(), 81);
+	TEST_ASSERT_EQ(settings.ipcPrefix(), QString("ipc:prefix"));
 
-    ffi::HandlerCliArgs argsFfiEmpty = {
-        const_cast<char*>(configFile.c_str()),  // config_file
-        const_cast<char*>(""),                  // log_file
-        2,                                      // log_level
-        const_cast<char*>(""),                  // ipc_prefix
-        -1                                      // port_offset
-    };
+	ffi::HandlerCliArgs argsFfiEmpty = {
+		const_cast<char*>(configFile.c_str()),  // config_file
+		const_cast<char*>(""),                  // log_file
+		2,                                      // log_level
+		const_cast<char*>(""),                  // ipc_prefix
+		-1                                      // port_offset
+	};
 
-    // Verify HandlerArgsData parsing with empty arguments
-    HandlerArgsData argsEmpty(&argsFfiEmpty);
-    TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
-    TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
-    TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
-    TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
-    TEST_ASSERT_EQ(argsEmpty.portOffset, -1);
-    
-    Settings settingsEmpty(argsEmpty.configFile);
-    if (!argsEmpty.ipcPrefix.isEmpty()) settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
-    if (argsEmpty.portOffset != -1) settingsEmpty.setPortOffset(argsEmpty.portOffset);
+	// Verify HandlerArgsData parsing with empty arguments
+	HandlerArgsData argsEmpty(&argsFfiEmpty);
+	TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
+	TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
+	TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
+	TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
+	TEST_ASSERT_EQ(argsEmpty.portOffset, -1);
 
-    // Test that no overrides were applied (should use config file defaults)
-    TEST_ASSERT_EQ(settingsEmpty.getPortOffset(), 0);
-    TEST_ASSERT_EQ(settingsEmpty.getIpcPrefix(), QString("pushpin-"));
+	Settings settingsEmpty(argsEmpty.configFile);
+	if (!argsEmpty.ipcPrefix.isEmpty()) settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
+	if (argsEmpty.portOffset != -1) settingsEmpty.setPortOffset(argsEmpty.portOffset);
+
+	// Test that no overrides were applied (should use config file defaults)
+	TEST_ASSERT_EQ(settingsEmpty.portOffset(), 0);
+	TEST_ASSERT_EQ(settingsEmpty.ipcPrefix(), QString("pushpin-"));
 }
 
 extern "C" int handlerargs_test(ffi::TestException *out_ex)
 {
-    TEST_CATCH(handlerargstest());
+	TEST_CATCH(handlerargstest());
 
-    return 0;
+	return 0;
 }

--- a/src/proxy/cliargs.rs
+++ b/src/proxy/cliargs.rs
@@ -204,8 +204,9 @@ mod tests {
             config_file: Some(config_test_file.clone()),
             log_file: Some("pushpin.log".to_string()),
             log_level: 3,
+            verbose: false,
             ipc_prefix: Some("ipc".to_string()),
-            route: Some(vec!["route1".to_string(), "route2".to_string()]),
+            route: vec!["route1".to_string(), "route2".to_string()],
         };
 
         let args_ffi = args.to_ffi();
@@ -215,10 +216,11 @@ mod tests {
         assert_eq!(verified_args.config_file, Some(config_test_file.clone()));
         assert_eq!(verified_args.log_file, Some("pushpin.log".to_string()));
         assert_eq!(verified_args.log_level, 3);
+        assert_eq!(verified_args.verbose, false);
         assert_eq!(verified_args.ipc_prefix, Some("ipc".to_string()));
         assert_eq!(
             verified_args.route,
-            Some(vec!["route1".to_string(), "route2".to_string()])
+            vec!["route1".to_string(), "route2".to_string()]
         );
 
         // Test conversion to C++-compatible struct
@@ -270,8 +272,9 @@ mod tests {
             config_file: None,
             log_file: None,
             log_level: 2,
+            verbose: false,
             ipc_prefix: None,
-            route: None,
+            route: Vec::new(),
         };
 
         let empty_args_ffi = empty_args.to_ffi();
@@ -288,8 +291,9 @@ mod tests {
         );
         assert_eq!(verified_empty_args.log_file, None);
         assert_eq!(verified_empty_args.log_level, 2);
+        assert_eq!(verified_empty_args.verbose, false);
         assert_eq!(verified_empty_args.ipc_prefix, None);
-        assert_eq!(verified_empty_args.route, None);
+        assert!(verified_empty_args.route.is_empty());
 
         // Test conversion to C++-compatible struct
         unsafe {
@@ -319,5 +323,19 @@ mod tests {
         unsafe {
             destroy_proxy_cli_args(empty_args_ffi);
         }
+
+        // Test verbose
+        let args = CliArgs {
+            config_file: None,
+            log_file: None,
+            log_level: 2,
+            verbose: true,
+            ipc_prefix: None,
+            route: Vec::new(),
+        };
+
+        // Test verify() method
+        let verified_args = args.verify();
+        assert_eq!(verified_args.log_level, 3);
     }
 }

--- a/src/proxy/cliargs.rs
+++ b/src/proxy/cliargs.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Fastly, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 // Struct to hold the command line arguments
 #[derive(Parser, Debug)]
 #[command(
-    name= "Pushpin Proxy",
+    name= "pushpin-proxy",
     version = version(),
     about = "Pushpin proxy component."
 )]
@@ -41,13 +41,17 @@ pub struct CliArgs {
     #[arg(short = 'L', long = "loglevel", value_name = "x", default_value_t = 2, value_parser = clap::value_parser!(u32).range(1..=4))]
     pub log_level: u32,
 
-    /// Override ipc_prefix config option, which is used to add a prefix to all ZeroMQ IPC filenames
+    /// Set verbose output; same as --loglevel=3
+    #[arg(long = "verbose")]
+    pub verbose: bool,
+
+    /// Add a prefix to all ZeroMQ IPC filenames
     #[arg(long, value_name = "prefix")]
     pub ipc_prefix: Option<String>,
 
     /// Add route (overrides routes file)
-    #[arg(long, value_name = "route")]
-    pub route: Option<Vec<String>>,
+    #[arg(long, value_name = "route line")]
+    pub route: Vec<String>,
 }
 
 impl CliArgs {
@@ -64,6 +68,10 @@ impl CliArgs {
                 std::process::exit(1);
             }
         };
+
+        if self.verbose {
+            self.log_level = 3;
+        }
 
         self
     }
@@ -101,28 +109,25 @@ impl CliArgs {
             )
             .into_raw();
 
-        let (routes, routes_count) = match &self.route {
-            Some(routes_vec) if !routes_vec.is_empty() => {
-                // Allocate array of string pointers
-                let routes_array = unsafe {
-                    libc::malloc(routes_vec.len() * std::mem::size_of::<*mut libc::c_char>())
-                        as *mut *mut libc::c_char
-                };
+        let (routes, routes_count) = if !self.route.is_empty() {
+            // Allocate array of string pointers
+            let routes_array = unsafe {
+                libc::malloc(self.route.len() * std::mem::size_of::<*mut libc::c_char>())
+                    as *mut *mut libc::c_char
+            };
 
-                // Convert each route to CString and store pointer in array
-                for (i, item) in routes_vec.iter().enumerate() {
-                    let c_string = CString::new(item.to_string()).unwrap().into_raw();
-                    unsafe {
-                        *routes_array.add(i) = c_string;
-                    }
+            // Convert each route to CString and store pointer in array
+            for (i, item) in self.route.iter().enumerate() {
+                let c_string = CString::new(item.to_string()).unwrap().into_raw();
+                unsafe {
+                    *routes_array.add(i) = c_string;
                 }
+            }
 
-                (routes_array, routes_vec.len() as libc::c_uint)
-            }
-            _ => {
-                let routes_array = unsafe { libc::malloc(0) as *mut *mut libc::c_char };
-                (routes_array, 0)
-            }
+            (routes_array, self.route.len() as libc::c_uint)
+        } else {
+            let routes_array = unsafe { libc::malloc(0) as *mut *mut libc::c_char };
+            (routes_array, 0)
         };
 
         ffi::ProxyCliArgs {

--- a/src/proxy/proxyargsdata.cpp
+++ b/src/proxy/proxyargsdata.cpp
@@ -22,22 +22,16 @@
  */
 
 #include "proxyargsdata.h"
-#include "settings.h"
-#include "config.h"
-#include "log.h"
-#include "rust/bindings.h"
-#include <QCoreApplication>
-#include <QFile>
 
 ProxyArgsData::ProxyArgsData(const ffi::ProxyCliArgs *argsFfi)
 {
-    configFile  = QString::fromUtf8(argsFfi->config_file);
-    logFile     = QString::fromUtf8(argsFfi->log_file);
-    logLevel 	= argsFfi->log_level;
-    ipcPrefix 	= QString::fromUtf8(argsFfi->ipc_prefix);
-    routeLines = QStringList();
-    for (unsigned int i = 0; i < argsFfi->routes_count; ++i)
-    {
-        routeLines << QString::fromUtf8(argsFfi->routes[i]);
-    }
+	configFile = QString::fromUtf8(argsFfi->config_file);
+	logFile    = QString::fromUtf8(argsFfi->log_file);
+	logLevel   = argsFfi->log_level;
+	ipcPrefix  = QString::fromUtf8(argsFfi->ipc_prefix);
+
+	for (unsigned int i = 0; i < argsFfi->routes_count; ++i)
+	{
+		routeLines << QString::fromUtf8(argsFfi->routes[i]);
+	}
 }

--- a/src/proxy/proxyargsdata.h
+++ b/src/proxy/proxyargsdata.h
@@ -30,14 +30,14 @@
 
 class ProxyArgsData
 {
-	public:
-		QString configFile;
-		QString logFile;
-		int logLevel;
-		QString ipcPrefix;
-		QStringList routeLines;
+public:
+	QString configFile;
+	QString logFile;
+	int logLevel;
+	QString ipcPrefix;
+	QStringList routeLines;
 
-		ProxyArgsData(const ffi::ProxyCliArgs *argsFfi);
+	ProxyArgsData(const ffi::ProxyCliArgs *argsFfi);
 };
 
 #endif

--- a/src/proxy/proxyargstest.cpp
+++ b/src/proxy/proxyargstest.cpp
@@ -20,78 +20,77 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include <filesystem>
+#include "test.h"
+#include "log.h"
+#include "config.h"
+#include "settings.h"
+#include "proxyargsdata.h"
 
- #include "config.h"
- #include "settings.h"
- #include "test.h"
- #include "proxyargsdata.h"
- #include "log.h"
- #include <filesystem>
- 
- void proxyargstest()
- {
-    // Get file for example config
-    std::string configFile = "examples/config/pushpin.conf";
+static void proxyargstest()
+{
+	// Get file for example config
+	std::string configFile = "examples/config/pushpin.conf";
 
-    // Create test routes array
-    const char* route1 = "route1";
-    const char* route2 = "route2"; 
-    const char* routes[] = { route1, route2 };
+	// Create test routes array
+	const char* route1 = "route1";
+	const char* route2 = "route2";
+	const char* routes[] = { route1, route2 };
 
-    ffi::ProxyCliArgs argsFfi = {
-        const_cast<char*>(configFile.c_str()),  // config_file
-        const_cast<char*>("proxy-log.txt"),           // log_file
-        3,                                      // log_level
-        const_cast<char*>("ipc:prefix"),        // ipc_prefix
-        const_cast<char**>(routes),             // routes
-        2                                       // routes_count
-    };
- 
-    // Verify ProxyArgsData parsing
-    ProxyArgsData args(&argsFfi);
-    TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
-    TEST_ASSERT_EQ(args.logFile, QString("proxy-log.txt"));
-    TEST_ASSERT_EQ(args.logLevel, 3);
-    TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
-    TEST_ASSERT_EQ(args.routeLines, QStringList({"route1", "route2"}));
+	ffi::ProxyCliArgs argsFfi = {
+		const_cast<char*>(configFile.c_str()),  // config_file
+		const_cast<char*>("proxy-log.txt"),     // log_file
+		3,                                      // log_level
+		const_cast<char*>("ipc:prefix"),        // ipc_prefix
+		const_cast<char**>(routes),             // routes
+		2                                       // routes_count
+	};
 
-    Settings settings(args.configFile);
-    if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+	// Verify ProxyArgsData parsing
+	ProxyArgsData args(&argsFfi);
+	TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
+	TEST_ASSERT_EQ(args.logFile, QString("proxy-log.txt"));
+	TEST_ASSERT_EQ(args.logLevel, 3);
+	TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
+	TEST_ASSERT_EQ(args.routeLines, QStringList({"route1", "route2"}));
 
-    // Test command-line overrides were applied
-    TEST_ASSERT_EQ(settings.getIpcPrefix(), QString("ipc:prefix"));
+	Settings settings(args.configFile);
+	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
 
-    // Create empty routes array for testing
-    static const char* routesEmpty[] = {};
+	// Test command-line overrides were applied
+	TEST_ASSERT_EQ(settings.ipcPrefix(), QString("ipc:prefix"));
 
-    // Set up valid empty command line arguments
-    ffi::ProxyCliArgs argsFfiEmpty = {
-        const_cast<char*>(configFile.c_str()),  // config_file
-        const_cast<char*>(""),                  // log_file
-        2,                                      // log_level
-        const_cast<char*>(""),                  // ipc_prefix
-        const_cast<char**>(routesEmpty),        // routes array
-        0                                       // routes_count
-    };
+	// Create empty routes array for testing
+	static const char* routesEmpty[] = {};
 
-    // Verify ProxyArgsData parsing with empty arguments
-    ProxyArgsData argsEmpty(&argsFfiEmpty);
-    TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
-    TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
-    TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
-    TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
-    TEST_ASSERT_EQ(argsEmpty.routeLines, QStringList());
+	// Set up valid empty command line arguments
+	ffi::ProxyCliArgs argsFfiEmpty = {
+		const_cast<char*>(configFile.c_str()),  // config_file
+		const_cast<char*>(""),                  // log_file
+		2,                                      // log_level
+		const_cast<char*>(""),                  // ipc_prefix
+		const_cast<char**>(routesEmpty),        // routes array
+		0                                       // routes_count
+	};
 
-    Settings settingsEmpty(argsEmpty.configFile);
-    if (!argsEmpty.ipcPrefix.isEmpty()) settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
+	// Verify ProxyArgsData parsing with empty arguments
+	ProxyArgsData argsEmpty(&argsFfiEmpty);
+	TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
+	TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
+	TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
+	TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
+	TEST_ASSERT_EQ(argsEmpty.routeLines, QStringList());
 
-    // Test that no overrides were applied (should use config file defaults)
-    TEST_ASSERT_EQ(settingsEmpty.getIpcPrefix(), QString("pushpin-")); 
- }
- 
- extern "C" int proxyargs_test(ffi::TestException *out_ex)
- {
-     TEST_CATCH(proxyargstest());
- 
-     return 0;
- }
+	Settings settingsEmpty(argsEmpty.configFile);
+	if (!argsEmpty.ipcPrefix.isEmpty()) settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
+
+	// Test that no overrides were applied (should use config file defaults)
+	TEST_ASSERT_EQ(settingsEmpty.ipcPrefix(), QString("pushpin-"));
+}
+
+extern "C" int proxyargs_test(ffi::TestException *out_ex)
+{
+	TEST_CATCH(proxyargstest());
+
+	return 0;
+}


### PR DESCRIPTION
This does a few small things:

* Use tabs instead of spaces in C++ source files.
* Ensure files end with a newline.
* Remove some errant whitespace.
* Drop `get` prefix from getters.
* Mark test functions `static`.
* Some #include block reordering/simplifying.
* Update the args structs a little bit, such as adding `verbose` fields, and changing `Option<Vec<String>>` to `Vec<String>` which clap still counts as optional.