### PR TITLE
proxy/handler: remove pointless app class wrapping

### DIFF
--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -83,278 +83,246 @@ static QString firstSpec(const QString &s, int peerCount)
 	return s;
 }
 
-class HandlerApp
+static int runLoop(const HandlerEngine::Configuration &config)
 {
-public:
-	HandlerApp();
-	~HandlerApp();
+	// includes worst-case subscriptions and update registrations
+	int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
+		(config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +
+		TIMERS_PER_UNIQUE_UPDATE_REGISTRATION;
 
-	int run(const ffi::HandlerCliArgs *argsFfi);
+	// enough timers for sessions, plus an extra 100 for misc
+	int timersMax = (config.connectionsMax * timersPerSession) + 100;
 
-private:
-	class Private;
-};
+	// enough for control requests and prometheus requests, plus an
+	// extra 100 for misc. client sessions don't use socket notifiers
+	int socketNotifiersMax = (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX)) + 100;
 
-class HandlerApp::Private
-{
-public:
-	static int run(const ffi::HandlerCliArgs *argsFfi)
-	{
-		HandlerArgsData args(argsFfi);
+	int registrationsMax = timersMax + socketNotifiersMax;
+	std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
 
-		// Set the log level
-		if(args.logLevel != -1)
-			log_setOutputLevel(args.logLevel);
-		else
-			log_setOutputLevel(LOG_LEVEL_INFO);
+	std::unique_ptr<HandlerEngine> engine;
 
-		// Set the log file if specified
-		if(!args.logFile.isEmpty())
-		{
-			if(!log_setFile(args.logFile))
-			{
-				log_error("failed to open log file: %s", qPrintable(args.logFile));
-				return 1;
-			}
-		}
+	DeferCall deferCall;
+	deferCall.defer([&] {
+		engine = std::make_unique<HandlerEngine>();
 
-		log_debug("starting...");
+		ProcessQuit::instance()->quit.connect([&] {
+			log_info("stopping...");
 
-		// QSettings doesn't inform us if the config file can't be opened, so do that ourselves
-		{
-			QFile file(args.configFile);
-			if(!file.open(QIODevice::ReadOnly))
-			{
-				log_error("failed to open config file: %s", qPrintable(args.configFile));
-				return 1;
-			}
-		}
+			// remove the handler, so if we get another signal then we crash out
+			ProcessQuit::cleanup();
 
-		Settings settings(args.configFile);
-		if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
-		if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
+			engine.reset();
 
-		QStringList services = settings.value("runner/services").toStringList();
+			log_debug("stopped");
 
-		QStringList connmgr_in_stream_specs = settings.value("proxy/connmgr_in_stream_specs").toStringList();
-		trimlist(&connmgr_in_stream_specs);
-		QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
-		trimlist(&connmgr_out_specs);
-		QStringList condure_in_stream_specs = settings.value("proxy/condure_in_stream_specs").toStringList();
-		trimlist(&condure_in_stream_specs);
-		connmgr_in_stream_specs += condure_in_stream_specs;
-		QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
-		trimlist(&condure_out_specs);
-		connmgr_out_specs += condure_out_specs;
-		int proxyWorkerCount = settings.value("proxy/workers", 1).toInt();
-		QStringList m2a_in_stream_specs = settings.value("handler/m2a_in_stream_specs").toStringList();
-		trimlist(&m2a_in_stream_specs);
-		QStringList m2a_out_specs = settings.value("handler/m2a_out_specs").toStringList();
-		trimlist(&m2a_out_specs);
-		QStringList intreq_out_specs = settings.value("handler/proxy_intreq_out_specs").toStringList();
-		trimlist(&intreq_out_specs);
-		QStringList intreq_out_stream_specs = settings.value("handler/proxy_intreq_out_stream_specs").toStringList();
-		trimlist(&intreq_out_stream_specs);
-		QStringList intreq_in_specs = settings.value("handler/proxy_intreq_in_specs").toStringList();
-		trimlist(&intreq_in_specs);
-		QStringList proxy_inspect_specs = settings.value("handler/proxy_inspect_specs").toStringList();
-		trimlist(&proxy_inspect_specs);
-		QString proxy_inspect_spec = settings.value("handler/proxy_inspect_spec").toString();
-		if(!proxy_inspect_spec.isEmpty())
-			proxy_inspect_specs += proxy_inspect_spec;
-		QStringList proxy_accept_specs = settings.value("handler/proxy_accept_specs").toStringList();
-		trimlist(&proxy_accept_specs);
-		QString proxy_accept_spec = settings.value("handler/proxy_accept_spec").toString();
-		if(!proxy_accept_spec.isEmpty())
-			proxy_accept_specs += proxy_accept_spec;
-		QStringList proxy_retry_out_specs = settings.value("handler/proxy_retry_out_specs").toStringList();
-		trimlist(&proxy_retry_out_specs);
-		QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
-		if(!proxy_retry_out_spec.isEmpty())
-			proxy_retry_out_specs += proxy_retry_out_spec;
-		QStringList ws_control_init_specs = settings.value("handler/proxy_ws_control_init_specs").toStringList();
-		trimlist(&ws_control_init_specs);
-		QStringList ws_control_stream_specs = settings.value("handler/proxy_ws_control_stream_specs").toStringList();
-		trimlist(&ws_control_stream_specs);
-		QString stats_spec = settings.value("handler/stats_spec").toString();
-		QString command_spec = settings.value("handler/command_spec").toString();
-		QString state_spec = settings.value("handler/state_spec").toString();
-		QStringList proxy_stats_specs = settings.value("handler/proxy_stats_specs").toStringList();
-		trimlist(&proxy_stats_specs);
-		QString proxy_stats_spec = settings.value("handler/proxy_stats_spec").toString();
-		if(!proxy_stats_spec.isEmpty())
-			proxy_stats_specs += proxy_stats_spec;
-		QString proxy_command_spec = settings.value("handler/proxy_command_spec").toString();
-		QString push_in_spec = settings.value("handler/push_in_spec").toString();
-		QStringList push_in_sub_specs = settings.value("handler/push_in_sub_specs").toStringList();
-		trimlist(&push_in_sub_specs);
-		QString push_in_sub_spec = settings.value("handler/push_in_sub_spec").toString();
-		if(!push_in_sub_spec.isEmpty())
-			push_in_sub_specs += push_in_sub_spec;
-		bool push_in_sub_connect = settings.value("handler/push_in_sub_connect").toBool();
-		QString push_in_http_addr = settings.value("handler/push_in_http_addr").toString();
-		int push_in_http_port = settings.adjustedPort("handler/push_in_http_port");
-		int push_in_http_max_headers_size = settings.value("handler/push_in_http_max_headers_size", DEFAULT_HTTP_MAX_HEADERS_SIZE).toInt();
-		int push_in_http_max_body_size = settings.value("handler/push_in_http_max_body_size", DEFAULT_HTTP_MAX_BODY_SIZE).toInt();
-		bool ok;
-		int ipcFileMode = settings.value("handler/ipc_file_mode", -1).toString().toInt(&ok, 8);
-		bool shareAll = settings.value("handler/share_all").toBool();
-		int messageRate = settings.value("handler/message_rate", -1).toInt();
-		int messageHwm = settings.value("handler/message_hwm", -1).toInt();
-		int messageBlockSize = settings.value("handler/message_block_size", -1).toInt();
-		int messageWait = settings.value("handler/message_wait", 5000).toInt();
-		int idCacheTtl = settings.value("handler/id_cache_ttl", 0).toInt();
-		bool updateOnFirstSubscription = settings.value("handler/update_on_first_subscription", true).toBool();
-		int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
-		int connectionSubscriptionMax = settings.value("handler/connection_subscription_max", 20).toInt();
-		int subscriptionLinger = settings.value("handler/subscription_linger", 60).toInt();
-		int statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
-		int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
-		int statsSubscriptionTtl = settings.value("handler/stats_subscription_ttl", 60).toInt();
-		int statsReportInterval = settings.value("handler/stats_report_interval", 10).toInt();
-		QString statsFormat = settings.value("handler/stats_format").toString();
-		QString prometheusPort = settings.value("handler/prometheus_port").toString();
-		QString prometheusPrefix = settings.value("handler/prometheus_prefix").toString();
-
-		if(m2a_in_stream_specs.isEmpty() || m2a_out_specs.isEmpty())
-		{
-			log_error("must set m2a_in_stream_specs and m2a_out_specs");
-			return 1;
-		}
-
-		if(proxy_inspect_specs.isEmpty() || proxy_accept_specs.isEmpty() || proxy_retry_out_specs.isEmpty())
-		{
-			log_error("must set proxy_inspect_specs, proxy_accept_specs, and proxy_retry_out_specs");
-			return 1;
-		}
-
-		HandlerEngine::Configuration config;
-		config.appVersion = Config::get().version;
-		config.instanceId = "handler_" + QByteArray::number(getpid());
-		if(!services.contains("mongrel2") && (!connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
-		{
-			config.serverInStreamSpecs = connmgr_in_stream_specs;
-			config.serverOutSpecs = connmgr_out_specs;
-		}
-		else
-		{
-			config.serverInStreamSpecs = m2a_in_stream_specs;
-			config.serverOutSpecs = m2a_out_specs;
-		}
-		config.clientOutSpecs = expandSpecs(intreq_out_specs, proxyWorkerCount);
-		config.clientOutStreamSpecs = expandSpecs(intreq_out_stream_specs, proxyWorkerCount);
-		config.clientInSpecs = expandSpecs(intreq_in_specs, proxyWorkerCount);
-		config.inspectSpecs = expandSpecs(proxy_inspect_specs, proxyWorkerCount);
-		config.acceptSpecs = expandSpecs(proxy_accept_specs, proxyWorkerCount);
-		config.retryOutSpecs = expandSpecs(proxy_retry_out_specs, proxyWorkerCount);
-		config.wsControlInitSpecs = expandSpecs(ws_control_init_specs, proxyWorkerCount);
-		config.wsControlStreamSpecs = expandSpecs(ws_control_stream_specs, proxyWorkerCount);
-		config.statsSpec = stats_spec;
-		config.commandSpec = command_spec;
-		config.stateSpec = state_spec;
-		config.proxyStatsSpecs = expandSpecs(proxy_stats_specs, proxyWorkerCount);
-		config.proxyCommandSpec = firstSpec(proxy_command_spec, proxyWorkerCount);
-		config.pushInSpec = push_in_spec;
-		config.pushInSubSpecs = push_in_sub_specs;
-		config.pushInSubConnect = push_in_sub_connect;
-		config.pushInHttpAddr = QHostAddress(push_in_http_addr);
-		config.pushInHttpPort = push_in_http_port;
-		config.pushInHttpMaxHeadersSize = push_in_http_max_headers_size;
-		config.pushInHttpMaxBodySize = push_in_http_max_body_size;
-		config.ipcFileMode = ipcFileMode;
-		config.shareAll = shareAll;
-		config.messageRate = messageRate;
-		config.messageHwm = messageHwm;
-		config.messageBlockSize = messageBlockSize;
-		config.messageWait = messageWait;
-		config.idCacheTtl = idCacheTtl;
-		config.updateOnFirstSubscription = updateOnFirstSubscription;
-		config.connectionsMax = clientMaxconn;
-		config.connectionSubscriptionMax = connectionSubscriptionMax;
-		config.subscriptionLinger = subscriptionLinger;
-		config.statsConnectionSend = statsConnectionSend;
-		config.statsConnectionTtl = statsConnectionTtl;
-		config.statsSubscriptionTtl = statsSubscriptionTtl;
-		config.statsReportInterval = statsReportInterval;
-		config.statsFormat = statsFormat;
-		config.prometheusPort = prometheusPort;
-		config.prometheusPrefix = prometheusPrefix;
-
-		return runLoop(config);
-	}
-
-private:
-	static int runLoop(const HandlerEngine::Configuration &config)
-	{
-		// includes worst-case subscriptions and update registrations
-		int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
-			(config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +
-			TIMERS_PER_UNIQUE_UPDATE_REGISTRATION;
-
-		// enough timers for sessions, plus an extra 100 for misc
-		int timersMax = (config.connectionsMax * timersPerSession) + 100;
-
-		// enough for control requests and prometheus requests, plus an
-		// extra 100 for misc. client sessions don't use socket notifiers
-		int socketNotifiersMax = (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX)) + 100;
-
-		int registrationsMax = timersMax + socketNotifiersMax;
-		std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
-
-		std::unique_ptr<HandlerEngine> engine;
-
-		DeferCall deferCall;
-		deferCall.defer([&] {
-			engine = std::make_unique<HandlerEngine>();
-
-			ProcessQuit::instance()->quit.connect([&] {
-				log_info("stopping...");
-		
-				// remove the handler, so if we get another signal then we crash out
-				ProcessQuit::cleanup();
-
-				engine.reset();
-
-				log_debug("stopped");
-
-				loop->exit(0);
-			});
-
-			ProcessQuit::instance()->hup.connect([&] {
-				log_info("reloading");
-				log_rotate();
-				engine->reload();
-			});
-
-			if(!engine->start(config))
-			{
-				engine.reset();
-				loop->exit(1);
-				return;
-			}
-
-			log_info("started");
+			loop->exit(0);
 		});
 
-		return loop->exec();
-	}
-};
+		ProcessQuit::instance()->hup.connect([&] {
+			log_info("reloading");
+			log_rotate();
+			engine->reload();
+		});
 
-HandlerApp::HandlerApp() = default;
+		if(!engine->start(config))
+		{
+			engine.reset();
+			loop->exit(1);
+			return;
+		}
 
-HandlerApp::~HandlerApp() = default;
+		log_info("started");
+	});
 
-int HandlerApp::run(const ffi::HandlerCliArgs *argsFfi)
-{
-	return Private::run(argsFfi);
+	return loop->exec();
 }
 
 extern "C" {
 
 int handler_init(const ffi::HandlerCliArgs *argsFfi)
 {
-	HandlerApp app;
-	return app.run(argsFfi);
+	HandlerArgsData args(argsFfi);
+
+	// Set the log level
+	if(args.logLevel != -1)
+		log_setOutputLevel(args.logLevel);
+	else
+		log_setOutputLevel(LOG_LEVEL_INFO);
+
+	// Set the log file if specified
+	if(!args.logFile.isEmpty())
+	{
+		if(!log_setFile(args.logFile))
+		{
+			log_error("failed to open log file: %s", qPrintable(args.logFile));
+			return 1;
+		}
+	}
+
+	log_debug("starting...");
+
+	// QSettings doesn't inform us if the config file can't be opened, so do that ourselves
+	{
+		QFile file(args.configFile);
+		if(!file.open(QIODevice::ReadOnly))
+		{
+			log_error("failed to open config file: %s", qPrintable(args.configFile));
+			return 1;
+		}
+	}
+
+	Settings settings(args.configFile);
+	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+	if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
+
+	QStringList services = settings.value("runner/services").toStringList();
+
+	QStringList connmgr_in_stream_specs = settings.value("proxy/connmgr_in_stream_specs").toStringList();
+	trimlist(&connmgr_in_stream_specs);
+	QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
+	trimlist(&connmgr_out_specs);
+	QStringList condure_in_stream_specs = settings.value("proxy/condure_in_stream_specs").toStringList();
+	trimlist(&condure_in_stream_specs);
+	connmgr_in_stream_specs += condure_in_stream_specs;
+	QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
+	trimlist(&condure_out_specs);
+	connmgr_out_specs += condure_out_specs;
+	int proxyWorkerCount = settings.value("proxy/workers", 1).toInt();
+	QStringList m2a_in_stream_specs = settings.value("handler/m2a_in_stream_specs").toStringList();
+	trimlist(&m2a_in_stream_specs);
+	QStringList m2a_out_specs = settings.value("handler/m2a_out_specs").toStringList();
+	trimlist(&m2a_out_specs);
+	QStringList intreq_out_specs = settings.value("handler/proxy_intreq_out_specs").toStringList();
+	trimlist(&intreq_out_specs);
+	QStringList intreq_out_stream_specs = settings.value("handler/proxy_intreq_out_stream_specs").toStringList();
+	trimlist(&intreq_out_stream_specs);
+	QStringList intreq_in_specs = settings.value("handler/proxy_intreq_in_specs").toStringList();
+	trimlist(&intreq_in_specs);
+	QStringList proxy_inspect_specs = settings.value("handler/proxy_inspect_specs").toStringList();
+	trimlist(&proxy_inspect_specs);
+	QString proxy_inspect_spec = settings.value("handler/proxy_inspect_spec").toString();
+	if(!proxy_inspect_spec.isEmpty())
+		proxy_inspect_specs += proxy_inspect_spec;
+	QStringList proxy_accept_specs = settings.value("handler/proxy_accept_specs").toStringList();
+	trimlist(&proxy_accept_specs);
+	QString proxy_accept_spec = settings.value("handler/proxy_accept_spec").toString();
+	if(!proxy_accept_spec.isEmpty())
+		proxy_accept_specs += proxy_accept_spec;
+	QStringList proxy_retry_out_specs = settings.value("handler/proxy_retry_out_specs").toStringList();
+	trimlist(&proxy_retry_out_specs);
+	QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
+	if(!proxy_retry_out_spec.isEmpty())
+		proxy_retry_out_specs += proxy_retry_out_spec;
+	QStringList ws_control_init_specs = settings.value("handler/proxy_ws_control_init_specs").toStringList();
+	trimlist(&ws_control_init_specs);
+	QStringList ws_control_stream_specs = settings.value("handler/proxy_ws_control_stream_specs").toStringList();
+	trimlist(&ws_control_stream_specs);
+	QString stats_spec = settings.value("handler/stats_spec").toString();
+	QString command_spec = settings.value("handler/command_spec").toString();
+	QString state_spec = settings.value("handler/state_spec").toString();
+	QStringList proxy_stats_specs = settings.value("handler/proxy_stats_specs").toStringList();
+	trimlist(&proxy_stats_specs);
+	QString proxy_stats_spec = settings.value("handler/proxy_stats_spec").toString();
+	if(!proxy_stats_spec.isEmpty())
+		proxy_stats_specs += proxy_stats_spec;
+	QString proxy_command_spec = settings.value("handler/proxy_command_spec").toString();
+	QString push_in_spec = settings.value("handler/push_in_spec").toString();
+	QStringList push_in_sub_specs = settings.value("handler/push_in_sub_specs").toStringList();
+	trimlist(&push_in_sub_specs);
+	QString push_in_sub_spec = settings.value("handler/push_in_sub_spec").toString();
+	if(!push_in_sub_spec.isEmpty())
+		push_in_sub_specs += push_in_sub_spec;
+	bool push_in_sub_connect = settings.value("handler/push_in_sub_connect").toBool();
+	QString push_in_http_addr = settings.value("handler/push_in_http_addr").toString();
+	int push_in_http_port = settings.adjustedPort("handler/push_in_http_port");
+	int push_in_http_max_headers_size = settings.value("handler/push_in_http_max_headers_size", DEFAULT_HTTP_MAX_HEADERS_SIZE).toInt();
+	int push_in_http_max_body_size = settings.value("handler/push_in_http_max_body_size", DEFAULT_HTTP_MAX_BODY_SIZE).toInt();
+	bool ok;
+	int ipcFileMode = settings.value("handler/ipc_file_mode", -1).toString().toInt(&ok, 8);
+	bool shareAll = settings.value("handler/share_all").toBool();
+	int messageRate = settings.value("handler/message_rate", -1).toInt();
+	int messageHwm = settings.value("handler/message_hwm", -1).toInt();
+	int messageBlockSize = settings.value("handler/message_block_size", -1).toInt();
+	int messageWait = settings.value("handler/message_wait", 5000).toInt();
+	int idCacheTtl = settings.value("handler/id_cache_ttl", 0).toInt();
+	bool updateOnFirstSubscription = settings.value("handler/update_on_first_subscription", true).toBool();
+	int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
+	int connectionSubscriptionMax = settings.value("handler/connection_subscription_max", 20).toInt();
+	int subscriptionLinger = settings.value("handler/subscription_linger", 60).toInt();
+	int statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
+	int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
+	int statsSubscriptionTtl = settings.value("handler/stats_subscription_ttl", 60).toInt();
+	int statsReportInterval = settings.value("handler/stats_report_interval", 10).toInt();
+	QString statsFormat = settings.value("handler/stats_format").toString();
+	QString prometheusPort = settings.value("handler/prometheus_port").toString();
+	QString prometheusPrefix = settings.value("handler/prometheus_prefix").toString();
+
+	if(m2a_in_stream_specs.isEmpty() || m2a_out_specs.isEmpty())
+	{
+		log_error("must set m2a_in_stream_specs and m2a_out_specs");
+		return 1;
+	}
+
+	if(proxy_inspect_specs.isEmpty() || proxy_accept_specs.isEmpty() || proxy_retry_out_specs.isEmpty())
+	{
+		log_error("must set proxy_inspect_specs, proxy_accept_specs, and proxy_retry_out_specs");
+		return 1;
+	}
+
+	HandlerEngine::Configuration config;
+	config.appVersion = Config::get().version;
+	config.instanceId = "handler_" + QByteArray::number(getpid());
+	if(!services.contains("mongrel2") && (!connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
+	{
+		config.serverInStreamSpecs = connmgr_in_stream_specs;
+		config.serverOutSpecs = connmgr_out_specs;
+	}
+	else
+	{
+		config.serverInStreamSpecs = m2a_in_stream_specs;
+		config.serverOutSpecs = m2a_out_specs;
+	}
+	config.clientOutSpecs = expandSpecs(intreq_out_specs, proxyWorkerCount);
+	config.clientOutStreamSpecs = expandSpecs(intreq_out_stream_specs, proxyWorkerCount);
+	config.clientInSpecs = expandSpecs(intreq_in_specs, proxyWorkerCount);
+	config.inspectSpecs = expandSpecs(proxy_inspect_specs, proxyWorkerCount);
+	config.acceptSpecs = expandSpecs(proxy_accept_specs, proxyWorkerCount);
+	config.retryOutSpecs = expandSpecs(proxy_retry_out_specs, proxyWorkerCount);
+	config.wsControlInitSpecs = expandSpecs(ws_control_init_specs, proxyWorkerCount);
+	config.wsControlStreamSpecs = expandSpecs(ws_control_stream_specs, proxyWorkerCount);
+	config.statsSpec = stats_spec;
+	config.commandSpec = command_spec;
+	config.stateSpec = state_spec;
+	config.proxyStatsSpecs = expandSpecs(proxy_stats_specs, proxyWorkerCount);
+	config.proxyCommandSpec = firstSpec(proxy_command_spec, proxyWorkerCount);
+	config.pushInSpec = push_in_spec;
+	config.pushInSubSpecs = push_in_sub_specs;
+	config.pushInSubConnect = push_in_sub_connect;
+	config.pushInHttpAddr = QHostAddress(push_in_http_addr);
+	config.pushInHttpPort = push_in_http_port;
+	config.pushInHttpMaxHeadersSize = push_in_http_max_headers_size;
+	config.pushInHttpMaxBodySize = push_in_http_max_body_size;
+	config.ipcFileMode = ipcFileMode;
+	config.shareAll = shareAll;
+	config.messageRate = messageRate;
+	config.messageHwm = messageHwm;
+	config.messageBlockSize = messageBlockSize;
+	config.messageWait = messageWait;
+	config.idCacheTtl = idCacheTtl;
+	config.updateOnFirstSubscription = updateOnFirstSubscription;
+	config.connectionsMax = clientMaxconn;
+	config.connectionSubscriptionMax = connectionSubscriptionMax;
+	config.subscriptionLinger = subscriptionLinger;
+	config.statsConnectionSend = statsConnectionSend;
+	config.statsConnectionTtl = statsConnectionTtl;
+	config.statsSubscriptionTtl = statsSubscriptionTtl;
+	config.statsReportInterval = statsReportInterval;
+	config.statsFormat = statsFormat;
+	config.prometheusPort = prometheusPort;
+	config.prometheusPrefix = prometheusPrefix;
+
+	return runLoop(config);
 }
 
 }

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -266,356 +266,324 @@ public:
 	}
 };
 
-class App
+static int runLoop(const Engine::Configuration &config, const QStringList &routeLines, const QString &routesFile, int workerCount)
 {
-public:
-	App();
-	~App();
+	// plenty for the main thread
+	int timersMax = 100;
 
-	int run(const ffi::ProxyCliArgs *argsFfi);
+	// for processquit
+	int socketNotifiersMax = 1;
 
-private:
-	class Private;
-};
+	int registrationsMax = timersMax + socketNotifiersMax;
+	std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
 
-class App::Private
-{
-public:
-	static int run(const ffi::ProxyCliArgs *argsFfi)
-	{
-		ProxyArgsData args(argsFfi);
+	std::unique_ptr<DomainMap> domainMap;
+	std::list<EngineThread*> threads;
 
-		// Set the log level
-		if(args.logLevel != -1)
-			log_setOutputLevel(args.logLevel);
-		else
-			log_setOutputLevel(LOG_LEVEL_INFO);
-
-		// Set the log file if specified
-		if(!args.logFile.isEmpty())
+	DeferCall deferCall;
+	deferCall.defer([&] {
+		if(!routeLines.isEmpty())
 		{
-			if(!log_setFile(args.logFile))
+			domainMap = std::make_unique<DomainMap>();
+			foreach(const QString &line, routeLines)
+				domainMap->addRouteLine(line);
+		}
+		else
+			domainMap = std::make_unique<DomainMap>(routesFile);
+
+		domainMap->changed.connect([&] {
+			for(EngineThread *t : threads)
+				t->routesChanged();
+		});
+
+		ProcessQuit::instance()->quit.connect([&] {
+			log_info("stopping...");
+
+			// remove the handler, so if we get another signal then we crash out
+			ProcessQuit::cleanup();
+
+			for(EngineThread *t : threads)
+				t->stop();
+
+			for(EngineThread *t : threads)
+				delete t;
+
+			threads.clear();
+
+			log_debug("stopped");
+
+			loop->exit(0);
+		});
+
+		ProcessQuit::instance()->hup.connect([&] {
+			log_info("reloading");
+			log_rotate();
+			domainMap->reload();
+		});
+
+		for(int n = 0; n < workerCount; ++n)
+		{
+			Engine::Configuration wconfig = config;
+
+			wconfig.id = n;
+
+			if(workerCount > 1)
 			{
-				log_error("failed to open log file: %s", qPrintable(args.logFile));
-				return 1;
+				wconfig.clientId += '-' + QByteArray::number(n);
+
+				wconfig.inspectSpec = suffixSpec(wconfig.inspectSpec, n);
+				wconfig.acceptSpec = suffixSpec(wconfig.acceptSpec, n);
+				wconfig.retryInSpec = suffixSpec(wconfig.retryInSpec, n);
+				wconfig.wsControlInitSpecs = suffixSpecs(wconfig.wsControlInitSpecs, n);
+				wconfig.wsControlStreamSpecs = suffixSpecs(wconfig.wsControlStreamSpecs, n);
+				wconfig.statsSpec = suffixSpec(wconfig.statsSpec, n);
+				wconfig.commandSpec = suffixSpec(wconfig.commandSpec, n);
+				wconfig.intServerInSpecs = suffixSpecs(wconfig.intServerInSpecs, n);
+				wconfig.intServerInStreamSpecs = suffixSpecs(wconfig.intServerInStreamSpecs, n);
+				wconfig.intServerOutSpecs = suffixSpecs(wconfig.intServerOutSpecs, n);
 			}
-		}
 
-		log_debug("starting...");
-
-		// QSettings doesn't inform us if the config file can't be opened, so do that ourselves
-		{
-			QFile file(args.configFile);
-			if(!file.open(QIODevice::ReadOnly))
+			EngineThread *t = new EngineThread(wconfig, domainMap.get());
+			if(!t->start())
 			{
-				log_error("failed to open config file: %s", qPrintable(args.configFile));
-				return 1;
-			}
-		}
-
-		QDir configDir = QFileInfo(args.configFile).absoluteDir();
-
-		Settings settings(args.configFile);
-		if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
-
-		QStringList services = settings.value("runner/services").toStringList();
-
-		int workerCount = settings.value("proxy/workers", 1).toInt();
-		QStringList connmgr_in_specs = settings.value("proxy/connmgr_in_specs").toStringList();
-		trimlist(&connmgr_in_specs);
-		QStringList connmgr_in_stream_specs = settings.value("proxy/connmgr_in_stream_specs").toStringList();
-		trimlist(&connmgr_in_stream_specs);
-		QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
-		trimlist(&connmgr_out_specs);
-		QStringList condure_in_specs = settings.value("proxy/condure_in_specs").toStringList();
-		trimlist(&condure_in_specs);
-		connmgr_in_specs += condure_in_specs;
-		QStringList condure_in_stream_specs = settings.value("proxy/condure_in_stream_specs").toStringList();
-		trimlist(&condure_in_stream_specs);
-		connmgr_in_stream_specs += condure_in_stream_specs;
-		QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
-		trimlist(&condure_out_specs);
-		connmgr_out_specs += condure_out_specs;
-		QStringList m2a_in_specs = settings.value("proxy/m2a_in_specs").toStringList();
-		trimlist(&m2a_in_specs);
-		QStringList m2a_in_stream_specs = settings.value("proxy/m2a_in_stream_specs").toStringList();
-		trimlist(&m2a_in_stream_specs);
-		QStringList m2a_out_specs = settings.value("proxy/m2a_out_specs").toStringList();
-		trimlist(&m2a_out_specs);
-		QStringList connmgr_client_out_specs = settings.value("proxy/connmgr_client_out_specs").toStringList();
-		trimlist(&connmgr_client_out_specs);
-		QStringList connmgr_client_out_stream_specs = settings.value("proxy/connmgr_client_out_stream_specs").toStringList();
-		trimlist(&connmgr_client_out_stream_specs);
-		QStringList connmgr_client_in_specs = settings.value("proxy/connmgr_client_in_specs").toStringList();
-		trimlist(&connmgr_client_in_specs);
-		QStringList condure_client_out_specs = settings.value("proxy/condure_client_out_specs").toStringList();
-		trimlist(&condure_client_out_specs);
-		connmgr_client_out_specs += condure_client_out_specs;
-		QStringList condure_client_out_stream_specs = settings.value("proxy/condure_client_out_stream_specs").toStringList();
-		trimlist(&condure_client_out_stream_specs);
-		connmgr_client_out_stream_specs += condure_client_out_stream_specs;
-		QStringList condure_client_in_specs = settings.value("proxy/condure_client_in_specs").toStringList();
-		trimlist(&condure_client_in_specs);
-		connmgr_client_in_specs += condure_client_in_specs;
-		QStringList zurl_out_specs = settings.value("proxy/zurl_out_specs").toStringList();
-		trimlist(&zurl_out_specs);
-		QStringList zurl_out_stream_specs = settings.value("proxy/zurl_out_stream_specs").toStringList();
-		trimlist(&zurl_out_stream_specs);
-		QStringList zurl_in_specs = settings.value("proxy/zurl_in_specs").toStringList();
-		trimlist(&zurl_in_specs);
-		QString handler_inspect_spec = settings.value("proxy/handler_inspect_spec").toString();
-		QString handler_accept_spec = settings.value("proxy/handler_accept_spec").toString();
-		QString handler_retry_in_spec = settings.value("proxy/handler_retry_in_spec").toString();
-		QStringList handler_ws_control_init_specs = settings.value("proxy/handler_ws_control_init_specs").toStringList();
-		trimlist(&handler_ws_control_init_specs);
-		QStringList handler_ws_control_stream_specs = settings.value("proxy/handler_ws_control_stream_specs").toStringList();
-		trimlist(&handler_ws_control_stream_specs);
-		QString stats_spec = settings.value("proxy/stats_spec").toString();
-		QString command_spec = settings.value("proxy/command_spec").toString();
-		QStringList intreq_in_specs = settings.value("proxy/intreq_in_specs").toStringList();
-		trimlist(&intreq_in_specs);
-		QStringList intreq_in_stream_specs = settings.value("proxy/intreq_in_stream_specs").toStringList();
-		trimlist(&intreq_in_stream_specs);
-		QStringList intreq_out_specs = settings.value("proxy/intreq_out_specs").toStringList();
-		trimlist(&intreq_out_specs);
-		bool ok;
-		int ipcFileMode = settings.value("proxy/ipc_file_mode", -1).toString().toInt(&ok, 8);
-		int sessionsMax = settings.value("proxy/max_open_requests", -1).toInt();
-		QString routesFile = settings.value("proxy/routesfile").toString();
-		bool debug = settings.value("proxy/debug").toBool();
-		bool autoCrossOrigin = settings.value("proxy/auto_cross_origin").toBool();
-		bool acceptXForwardedProtocol = settings.value("proxy/accept_x_forwarded_protocol").toBool();
-		QString setXForwardedProtocol = settings.value("proxy/set_x_forwarded_protocol").toString();
-		bool setXfProto = (setXForwardedProtocol == "true" || setXForwardedProtocol == "proto-only");
-		bool setXfProtocol = (setXForwardedProtocol == "true");
-		XffRule xffRule = parse_xffRule(settings.value("proxy/x_forwarded_for").toStringList());
-		XffRule xffTrustedRule = parse_xffRule(settings.value("proxy/x_forwarded_for_trusted").toStringList());
-		QStringList origHeadersNeedMarkStr = settings.value("proxy/orig_headers_need_mark").toStringList();
-		trimlist(&origHeadersNeedMarkStr);
-		bool acceptPushpinRoute = settings.value("proxy/accept_pushpin_route").toBool();
-		QByteArray cdnLoop = settings.value("proxy/cdn_loop").toString().toUtf8();
-		bool logFrom = settings.value("proxy/log_from").toBool();
-		bool logUserAgent = settings.value("proxy/log_user_agent").toBool();
-		QByteArray sigIss = settings.value("proxy/sig_iss", "pushpin").toString().toUtf8();
-		Jwt::EncodingKey sigKey = Jwt::EncodingKey::fromConfigString(settings.value("proxy/sig_key").toString(), configDir);
-		Jwt::DecodingKey upstreamKey = Jwt::DecodingKey::fromConfigString(settings.value("proxy/upstream_key").toString(), configDir);
-		QString sockJsUrl = settings.value("proxy/sockjs_url").toString();
-		int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
-		bool statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
-		int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
-		int statsConnectionsMaxTtl = settings.value("proxy/stats_connections_max_ttl", 60).toInt();
-		int statsReportInterval = settings.value("proxy/stats_report_interval", 10).toInt();
-		QString prometheusPort = settings.value("proxy/prometheus_port").toString();
-		QString prometheusPrefix = settings.value("proxy/prometheus_prefix").toString();
-
-		QList<QByteArray> origHeadersNeedMark;
-		foreach(const QString &s, origHeadersNeedMarkStr)
-			origHeadersNeedMark += s.toUtf8();
-
-		// if routesfile is a relative path, then use it relative to the config file location
-		QFileInfo fi(routesFile);
-		if(fi.isRelative())
-			routesFile = QFileInfo(configDir, routesFile).filePath();
-
-		if(!(!connmgr_in_specs.isEmpty() && !connmgr_in_stream_specs.isEmpty() && !connmgr_out_specs.isEmpty()) && !(!m2a_in_specs.isEmpty() && !m2a_in_stream_specs.isEmpty() && !m2a_out_specs.isEmpty()))
-		{
-			log_error("must set connmgr_in_specs, connmgr_in_stream_specs, and connmgr_out_specs, or m2a_in_specs, m2a_in_stream_specs, and m2a_out_specs");
-			return 1;
-		}
-
-		if(!(!connmgr_client_out_specs.isEmpty() && !connmgr_client_out_stream_specs.isEmpty() && !connmgr_client_in_specs.isEmpty()) && !(!zurl_out_specs.isEmpty() && !zurl_out_stream_specs.isEmpty() && !zurl_in_specs.isEmpty()))
-		{
-			log_error("must set connmgr_client_out_specs, connmgr_client_out_stream_specs, and connmgr_client_in_specs, or zurl_out_specs, zurl_out_stream_specs, and zurl_in_specs");
-			return 1;
-		}
-
-		// sessionsMax should not exceed clientMaxconn
-		if(sessionsMax >= 0)
-			sessionsMax = qMin(sessionsMax, clientMaxconn);
-		else
-			sessionsMax = clientMaxconn;
-
-		Engine::Configuration config;
-		config.appVersion = Config::get().version;
-		config.clientId = "proxy_" + QByteArray::number(getpid());
-		if(!services.contains("mongrel2") && (!connmgr_in_specs.isEmpty() || !connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
-		{
-			config.serverInSpecs = connmgr_in_specs;
-			config.serverInStreamSpecs = connmgr_in_stream_specs;
-			config.serverOutSpecs = connmgr_out_specs;
-		}
-		else
-		{
-			config.serverInSpecs = m2a_in_specs;
-			config.serverInStreamSpecs = m2a_in_stream_specs;
-			config.serverOutSpecs = m2a_out_specs;
-		}
-		if(!services.contains("zurl") && (!connmgr_client_out_specs.isEmpty() || !connmgr_client_out_stream_specs.isEmpty() || !connmgr_client_in_specs.isEmpty()))
-		{
-			config.clientOutSpecs = connmgr_client_out_specs;
-			config.clientOutStreamSpecs = connmgr_client_out_stream_specs;
-			config.clientInSpecs = connmgr_client_in_specs;
-		}
-		else
-		{
-			config.clientOutSpecs = zurl_out_specs;
-			config.clientOutStreamSpecs = zurl_out_stream_specs;
-			config.clientInSpecs = zurl_in_specs;
-		}
-		config.inspectSpec = handler_inspect_spec;
-		config.acceptSpec = handler_accept_spec;
-		config.retryInSpec = handler_retry_in_spec;
-		config.wsControlInitSpecs = handler_ws_control_init_specs;
-		config.wsControlStreamSpecs = handler_ws_control_stream_specs;
-		config.statsSpec = stats_spec;
-		config.commandSpec = command_spec;
-		config.intServerInSpecs = intreq_in_specs;
-		config.intServerInStreamSpecs = intreq_in_stream_specs;
-		config.intServerOutSpecs = intreq_out_specs;
-		config.ipcFileMode = ipcFileMode;
-		config.sessionsMax = sessionsMax / workerCount;
-		config.debug = debug;
-		config.autoCrossOrigin = autoCrossOrigin;
-		config.acceptXForwardedProto = acceptXForwardedProtocol;
-		config.setXForwardedProto = setXfProto;
-		config.setXForwardedProtocol = setXfProtocol;
-		config.xffUntrustedRule = xffRule;
-		config.xffTrustedRule = xffTrustedRule;
-		config.origHeadersNeedMark = origHeadersNeedMark;
-		config.acceptPushpinRoute = acceptPushpinRoute;
-		config.cdnLoop = cdnLoop;
-		config.logFrom = logFrom;
-		config.logUserAgent = logUserAgent;
-		config.sigIss = sigIss;
-		config.sigKey = sigKey;
-		config.upstreamKey = upstreamKey;
-		config.sockJsUrl = sockJsUrl;
-		config.statsConnectionSend = statsConnectionSend;
-		config.statsConnectionTtl = statsConnectionTtl;
-		config.statsConnectionsMaxTtl = statsConnectionsMaxTtl;
-		config.statsReportInterval = statsReportInterval;
-		config.prometheusPort = prometheusPort;
-		config.prometheusPrefix = prometheusPrefix;
-
-		return runLoop(config, args.routeLines, routesFile, workerCount);
-	}
-
-private:
-	static int runLoop(const Engine::Configuration &config, const QStringList &routeLines, const QString &routesFile, int workerCount)
-	{
-		// plenty for the main thread
-		int timersMax = 100;
-
-		// for processquit
-		int socketNotifiersMax = 1;
-
-		int registrationsMax = timersMax + socketNotifiersMax;
-		std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
-
-		std::unique_ptr<DomainMap> domainMap;
-		std::list<EngineThread*> threads;
-
-		DeferCall deferCall;
-		deferCall.defer([&] {
-			if(!routeLines.isEmpty())
-			{
-				domainMap = std::make_unique<DomainMap>();
-				foreach(const QString &line, routeLines)
-					domainMap->addRouteLine(line);
-			}
-			else
-				domainMap = std::make_unique<DomainMap>(routesFile);
-
-			domainMap->changed.connect([&] {
-				for(EngineThread *t : threads)
-					t->routesChanged();
-			});
-
-			ProcessQuit::instance()->quit.connect([&] {
-				log_info("stopping...");
-
-				// remove the handler, so if we get another signal then we crash out
-				ProcessQuit::cleanup();
-
-				for(EngineThread *t : threads)
-					t->stop();
+				delete t;
 
 				for(EngineThread *t : threads)
 					delete t;
 
 				threads.clear();
-
-				log_debug("stopped");
-
-				loop->exit(0);
-			});
-
-			ProcessQuit::instance()->hup.connect([&] {
-				log_info("reloading");
-				log_rotate();
-				domainMap->reload();
-			});
-
-			for(int n = 0; n < workerCount; ++n)
-			{
-				Engine::Configuration wconfig = config;
-
-				wconfig.id = n;
-
-				if(workerCount > 1)
-				{
-					wconfig.clientId += '-' + QByteArray::number(n);
-
-					wconfig.inspectSpec = suffixSpec(wconfig.inspectSpec, n);
-					wconfig.acceptSpec = suffixSpec(wconfig.acceptSpec, n);
-					wconfig.retryInSpec = suffixSpec(wconfig.retryInSpec, n);
-					wconfig.wsControlInitSpecs = suffixSpecs(wconfig.wsControlInitSpecs, n);
-					wconfig.wsControlStreamSpecs = suffixSpecs(wconfig.wsControlStreamSpecs, n);
-					wconfig.statsSpec = suffixSpec(wconfig.statsSpec, n);
-					wconfig.commandSpec = suffixSpec(wconfig.commandSpec, n);
-					wconfig.intServerInSpecs = suffixSpecs(wconfig.intServerInSpecs, n);
-					wconfig.intServerInStreamSpecs = suffixSpecs(wconfig.intServerInStreamSpecs, n);
-					wconfig.intServerOutSpecs = suffixSpecs(wconfig.intServerOutSpecs, n);
-				}
-
-				EngineThread *t = new EngineThread(wconfig, domainMap.get());
-				if(!t->start())
-				{
-					delete t;
-
-					for(EngineThread *t : threads)
-						delete t;
-
-					threads.clear();
-					loop->exit(1);
-					return;
-				}
-
-				threads.push_back(t);
+				loop->exit(1);
+				return;
 			}
 
-			log_info("started");
-		});
+			threads.push_back(t);
+		}
 
-		return loop->exec();
-	}
-};
+		log_info("started");
+	});
 
-App::App() = default;
-
-App::~App() = default;
-
-int App::run(const ffi::ProxyCliArgs *argsFfi)
-{
-	return Private::run(argsFfi);
+	return loop->exec();
 }
 
 extern "C" {
 
 int proxy_init(const ffi::ProxyCliArgs *argsFfi)
-{	
-	App app;
-	return app.run(argsFfi);
+{
+	ProxyArgsData args(argsFfi);
+
+	// Set the log level
+	if(args.logLevel != -1)
+		log_setOutputLevel(args.logLevel);
+	else
+		log_setOutputLevel(LOG_LEVEL_INFO);
+
+	// Set the log file if specified
+	if(!args.logFile.isEmpty())
+	{
+		if(!log_setFile(args.logFile))
+		{
+			log_error("failed to open log file: %s", qPrintable(args.logFile));
+			return 1;
+		}
+	}
+
+	log_debug("starting...");
+
+	// QSettings doesn't inform us if the config file can't be opened, so do that ourselves
+	{
+		QFile file(args.configFile);
+		if(!file.open(QIODevice::ReadOnly))
+		{
+			log_error("failed to open config file: %s", qPrintable(args.configFile));
+			return 1;
+		}
+	}
+
+	QDir configDir = QFileInfo(args.configFile).absoluteDir();
+
+	Settings settings(args.configFile);
+	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+
+	QStringList services = settings.value("runner/services").toStringList();
+
+	int workerCount = settings.value("proxy/workers", 1).toInt();
+	QStringList connmgr_in_specs = settings.value("proxy/connmgr_in_specs").toStringList();
+	trimlist(&connmgr_in_specs);
+	QStringList connmgr_in_stream_specs = settings.value("proxy/connmgr_in_stream_specs").toStringList();
+	trimlist(&connmgr_in_stream_specs);
+	QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
+	trimlist(&connmgr_out_specs);
+	QStringList condure_in_specs = settings.value("proxy/condure_in_specs").toStringList();
+	trimlist(&condure_in_specs);
+	connmgr_in_specs += condure_in_specs;
+	QStringList condure_in_stream_specs = settings.value("proxy/condure_in_stream_specs").toStringList();
+	trimlist(&condure_in_stream_specs);
+	connmgr_in_stream_specs += condure_in_stream_specs;
+	QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
+	trimlist(&condure_out_specs);
+	connmgr_out_specs += condure_out_specs;
+	QStringList m2a_in_specs = settings.value("proxy/m2a_in_specs").toStringList();
+	trimlist(&m2a_in_specs);
+	QStringList m2a_in_stream_specs = settings.value("proxy/m2a_in_stream_specs").toStringList();
+	trimlist(&m2a_in_stream_specs);
+	QStringList m2a_out_specs = settings.value("proxy/m2a_out_specs").toStringList();
+	trimlist(&m2a_out_specs);
+	QStringList connmgr_client_out_specs = settings.value("proxy/connmgr_client_out_specs").toStringList();
+	trimlist(&connmgr_client_out_specs);
+	QStringList connmgr_client_out_stream_specs = settings.value("proxy/connmgr_client_out_stream_specs").toStringList();
+	trimlist(&connmgr_client_out_stream_specs);
+	QStringList connmgr_client_in_specs = settings.value("proxy/connmgr_client_in_specs").toStringList();
+	trimlist(&connmgr_client_in_specs);
+	QStringList condure_client_out_specs = settings.value("proxy/condure_client_out_specs").toStringList();
+	trimlist(&condure_client_out_specs);
+	connmgr_client_out_specs += condure_client_out_specs;
+	QStringList condure_client_out_stream_specs = settings.value("proxy/condure_client_out_stream_specs").toStringList();
+	trimlist(&condure_client_out_stream_specs);
+	connmgr_client_out_stream_specs += condure_client_out_stream_specs;
+	QStringList condure_client_in_specs = settings.value("proxy/condure_client_in_specs").toStringList();
+	trimlist(&condure_client_in_specs);
+	connmgr_client_in_specs += condure_client_in_specs;
+	QStringList zurl_out_specs = settings.value("proxy/zurl_out_specs").toStringList();
+	trimlist(&zurl_out_specs);
+	QStringList zurl_out_stream_specs = settings.value("proxy/zurl_out_stream_specs").toStringList();
+	trimlist(&zurl_out_stream_specs);
+	QStringList zurl_in_specs = settings.value("proxy/zurl_in_specs").toStringList();
+	trimlist(&zurl_in_specs);
+	QString handler_inspect_spec = settings.value("proxy/handler_inspect_spec").toString();
+	QString handler_accept_spec = settings.value("proxy/handler_accept_spec").toString();
+	QString handler_retry_in_spec = settings.value("proxy/handler_retry_in_spec").toString();
+	QStringList handler_ws_control_init_specs = settings.value("proxy/handler_ws_control_init_specs").toStringList();
+	trimlist(&handler_ws_control_init_specs);
+	QStringList handler_ws_control_stream_specs = settings.value("proxy/handler_ws_control_stream_specs").toStringList();
+	trimlist(&handler_ws_control_stream_specs);
+	QString stats_spec = settings.value("proxy/stats_spec").toString();
+	QString command_spec = settings.value("proxy/command_spec").toString();
+	QStringList intreq_in_specs = settings.value("proxy/intreq_in_specs").toStringList();
+	trimlist(&intreq_in_specs);
+	QStringList intreq_in_stream_specs = settings.value("proxy/intreq_in_stream_specs").toStringList();
+	trimlist(&intreq_in_stream_specs);
+	QStringList intreq_out_specs = settings.value("proxy/intreq_out_specs").toStringList();
+	trimlist(&intreq_out_specs);
+	bool ok;
+	int ipcFileMode = settings.value("proxy/ipc_file_mode", -1).toString().toInt(&ok, 8);
+	int sessionsMax = settings.value("proxy/max_open_requests", -1).toInt();
+	QString routesFile = settings.value("proxy/routesfile").toString();
+	bool debug = settings.value("proxy/debug").toBool();
+	bool autoCrossOrigin = settings.value("proxy/auto_cross_origin").toBool();
+	bool acceptXForwardedProtocol = settings.value("proxy/accept_x_forwarded_protocol").toBool();
+	QString setXForwardedProtocol = settings.value("proxy/set_x_forwarded_protocol").toString();
+	bool setXfProto = (setXForwardedProtocol == "true" || setXForwardedProtocol == "proto-only");
+	bool setXfProtocol = (setXForwardedProtocol == "true");
+	XffRule xffRule = parse_xffRule(settings.value("proxy/x_forwarded_for").toStringList());
+	XffRule xffTrustedRule = parse_xffRule(settings.value("proxy/x_forwarded_for_trusted").toStringList());
+	QStringList origHeadersNeedMarkStr = settings.value("proxy/orig_headers_need_mark").toStringList();
+	trimlist(&origHeadersNeedMarkStr);
+	bool acceptPushpinRoute = settings.value("proxy/accept_pushpin_route").toBool();
+	QByteArray cdnLoop = settings.value("proxy/cdn_loop").toString().toUtf8();
+	bool logFrom = settings.value("proxy/log_from").toBool();
+	bool logUserAgent = settings.value("proxy/log_user_agent").toBool();
+	QByteArray sigIss = settings.value("proxy/sig_iss", "pushpin").toString().toUtf8();
+	Jwt::EncodingKey sigKey = Jwt::EncodingKey::fromConfigString(settings.value("proxy/sig_key").toString(), configDir);
+	Jwt::DecodingKey upstreamKey = Jwt::DecodingKey::fromConfigString(settings.value("proxy/upstream_key").toString(), configDir);
+	QString sockJsUrl = settings.value("proxy/sockjs_url").toString();
+	int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
+	bool statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
+	int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
+	int statsConnectionsMaxTtl = settings.value("proxy/stats_connections_max_ttl", 60).toInt();
+	int statsReportInterval = settings.value("proxy/stats_report_interval", 10).toInt();
+	QString prometheusPort = settings.value("proxy/prometheus_port").toString();
+	QString prometheusPrefix = settings.value("proxy/prometheus_prefix").toString();
+
+	QList<QByteArray> origHeadersNeedMark;
+	foreach(const QString &s, origHeadersNeedMarkStr)
+		origHeadersNeedMark += s.toUtf8();
+
+	// if routesfile is a relative path, then use it relative to the config file location
+	QFileInfo fi(routesFile);
+	if(fi.isRelative())
+		routesFile = QFileInfo(configDir, routesFile).filePath();
+
+	if(!(!connmgr_in_specs.isEmpty() && !connmgr_in_stream_specs.isEmpty() && !connmgr_out_specs.isEmpty()) && !(!m2a_in_specs.isEmpty() && !m2a_in_stream_specs.isEmpty() && !m2a_out_specs.isEmpty()))
+	{
+		log_error("must set connmgr_in_specs, connmgr_in_stream_specs, and connmgr_out_specs, or m2a_in_specs, m2a_in_stream_specs, and m2a_out_specs");
+		return 1;
+	}
+
+	if(!(!connmgr_client_out_specs.isEmpty() && !connmgr_client_out_stream_specs.isEmpty() && !connmgr_client_in_specs.isEmpty()) && !(!zurl_out_specs.isEmpty() && !zurl_out_stream_specs.isEmpty() && !zurl_in_specs.isEmpty()))
+	{
+		log_error("must set connmgr_client_out_specs, connmgr_client_out_stream_specs, and connmgr_client_in_specs, or zurl_out_specs, zurl_out_stream_specs, and zurl_in_specs");
+		return 1;
+	}
+
+	// sessionsMax should not exceed clientMaxconn
+	if(sessionsMax >= 0)
+		sessionsMax = qMin(sessionsMax, clientMaxconn);
+	else
+		sessionsMax = clientMaxconn;
+
+	Engine::Configuration config;
+	config.appVersion = Config::get().version;
+	config.clientId = "proxy_" + QByteArray::number(getpid());
+	if(!services.contains("mongrel2") && (!connmgr_in_specs.isEmpty() || !connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
+	{
+		config.serverInSpecs = connmgr_in_specs;
+		config.serverInStreamSpecs = connmgr_in_stream_specs;
+		config.serverOutSpecs = connmgr_out_specs;
+	}
+	else
+	{
+		config.serverInSpecs = m2a_in_specs;
+		config.serverInStreamSpecs = m2a_in_stream_specs;
+		config.serverOutSpecs = m2a_out_specs;
+	}
+	if(!services.contains("zurl") && (!connmgr_client_out_specs.isEmpty() || !connmgr_client_out_stream_specs.isEmpty() || !connmgr_client_in_specs.isEmpty()))
+	{
+		config.clientOutSpecs = connmgr_client_out_specs;
+		config.clientOutStreamSpecs = connmgr_client_out_stream_specs;
+		config.clientInSpecs = connmgr_client_in_specs;
+	}
+	else
+	{
+		config.clientOutSpecs = zurl_out_specs;
+		config.clientOutStreamSpecs = zurl_out_stream_specs;
+		config.clientInSpecs = zurl_in_specs;
+	}
+	config.inspectSpec = handler_inspect_spec;
+	config.acceptSpec = handler_accept_spec;
+	config.retryInSpec = handler_retry_in_spec;
+	config.wsControlInitSpecs = handler_ws_control_init_specs;
+	config.wsControlStreamSpecs = handler_ws_control_stream_specs;
+	config.statsSpec = stats_spec;
+	config.commandSpec = command_spec;
+	config.intServerInSpecs = intreq_in_specs;
+	config.intServerInStreamSpecs = intreq_in_stream_specs;
+	config.intServerOutSpecs = intreq_out_specs;
+	config.ipcFileMode = ipcFileMode;
+	config.sessionsMax = sessionsMax / workerCount;
+	config.debug = debug;
+	config.autoCrossOrigin = autoCrossOrigin;
+	config.acceptXForwardedProto = acceptXForwardedProtocol;
+	config.setXForwardedProto = setXfProto;
+	config.setXForwardedProtocol = setXfProtocol;
+	config.xffUntrustedRule = xffRule;
+	config.xffTrustedRule = xffTrustedRule;
+	config.origHeadersNeedMark = origHeadersNeedMark;
+	config.acceptPushpinRoute = acceptPushpinRoute;
+	config.cdnLoop = cdnLoop;
+	config.logFrom = logFrom;
+	config.logUserAgent = logUserAgent;
+	config.sigIss = sigIss;
+	config.sigKey = sigKey;
+	config.upstreamKey = upstreamKey;
+	config.sockJsUrl = sockJsUrl;
+	config.statsConnectionSend = statsConnectionSend;
+	config.statsConnectionTtl = statsConnectionTtl;
+	config.statsConnectionsMaxTtl = statsConnectionsMaxTtl;
+	config.statsReportInterval = statsReportInterval;
+	config.prometheusPort = prometheusPort;
+	config.prometheusPrefix = prometheusPrefix;
+
+	return runLoop(config, args.routeLines, routesFile, workerCount);
 }
 
 }


### PR DESCRIPTION
The app classes originally had a purpose but after several refactors they only have static methods, which we can just turn into regular functions at this point.

The diff looks like a lot but it's really just reordering and unindenting a bunch of otherwise unmodified code.