### PR TITLE
proxy/handler: rework args handling a little bit

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -426,6 +426,10 @@ impl CustomConfig {
     }
 }
 
+pub fn default_config_file() -> PathBuf {
+    PathBuf::from(env!("CONFIG_DIR")).join("pushpin.conf")
+}
+
 pub fn get_config_file(
     work_dir: &Path,
     arg_config: Option<PathBuf>,
@@ -446,10 +450,7 @@ pub fn get_config_file(
                     .join("pushpin.conf"),
             );
             // default
-            config_files.push(PathBuf::from(format!(
-                "{}/pushpin.conf",
-                env!("CONFIG_DIR")
-            )));
+            config_files.push(default_config_file());
         }
     }
 

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -104,9 +104,6 @@ public:
 		QCoreApplication::setApplicationVersion(Config::get().version);
 
 		HandlerArgsData args(argsFfi);
-		Settings settings(args.configFile);
-		if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
-		if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
 
 		// Set the log level
 		if(args.logLevel != -1)
@@ -131,10 +128,14 @@ public:
 			QFile file(args.configFile);
 			if(!file.open(QIODevice::ReadOnly))
 			{
-				log_error("failed to open %s", qPrintable(args.configFile));
+				log_error("failed to open config file: %s", qPrintable(args.configFile));
 				return 1;
 			}
 		}
+
+		Settings settings(args.configFile);
+		if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+		if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
 
 		QStringList services = settings.value("runner/services").toStringList();
 

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -327,8 +327,6 @@ public:
 		QCoreApplication::setApplicationVersion(Config::get().version);
 
 		ProxyArgsData args(argsFfi);
-		Settings settings(args.configFile);
-		if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
 
 		// Set the log level
 		if(args.logLevel != -1)
@@ -353,12 +351,16 @@ public:
 			QFile file(args.configFile);
 			if(!file.open(QIODevice::ReadOnly))
 			{
-				log_error("failed to open %s", qPrintable(args.configFile));
+				log_error("failed to open config file: %s", qPrintable(args.configFile));
 				return 1;
 			}
 		}
 
 		QDir configDir = QFileInfo(args.configFile).absoluteDir();
+
+		Settings settings(args.configFile);
+		if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+
 		QStringList services = settings.value("runner/services").toStringList();
 
 		int workerCount = settings.value("proxy/workers", 1).toInt();


### PR DESCRIPTION
A few small changes to the args handling:

* Revert config file discovery to the old behavior of explicit arg or single default location. Only the runner should use the more advanced `get_config_file()` which checks extra paths.
* Revert to creating `Settings` objects only after checking the config file.
* Remove config file checking from the `CliArgs::verify()` methods since `ProxyApp` and `HandlerApp` already do this. Notably, this avoids having a `std::process::exit` call in those methods.
* When constructing the array of C strings, use Box for memory management rather than `malloc/free`.
