### PR TITLE
wssession: pass non-prefixed channels to filters

### DIFF
--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1854,8 +1854,14 @@ private:
 
 	void removeSessionChannels(WsSession *s)
 	{
-		foreach(const QString &channel, s->channels)
+		QHashIterator it(s->channels);
+		while(it.hasNext())
+		{
+			it.next();
+			const QString &channel = it.key();
+
 			removeSessionChannel(s, channel);
+		}
 	}
 
 	static void hs_subscribe_cb(void *data, std::tuple<HttpSession *, const QString &> value)
@@ -2648,8 +2654,12 @@ private:
 						}
 
 						QString channel = s->channelPrefix + cm.channel;
-						s->channels += channel;
-						s->channelFilters[channel] = cm.filters;
+
+						Instruct::Channel c;
+						c.name = cm.channel;
+						c.filters = cm.filters;
+
+						s->channels.insert(channel, c);
 
 						if(!cs.wsSessionsByChannel.contains(channel))
 							cs.wsSessionsByChannel.insert(channel, QSet<WsSession*>());
@@ -2676,7 +2686,6 @@ private:
 					if(!s->implicitChannels.contains(channel))
 					{
 						s->channels.remove(channel);
-						s->channelFilters.remove(channel);
 
 						removeSessionChannel(s, channel);
 					}
@@ -2782,8 +2791,12 @@ private:
 			else if(item.type == WsControlPacket::Item::Subscribe)
 			{
 				QString channel = QString::fromUtf8(item.channel);
-				s->channels += channel;
+
 				s->implicitChannels += channel;
+
+				Instruct::Channel c;
+				c.name = channel;
+				s->channels.insert(channel, c);
 
 				if(!cs.wsSessionsByChannel.contains(channel))
 					cs.wsSessionsByChannel.insert(channel, QSet<WsSession*>());

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1854,12 +1854,11 @@ private:
 
 	void removeSessionChannels(WsSession *s)
 	{
-		QHashIterator it(s->channels);
+		QHashIterator<QString, Instruct::Channel> it(s->channels);
 		while(it.hasNext())
 		{
 			it.next();
 			const QString &channel = it.key();
-
 			removeSessionChannel(s, channel);
 		}
 	}

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -30,6 +30,7 @@
 #include "packet/httprequestdata.h"
 #include "packet/wscontrolpacket.h"
 #include "ratelimiter.h"
+#include "instruct.h"
 #include "filter.h"
 #include "clientsession.h"
 
@@ -60,8 +61,7 @@ public:
 	bool targetTrusted;
 	QString sid;
 	QHash<QString, QString> meta;
-	QHash<QString, QStringList> channelFilters; // k=channel, v=list(filters)
-	QSet<QString> channels;
+	QHash<QString, Instruct::Channel> channels;
 	QSet<QString> implicitChannels;
 	int ttl;
 	QByteArray keepAliveType;


### PR DESCRIPTION
The channels passed to filters need to be non-prefixed. This is already the case for HTTP sessions, but not for WebSocket sessions. Basically, I missed this nuance when writing #48258.

For HTTP sessions, the way this works is each session keeps a hashmap of prefixed-channels to channel details, where one of the details is the original non-prefixed channel name. This PR updates WebSocket sessions to work the same way.

Tested manually.