### PR TITLE
add ffi & wrapper for eventloop task method

### DIFF
--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -661,13 +661,10 @@ mod ffi {
         let fut = EventLoop::<RawCallback>::task(
             capacity,
             Box::new(move |l: &Rc<EventLoop<RawCallback>>| {
+                let l_ptr = &**l as *const EventLoop<RawCallback> as *const EventLoopRaw;
+
                 // SAFETY: calling with the provided ctx
-                unsafe {
-                    setup_fn(
-                        setup_ctx,
-                        &**l as *const EventLoop<RawCallback> as *const EventLoopRaw,
-                    )
-                };
+                unsafe { setup_fn(setup_ctx, l_ptr) };
             }),
             Box::new(move |code| {
                 // SAFETY: calling with the provided ctx

--- a/src/core/future.rs
+++ b/src/core/future.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::future::Future;
+use std::mem;
+use std::pin::Pin;
+
+pub trait SizedFuture: Future {
+    fn size(&self) -> usize;
+
+    fn into_future<'a>(self: Pin<Box<Self>>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>>
+    where
+        Self: 'a;
+}
+
+impl<T: Future> SizedFuture for T {
+    fn size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    fn into_future<'a>(self: Pin<Box<Self>>) -> Pin<Box<dyn Future<Output = Self::Output> + 'a>>
+    where
+        Self: 'a,
+    {
+        self
+    }
+}
+
+pub mod ffi {
+    use super::*;
+
+    pub struct UnitFuture(pub Pin<Box<dyn SizedFuture<Output = ()>>>);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::pending;
+
+    #[test]
+    fn sized_future() {
+        // a future that should be at least 100 bytes
+        let fut = Box::pin(async {
+            let mut arr = [0u8; 100];
+            pending::<()>().await;
+            arr[arr.len() - 1] = 1;
+            println!("{}", arr[arr.len() - 1]);
+        });
+
+        let size = mem::size_of_val(&*fut);
+        assert!(size >= 100);
+
+        let fut = fut as Pin<Box<dyn SizedFuture<Output = ()>>>;
+        assert_eq!((*fut).size(), size);
+
+        let _fut: Pin<Box<dyn Future<Output = ()>>> = fut.into_future();
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,6 +23,7 @@ pub mod event;
 pub mod eventloop;
 pub mod executor;
 pub mod fs;
+pub mod future;
 pub mod http1;
 pub mod io;
 pub mod jwt;


### PR DESCRIPTION
The C++ wrapper for `EventLoop` is meant to be owned, however the EventLoop "task" only shares a reference to the underlying Rust instance in its callback. In order to allow C++ code to use this reference, the wrapper now has two modes: the default mode, where it owns its handle and maintains the global instance pointer, and task-managed mode, where it only makes const ref calls on the handle and doesn't touch the global instance pointer. After we convert all `EventLoop` usage to task-managed, we can clean this up.

The C++ `EventLoop::task()` method takes pointers to callbacks, instead of references. This is to help make it clear that the caller needs to manage their lifetimes appropriately. We can't take them by value like the Rust `EventLoop::task()` since we have nowhere to put them.

The FFI returns a `UnitFuture`, which is just a wrapper for a pinned boxed future with no return value.

This PR also introduces the trait `SizedFuture`, that enables getting the size of a concrete Future type behind a Box. Later, we'll update `Executor` with awareness of this trait so it can log the size of boxed futures for debugging purposes.