### PR TITLE
add ffi & c++ wrapper for reactor and executor

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -58,6 +58,8 @@ HEADERS += \
 	$$PWD/callback.h \
 	$$PWD/config.h \
 	$$PWD/timerwheel.h \
+	$$PWD/reactor.h \
+	$$PWD/executor.h \
 	$$PWD/jwt.h \
 	$$PWD/timer.h \
 	$$PWD/defercall.h \
@@ -91,6 +93,8 @@ HEADERS += \
 SOURCES += \
 	$$PWD/config.cpp \
 	$$PWD/timerwheel.cpp \
+	$$PWD/reactor.cpp \
+	$$PWD/executor.cpp \
 	$$PWD/jwt.cpp \
 	$$PWD/timer.cpp \
 	$$PWD/defercall.cpp \

--- a/src/core/executor.cpp
+++ b/src/core/executor.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "executor.h"
+
+Executor::Executor(int tasksMax) :
+    inner_(ffi::executor_create(tasksMax))
+{
+}
+
+Executor::~Executor()
+{
+    ffi::executor_destroy(inner_);
+}
+
+int Executor::park_cb(void *ctx, int ms)
+{
+    std::function<bool (std::optional<int>)> *park = (std::function<bool (std::optional<int>)> *)ctx;
+
+    std::optional<int> x;
+    if(ms >= 0)
+        x = ms;
+
+    if(!(*park)(x))
+        return -1;
+
+    return 0;
+}
+
+bool Executor::run(std::function<bool (std::optional<int>)> park)
+{
+    if(ffi::executor_run(inner_, park_cb, &park) != 0)
+        return false;
+
+    return true;
+}

--- a/src/core/executor.h
+++ b/src/core/executor.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EXECUTOR_H
+#define EXECUTOR_H
+
+#include <optional>
+#include <functional>
+#include "rust/bindings.h"
+
+class Executor
+{
+public:
+    Executor(int tasksMax);
+    ~Executor();
+
+    bool run(std::function<bool (std::optional<int>)> park);
+
+private:
+    ffi::Executor *inner_;
+
+    static int park_cb(void *ctx, int ms);
+};
+
+#endif

--- a/src/core/reactor.cpp
+++ b/src/core/reactor.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "reactor.h"
+
+Reactor::Reactor(int registrationsMax) :
+    inner_(ffi::reactor_create(registrationsMax))
+{
+}
+
+Reactor::~Reactor()
+{
+    ffi::reactor_destroy(inner_);
+}
+
+bool Reactor::poll(std::optional<int> ms)
+{
+    if(ffi::reactor_poll(inner_, ms.value_or(-1)) != 0)
+        return false;
+
+    return true;
+}

--- a/src/core/reactor.h
+++ b/src/core/reactor.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REACTOR_H
+#define REACTOR_H
+
+#include <optional>
+#include "rust/bindings.h"
+
+class Reactor
+{
+public:
+    Reactor(int registrationsMax);
+    ~Reactor();
+
+    bool poll(std::optional<int> ms);
+
+private:
+    ffi::Reactor *inner_;
+};
+
+#endif


### PR DESCRIPTION
This adds a C++ API for working with Reactor and Executor.

The plan is to allow proxy and handler to work with these objects so that they may run their EventLoop as a Future within an Executor. This will make proxy and handler evented execution consistent with how connmgr works (i.e. always through an Executor), and will allow running other Futures concurrent with the EventLoop in the same thread. The EventLoop implementation already supports being run as a Future (via `EventLoop::exec_async()`), so getting this to work is mostly a matter of exposing the needed pieces to C++.

To start out, this PR adds an initial API to allow constructing Reactor and Executor from C++, as well as running the Executor.