### PR TITLE
eventloop: add task method to run with lifecycle callbacks

### DIFF
--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -948,9 +948,7 @@ mod tests {
         };
 
         executor
-            .spawn(async {
-                EventLoop::<Box<dyn Callback>>::task(1, setup_fn, done_fn).await;
-            })
+            .spawn(EventLoop::<Box<dyn Callback>>::task(1, setup_fn, done_fn))
             .unwrap();
 
         executor.run(|timeout| reactor.poll(timeout)).unwrap();


### PR DESCRIPTION
This adds an async convenience method, `EventLoop::task()`, that constructs an event loop and asynchronously runs it to completion, triggering a callback just prior to running it and another after it finishes.

The purpose of this method is to make it easy to instantiate an asynchronously-executed `EventLoop` without having to write async code. Normally, a task would need to be written out as an async function/block that calls `exec_async().await`, and notably this would be prohibitive to do from C++ due to the use of `async` and `await` keywords. Instead, non-async code can pass the return value of `task()` directly to a spawning function, and simply handle the callbacks.

This PR also corrects some FFI functions to use const refs.