### PR TITLE
use cow types in zhttp packets

### DIFF
--- a/src/core/cowbytearray.h
+++ b/src/core/cowbytearray.h
@@ -80,12 +80,14 @@ class CowByteArray
 {
 public:
 	CowByteArray() = default;
+	CowByteArray(const CowByteArray &other): inner_(other.inner_) {}
 	CowByteArray(CowByteArrayConstRef ref): inner_(ref.inner_) {}
 	CowByteArray(CowByteArrayRef ref): inner_(ref.inner_) {}
 	CowByteArray(const char *data, ssize_t size = -1) : inner_(data, size) {}
 	CowByteArray(ssize_t size, char ch) : inner_(size, ch) {}
 	CowByteArray(const QByteArray &other) : inner_(other) {}
 
+	bool isNull() const { return inner_.isNull(); }
 	bool isEmpty() const { return inner_.isEmpty(); }
 	ssize_t size() const { return inner_.size(); }
 	ssize_t length() const { return size(); }
@@ -95,6 +97,7 @@ public:
 	ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
 	CowByteArray mid(ssize_t pos, ssize_t len = -1) const { return inner_.mid(pos, len); }
 
+	void clear() { inner_.clear(); }
 	void resize(ssize_t size) { inner_.resize(size); }
 
 	char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }

--- a/src/core/cowbytearray.h
+++ b/src/core/cowbytearray.h
@@ -86,6 +86,7 @@ public:
 	CowByteArray(const char *data, ssize_t size = -1) : inner_(data, size) {}
 	CowByteArray(ssize_t size, char ch) : inner_(size, ch) {}
 	CowByteArray(const QByteArray &other) : inner_(other) {}
+	CowByteArray & operator=(const CowByteArray &other) { inner_ = other.inner_; return *this; }
 
 	bool isNull() const { return inner_.isNull(); }
 	bool isEmpty() const { return inner_.isEmpty(); }

--- a/src/core/cowbytearraytest.cpp
+++ b/src/core/cowbytearraytest.cpp
@@ -111,7 +111,10 @@ static void methods()
 
 static void operators()
 {
-	CowByteArray a("hello");
+	CowByteArray a;
+	a = CowByteArray("hello");
+	TEST_ASSERT_EQ(a, "hello");
+
 	TEST_ASSERT_EQ(std::as_const(a)[1], 'e');
 	TEST_ASSERT_EQ(a[1], 'e');
 

--- a/src/core/cowbytearraytest.cpp
+++ b/src/core/cowbytearraytest.cpp
@@ -64,8 +64,14 @@ static void constructors()
 
 static void methods()
 {
+	// isNull
+	CowByteArray n;
+	TEST_ASSERT(n.isNull());
+	TEST_ASSERT(n.isEmpty());
+
 	// isEmpty
-	CowByteArray empty;
+	CowByteArray empty("");
+	TEST_ASSERT(!empty.isNull());
 	TEST_ASSERT(empty.isEmpty());
 
 	// size and length
@@ -87,6 +93,12 @@ static void methods()
 	CowByteArray c = a.mid(3);
 	TEST_ASSERT_EQ(b, "hel");
 	TEST_ASSERT_EQ(c, "lo");
+
+	// clear
+	CowByteArray d("hello");
+	TEST_ASSERT(!d.isEmpty());
+	d.clear();
+	TEST_ASSERT(d.isEmpty());
 
 	// resize down
 	a.resize(3);

--- a/src/core/cowstring.h
+++ b/src/core/cowstring.h
@@ -26,15 +26,33 @@
 class CowString
 {
 public:
+	CowString() = default;
+	CowString(const CowString &other): inner_(other.inner_) {}
+	CowString(const char *str) : inner_(str) {}
 	CowString(const QString &other) : inner_(other) {}
+
+	bool isEmpty() const { return inner_.isEmpty(); }
+
+	void clear() { inner_.clear(); }
 
 	CowByteArray toUtf8() const { return inner_.toUtf8(); }
 
 	const QString & asQString() const { return inner_; }
 	QString & asQString() { return inner_; }
 
+	friend bool operator==(const CowString &lhs, const CowString &rhs);
+	friend bool operator==(const CowString &lhs, const char *const &rhs);
+	friend bool operator==(const char *const &lhs, const CowString &rhs);
+
 private:
 	QString inner_;
 };
+
+inline bool operator==(const CowString &lhs, const CowString &rhs) { return lhs.inner_ == rhs.inner_; }
+inline bool operator==(const CowString &lhs, const char *const &rhs) { return lhs.inner_ == rhs; }
+inline bool operator==(const char *const &lhs, const CowString &rhs) { return lhs == rhs.inner_; }
+inline bool operator!=(const CowString &lhs, const CowString &rhs) { return !(lhs == rhs); }
+inline bool operator!=(const CowString &lhs, const char *const &rhs) { return !(lhs == rhs); }
+inline bool operator!=(const char *const &lhs, const CowString &rhs) { return !(lhs == rhs); }
 
 #endif

--- a/src/core/cowstring.h
+++ b/src/core/cowstring.h
@@ -30,6 +30,7 @@ public:
 	CowString(const CowString &other): inner_(other.inner_) {}
 	CowString(const char *str) : inner_(str) {}
 	CowString(const QString &other) : inner_(other) {}
+	CowString & operator=(const CowString &other) { inner_ = other.inner_; return *this; }
 
 	bool isEmpty() const { return inner_.isEmpty(); }
 

--- a/src/core/cowstringtest.cpp
+++ b/src/core/cowstringtest.cpp
@@ -23,16 +23,67 @@
 #include "test.h"
 #include "cowstring.h"
 
-static void basicUsage()
+static void constructors()
 {
-	CowString s("hello");
-	CowByteArray a = s.toUtf8();
-	TEST_ASSERT_EQ(s.asQString().toUtf8(), a.asQByteArray());
+	// default
+	CowString a;
+	TEST_ASSERT(a.isEmpty());
+
+	// char*
+	CowString b("hello");
+	TEST_ASSERT_EQ(b, "hello");
+
+	// copy
+	CowString c(b);
+	TEST_ASSERT_EQ(c, "hello");
+
+	// QString
+	QString qs("hello");
+	CowString d(qs);
+	TEST_ASSERT_EQ(d, "hello");
+}
+
+static void methods()
+{
+	// isEmpty
+	CowString empty;
+	TEST_ASSERT(empty.isEmpty());
+
+	// clear
+	CowString a("hello");
+	TEST_ASSERT(!a.isEmpty());
+	a.clear();
+	TEST_ASSERT(a.isEmpty());
+
+	// toUtf8
+	CowString b("hello");
+	CowByteArray ba = b.toUtf8();
+	TEST_ASSERT_EQ(ba, "hello");
+}
+
+static void operators()
+{
+	TEST_ASSERT(CowString("hello") == CowString("hello"));
+	TEST_ASSERT(CowString("hello") == "hello");
+	TEST_ASSERT("hello" == CowString("hello"));
+
+	TEST_ASSERT(CowString("hello") != CowString("world"));
+	TEST_ASSERT(CowString("hello") != "world");
+	TEST_ASSERT("hello" != CowString("world"));
+}
+
+static void conversions()
+{
+	CowString a("hello");
+	TEST_ASSERT_EQ(a, "hello");
 }
 
 extern "C" int cowstring_test(ffi::TestException *out_ex)
 {
-	TEST_CATCH(basicUsage());
+	TEST_CATCH(constructors());
+	TEST_CATCH(methods());
+	TEST_CATCH(operators());
+	TEST_CATCH(conversions());
 
 	return 0;
 }

--- a/src/core/cowstringtest.cpp
+++ b/src/core/cowstringtest.cpp
@@ -63,6 +63,10 @@ static void methods()
 
 static void operators()
 {
+	CowString a;
+	a = CowString("hello");
+	TEST_ASSERT_EQ(a, "hello");
+
 	TEST_ASSERT(CowString("hello") == CowString("hello"));
 	TEST_ASSERT(CowString("hello") == "hello");
 	TEST_ASSERT("hello" == CowString("hello"));

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -211,10 +211,10 @@ public:
 		if(packet.credits != -1)
 			outCredits = packet.credits;
 
-		requestMethod = packet.method;
+		requestMethod = packet.method.asQString();
 		requestUri = packet.uri;
 		requestHeaders = packet.headers;
-		requestBodyBuf += packet.body;
+		requestBodyBuf += packet.body.asQByteArray();
 
 		passthrough = packet.passthrough;
 
@@ -519,7 +519,7 @@ public:
 		if(packet.type == ZhttpRequestPacket::Error)
 		{
 			errored = true;
-			errorCondition = convertError(packet.condition);
+			errorCondition = convertError(packet.condition.asQByteArray());
 
 			log_debug("zhttp server: error id=%s cond=%s", id.data(), packet.condition.data());
 
@@ -581,7 +581,7 @@ public:
 
 		if(packet.type == ZhttpRequestPacket::Data)
 		{
-			requestBodyBuf += packet.body;
+			requestBodyBuf += packet.body.asQByteArray();
 
 			bool done = haveRequestBody;
 
@@ -646,7 +646,7 @@ public:
 				return;
 			}
 
-			toAddress = packet.from;
+			toAddress = packet.from.asQByteArray();
 
 			state = ClientRequesting;
 
@@ -654,7 +654,7 @@ public:
 		}
 		else if(state == ClientRequestFinishWait)
 		{
-			toAddress = packet.from;
+			toAddress = packet.from.asQByteArray();
 
 			state = ClientReceiving;
 
@@ -665,7 +665,7 @@ public:
 		if(packet.type == ZhttpResponsePacket::Error)
 		{
 			errored = true;
-			errorCondition = convertError(packet.condition);
+			errorCondition = convertError(packet.condition.asQByteArray());
 
 			log_debug("zhttp client: error id=%s cond=%s", id.data(), packet.condition.data());
 
@@ -739,7 +739,7 @@ public:
 				haveResponseValues = true;
 
 				responseCode = packet.code;
-				responseReason = packet.reason;
+				responseReason = packet.reason.asQByteArray();
 				responseHeaders = packet.headers;
 
 				needToSendHeaders = true;
@@ -756,7 +756,7 @@ public:
 					log_warning("zhttp client: id=%s server is sending too fast", id.data());
 			}
 
-			responseBodyBuf += packet.body;
+			responseBodyBuf += packet.body.asQByteArray();
 
 			if(packet.more)
 			{
@@ -1421,7 +1421,7 @@ bool ZhttpRequest::setupServer(ZhttpManager *manager, const QByteArray &id, int 
 {
 	d->manager = manager;
 	d->server = true;
-	d->rid = Rid(packet.from, id);
+	d->rid = Rid(packet.from.asQByteArray(), id);
 	return d->setupServer(seq, packet);
 }
 

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -30,7 +30,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 	QVariantHash obj;
 
 	if(!from.isEmpty())
-		obj["from"] = from;
+		obj["from"] = from.asQByteArray();
 
 	if(!ids.isEmpty())
 	{
@@ -38,7 +38,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 		{
 			const Id &id = ids.first();
 			if(!id.id.isEmpty())
-				obj["id"] = id.id;
+				obj["id"] = id.id.asQByteArray();
 			if(id.seq != -1)
 				obj["seq"] = id.seq;
 		}
@@ -49,7 +49,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 			{
 				QVariantHash vh;
 				if(!id.id.isEmpty())
-					vh["id"] = id.id;
+					vh["id"] = id.id.asQByteArray();
 				if(id.seq != -1)
 					vh["seq"] = id.seq;
 				vl += vh;
@@ -77,7 +77,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 		obj["type"] = typeStr;
 
 	if(type == Error && !condition.isEmpty())
-		obj["condition"] = condition;
+		obj["condition"] = condition.asQByteArray();
 
 	if(credits != -1)
 		obj["credits"] = credits;
@@ -98,7 +98,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 		obj["timeout"] = timeout;
 
 	if(!method.isEmpty())
-		obj["method"] = method.toLatin1();
+		obj["method"] = method.toUtf8().asQByteArray();
 
 	if(!uri.isEmpty())
 		obj["uri"] = uri.toEncoded();
@@ -118,10 +118,10 @@ QVariant ZhttpRequestPacket::toVariant() const
 	}
 
 	if(!body.isNull())
-		obj["body"] = body;
+		obj["body"] = body.asQByteArray();
 
 	if(!contentType.isEmpty())
-		obj["content-type"] = contentType;
+		obj["content-type"] = contentType.asQByteArray();
 
 	if(code != -1)
 		obj["code"] = code;
@@ -136,7 +136,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 		obj["peer-port"] = QByteArray::number(peerPort);
 
 	if(!connectHost.isEmpty())
-		obj["connect-host"] = connectHost.toUtf8();
+		obj["connect-host"] = connectHost.toUtf8().asQByteArray();
 
 	if(connectPort != -1)
 		obj["connect-port"] = connectPort;
@@ -151,10 +151,10 @@ QVariant ZhttpRequestPacket::toVariant() const
 		obj["ignore-tls-errors"] = true;
 
 	if(!clientCert.isEmpty())
-		obj["client-cert"] = clientCert.toUtf8();
+		obj["client-cert"] = clientCert.toUtf8().asQByteArray();
 
 	if(!clientKey.isEmpty())
-		obj["client-key"] = clientKey.toUtf8();
+		obj["client-key"] = clientKey.toUtf8().asQByteArray();
 
 	if(followRedirects)
 		obj["follow-redirects"] = true;

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2016 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * $FANOUT_BEGIN_LICENSE:APACHE2$
  *
@@ -25,6 +25,8 @@
 #include <QUrl>
 #include <QVariant>
 #include <QHostAddress>
+#include "cowstring.h"
+#include "cowbytearray.h"
 #include "httpheaders.h"
 
 class ZhttpRequestPacket
@@ -33,7 +35,7 @@ public:
 	class Id
 	{
 	public:
-		QByteArray id;
+		CowByteArray id;
 		int seq;
 
 		Id() :
@@ -41,7 +43,7 @@ public:
 		{
 		}
 
-		Id(const QByteArray &_id, int _seq = -1) :
+		Id(const CowByteArray &_id, int _seq = -1) :
 			id(_id),
 			seq(_seq)
 		{
@@ -62,11 +64,11 @@ public:
 		Pong // WebSocket
 	};
 
-	QByteArray from;
+	CowByteArray from;
 	QList<Id> ids;
 
 	Type type;
-	QByteArray condition;
+	CowByteArray condition;
 
 	int credits;
 	bool more;
@@ -75,12 +77,12 @@ public:
 	int maxSize;
 	int timeout;
 
-	QString method;
+	CowString method;
 	QUrl uri;
 	HttpHeaders headers;
-	QByteArray body;
+	CowByteArray body;
 
-	QByteArray contentType; // WebSocket
+	CowByteArray contentType; // WebSocket
 	int code; // WebSocket
 
 	QVariant userData;
@@ -88,13 +90,13 @@ public:
 	QHostAddress peerAddress;
 	int peerPort;
 
-	QString connectHost;
+	CowString connectHost;
 	int connectPort;
 	bool ignorePolicies;
 	bool trustConnectHost;
 	bool ignoreTlsErrors;
-	QString clientCert;
-	QString clientKey;
+	CowString clientCert;
+	CowString clientKey;
 	bool followRedirects;
 	QVariant passthrough; // if valid, may contain pushpin-specific passthrough info
 	bool multi;

--- a/src/core/zhttpresponsepacket.cpp
+++ b/src/core/zhttpresponsepacket.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012-2013 Fanout, Inc.
- * Copyright (C) 2024 Fastly, Inc.
+ * Copyright (C) 2024-2025 Fastly, Inc.
  *
  * $FANOUT_BEGIN_LICENSE:APACHE2$
  *
@@ -28,7 +28,7 @@ QVariant ZhttpResponsePacket::toVariant() const
 	QVariantHash obj;
 
 	if(!from.isEmpty())
-		obj["from"] = from;
+		obj["from"] = from.asQByteArray();
 
 	if(!ids.isEmpty())
 	{
@@ -36,7 +36,7 @@ QVariant ZhttpResponsePacket::toVariant() const
 		{
 			const Id &id = ids.first();
 			if(!id.id.isEmpty())
-				obj["id"] = id.id;
+				obj["id"] = id.id.asQByteArray();
 			if(id.seq != -1)
 				obj["seq"] = id.seq;
 		}
@@ -47,7 +47,7 @@ QVariant ZhttpResponsePacket::toVariant() const
 			{
 				QVariantHash vh;
 				if(!id.id.isEmpty())
-					vh["id"] = id.id;
+					vh["id"] = id.id.asQByteArray();
 				if(id.seq != -1)
 					vh["seq"] = id.seq;
 				vl += vh;
@@ -75,7 +75,7 @@ QVariant ZhttpResponsePacket::toVariant() const
 		obj["type"] = typeStr;
 
 	if(type == Error && !condition.isEmpty())
-		obj["condition"] = condition;
+		obj["condition"] = condition.asQByteArray();
 
 	if(credits != -1)
 		obj["credits"] = credits;
@@ -89,7 +89,7 @@ QVariant ZhttpResponsePacket::toVariant() const
 
 		if(type == Data || (type == Error && condition == "rejected"))
 		{
-			obj["reason"] = reason;
+			obj["reason"] = reason.asQByteArray();
 			QVariantList vheaders;
 			foreach(const HttpHeader &h, headers)
 			{
@@ -103,10 +103,10 @@ QVariant ZhttpResponsePacket::toVariant() const
 	}
 
 	if(!body.isNull())
-		obj["body"] = body;
+		obj["body"] = body.asQByteArray();
 
 	if(!contentType.isEmpty())
-		obj["content-type"] = contentType;
+		obj["content-type"] = contentType.asQByteArray();
 
 	if(userData.isValid())
 		obj["user-data"] = userData;

--- a/src/core/zhttpresponsepacket.h
+++ b/src/core/zhttpresponsepacket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2016 Fanout, Inc.
+ * Copyright (C) 2025 Fastly, Inc.
  *
  * $FANOUT_BEGIN_LICENSE:APACHE2$
  *
@@ -22,6 +23,8 @@
 #define ZHTTPRESPONSEPACKET_H
 
 #include <QVariant>
+#include "cowstring.h"
+#include "cowbytearray.h"
 #include "httpheaders.h"
 
 class ZhttpResponsePacket
@@ -30,7 +33,7 @@ public:
 	class Id
 	{
 	public:
-		QByteArray id;
+		CowByteArray id;
 		int seq;
 
 		Id() :
@@ -38,7 +41,7 @@ public:
 		{
 		}
 
-		Id(const QByteArray &_id, int _seq = -1) :
+		Id(const CowByteArray &_id, int _seq = -1) :
 			id(_id),
 			seq(_seq)
 		{
@@ -59,21 +62,21 @@ public:
 		Pong // WebSocket
 	};
 
-	QByteArray from;
+	CowByteArray from;
 	QList<Id> ids;
 
 	Type type;
-	QByteArray condition;
+	CowByteArray condition;
 
 	int credits;
 	bool more;
 
 	int code;
-	QByteArray reason;
+	CowByteArray reason;
 	HttpHeaders headers;
-	QByteArray body;
+	CowByteArray body;
 
-	QByteArray contentType; // WebSocket
+	CowByteArray contentType; // WebSocket
 
 	QVariant userData;
 

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -465,7 +465,7 @@ public:
 	{
 		if(packet.type == ZhttpRequestPacket::Error)
 		{
-			errorCondition = convertError(packet.condition);
+			errorCondition = convertError(packet.condition.asQByteArray());
 
 			log_debug("zws server: error id=%s cond=%s", id.data(), packet.condition.data());
 
@@ -516,16 +516,16 @@ public:
 
 			if(packet.type == ZhttpRequestPacket::Data)
 			{
-				handleIncomingDataPacket(packet.contentType, packet.body, packet.more);
+				handleIncomingDataPacket(packet.contentType.asQByteArray(), packet.body.asQByteArray(), packet.more);
 			}
 			else if(packet.type == ZhttpRequestPacket::Ping)
 			{
-				inFrames += Frame(Frame::Ping, packet.body, false);
+				inFrames += Frame(Frame::Ping, packet.body.asQByteArray(), false);
 				inSize += packet.body.size();
 			}
 			else if(packet.type == ZhttpRequestPacket::Pong)
 			{
-				inFrames += Frame(Frame::Pong, packet.body, false);
+				inFrames += Frame(Frame::Pong, packet.body.asQByteArray(), false);
 				inSize += packet.body.size();
 			}
 
@@ -540,7 +540,7 @@ public:
 		}
 		else if(packet.type == ZhttpRequestPacket::Close)
 		{
-			handlePeerClose(packet.code, QString::fromUtf8(packet.body));
+			handlePeerClose(packet.code, QString::fromUtf8(packet.body.asQByteArray()));
 		}
 		else if(packet.type == ZhttpRequestPacket::Credit)
 		{
@@ -565,14 +565,14 @@ public:
 	{
 		if(packet.type == ZhttpResponsePacket::Error)
 		{
-			errorCondition = convertError(packet.condition);
+			errorCondition = convertError(packet.condition.asQByteArray());
 
 			log_debug("zws client: error id=%s cond=%s", id.data(), packet.condition.data());
 
 			responseCode = packet.code;
-			responseReason = packet.reason;
+			responseReason = packet.reason.asQByteArray();
 			responseHeaders = packet.headers;
-			responseBody = packet.body;
+			responseBody = packet.body.asQByteArray();
 
 			state = Idle;
 			cleanup();
@@ -591,7 +591,7 @@ public:
 		}
 
 		if(!packet.from.isEmpty())
-			toAddress = packet.from;
+			toAddress = packet.from.asQByteArray();
 
 		if(seq != inSeq)
 		{
@@ -651,7 +651,7 @@ public:
 				assert(packet.type == ZhttpResponsePacket::Data);
 
 				responseCode = packet.code;
-				responseReason = packet.reason;
+				responseReason = packet.reason.asQByteArray();
 				responseHeaders = packet.headers;
 
 				if(packet.credits > 0)
@@ -668,16 +668,16 @@ public:
 
 				if(packet.type == ZhttpResponsePacket::Data)
 				{
-					handleIncomingDataPacket(packet.contentType, packet.body, packet.more);
+					handleIncomingDataPacket(packet.contentType.asQByteArray(), packet.body.asQByteArray(), packet.more);
 				}
 				else if(packet.type == ZhttpResponsePacket::Ping)
 				{
-					inFrames += Frame(Frame::Ping, packet.body, false);
+					inFrames += Frame(Frame::Ping, packet.body.asQByteArray(), false);
 					inSize += packet.body.size();
 				}
 				else if(packet.type == ZhttpResponsePacket::Pong)
 				{
-					inFrames += Frame(Frame::Pong, packet.body, false);
+					inFrames += Frame(Frame::Pong, packet.body.asQByteArray(), false);
 					inSize += packet.body.size();
 				}
 
@@ -693,7 +693,7 @@ public:
 		}
 		else if(packet.type == ZhttpResponsePacket::Close)
 		{
-			handlePeerClose(packet.code, QString::fromUtf8(packet.body));
+			handlePeerClose(packet.code, QString::fromUtf8(packet.body.asQByteArray()));
 		}
 		else if(packet.type == ZhttpResponsePacket::Credit)
 		{
@@ -1272,7 +1272,7 @@ bool ZWebSocket::setupServer(ZhttpManager *manager, const QByteArray &id, int se
 {
 	d->manager = manager;
 	d->server = true;
-	d->rid = Rid(packet.from, id);
+	d->rid = Rid(packet.from.asQByteArray(), id);
 	return d->setupServer(seq, packet);
 }
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -167,16 +167,16 @@ public:
 		zresp.fromVariant(v);
 		if(zresp.type == ZhttpResponsePacket::Data)
 		{
-			if(!responses.contains(zresp.ids.first().id))
+			if(!responses.contains(zresp.ids.first().id.asQByteArray()))
 			{
 				HttpResponseData rd;
 				rd.code = zresp.code;
-				rd.reason = zresp.reason;
+				rd.reason = zresp.reason.asQByteArray();
 				rd.headers = zresp.headers;
-				responses[zresp.ids.first().id] = rd;
+				responses[zresp.ids.first().id.asQByteArray()] = rd;
 			}
 
-			responses[zresp.ids.first().id].body += zresp.body;
+			responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
 
 			if(!zresp.more)
 				finished = true;
@@ -231,7 +231,7 @@ public:
 		}
 
 		if(zreq.type == ZhttpRequestPacket::Data)
-			requestBody += zreq.body;
+			requestBody += zreq.body.asQByteArray();
 
 		if(zreq.more)
 		{
@@ -243,7 +243,7 @@ public:
 				zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
 				zresp.type = ZhttpResponsePacket::Credit;
 				zresp.credits = 200000;
-				QByteArray buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+				QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 				zhttpServerOutSock->write(QList<QByteArray>() << buf);
 			}
 
@@ -263,7 +263,7 @@ public:
 		zresp.body = "this is what's next\n";
 
 		zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
-		QByteArray buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+		QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 		zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
 		// zero out so we can accept another request

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -1480,7 +1480,7 @@ public:
 		}
 
 		foreach(const ZhttpResponsePacket::Id &id, zresp.ids)
-			handleZhttpIn(logprefix, mode, id.id, id.seq, zresp);
+			handleZhttpIn(logprefix, mode, id.id.asQByteArray(), id.seq, zresp);
 	}
 
 	void handleZhttpIn(const char *logprefix, Mode mode, const QByteArray &id, int seq, const ZhttpResponsePacket &zresp)
@@ -1502,7 +1502,7 @@ public:
 				zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
 				zreq.ids += ZhttpRequestPacket::Id(id);
 				zreq.type = ZhttpRequestPacket::Cancel;
-				zhttp_out_write(mode, zreq, zresp.from);
+				zhttp_out_write(mode, zreq, zresp.from.asQByteArray());
 			}
 
 			return;
@@ -1524,7 +1524,7 @@ public:
 					return;
 				}
 
-				s->zhttpAddress = zresp.from;
+				s->zhttpAddress = zresp.from.asQByteArray();
 
 				if(seq != 0)
 				{
@@ -1540,7 +1540,7 @@ public:
 			{
 				// if not sequenced, then there might be a from address
 				if(!zresp.from.isEmpty())
-					s->zhttpAddress = zresp.from;
+					s->zhttpAddress = zresp.from.asQByteArray();
 
 				// if not sequenced, but seq is provided, then it must be 0
 				if(seq != -1 && seq != 0)
@@ -1573,7 +1573,7 @@ public:
 
 			// if a new from address is provided, update our copy
 			if(!zresp.from.isEmpty())
-				s->zhttpAddress = zresp.from;
+				s->zhttpAddress = zresp.from.asQByteArray();
 		}
 
 		// only bump sequence if seq was provided
@@ -1783,7 +1783,7 @@ public:
 
 						log_info("OUT %s id=%s code=%d %d%s", m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(), zresp.code, zresp.body.size(), zresp.more ? " M": "");
 
-						m2_queueHeaders(s->conn, createResponseHeader(zresp.code, zresp.reason, headers));
+						m2_queueHeaders(s->conn, createResponseHeader(zresp.code, zresp.reason.asQByteArray(), headers));
 					}
 
 					if(!zresp.body.isEmpty())
@@ -1808,7 +1808,7 @@ public:
 							return;
 						}
 
-						m2_queueResponse(s->conn, zresp.body, s->chunked);
+						m2_queueResponse(s->conn, zresp.body.asQByteArray(), s->chunked);
 					}
 
 					if(!zresp.more && s->chunked)
@@ -1859,7 +1859,7 @@ public:
 
 					QByteArray reason;
 					if(!zresp.reason.isEmpty())
-						reason = zresp.reason;
+						reason = zresp.reason.asQByteArray();
 					else
 						reason = "Switching Protocols";
 
@@ -1884,7 +1884,7 @@ public:
 
 					s->conn->continuation = zresp.more;
 
-					QByteArray frame = makeWsHeader(!zresp.more, opcode, zresp.body.size()) + zresp.body;
+					QByteArray frame = makeWsHeader(!zresp.more, opcode, zresp.body.size()) + zresp.body.asQByteArray();
 
 					m2_queueFrame(s->conn, frame, zresp.body.size());
 				}
@@ -1917,8 +1917,8 @@ public:
 
 				log_info("OUT %s id=%s code=%d %d", m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(), zresp.code, zresp.body.size());
 
-				m2_queueHeaders(s->conn, createResponseHeader(zresp.code, zresp.reason, headers));
-				m2_queueResponse(s->conn, zresp.body, false);
+				m2_queueHeaders(s->conn, createResponseHeader(zresp.code, zresp.reason.asQByteArray(), headers));
+				m2_queueResponse(s->conn, zresp.body.asQByteArray(), false);
 
 				M2Connection *conn = s->conn;
 				destroySession(s);
@@ -1981,7 +1981,7 @@ public:
 					memcpy(data.data() + 2, zresp.body.data(), zresp.body.size());
 				}
 			} else {
-				data = zresp.body;
+				data = zresp.body.asQByteArray();
 			}
 
 			QByteArray frame = makeWsHeader(true, opcode, data.size()) + data;

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -206,17 +206,17 @@ private:
 		zresp.fromVariant(v);
 		if(zresp.type == ZhttpResponsePacket::Data)
 		{
-			if(!responses.contains(zresp.ids.first().id))
+			if(!responses.contains(zresp.ids.first().id.asQByteArray()))
 			{
 				HttpResponseData rd;
 				rd.code = zresp.code;
-				rd.reason = zresp.reason;
+				rd.reason = zresp.reason.asQByteArray();
 				rd.headers = zresp.headers;
-				responses[zresp.ids.first().id] = rd;
+				responses[zresp.ids.first().id.asQByteArray()] = rd;
 			}
 
-			responses[zresp.ids.first().id].body += zresp.body;
-			in += zresp.body;
+			responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
+			in += zresp.body.asQByteArray();
 
 			if(!isWs && !zresp.more)
 			{
@@ -271,10 +271,10 @@ private:
 		zreq.fromVariant(v);
 
 		HttpRequestData rd;
-		rd.method = zreq.method;
+		rd.method = zreq.method.asQString();
 		rd.uri = zreq.uri;
 		rd.headers = zreq.headers;
-		serverReqs[zreq.ids[0].id] = rd;
+		serverReqs[zreq.ids[0].id.asQByteArray()] = rd;
 
 		handleServerIn(zreq);
 	}
@@ -302,10 +302,10 @@ private:
 			return;
 		}
 
-		serverReqs[zreq.ids[0].id].body += zreq.body;
+		serverReqs[zreq.ids[0].id.asQByteArray()].body += zreq.body.asQByteArray();
 
 		if(zreq.type == ZhttpRequestPacket::Data)
-			requestBody += zreq.body;
+			requestBody += zreq.body.asQByteArray();
 
 		if(zreq.more)
 		{
@@ -317,7 +317,7 @@ private:
 				zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
 				zresp.type = ZhttpResponsePacket::Credit;
 				zresp.credits = 200000;
-				QByteArray buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+				QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 				zhttpServerOutSock->write(QList<QByteArray>() << buf);
 			}
 
@@ -337,7 +337,7 @@ private:
 			zresp.code = 101;
 			zresp.reason = "Switching Protocols";
 			zresp.credits = 200000;
-			QByteArray buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+			QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 			zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
 			// send message
@@ -346,7 +346,7 @@ private:
 			zresp.code = -1;
 			zresp.reason.clear();
 			zresp.body = "hello world";
-			buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+			buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 			zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
 			return;
@@ -356,7 +356,7 @@ private:
 		{
 			// close
 			zresp.type = ZhttpResponsePacket::Close;
-			QByteArray buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+			QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 			zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
 			return;
@@ -461,7 +461,7 @@ private:
 			}
 		}
 		zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
-		QByteArray buf = zreq.from + " T" + TnetString::fromVariant(zresp.toVariant());
+		QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
 		zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
 		// zero out so we can accept another request


### PR DESCRIPTION
This updates the `ZhttpRequestPacket` and `ZhttpResponsePacket` classes to use Cow types in public fields.

One slight change is the request method is serialized as UTF-8 instead of Latin1, in order to avoid adding a `CowString::toLatin1()` method. This should be fine since we already make assumptions about UTF-8 encoding elsewhere (for example, `zhttppacket.rs` deserializes the method using `str::from_utf8`), and UTF-8 and Latin1 are basically interchangeable for real world request methods. Eventually we should replace the remaining uses of Latin1 to make everything consistent.