### PR TITLE
ensure timeouts with sub-ms resolution don't occur early and hang

### DIFF
--- a/src/core/reactor.rs
+++ b/src/core/reactor.rs
@@ -453,7 +453,9 @@ impl Registration {
             timer.wheel.remove(timer_key);
         }
 
-        let expires_ticks = duration_to_ticks_round_up(expires - timer.start);
+        let duration = expires.saturating_duration_since(timer.start);
+
+        let expires_ticks = duration_to_ticks_round_up(duration);
 
         let timer_key = match timer.wheel.add(expires_ticks, self.key) {
             Ok(timer_key) => timer_key,
@@ -661,7 +663,9 @@ impl Reactor {
 
         let timer = &mut *self.inner.timer.borrow_mut();
 
-        let expires_ticks = duration_to_ticks_round_up(expires - timer.start);
+        let duration = expires.saturating_duration_since(timer.start);
+
+        let expires_ticks = duration_to_ticks_round_up(duration);
 
         let timer_key = match timer.wheel.add(expires_ticks, key) {
             Ok(timer_key) => timer_key,

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -59,7 +59,8 @@ impl Future for ElapsedFuture<'_> {
         let now = evented.registration().reactor().now();
         let expired = now >= evented.expires();
 
-        // if registration ready, reactor guarantees enough time has passed
+        // if the registration is ready, the reactor guarantees enough time
+        // has passed
         assert!(!evented.registration().is_ready() || expired);
 
         // even if the registration is not ready, we can still return ready


### PR DESCRIPTION
This corrects the rounding of `Duration` values in `Reactor`. Internally, `Reactor` uses a clock with 10ms "ticks", and when a timer is registered to expire after a given `Duration`, the value needs to be rounded up to the nearest tick. Currently, before rounding up, `as_millis()` is called which rounds down to the nearest millisecond. This means that while 11ms correctly rounds to 2 ticks, 10.1ms incorrectly rounds to 1 tick. With the fix, 10.1ms correctly rounds to 2 ticks.

Additionally, `Timeout` is reworked to panic if a timer notification occurs before enough time has passed. This way, a rounding bug like the one in `Reactor` can be immediately caught rather than silently result in a timeout never completing.