### PR TITLE
add generic list api with slab and rc impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ name = "memorypool"
 harness = false
 
 [[bench]]
+name = "list"
+harness = false
+
+[[bench]]
 name = "server"
 harness = false
 

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use pushpin::core::arena;
+use pushpin::core::list;
+use slab::Slab;
+use std::rc::Rc;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    const NODE_COUNT: usize = 10000;
+
+    {
+        // Preallocate the nodes memory
+        let mut nodes_slab = Some(Slab::with_capacity(NODE_COUNT));
+
+        c.bench_function(&format!("index slab list push pop {NODE_COUNT}"), |b| {
+            b.iter(|| {
+                let mut nodes = nodes_slab.take().unwrap();
+                let mut l = list::List::default();
+
+                let mut next_value: u64 = 0;
+                while nodes.len() < nodes.capacity() {
+                    let n = nodes.insert(list::Node::new(next_value));
+                    l.push_back(&mut nodes, n);
+                    next_value += 1;
+                }
+
+                let mut expected_value = 0;
+                while !nodes.is_empty() {
+                    let n = l.pop_front(&mut nodes).unwrap();
+                    assert_eq!(nodes[n].value, expected_value);
+                    nodes.remove(n);
+                    expected_value += 1;
+                }
+
+                nodes_slab = Some(nodes);
+            })
+        });
+    }
+
+    {
+        // Preallocate the nodes memory
+        let mut nodes_slab = Some(Slab::with_capacity(NODE_COUNT));
+
+        c.bench_function(&format!("generic slab list push pop {NODE_COUNT}"), |b| {
+            b.iter(|| {
+                let mut nodes = nodes_slab.take().unwrap();
+                let mut l = list::SlabList::default();
+
+                let mut next_value: u64 = 0;
+                while nodes.len() < nodes.capacity() {
+                    let n = nodes.insert(list::SlabNode::new(next_value));
+                    l.push_back(&mut nodes, n);
+                    next_value += 1;
+                }
+
+                let mut expected_value = 0;
+                while !nodes.is_empty() {
+                    let n = l.pop_front(&mut nodes).unwrap();
+                    assert_eq!(nodes[n].value, expected_value);
+                    nodes.remove(n);
+                    expected_value += 1;
+                }
+
+                nodes_slab = Some(nodes);
+            })
+        });
+    }
+
+    {
+        // Preallocate the nodes memory
+        let nodes_memory = Rc::new(arena::RcMemory::new(NODE_COUNT));
+
+        c.bench_function(&format!("arena rc list push pop {NODE_COUNT}"), |b| {
+            b.iter(|| {
+                let mut b = list::RcBackend::default();
+                let mut l = list::GenericList::default();
+
+                let mut next_value: [u64; 32] = [0; 32];
+                while next_value[0] < NODE_COUNT as u64 {
+                    let n = list::RcNode::new(next_value, Some(&nodes_memory));
+                    l.push_back(&mut b, n);
+                    next_value[0] += 1;
+                }
+
+                let mut expected_value = 0;
+                while expected_value < NODE_COUNT as u64 {
+                    let n = l.pop_front(&mut b).unwrap();
+                    assert_eq!(n.value()[0], expected_value);
+                    expected_value += 1;
+                }
+            })
+        });
+    }
+
+    {
+        c.bench_function(&format!("std rc list push pop {NODE_COUNT}"), |b| {
+            b.iter(|| {
+                let mut b = list::RcBackend::default();
+                let mut l = list::GenericList::default();
+
+                let mut next_value: [u64; 32] = [0; 32];
+                while next_value[0] < NODE_COUNT as u64 {
+                    let n = list::RcNode::new(next_value, None);
+                    l.push_back(&mut b, n);
+                    next_value[0] += 1;
+                }
+
+                let mut expected_value = 0;
+                while expected_value < NODE_COUNT as u64 {
+                    let n = l.pop_front(&mut b).unwrap();
+                    assert_eq!(n.value()[0], expected_value);
+                    expected_value += 1;
+                }
+            })
+        });
+    }
+
+    {
+        // Preallocate the nodes
+        let nodes_memory = Rc::new(arena::RcMemory::new(NODE_COUNT));
+        let mut nodes = Vec::new();
+        let mut next_value: [u64; 32] = [0; 32];
+        while nodes_memory.len() < nodes_memory.capacity() {
+            let n = list::RcNode::new(next_value, Some(&nodes_memory));
+            nodes.push(n);
+            next_value[0] += 1;
+        }
+
+        c.bench_function(
+            &format!("arena rc list push pop {NODE_COUNT} (preallocated nodes)"),
+            |b| {
+                b.iter(|| {
+                    let mut b = list::RcBackend::default();
+                    let mut l = list::GenericList::default();
+
+                    for n in &nodes {
+                        l.push_back(&mut b, n.clone());
+                    }
+
+                    let mut expected_value = 0;
+                    while expected_value < NODE_COUNT as u64 {
+                        let n = l.pop_front(&mut b).unwrap();
+                        assert_eq!(n.value()[0], expected_value);
+                        expected_value += 1;
+                    }
+                })
+            },
+        );
+    }
+
+    {
+        // Preallocate the nodes
+        let mut nodes = Vec::new();
+        let mut next_value: [u64; 32] = [0; 32];
+        while next_value[0] < NODE_COUNT as u64 {
+            let n = list::RcNode::new(next_value, None);
+            nodes.push(n);
+            next_value[0] += 1;
+        }
+
+        c.bench_function(
+            &format!("std rc list push pop {NODE_COUNT} (preallocated nodes)"),
+            |b| {
+                b.iter(|| {
+                    let mut b = list::RcBackend::default();
+                    let mut l = list::GenericList::default();
+
+                    for n in &nodes {
+                        l.push_back(&mut b, n.clone());
+                    }
+
+                    let mut expected_value = 0;
+                    while expected_value < NODE_COUNT as u64 {
+                        let n = l.pop_front(&mut b).unwrap();
+                        assert_eq!(n.value()[0], expected_value);
+                        expected_value += 1;
+                    }
+                })
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -92,17 +92,17 @@ fn criterion_benchmark(c: &mut Criterion) {
                 let mut b = list::RcBackend::default();
                 let mut l = list::GenericList::default();
 
-                let mut next_value: [u64; 32] = [0; 32];
-                while next_value[0] < node_count as u64 {
+                let mut next_value: u64 = 0;
+                while next_value < node_count as u64 {
                     let n = list::RcNode::new(next_value, Some(&nodes_memory));
                     l.push_back(&mut b, n);
-                    next_value[0] += 1;
+                    next_value += 1;
                 }
 
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
                     let n = l.pop_front(&mut b).unwrap();
-                    assert_eq!(n.value()[0], expected_value);
+                    assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
             })
@@ -117,17 +117,17 @@ fn criterion_benchmark(c: &mut Criterion) {
                 let mut b = list::RcBackend::default();
                 let mut l = list::GenericList::default();
 
-                let mut next_value: [u64; 32] = [0; 32];
-                while next_value[0] < node_count as u64 {
+                let mut next_value: u64 = 0;
+                while next_value < node_count as u64 {
                     let n = list::RcNode::new(next_value, None);
                     l.push_back(&mut b, n);
-                    next_value[0] += 1;
+                    next_value += 1;
                 }
 
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
                     let n = l.pop_front(&mut b).unwrap();
-                    assert_eq!(n.value()[0], expected_value);
+                    assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
             })
@@ -140,11 +140,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         // Preallocate the nodes
         let nodes_memory = Rc::new(memorypool::RcMemory::new(node_count));
         let mut nodes = Vec::new();
-        let mut next_value: [u64; 32] = [0; 32];
+        let mut next_value: u64 = 0;
         while nodes_memory.len() < nodes_memory.capacity() {
             let n = list::RcNode::new(next_value, Some(&nodes_memory));
             nodes.push(n);
-            next_value[0] += 1;
+            next_value += 1;
         }
 
         c.bench_function(&format!("pre-mp-push-pop-x{NODE_KCOUNT}k"), |b| {
@@ -159,7 +159,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
                     let n = l.pop_front(&mut b).unwrap();
-                    assert_eq!(n.value()[0], expected_value);
+                    assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
             })
@@ -171,11 +171,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         // Preallocate the nodes
         let mut nodes = Vec::new();
-        let mut next_value: [u64; 32] = [0; 32];
-        while next_value[0] < node_count as u64 {
+        let mut next_value: u64 = 0;
+        while next_value < node_count as u64 {
             let n = list::RcNode::new(next_value, None);
             nodes.push(n);
-            next_value[0] += 1;
+            next_value += 1;
         }
 
         c.bench_function(&format!("pre-sys-push-pop-x{NODE_KCOUNT}k"), |b| {
@@ -190,7 +190,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
                     let n = l.pop_front(&mut b).unwrap();
-                    assert_eq!(n.value()[0], expected_value);
+                    assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
             })

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -54,7 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the nodes memory
-        let mut nodes_slab = Some(Slab::with_capacity(NODE_KCOUNT));
+        let mut nodes_slab = Some(Slab::with_capacity(NODE_KCOUNT * 1000));
 
         c.bench_function(&format!("gen-slab-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -15,8 +15,8 @@
  */
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use pushpin::core::arena;
 use pushpin::core::list;
+use pushpin::core::memorypool;
 use slab::Slab;
 use std::rc::Rc;
 
@@ -83,9 +83,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the nodes memory
-        let nodes_memory = Rc::new(arena::RcMemory::new(NODE_COUNT));
+        let nodes_memory = Rc::new(memorypool::RcMemory::new(NODE_COUNT));
 
-        c.bench_function(&format!("arena rc list push pop {NODE_COUNT}"), |b| {
+        c.bench_function(&format!("mp rc list push pop {NODE_COUNT}"), |b| {
             b.iter(|| {
                 let mut b = list::RcBackend::default();
                 let mut l = list::GenericList::default();
@@ -132,7 +132,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the nodes
-        let nodes_memory = Rc::new(arena::RcMemory::new(NODE_COUNT));
+        let nodes_memory = Rc::new(memorypool::RcMemory::new(NODE_COUNT));
         let mut nodes = Vec::new();
         let mut next_value: [u64; 32] = [0; 32];
         while nodes_memory.len() < nodes_memory.capacity() {
@@ -142,7 +142,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
 
         c.bench_function(
-            &format!("arena rc list push pop {NODE_COUNT} (preallocated nodes)"),
+            &format!("mp rc list push pop {NODE_COUNT} (preallocated nodes)"),
             |b| {
                 b.iter(|| {
                     let mut b = list::RcBackend::default();

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -89,19 +89,18 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function(&format!("mp-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut b = list::RcBackend::default();
-                let mut l = list::GenericList::default();
+                let mut l = list::RcList::default();
 
                 let mut next_value: u64 = 0;
                 while next_value < node_count as u64 {
                     let n = list::RcNode::new(next_value, Some(&nodes_memory));
-                    l.push_back(&mut b, n);
+                    l.push_back(n);
                     next_value += 1;
                 }
 
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
-                    let n = l.pop_front(&mut b).unwrap();
+                    let n = l.pop_front().unwrap();
                     assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
@@ -114,19 +113,18 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function(&format!("sys-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut b = list::RcBackend::default();
-                let mut l = list::GenericList::default();
+                let mut l = list::RcList::default();
 
                 let mut next_value: u64 = 0;
                 while next_value < node_count as u64 {
                     let n = list::RcNode::new(next_value, None);
-                    l.push_back(&mut b, n);
+                    l.push_back(n);
                     next_value += 1;
                 }
 
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
-                    let n = l.pop_front(&mut b).unwrap();
+                    let n = l.pop_front().unwrap();
                     assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
@@ -149,16 +147,15 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function(&format!("pre-mp-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut b = list::RcBackend::default();
-                let mut l = list::GenericList::default();
+                let mut l = list::RcList::default();
 
                 for n in &nodes {
-                    l.push_back(&mut b, n.clone());
+                    l.push_back(n.clone());
                 }
 
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
-                    let n = l.pop_front(&mut b).unwrap();
+                    let n = l.pop_front().unwrap();
                     assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }
@@ -180,16 +177,15 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function(&format!("pre-sys-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut b = list::RcBackend::default();
-                let mut l = list::GenericList::default();
+                let mut l = list::RcList::default();
 
                 for n in &nodes {
-                    l.push_back(&mut b, n.clone());
+                    l.push_back(n.clone());
                 }
 
                 let mut expected_value = 0;
                 while expected_value < node_count as u64 {
-                    let n = l.pop_front(&mut b).unwrap();
+                    let n = l.pop_front().unwrap();
                     assert_eq!(*n.value(), expected_value);
                     expected_value += 1;
                 }

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -21,13 +21,13 @@ use slab::Slab;
 use std::rc::Rc;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    const NODE_COUNT: usize = 10000;
+    const NODE_KCOUNT: usize = 10;
 
     {
         // Preallocate the nodes memory
-        let mut nodes_slab = Some(Slab::with_capacity(NODE_COUNT));
+        let mut nodes_slab = Some(Slab::with_capacity(NODE_KCOUNT * 1000));
 
-        c.bench_function(&format!("index slab list push pop {NODE_COUNT}"), |b| {
+        c.bench_function(&format!("slab-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
                 let mut nodes = nodes_slab.take().unwrap();
                 let mut l = list::List::default();
@@ -54,9 +54,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the nodes memory
-        let mut nodes_slab = Some(Slab::with_capacity(NODE_COUNT));
+        let mut nodes_slab = Some(Slab::with_capacity(NODE_KCOUNT));
 
-        c.bench_function(&format!("generic slab list push pop {NODE_COUNT}"), |b| {
+        c.bench_function(&format!("gen-slab-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
                 let mut nodes = nodes_slab.take().unwrap();
                 let mut l = list::SlabList::default();
@@ -82,23 +82,25 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     {
-        // Preallocate the nodes memory
-        let nodes_memory = Rc::new(memorypool::RcMemory::new(NODE_COUNT));
+        let node_count = NODE_KCOUNT * 1000;
 
-        c.bench_function(&format!("mp rc list push pop {NODE_COUNT}"), |b| {
+        // Preallocate the nodes memory
+        let nodes_memory = Rc::new(memorypool::RcMemory::new(node_count));
+
+        c.bench_function(&format!("mp-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
                 let mut b = list::RcBackend::default();
                 let mut l = list::GenericList::default();
 
                 let mut next_value: [u64; 32] = [0; 32];
-                while next_value[0] < NODE_COUNT as u64 {
+                while next_value[0] < node_count as u64 {
                     let n = list::RcNode::new(next_value, Some(&nodes_memory));
                     l.push_back(&mut b, n);
                     next_value[0] += 1;
                 }
 
                 let mut expected_value = 0;
-                while expected_value < NODE_COUNT as u64 {
+                while expected_value < node_count as u64 {
                     let n = l.pop_front(&mut b).unwrap();
                     assert_eq!(n.value()[0], expected_value);
                     expected_value += 1;
@@ -108,20 +110,22 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     {
-        c.bench_function(&format!("std rc list push pop {NODE_COUNT}"), |b| {
+        let node_count = NODE_KCOUNT * 1000;
+
+        c.bench_function(&format!("sys-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
                 let mut b = list::RcBackend::default();
                 let mut l = list::GenericList::default();
 
                 let mut next_value: [u64; 32] = [0; 32];
-                while next_value[0] < NODE_COUNT as u64 {
+                while next_value[0] < node_count as u64 {
                     let n = list::RcNode::new(next_value, None);
                     l.push_back(&mut b, n);
                     next_value[0] += 1;
                 }
 
                 let mut expected_value = 0;
-                while expected_value < NODE_COUNT as u64 {
+                while expected_value < node_count as u64 {
                     let n = l.pop_front(&mut b).unwrap();
                     assert_eq!(n.value()[0], expected_value);
                     expected_value += 1;
@@ -131,8 +135,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     {
+        let node_count = NODE_KCOUNT * 1000;
+
         // Preallocate the nodes
-        let nodes_memory = Rc::new(memorypool::RcMemory::new(NODE_COUNT));
+        let nodes_memory = Rc::new(memorypool::RcMemory::new(node_count));
         let mut nodes = Vec::new();
         let mut next_value: [u64; 32] = [0; 32];
         while nodes_memory.len() < nodes_memory.capacity() {
@@ -141,58 +147,54 @@ fn criterion_benchmark(c: &mut Criterion) {
             next_value[0] += 1;
         }
 
-        c.bench_function(
-            &format!("mp rc list push pop {NODE_COUNT} (preallocated nodes)"),
-            |b| {
-                b.iter(|| {
-                    let mut b = list::RcBackend::default();
-                    let mut l = list::GenericList::default();
+        c.bench_function(&format!("pre-mp-push-pop-x{NODE_KCOUNT}k"), |b| {
+            b.iter(|| {
+                let mut b = list::RcBackend::default();
+                let mut l = list::GenericList::default();
 
-                    for n in &nodes {
-                        l.push_back(&mut b, n.clone());
-                    }
+                for n in &nodes {
+                    l.push_back(&mut b, n.clone());
+                }
 
-                    let mut expected_value = 0;
-                    while expected_value < NODE_COUNT as u64 {
-                        let n = l.pop_front(&mut b).unwrap();
-                        assert_eq!(n.value()[0], expected_value);
-                        expected_value += 1;
-                    }
-                })
-            },
-        );
+                let mut expected_value = 0;
+                while expected_value < node_count as u64 {
+                    let n = l.pop_front(&mut b).unwrap();
+                    assert_eq!(n.value()[0], expected_value);
+                    expected_value += 1;
+                }
+            })
+        });
     }
 
     {
+        let node_count = NODE_KCOUNT * 1000;
+
         // Preallocate the nodes
         let mut nodes = Vec::new();
         let mut next_value: [u64; 32] = [0; 32];
-        while next_value[0] < NODE_COUNT as u64 {
+        while next_value[0] < node_count as u64 {
             let n = list::RcNode::new(next_value, None);
             nodes.push(n);
             next_value[0] += 1;
         }
 
-        c.bench_function(
-            &format!("std rc list push pop {NODE_COUNT} (preallocated nodes)"),
-            |b| {
-                b.iter(|| {
-                    let mut b = list::RcBackend::default();
-                    let mut l = list::GenericList::default();
+        c.bench_function(&format!("pre-sys-push-pop-x{NODE_KCOUNT}k"), |b| {
+            b.iter(|| {
+                let mut b = list::RcBackend::default();
+                let mut l = list::GenericList::default();
 
-                    for n in &nodes {
-                        l.push_back(&mut b, n.clone());
-                    }
+                for n in &nodes {
+                    l.push_back(&mut b, n.clone());
+                }
 
-                    let mut expected_value = 0;
-                    while expected_value < NODE_COUNT as u64 {
-                        let n = l.pop_front(&mut b).unwrap();
-                        assert_eq!(n.value()[0], expected_value);
-                        expected_value += 1;
-                    }
-                })
-            },
-        );
+                let mut expected_value = 0;
+                while expected_value < node_count as u64 {
+                    let n = l.pop_front(&mut b).unwrap();
+                    assert_eq!(n.value()[0], expected_value);
+                    expected_value += 1;
+                }
+            })
+        });
     }
 }
 

--- a/src/connmgr/pool.rs
+++ b/src/connmgr/pool.rs
@@ -35,8 +35,8 @@ struct PoolItem<K, V> {
 }
 
 pub struct Pool<K, V> {
-    nodes: Slab<list::Node<PoolItem<K, V>>>,
-    by_key: HashMap<K, list::List>,
+    nodes: Slab<list::SlabNode<PoolItem<K, V>>>,
+    by_key: HashMap<K, list::SlabList<PoolItem<K, V>>>,
     wheel: TimerWheel,
     start: Instant,
     current_ticks: u64,
@@ -69,7 +69,7 @@ where
 
             let timer_id = self.wheel.add(expires, nkey).unwrap();
 
-            entry.insert(list::Node::new(PoolItem {
+            entry.insert(list::SlabNode::new(PoolItem {
                 key: key.clone(),
                 value,
                 timer_id,

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -268,21 +268,21 @@ pub trait Backend {
     ) -> Self::BorrowMut<'a>;
 }
 
-/// A linked list using arbitrary storage for nodes. Instances are are
-/// generic over a provided `Backend` which supplies node management
-/// behavior. The API is designed to allow for storing nodes in a single
-/// `Slab` (using `usize` for node references) or for storing nodes in
-/// individual `Rc` instances.
+/// A linked list with arbitrary node storage. Instances are generic over a
+/// provided `Backend` which supplies node management behavior. The API is
+/// designed to allow for storing nodes in a single `Slab` (using `usize` for
+/// node references) or for storing nodes in individual ref-counted
+/// instances.
 ///
 /// For storing nodes in a single `Slab`, `Backend` is implemented on `Slab`,
 /// so a `Slab` can be used as a backend directly, providing both the node
 /// management behavior as well as the storage. Notably, this backend allows
 /// the list to be `Send`.
 ///
-/// For storing nodes in individual `Rc` instances, there's `RcBackend` which
-/// is a zero-sized type providing the node management behavior. It doesn't
-/// need to provide storage since the nodes themselves provide their own
-/// storage.
+/// For storing nodes in individual ref-counted instances, there's
+/// `RcBackend` which is a zero-sized type providing the node management
+/// behavior based on `Rc`. It doesn't need to provide storage since the
+/// nodes themselves provide their own storage.
 pub struct GenericList<B: Backend> {
     head: Option<B::Index>,
     tail: Option<B::Index>,

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -682,7 +682,7 @@ impl<T> Backend for RcBackend<T> {
 
 pub type SlabList<T> = GenericList<Slab<SlabNode<T>>>;
 
-/*#[derive(Default)]
+#[derive(Default)]
 pub struct RcList<T> {
     inner: GenericList<RcBackend<T>>,
     backend: RcBackend<T>,
@@ -693,32 +693,28 @@ impl<T> RcList<T> {
         self.inner.is_empty()
     }
 
-    pub fn head(&self) -> Option<<RcBackend<T>::Index as Index>::Ref<'_>> {
+    pub fn head(&self) -> Option<&RcNode<T>> {
         self.inner.head()
     }
 
-    pub fn tail(&self) -> Option<<RcBackend<T>::Index as Index>::Ref<'_>> {
+    pub fn tail(&self) -> Option<&RcNode<T>> {
         self.inner.tail()
     }
 
-    pub fn insert(
-        &mut self,
-        index: RcBackend<T>::Index,
-        after: Option<<RcBackend<T>::Index as Index>::Ref<'_>>,
-    ) {
+    pub fn insert(&mut self, index: RcNode<T>, after: Option<&RcNode<T>>) {
         self.inner.insert(&mut self.backend, index, after)
     }
 
     #[track_caller]
-    pub fn remove(&mut self, index: <RcBackend<T>::Index as Index>::Ref<'_>) {
+    pub fn remove(&mut self, index: &RcNode<T>) {
         self.inner.remove(&mut self.backend, index)
     }
 
-    pub fn pop_front(&mut self) -> Option<RcBackend<T>::Index> {
+    pub fn pop_front(&mut self) -> Option<RcNode<T>> {
         self.inner.pop_front(&mut self.backend)
     }
 
-    pub fn push_back(&mut self, index: RcBackend<T>::Index) {
+    pub fn push_back(&mut self, index: RcNode<T>) {
         self.inner.push_back(&mut self.backend, index)
     }
 
@@ -729,7 +725,7 @@ impl<T> RcList<T> {
     pub fn iter(&self) -> GenericListIterator<'_, RcBackend<T>> {
         self.inner.iter(&self.backend)
     }
-}*/
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -94,6 +94,7 @@ impl List {
         }
     }
 
+    #[track_caller]
     pub fn remove<T, S>(&mut self, nodes: &mut S, key: usize)
     where
         S: IndexMut<usize, Output = Node<T>>,
@@ -252,6 +253,7 @@ pub trait Backend {
         value: Option<Self::Index>,
     );
 
+    #[track_caller]
     fn take_link(
         &mut self,
         index: <Self::Index as Index>::Ref<'_>,
@@ -321,6 +323,7 @@ impl<B: Backend> GenericList<B> {
         }
     }
 
+    #[track_caller]
     pub fn remove(&mut self, backend: &mut B, index: <B::Index as Index>::Ref<'_>) {
         let prev = backend.take_link(index, Relation::Prev);
         let next = backend.take_link(index, Relation::Next);
@@ -706,6 +709,7 @@ impl<T> RcList<T> {
         self.inner.insert(&mut self.backend, index, after)
     }
 
+    #[track_caller]
     pub fn remove(&mut self, index: <RcBackend<T>::Index as Index>::Ref<'_>) {
         self.inner.remove(&mut self.backend, index)
     }

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use crate::core::arena;
+use crate::core::memorypool;
 use slab::Slab;
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::fmt;
@@ -527,12 +527,9 @@ pub struct NodeData<T> {
     pub value: RefCell<T>,
 }
 
-pub type NodeMemory<T> = arena::RcMemory<NodeData<T>>;
+pub type NodeMemory<T> = memorypool::RcMemory<NodeData<T>>;
 
-pub enum RcNode<T> {
-    Arena(arena::Rc<NodeData<T>>),
-    Std(Rc<NodeData<T>>),
-}
+pub struct RcNode<T>(memorypool::Rc<NodeData<T>>);
 
 impl<T> RcNode<T> {
     pub fn new(value: T, memory: Option<&Rc<NodeMemory<T>>>) -> Self {
@@ -542,59 +539,38 @@ impl<T> RcNode<T> {
             value: RefCell::new(value),
         };
 
-        if let Some(memory) = memory {
-            match arena::Rc::new(data, memory) {
-                Ok(r) => Self::Arena(r),
-                Err(arena::InsertError(data)) => Self::Std(Rc::new(data)),
-            }
-        } else {
-            Self::Std(Rc::new(data))
-        }
+        let inner = match memory {
+            Some(m) if m.len() < m.capacity() => memorypool::Rc::try_new_in(data, m).unwrap(),
+            _ => memorypool::Rc::new(data),
+        };
+
+        Self(inner)
     }
 
     pub fn prev(&self) -> &Cell<Option<RcNode<T>>> {
-        match self {
-            Self::Arena(r) => &r.get().prev,
-            Self::Std(r) => &r.prev,
-        }
+        &self.0.prev
     }
 
     pub fn next(&self) -> &Cell<Option<RcNode<T>>> {
-        match self {
-            Self::Arena(r) => &r.get().next,
-            Self::Std(r) => &r.next,
-        }
+        &self.0.next
     }
 
     pub fn value(&self) -> Ref<'_, T> {
-        match self {
-            Self::Arena(r) => r.get().value.borrow(),
-            Self::Std(r) => r.value.borrow(),
-        }
+        self.0.value.borrow()
     }
 
     pub fn value_mut(&self) -> RefMut<'_, T> {
-        match self {
-            Self::Arena(r) => r.get().value.borrow_mut(),
-            Self::Std(r) => r.value.borrow_mut(),
-        }
+        self.0.value.borrow_mut()
     }
 
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
-        match (this, other) {
-            (Self::Arena(this), Self::Arena(other)) => arena::Rc::ptr_eq(this, other),
-            (Self::Std(this), Self::Std(other)) => Rc::ptr_eq(this, other),
-            _ => false,
-        }
+        memorypool::Rc::ptr_eq(&this.0, &other.0)
     }
 }
 
 impl<T> Clone for RcNode<T> {
     fn clone(&self) -> Self {
-        match self {
-            Self::Arena(r) => Self::Arena(arena::Rc::clone(r)),
-            Self::Std(r) => Self::Std(Rc::clone(r)),
-        }
+        Self(memorypool::Rc::clone(&self.0))
     }
 }
 

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -226,14 +226,6 @@ pub trait Index {
 pub trait Backend {
     type Value;
     type Index: Index + Clone + PartialEq + fmt::Debug;
-    type Borrow<'a>
-    where
-        Self::Value: 'a,
-        Self: 'a;
-    type BorrowMut<'a>
-    where
-        Self::Value: 'a,
-        Self: 'a;
 
     fn index_eq(
         this: <Self::Index as Index>::Ref<'_>,
@@ -260,12 +252,13 @@ pub trait Backend {
         rel: Relation,
     ) -> Option<Self::Index>;
 
-    fn borrow<'a, 'b: 'a>(&'b self, index: <Self::Index as Index>::Ref<'a>) -> Self::Borrow<'a>;
+    fn with_borrow<F, R>(&self, index: <Self::Index as Index>::Ref<'_>, f: F) -> R
+    where
+        F: for<'a> FnOnce(&'a Self::Value) -> R;
 
-    fn borrow_mut<'a, 'b: 'a>(
-        &'b mut self,
-        index: <Self::Index as Index>::Ref<'a>,
-    ) -> Self::BorrowMut<'a>;
+    fn with_borrow_mut<F, R>(&mut self, index: <Self::Index as Index>::Ref<'_>, f: F) -> R
+    where
+        F: for<'a> FnOnce(&'a mut Self::Value) -> R;
 }
 
 /// A linked list with arbitrary node storage. Instances are generic over a
@@ -532,14 +525,6 @@ impl Index for usize {
 impl<T> Backend for Slab<SlabNode<T>> {
     type Value = T;
     type Index = usize;
-    type Borrow<'a>
-        = &'a Self::Value
-    where
-        Self::Value: 'a;
-    type BorrowMut<'a>
-        = &'a mut Self::Value
-    where
-        Self::Value: 'a;
 
     fn index_eq(
         this: <Self::Index as Index>::Ref<'_>,
@@ -582,15 +567,18 @@ impl<T> Backend for Slab<SlabNode<T>> {
         }
     }
 
-    fn borrow<'a, 'b: 'a>(&'b self, index: <Self::Index as Index>::Ref<'a>) -> Self::Borrow<'a> {
-        &self[index].value
+    fn with_borrow<F, R>(&self, index: <Self::Index as Index>::Ref<'_>, f: F) -> R
+    where
+        F: for<'a> FnOnce(&'a Self::Value) -> R,
+    {
+        f(&self[index].value)
     }
 
-    fn borrow_mut<'a, 'b: 'a>(
-        &'b mut self,
-        index: <Self::Index as Index>::Ref<'a>,
-    ) -> Self::BorrowMut<'a> {
-        &mut self[index].value
+    fn with_borrow_mut<F, R>(&mut self, index: <Self::Index as Index>::Ref<'_>, f: F) -> R
+    where
+        F: for<'a> FnOnce(&'a mut Self::Value) -> R,
+    {
+        f(&mut self[index].value)
     }
 }
 
@@ -690,14 +678,6 @@ pub struct RcBackend<T>(PhantomData<T>);
 impl<T> Backend for RcBackend<T> {
     type Value = T;
     type Index = RcNode<Self::Value>;
-    type Borrow<'a>
-        = Ref<'a, Self::Value>
-    where
-        Self::Value: 'a;
-    type BorrowMut<'a>
-        = RefMut<'a, Self::Value>
-    where
-        Self::Value: 'a;
 
     fn index_eq(
         this: <Self::Index as Index>::Ref<'_>,
@@ -740,15 +720,18 @@ impl<T> Backend for RcBackend<T> {
         }
     }
 
-    fn borrow<'a, 'b: 'a>(&'b self, index: <Self::Index as Index>::Ref<'a>) -> Self::Borrow<'a> {
-        index.value()
+    fn with_borrow<F, R>(&self, index: <Self::Index as Index>::Ref<'_>, f: F) -> R
+    where
+        F: for<'a> FnOnce(&'a Self::Value) -> R,
+    {
+        f(&index.value())
     }
 
-    fn borrow_mut<'a, 'b: 'a>(
-        &'b mut self,
-        index: <Self::Index as Index>::Ref<'a>,
-    ) -> Self::BorrowMut<'a> {
-        index.value_mut()
+    fn with_borrow_mut<F, R>(&mut self, index: <Self::Index as Index>::Ref<'_>, f: F) -> R
+    where
+        F: for<'a> FnOnce(&'a mut Self::Value) -> R,
+    {
+        f(&mut index.value_mut())
     }
 }
 

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -268,6 +268,21 @@ pub trait Backend {
     ) -> Self::BorrowMut<'a>;
 }
 
+/// A linked list using arbitrary storage for nodes. Instances are are
+/// generic over a provided `Backend` which supplies node management
+/// behavior. The API is designed to allow for storing nodes in a single
+/// `Slab` (using `usize` for node references) or for storing nodes in
+/// individual `Rc` instances.
+///
+/// For storing nodes in a single `Slab`, `Backend` is implemented on `Slab`,
+/// so a `Slab` can be used as a backend directly, providing both the node
+/// management behavior as well as the storage. Notably, this backend allows
+/// the list to be `Send`.
+///
+/// For storing nodes in individual `Rc` instances, there's `RcBackend` which
+/// is a zero-sized type providing the node management behavior. It doesn't
+/// need to provide storage since the nodes themselves provide their own
+/// storage.
 pub struct GenericList<B: Backend> {
     head: Option<B::Index>,
     tail: Option<B::Index>,
@@ -431,6 +446,61 @@ impl<B: Backend> Iterator for GenericListIterator<'_, B> {
     }
 }
 
+/// Convenience wrapper around `GenericList` and a backend, obviating the
+/// need to pass the backend to every method call.
+pub struct BoundGenericList<B: Backend> {
+    inner: GenericList<B>,
+    backend: B,
+}
+
+impl<B: Backend> BoundGenericList<B> {
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn head(&self) -> Option<<B::Index as Index>::Ref<'_>> {
+        self.inner.head()
+    }
+
+    pub fn tail(&self) -> Option<<B::Index as Index>::Ref<'_>> {
+        self.inner.tail()
+    }
+
+    pub fn insert(&mut self, index: B::Index, after: Option<<B::Index as Index>::Ref<'_>>) {
+        self.inner.insert(&mut self.backend, index, after)
+    }
+
+    #[track_caller]
+    pub fn remove(&mut self, index: <B::Index as Index>::Ref<'_>) {
+        self.inner.remove(&mut self.backend, index)
+    }
+
+    pub fn pop_front(&mut self) -> Option<B::Index> {
+        self.inner.pop_front(&mut self.backend)
+    }
+
+    pub fn push_back(&mut self, index: B::Index) {
+        self.inner.push_back(&mut self.backend, index)
+    }
+
+    pub fn concat(&mut self, other: &mut Self) {
+        self.inner.concat(&mut self.backend, &mut other.inner)
+    }
+
+    pub fn iter(&self) -> GenericListIterator<'_, B> {
+        self.inner.iter(&self.backend)
+    }
+}
+
+impl<B: Backend + Default> Default for BoundGenericList<B> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            backend: B::default(),
+        }
+    }
+}
+
 pub struct SlabNode<T> {
     pub prev: Option<usize>,
     pub next: Option<usize>,
@@ -523,6 +593,8 @@ impl<T> Backend for Slab<SlabNode<T>> {
         &mut self[index].value
     }
 }
+
+pub type SlabList<T> = GenericList<Slab<SlabNode<T>>>;
 
 pub struct NodeData<T> {
     pub prev: Cell<Option<RcNode<T>>>,
@@ -680,52 +752,7 @@ impl<T> Backend for RcBackend<T> {
     }
 }
 
-pub type SlabList<T> = GenericList<Slab<SlabNode<T>>>;
-
-#[derive(Default)]
-pub struct RcList<T> {
-    inner: GenericList<RcBackend<T>>,
-    backend: RcBackend<T>,
-}
-
-impl<T> RcList<T> {
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-
-    pub fn head(&self) -> Option<&RcNode<T>> {
-        self.inner.head()
-    }
-
-    pub fn tail(&self) -> Option<&RcNode<T>> {
-        self.inner.tail()
-    }
-
-    pub fn insert(&mut self, index: RcNode<T>, after: Option<&RcNode<T>>) {
-        self.inner.insert(&mut self.backend, index, after)
-    }
-
-    #[track_caller]
-    pub fn remove(&mut self, index: &RcNode<T>) {
-        self.inner.remove(&mut self.backend, index)
-    }
-
-    pub fn pop_front(&mut self) -> Option<RcNode<T>> {
-        self.inner.pop_front(&mut self.backend)
-    }
-
-    pub fn push_back(&mut self, index: RcNode<T>) {
-        self.inner.push_back(&mut self.backend, index)
-    }
-
-    pub fn concat(&mut self, other: &mut Self) {
-        self.inner.concat(&mut self.backend, &mut other.inner)
-    }
-
-    pub fn iter(&self) -> GenericListIterator<'_, RcBackend<T>> {
-        self.inner.iter(&self.backend)
-    }
-}
+pub type RcList<T> = BoundGenericList<RcBackend<T>>;
 
 #[cfg(test)]
 mod tests {

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,13 @@
  * limitations under the License.
  */
 
+use crate::core::arena;
+use slab::Slab;
+use std::cell::{Cell, Ref, RefCell, RefMut};
+use std::fmt;
+use std::marker::PhantomData;
 use std::ops::IndexMut;
+use std::rc::Rc;
 
 pub struct Node<T> {
     pub prev: Option<usize>,
@@ -201,10 +208,552 @@ where
     }
 }
 
+pub enum Relation {
+    Prev,
+    Next,
+}
+
+pub trait Index {
+    type Ref<'a>: Clone + Copy + PartialEq + fmt::Debug
+    where
+        Self: 'a;
+
+    fn to_ref(&self) -> Self::Ref<'_>;
+    fn from_ref(r: Self::Ref<'_>) -> Self;
+}
+
+pub trait Backend {
+    type Value;
+    type Index: Index + Clone + PartialEq + fmt::Debug;
+    type Borrow<'a>
+    where
+        Self::Value: 'a,
+        Self: 'a;
+    type BorrowMut<'a>
+    where
+        Self::Value: 'a,
+        Self: 'a;
+
+    fn index_eq(
+        this: <Self::Index as Index>::Ref<'_>,
+        other: <Self::Index as Index>::Ref<'_>,
+    ) -> bool;
+
+    fn clone_link(
+        &self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+    ) -> Option<Self::Index>;
+
+    fn set_link(
+        &mut self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+        value: Option<Self::Index>,
+    );
+
+    fn take_link(
+        &mut self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+    ) -> Option<Self::Index>;
+
+    fn borrow<'a, 'b: 'a>(&'b self, index: <Self::Index as Index>::Ref<'a>) -> Self::Borrow<'a>;
+
+    fn borrow_mut<'a, 'b: 'a>(
+        &'b mut self,
+        index: <Self::Index as Index>::Ref<'a>,
+    ) -> Self::BorrowMut<'a>;
+}
+
+pub struct GenericList<B: Backend> {
+    head: Option<B::Index>,
+    tail: Option<B::Index>,
+}
+
+impl<B: Backend> GenericList<B> {
+    pub fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+
+    pub fn head(&self) -> Option<<B::Index as Index>::Ref<'_>> {
+        self.head.as_ref().map(|i| i.to_ref())
+    }
+
+    pub fn tail(&self) -> Option<<B::Index as Index>::Ref<'_>> {
+        self.tail.as_ref().map(|i| i.to_ref())
+    }
+
+    pub fn insert(
+        &mut self,
+        backend: &mut B,
+        index: B::Index,
+        after: Option<<B::Index as Index>::Ref<'_>>,
+    ) {
+        if let Some(after) = after {
+            let next = backend.take_link(after, Relation::Next);
+            backend.set_link(index.to_ref(), Relation::Next, next.clone());
+
+            backend.set_link(after, Relation::Next, Some(index.clone()));
+
+            if let Some(next) = next {
+                let prev = backend.take_link(next.to_ref(), Relation::Prev);
+                backend.set_link(index.to_ref(), Relation::Prev, prev);
+
+                backend.set_link(next.to_ref(), Relation::Prev, Some(index));
+            } else {
+                backend.set_link(index.to_ref(), Relation::Prev, Some(Index::from_ref(after)));
+
+                self.tail = Some(index);
+            }
+        } else {
+            if let Some(next) = self.head.take() {
+                backend.set_link(next.to_ref(), Relation::Prev, Some(index.clone()));
+
+                backend.set_link(index.to_ref(), Relation::Next, Some(next));
+            } else {
+                backend.set_link(index.to_ref(), Relation::Next, None);
+
+                self.tail = Some(index.clone());
+            }
+
+            self.head = Some(index);
+        }
+    }
+
+    pub fn remove(&mut self, backend: &mut B, index: <B::Index as Index>::Ref<'_>) {
+        let prev = backend.take_link(index, Relation::Prev);
+        let next = backend.take_link(index, Relation::Next);
+
+        if let Some(prev) = &prev {
+            backend.set_link(prev.to_ref(), Relation::Next, next.clone());
+        }
+
+        if let Some(next) = &next {
+            backend.set_link(next.to_ref(), Relation::Prev, prev.clone());
+        }
+
+        if let Some(head) = &self.head {
+            if B::index_eq(head.to_ref(), index) {
+                self.head = next;
+            }
+        }
+
+        if let Some(tail) = &self.tail {
+            if B::index_eq(tail.to_ref(), index) {
+                self.tail = prev;
+            }
+        }
+    }
+
+    pub fn pop_front(&mut self, backend: &mut B) -> Option<B::Index> {
+        let index = self.head.take()?;
+
+        let next = backend.take_link(index.to_ref(), Relation::Next);
+
+        if let Some(next) = &next {
+            backend.set_link(next.to_ref(), Relation::Prev, None);
+        } else {
+            self.tail = None;
+        }
+
+        backend.set_link(index.to_ref(), Relation::Prev, None);
+
+        self.head = next;
+
+        Some(index)
+    }
+
+    pub fn push_back(&mut self, backend: &mut B, index: B::Index) {
+        if let Some(after) = self.tail.take() {
+            backend.set_link(after.to_ref(), Relation::Next, Some(index.clone()));
+
+            backend.set_link(index.to_ref(), Relation::Prev, Some(after));
+            backend.set_link(index.to_ref(), Relation::Next, None);
+
+            self.tail = Some(index);
+        } else {
+            self.insert(backend, index, None);
+        }
+    }
+
+    pub fn concat(&mut self, backend: &mut B, other: &mut Self) {
+        let Some(head) = other.head.take() else {
+            // Nothing to do
+            return;
+        };
+
+        // Move the next link aside so push_back doesn't delete it
+        let next = backend.take_link(head.to_ref(), Relation::Next);
+
+        self.push_back(backend, head.clone());
+
+        // Restore the node's next link
+        backend.set_link(head.to_ref(), Relation::Next, next);
+
+        self.tail = other.tail.take();
+    }
+
+    pub fn iter<'a>(&self, backend: &'a B) -> GenericListIterator<'a, B> {
+        GenericListIterator {
+            backend,
+            next: self.head.clone(),
+        }
+    }
+}
+
+impl<B: Backend> Default for GenericList<B> {
+    fn default() -> Self {
+        Self {
+            head: None,
+            tail: None,
+        }
+    }
+}
+
+pub struct GenericListIterator<'a, B: Backend> {
+    backend: &'a B,
+    next: Option<B::Index>,
+}
+
+impl<B: Backend> Iterator for GenericListIterator<'_, B> {
+    type Item = B::Index;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.next.take()?;
+
+        self.next = self.backend.clone_link(next.to_ref(), Relation::Next);
+
+        Some(next)
+    }
+}
+
+pub struct SlabNode<T> {
+    pub prev: Option<usize>,
+    pub next: Option<usize>,
+    pub value: T,
+}
+
+impl<T> SlabNode<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            prev: None,
+            next: None,
+            value,
+        }
+    }
+}
+
+impl Index for usize {
+    type Ref<'a> = usize;
+
+    fn to_ref(&self) -> Self::Ref<'_> {
+        *self
+    }
+
+    fn from_ref(r: Self::Ref<'_>) -> Self {
+        r
+    }
+}
+
+impl<T> Backend for Slab<SlabNode<T>> {
+    type Value = T;
+    type Index = usize;
+    type Borrow<'a>
+        = &'a Self::Value
+    where
+        Self::Value: 'a;
+    type BorrowMut<'a>
+        = &'a mut Self::Value
+    where
+        Self::Value: 'a;
+
+    fn index_eq(
+        this: <Self::Index as Index>::Ref<'_>,
+        other: <Self::Index as Index>::Ref<'_>,
+    ) -> bool {
+        this == other
+    }
+
+    fn clone_link(
+        &self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+    ) -> Option<Self::Index> {
+        match rel {
+            Relation::Prev => self[index].prev,
+            Relation::Next => self[index].next,
+        }
+    }
+
+    fn set_link(
+        &mut self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+        value: Option<Self::Index>,
+    ) {
+        match rel {
+            Relation::Prev => self[index].prev = value,
+            Relation::Next => self[index].next = value,
+        }
+    }
+
+    fn take_link(
+        &mut self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+    ) -> Option<Self::Index> {
+        match rel {
+            Relation::Prev => self[index].prev.take(),
+            Relation::Next => self[index].next.take(),
+        }
+    }
+
+    fn borrow<'a, 'b: 'a>(&'b self, index: <Self::Index as Index>::Ref<'a>) -> Self::Borrow<'a> {
+        &self[index].value
+    }
+
+    fn borrow_mut<'a, 'b: 'a>(
+        &'b mut self,
+        index: <Self::Index as Index>::Ref<'a>,
+    ) -> Self::BorrowMut<'a> {
+        &mut self[index].value
+    }
+}
+
+pub struct NodeData<T> {
+    pub prev: Cell<Option<RcNode<T>>>,
+    pub next: Cell<Option<RcNode<T>>>,
+    pub value: RefCell<T>,
+}
+
+pub type NodeMemory<T> = arena::RcMemory<NodeData<T>>;
+
+pub enum RcNode<T> {
+    Arena(arena::Rc<NodeData<T>>),
+    Std(Rc<NodeData<T>>),
+}
+
+impl<T> RcNode<T> {
+    pub fn new(value: T, memory: Option<&Rc<NodeMemory<T>>>) -> Self {
+        let data = NodeData {
+            prev: Cell::new(None),
+            next: Cell::new(None),
+            value: RefCell::new(value),
+        };
+
+        if let Some(memory) = memory {
+            match arena::Rc::new(data, memory) {
+                Ok(r) => Self::Arena(r),
+                Err(arena::InsertError(data)) => Self::Std(Rc::new(data)),
+            }
+        } else {
+            Self::Std(Rc::new(data))
+        }
+    }
+
+    pub fn prev(&self) -> &Cell<Option<RcNode<T>>> {
+        match self {
+            Self::Arena(r) => &r.get().prev,
+            Self::Std(r) => &r.prev,
+        }
+    }
+
+    pub fn next(&self) -> &Cell<Option<RcNode<T>>> {
+        match self {
+            Self::Arena(r) => &r.get().next,
+            Self::Std(r) => &r.next,
+        }
+    }
+
+    pub fn value(&self) -> Ref<'_, T> {
+        match self {
+            Self::Arena(r) => r.get().value.borrow(),
+            Self::Std(r) => r.value.borrow(),
+        }
+    }
+
+    pub fn value_mut(&self) -> RefMut<'_, T> {
+        match self {
+            Self::Arena(r) => r.get().value.borrow_mut(),
+            Self::Std(r) => r.value.borrow_mut(),
+        }
+    }
+
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        match (this, other) {
+            (Self::Arena(this), Self::Arena(other)) => arena::Rc::ptr_eq(this, other),
+            (Self::Std(this), Self::Std(other)) => Rc::ptr_eq(this, other),
+            _ => false,
+        }
+    }
+}
+
+impl<T> Clone for RcNode<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Arena(r) => Self::Arena(arena::Rc::clone(r)),
+            Self::Std(r) => Self::Std(Rc::clone(r)),
+        }
+    }
+}
+
+impl<T> PartialEq for RcNode<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Self::ptr_eq(self, other)
+    }
+}
+
+impl<T> fmt::Debug for RcNode<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RcNode")
+    }
+}
+
+impl<T> Index for RcNode<T> {
+    type Ref<'a>
+        = &'a RcNode<T>
+    where
+        T: 'a;
+
+    fn to_ref(&self) -> Self::Ref<'_> {
+        self
+    }
+
+    fn from_ref(r: Self::Ref<'_>) -> Self {
+        r.clone()
+    }
+}
+
+fn cell_get_cloned<T: Clone + Default>(c: &Cell<T>) -> T {
+    let cur = c.take();
+    let out = cur.clone();
+    c.set(cur);
+
+    out
+}
+
+#[derive(Default)]
+pub struct RcBackend<T>(PhantomData<T>);
+
+impl<T> Backend for RcBackend<T> {
+    type Value = T;
+    type Index = RcNode<Self::Value>;
+    type Borrow<'a>
+        = Ref<'a, Self::Value>
+    where
+        Self::Value: 'a;
+    type BorrowMut<'a>
+        = RefMut<'a, Self::Value>
+    where
+        Self::Value: 'a;
+
+    fn index_eq(
+        this: <Self::Index as Index>::Ref<'_>,
+        other: <Self::Index as Index>::Ref<'_>,
+    ) -> bool {
+        this == other
+    }
+
+    fn clone_link(
+        &self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+    ) -> Option<Self::Index> {
+        match rel {
+            Relation::Prev => cell_get_cloned(index.prev()),
+            Relation::Next => cell_get_cloned(index.next()),
+        }
+    }
+
+    fn set_link(
+        &mut self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+        value: Option<Self::Index>,
+    ) {
+        match rel {
+            Relation::Prev => index.prev().set(value),
+            Relation::Next => index.next().set(value),
+        }
+    }
+
+    fn take_link(
+        &mut self,
+        index: <Self::Index as Index>::Ref<'_>,
+        rel: Relation,
+    ) -> Option<Self::Index> {
+        match rel {
+            Relation::Prev => index.prev().take(),
+            Relation::Next => index.next().take(),
+        }
+    }
+
+    fn borrow<'a, 'b: 'a>(&'b self, index: <Self::Index as Index>::Ref<'a>) -> Self::Borrow<'a> {
+        index.value()
+    }
+
+    fn borrow_mut<'a, 'b: 'a>(
+        &'b mut self,
+        index: <Self::Index as Index>::Ref<'a>,
+    ) -> Self::BorrowMut<'a> {
+        index.value_mut()
+    }
+}
+
+pub type SlabList<T> = GenericList<Slab<SlabNode<T>>>;
+
+/*#[derive(Default)]
+pub struct RcList<T> {
+    inner: GenericList<RcBackend<T>>,
+    backend: RcBackend<T>,
+}
+
+impl<T> RcList<T> {
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn head(&self) -> Option<<RcBackend<T>::Index as Index>::Ref<'_>> {
+        self.inner.head()
+    }
+
+    pub fn tail(&self) -> Option<<RcBackend<T>::Index as Index>::Ref<'_>> {
+        self.inner.tail()
+    }
+
+    pub fn insert(
+        &mut self,
+        index: RcBackend<T>::Index,
+        after: Option<<RcBackend<T>::Index as Index>::Ref<'_>>,
+    ) {
+        self.inner.insert(&mut self.backend, index, after)
+    }
+
+    pub fn remove(&mut self, index: <RcBackend<T>::Index as Index>::Ref<'_>) {
+        self.inner.remove(&mut self.backend, index)
+    }
+
+    pub fn pop_front(&mut self) -> Option<RcBackend<T>::Index> {
+        self.inner.pop_front(&mut self.backend)
+    }
+
+    pub fn push_back(&mut self, index: RcBackend<T>::Index) {
+        self.inner.push_back(&mut self.backend, index)
+    }
+
+    pub fn concat(&mut self, other: &mut Self) {
+        self.inner.concat(&mut self.backend, &mut other.inner)
+    }
+
+    pub fn iter(&self) -> GenericListIterator<'_, RcBackend<T>> {
+        self.inner.iter(&self.backend)
+    }
+}*/
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use slab::Slab;
 
     #[test]
     fn test_list_push_pop() {
@@ -284,7 +833,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove() {
+    fn test_list_remove() {
         let mut nodes = Slab::new();
         let n1 = nodes.insert(Node::new("n1"));
 
@@ -369,5 +918,227 @@ mod tests {
         assert_eq!(it.next(), Some((n2, &"n2")));
         assert_eq!(it.next(), Some((n3, &"n3")));
         assert_eq!(it.next(), None);
+    }
+
+    fn generic_push_pop<B, A>(mut b: B, mut l: GenericList<B>, add: A)
+    where
+        B: Backend<Value = &'static str>,
+        A: Fn(&mut B, &'static str) -> B::Index,
+    {
+        let n1 = add(&mut b, "n1");
+        let n2 = add(&mut b, "n2");
+        let n3 = add(&mut b, "n3");
+
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), None);
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Next), None);
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Next), None);
+
+        assert_eq!(l.is_empty(), true);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
+        assert_eq!(l.pop_front(&mut b), None);
+
+        l.push_back(&mut b, n1.clone());
+        assert_eq!(l.is_empty(), false);
+        assert_eq!(l.head(), Some(n1.to_ref()));
+        assert_eq!(l.tail(), Some(n1.to_ref()));
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), None);
+
+        l.push_back(&mut b, n2.clone());
+        assert_eq!(l.is_empty(), false);
+        assert_eq!(l.head(), Some(n1.to_ref()));
+        assert_eq!(l.tail(), Some(n2.to_ref()));
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), Some(n2.clone()));
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Prev), Some(n1.clone()));
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Next), None);
+
+        l.push_back(&mut b, n3.clone());
+        assert_eq!(l.is_empty(), false);
+        assert_eq!(l.head(), Some(n1.to_ref()));
+        assert_eq!(l.tail(), Some(n3.to_ref()));
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), Some(n2.clone()));
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Prev), Some(n1.clone()));
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Next), Some(n3.clone()));
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Prev), Some(n2.clone()));
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Next), None);
+
+        let i = l.pop_front(&mut b);
+        assert_eq!(i, Some(n1));
+        assert_eq!(l.is_empty(), false);
+        assert_eq!(l.head(), Some(n2.to_ref()));
+        assert_eq!(l.tail(), Some(n3.to_ref()));
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n2.to_ref(), Relation::Next), Some(n3.clone()));
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Prev), Some(n2.clone()));
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Next), None);
+
+        let i = l.pop_front(&mut b);
+        assert_eq!(i, Some(n2));
+        assert_eq!(l.is_empty(), false);
+        assert_eq!(l.head(), Some(n3.to_ref()));
+        assert_eq!(l.tail(), Some(n3.to_ref()));
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n3.to_ref(), Relation::Next), None);
+
+        let i = l.pop_front(&mut b);
+        assert_eq!(i, Some(n3));
+        assert_eq!(l.is_empty(), true);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
+
+        assert_eq!(l.pop_front(&mut b), None);
+    }
+
+    fn generic_remove<B, A>(mut b: B, mut l: GenericList<B>, add: A)
+    where
+        B: Backend<Value = &'static str>,
+        A: Fn(&mut B, &'static str) -> B::Index,
+    {
+        let n1 = add(&mut b, "n1");
+
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), None);
+
+        assert_eq!(l.is_empty(), true);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
+
+        l.push_back(&mut b, n1.clone());
+        assert_eq!(l.is_empty(), false);
+        assert_eq!(l.head(), Some(n1.to_ref()));
+        assert_eq!(l.tail(), Some(n1.to_ref()));
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), None);
+
+        l.remove(&mut b, n1.to_ref());
+        assert_eq!(l.is_empty(), true);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), None);
+
+        // Already removed
+        l.remove(&mut b, n1.to_ref());
+        assert_eq!(l.is_empty(), true);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(b.clone_link(n1.to_ref(), Relation::Next), None);
+    }
+
+    fn generic_concat<B, A>(mut be: B, mut a: GenericList<B>, mut b: GenericList<B>, add: A)
+    where
+        B: Backend<Value = &'static str>,
+        A: Fn(&mut B, &'static str) -> B::Index,
+    {
+        let n1 = add(&mut be, "n1");
+        let n2 = add(&mut be, "n2");
+
+        a.concat(&mut be, &mut b);
+        assert_eq!(a.is_empty(), true);
+        assert_eq!(a.head(), None);
+        assert_eq!(a.tail(), None);
+        assert_eq!(b.is_empty(), true);
+        assert_eq!(b.head(), None);
+        assert_eq!(b.tail(), None);
+
+        a.push_back(&mut be, n1.clone());
+        b.push_back(&mut be, n2.clone());
+
+        a.concat(&mut be, &mut b);
+        assert_eq!(a.is_empty(), false);
+        assert_eq!(a.head(), Some(n1.to_ref()));
+        assert_eq!(a.tail(), Some(n2.to_ref()));
+        assert_eq!(b.is_empty(), true);
+        assert_eq!(b.head(), None);
+        assert_eq!(b.tail(), None);
+        assert_eq!(be.clone_link(n1.to_ref(), Relation::Prev), None);
+        assert_eq!(be.clone_link(n1.to_ref(), Relation::Next), Some(n2.clone()));
+        assert_eq!(be.clone_link(n2.to_ref(), Relation::Prev), Some(n1));
+        assert_eq!(be.clone_link(n2.to_ref(), Relation::Next), None);
+    }
+
+    fn generic_iter<B, A>(mut b: B, mut l: GenericList<B>, add: A)
+    where
+        B: Backend<Value = &'static str>,
+        A: Fn(&mut B, &'static str) -> B::Index,
+    {
+        let n1 = add(&mut b, "n1");
+        let n2 = add(&mut b, "n2");
+        let n3 = add(&mut b, "n3");
+
+        l.push_back(&mut b, n1.clone());
+        l.push_back(&mut b, n2.clone());
+        l.push_back(&mut b, n3.clone());
+
+        let mut it = l.iter(&b);
+        assert_eq!(it.next(), Some(n1));
+        assert_eq!(it.next(), Some(n2));
+        assert_eq!(it.next(), Some(n3));
+        assert_eq!(it.next(), None);
+    }
+
+    #[test]
+    fn test_slab_push_pop() {
+        let nodes = Slab::new();
+        let l = GenericList::default();
+        generic_push_pop(nodes, l, |nodes, v| nodes.insert(SlabNode::new(v)));
+    }
+
+    #[test]
+    fn test_slab_remove() {
+        let nodes = Slab::new();
+        let l = GenericList::default();
+        generic_remove(nodes, l, |nodes, v| nodes.insert(SlabNode::new(v)));
+    }
+
+    #[test]
+    fn test_slab_concat() {
+        let nodes = Slab::new();
+        let a = GenericList::default();
+        let b = GenericList::default();
+        generic_concat(nodes, a, b, |nodes, v| nodes.insert(SlabNode::new(v)));
+    }
+
+    #[test]
+    fn test_slab_iter() {
+        let nodes = Slab::new();
+        let l = GenericList::default();
+        generic_iter(nodes, l, |nodes, v| nodes.insert(SlabNode::new(v)));
+    }
+
+    #[test]
+    fn test_rc_push_pop() {
+        let b = RcBackend::default();
+        let l = GenericList::default();
+        generic_push_pop(b, l, move |_, v| RcNode::new(v, None));
+    }
+
+    #[test]
+    fn test_rc_remove() {
+        let b = RcBackend::default();
+        let l = GenericList::default();
+        generic_remove(b, l, move |_, v| RcNode::new(v, None));
+    }
+
+    #[test]
+    fn test_rc_concat() {
+        let be = RcBackend::default();
+        let a = GenericList::default();
+        let b = GenericList::default();
+        generic_concat(be, a, b, move |_, v| RcNode::new(v, None));
+    }
+
+    #[test]
+    fn test_rc_iter() {
+        let b = RcBackend::default();
+        let l = GenericList::default();
+        generic_iter(b, l, move |_, v| RcNode::new(v, None));
     }
 }

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -276,6 +276,7 @@ pub trait Backend {
 /// `RcBackend` which is a zero-sized type providing the node management
 /// behavior based on `Rc`. It doesn't need to provide storage since the
 /// nodes themselves provide their own storage.
+#[derive(Clone)]
 pub struct GenericList<B: Backend> {
     head: Option<B::Index>,
     tail: Option<B::Index>,
@@ -494,6 +495,15 @@ impl<B: Backend + Default> Default for BoundGenericList<B> {
     }
 }
 
+impl<B: Backend + Clone> Clone for BoundGenericList<B> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            backend: self.backend.clone(),
+        }
+    }
+}
+
 pub struct SlabNode<T> {
     pub prev: Option<usize>,
     pub next: Option<usize>,
@@ -672,8 +682,21 @@ fn cell_get_cloned<T: Clone + Default>(c: &Cell<T>) -> T {
     out
 }
 
-#[derive(Default)]
 pub struct RcBackend<T>(PhantomData<T>);
+
+impl<T> Default for RcBackend<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Clone for RcBackend<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<T> Copy for RcBackend<T> {}
 
 impl<T> Backend for RcBackend<T> {
     type Value = T;

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -690,13 +690,13 @@ impl<T> Default for RcBackend<T> {
     }
 }
 
+impl<T> Copy for RcBackend<T> {}
+
 impl<T> Clone for RcBackend<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
-
-impl<T> Copy for RcBackend<T> {}
 
 impl<T> Backend for RcBackend<T> {
     type Value = T;

--- a/src/core/memorypool.rs
+++ b/src/core/memorypool.rs
@@ -52,9 +52,16 @@ impl<T> Memory<T> {
         }
     }
 
-    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.borrow().is_empty()
+    }
+
     pub fn len(&self) -> usize {
         self.entries.borrow().len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.entries.borrow().capacity()
     }
 
     // Returns a pointer to the inserted entry.
@@ -195,6 +202,11 @@ impl<T> Rc<T> {
             ptr,
             phantom: PhantomData,
         })
+    }
+
+    #[inline]
+    pub fn ptr_eq(this: &Rc<T>, other: &Rc<T>) -> bool {
+        this.ptr.as_ptr() == other.ptr.as_ptr()
     }
 
     #[inline(always)]

--- a/src/core/timer.rs
+++ b/src/core/timer.rs
@@ -18,6 +18,7 @@
 
 use crate::core::list;
 use slab::Slab;
+use std::array;
 use std::cmp;
 
 const WHEEL_BITS: usize = 6;
@@ -132,9 +133,9 @@ struct Timer {
 }
 
 pub struct TimerWheel {
-    nodes: Slab<list::Node<Timer>>,
-    wheel: [[list::List; WHEEL_LEN]; WHEEL_NUM],
-    expired: list::List,
+    nodes: Slab<list::SlabNode<Timer>>,
+    wheel: [[list::SlabList<Timer>; WHEEL_LEN]; WHEEL_NUM],
+    expired: list::SlabList<Timer>,
     pending: [u64; WHEEL_NUM],
     curtime: u64,
 }
@@ -143,8 +144,8 @@ impl TimerWheel {
     pub fn new(capacity: usize) -> Self {
         Self {
             nodes: Slab::with_capacity(capacity),
-            wheel: [[list::List::default(); WHEEL_LEN]; WHEEL_NUM],
-            expired: list::List::default(),
+            wheel: array::from_fn(|_| array::from_fn(|_| list::SlabList::default())),
+            expired: list::SlabList::default(),
             pending: [0; WHEEL_NUM],
             curtime: 0,
         }
@@ -162,7 +163,7 @@ impl TimerWheel {
             user_data,
         };
 
-        let key = self.nodes.insert(list::Node::new(t));
+        let key = self.nodes.insert(list::SlabNode::new(t));
 
         self.sched(key);
 
@@ -240,7 +241,7 @@ impl TimerWheel {
 
         let need = need_resched(self.curtime, curtime);
 
-        let mut l = list::List::default();
+        let mut l = list::SlabList::default();
 
         for (wheel, &pending) in need.iter().enumerate() {
             // Loop as long as we still have slots to process


### PR DESCRIPTION
This is a new linked list implementation that allows for a non-fixed capacity. It is added alongside the existing implementation and a fixed-capacity variant of it is used from a couple of places to confirm it works as expected. After it is merged, we can look at actually using dynamic capacities and eventually removing the old implementation.

## Background

Currently, our linked list implementation stores nodes in preallocated slabs in order to avoid heap operations at runtime. This approach is performant but requires knowing in advance how many nodes will be needed, and this isn't always easy to know. Notably, reactor registrations are kept in a linked list, and determining the number of needed registrations in the whole app pretty much requires reading the entire codebase since registrations can occur anywhere.

## Approach

This PR aims to provide a linked list that has a dynamic capacity while remaining performant. It introduces a new type, `RcList`, capable of working with ref-counted nodes using `memorypool::Rc` from our core lib. `memorypool::Rc` is like `std::rc::Rc` but it supports allocating with either the system allocator or a slab (pool). This approach lets us continue to use preallocated pools for node memory as desired, with the advantage that not every node in a list has to live in the same pool nor live in a pool at all.

`RcList` is naturally `!Send`, and there is at least one place where this would cause us trouble: connmgr's `Pool` (TCP connection pool) which is shared between threads. The simplest solution to that problem is to continue offering an implementation based on a single slab as well, for that specific use-case. In order to avoid having multiple linked list implementations, the new list is generic over a `Backend` which supplies indexing and linking logic.

Notable types/impls:

* `trait Backend` - Abstract API for node/link management.
* `impl<T> Backend for Slab<SlabNode<T>>` - A backend using `usize` indexes with a single slab for node memory, implemented directly on `Slab`.
* `RcBackend` - A backend using `Rc` for indexes with node memory living wherever. It is a zero-sized type.
* `struct GenericList<B: Backend>` - A linked list that operates on an arbitrary backend. Note that the type does not wrap a `Backend` instance, and instead a mutable reference to a `Backend` must be passed in every method call. This allows multiple lists to share the same backend, mainly in order to share node storage.
* `struct BoundGenericList<B: Backend>` - Like `GenericList`, but it owns a `Backend` instance and so it is not necessary to provide one in method calls. This is handy for when the backend instance does not need to be shared, either because only one list uses the backend or the backend is a zero-sized type.
* `type SlabList<T> = GenericList<Slab<SlabNode<T>>>` - Fixed-capacity list using a single slab for storage. Essentially a drop-in substitute for the current linked list implementation.
* `type RcList<T> = BoundGenericList<RcBackend<T>>` - Dynamic-capacity list using `Rc`.

`RcList` should be preferred for everything going forward, except for a couple of special cases:

* When the list needs to be sharable from multiple threads, such as with connmgr's `Pool`. In that case, use `SlabList`.
* When code needs to be generic over the list type, for example `TimerWheel` which needs to be sharable from multiple threads in one case (in `Pool`) but not others (`Reactor`). In that case, use `GenericList/BoundGenericList` and let the caller provide the appropriate backend.

## Compatibility / perf

The new API is basically the same as the current one. `RcList/SlabList` don't implement `Copy`, but they do still implement `Clone`. `SlabList` methods take `&mut Backend` instead of `&mut IndexMut`. However, since `Slab` implements `Backend`, it is possible to keep passing `&mut Slab` in the same argument position.

Care is taken to ensure the API doesn't require unnecessary cloning of ref-counted nodes, mainly in case we ever want to add an `Arc`-based backend. For example, the `remove()` method takes an index reference (`&RcNode` when using the rc-based backend) rather than an owned index.

At the same time, we don't want to have to pass a `&usize` when using the single slab backend as this adds unnecessary indirection. To work around that, the index reference type is made generic. For the single slab backend, the index type is `usize` and the index reference type is also `usize`, whereas for the rc-based backend, the index type is `RcNode` and the index reference type is `&RcNode`.

In theory, being able to index using `usize` by value should enable the single slab backend to remain as performant as the current list implementation which does the same, though the generified code is a bit noisy (`<Backend::Index as Index>::Ref` all over the place). The benchmarks appear to support this.

## Benchmarks

Benchmarks are included that do 10k pushes/pops against the various implementations. Results on Linux:

```
slab-push-pop-x10k      time:   [86.588 µs 86.607 µs 86.630 µs]
gen-slab-push-pop-x10k  time:   [84.222 µs 84.298 µs 84.393 µs]
mp-push-pop-x10k        time:   [238.39 µs 238.45 µs 238.52 µs]
sys-push-pop-x10k       time:   [432.94 µs 433.11 µs 433.31 µs]
pre-mp-push-pop-x10k    time:   [96.806 µs 96.829 µs 96.854 µs]
pre-sys-push-pop-x10k   time:   [101.55 µs 101.83 µs 102.31 µs]
```

The first benchmark is of the current implementation (single slab), and the second is of the new implementation with the single slab backend, and the numbers are very close. This makes sense since they're both the same logic. With static dispatch and good inlining they should compile down to more or less the same thing.

The rest are rc-based benches. `mp-` uses a memory pool and `sys-` uses the system allocator. With the pool, it's about 3x slower than rc-less slab. With the system allocator, it's about 5x slower. The `pre-` benches exclude node allocation and deallocation from the measurements, so that only the link manipulations are measured. In that case, the overhead is much smaller (~1.1x slower).

## Overhead

These results mean there is a cost for lists with dynamic capacity (the rc overhead). However, it is mostly due to the memory management and not the list operations themselves, and we still retain good control over how that memory management works. Technically, when using rc'd nodes backed by a memory pool there is no overhead from "conventionally costly operations", which is usually our highest bar for performance. Therefore, the overhead of dynamic capacity should be considered acceptable when the ergonomics of dynamic capacity are desired.

## Per-task memory pool opportunity

Since nodes in `RcList` can optionally live in different memory pools, this opens up the possibility of having per-task pools for node memory. Each task could create nodes within its own pools, even if the nodes will be added to lists shared among multiple tasks. If a task wants to create a node into a pool that's full, it can create it on the heap instead. There could be an automatic right-sizing mechanism too. If a node needs to go to the heap, it could be noted somewhere that the next spawned task should have a larger pool.