### PR TITLE
arena: optimize rc and add bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ time = { version = "0.3.36", features = ["formatting", "local-offset", "macros"]
 cbindgen = "0.27"
 
 [[bench]]
+name = "arena"
+harness = false
+
+[[bench]]
 name = "server"
 harness = false
 

--- a/benches/arena.rs
+++ b/benches/arena.rs
@@ -27,9 +27,7 @@ fn bench_arena_rc_new<const N: usize>(c: &mut Criterion, op_count: usize) {
 
     c.bench_function(&format!("arena rc new {bytes}b x{op_count}"), |b| {
         b.iter_batched_ref(
-            || {
-                instances.borrow_mut().clear();
-            },
+            || instances.borrow_mut().clear(),
             |_| {
                 let instances = &mut *instances.borrow_mut();
                 let mut next_value: [u64; N] = [0; N];
@@ -50,9 +48,7 @@ fn bench_std_rc_new<const N: usize>(c: &mut Criterion, op_count: usize) {
 
     c.bench_function(&format!("std rc new {bytes}b x{op_count}"), |b| {
         b.iter_batched_ref(
-            || {
-                instances.borrow_mut().clear();
-            },
+            || instances.borrow_mut().clear(),
             |_| {
                 let instances = &mut *instances.borrow_mut();
                 let mut next_value: [u64; N] = [0; N];
@@ -83,9 +79,7 @@ fn bench_arena_rc_drop<const N: usize>(c: &mut Criterion, op_count: usize) {
                     next_value[0] += 1;
                 }
             },
-            |_| {
-                instances.borrow_mut().clear();
-            },
+            |_| instances.borrow_mut().clear(),
             BatchSize::PerIteration,
         )
     });
@@ -106,9 +100,7 @@ fn bench_std_rc_drop<const N: usize>(c: &mut Criterion, op_count: usize) {
                     next_value[0] += 1;
                 }
             },
-            |_| {
-                instances.borrow_mut().clear();
-            },
+            |_| instances.borrow_mut().clear(),
             BatchSize::PerIteration,
         )
     });

--- a/benches/arena.rs
+++ b/benches/arena.rs
@@ -265,6 +265,12 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     bench_arena_rc_drop::<80>(c, OP_COUNT);
     bench_std_rc_drop::<80>(c, OP_COUNT);
+
+    bench_arena_rc_new::<160>(c, OP_COUNT);
+    bench_std_rc_new::<160>(c, OP_COUNT);
+
+    bench_arena_rc_drop::<160>(c, OP_COUNT);
+    bench_std_rc_drop::<160>(c, OP_COUNT);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/arena.rs
+++ b/benches/arena.rs
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use pushpin::core::arena;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    const OP_COUNT: usize = 100000;
+    const MEDIUM_ALLOC_OP_COUNT: usize = 100000;
+
+    {
+        // Preallocate the instances
+        let memory = Rc::new(arena::RcMemory::new(OP_COUNT));
+        let mut instances = Vec::new();
+        let mut next_value: u64 = 0;
+        while next_value < OP_COUNT as u64 {
+            let n = arena::Rc::new(next_value, &memory).unwrap();
+            instances.push(n);
+            next_value += 1;
+        }
+
+        let clones = RefCell::new(Vec::with_capacity(instances.len()));
+
+        c.bench_function(&format!("arena rc clone x{OP_COUNT}"), |b| {
+            b.iter_batched_ref(
+                || clones.borrow_mut().clear(),
+                |_| {
+                    let clones = &mut *clones.borrow_mut();
+                    for r in &instances {
+                        clones.push(arena::Rc::clone(&r));
+                    }
+                },
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    {
+        // Preallocate the instances
+        let mut instances = Vec::new();
+        let mut next_value: u64 = 0;
+        while next_value < OP_COUNT as u64 {
+            let n = Rc::new(next_value);
+            instances.push(n);
+            next_value += 1;
+        }
+
+        let clones = RefCell::new(Vec::with_capacity(instances.len()));
+
+        c.bench_function(&format!("std rc clone x{OP_COUNT}"), |b| {
+            b.iter_batched_ref(
+                || clones.borrow_mut().clear(),
+                |_| {
+                    let clones = &mut *clones.borrow_mut();
+                    for r in &instances {
+                        clones.push(Rc::clone(&r));
+                    }
+                },
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    {
+        // Preallocate the instances
+        let memory = Rc::new(arena::RcMemory::new(OP_COUNT));
+        let mut instances = Vec::new();
+        let mut next_value: u64 = 0;
+        while next_value < OP_COUNT as u64 {
+            let n = arena::Rc::new(next_value, &memory).unwrap();
+            instances.push(n);
+            next_value += 1;
+        }
+
+        let clones = RefCell::new(Vec::with_capacity(instances.len()));
+
+        c.bench_function(&format!("arena rc dec x{OP_COUNT}"), |b| {
+            b.iter_batched_ref(
+                || {
+                    let clones = &mut *clones.borrow_mut();
+                    for r in &instances {
+                        clones.push(arena::Rc::clone(r))
+                    }
+                },
+                |_| clones.borrow_mut().clear(),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    {
+        // Preallocate the instances
+        let mut instances = Vec::new();
+        let mut next_value: u64 = 0;
+        while next_value < OP_COUNT as u64 {
+            let n = Rc::new(next_value);
+            instances.push(n);
+            next_value += 1;
+        }
+
+        let clones = RefCell::new(Vec::with_capacity(instances.len()));
+
+        c.bench_function(&format!("std rc dec x{OP_COUNT}"), |b| {
+            b.iter_batched_ref(
+                || {
+                    let clones = &mut *clones.borrow_mut();
+                    for r in &instances {
+                        clones.push(Rc::clone(r))
+                    }
+                },
+                |_| clones.borrow_mut().clear(),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    {
+        // Preallocate the instances
+        let memory = Rc::new(arena::RcMemory::new(OP_COUNT));
+        let mut instances = Vec::new();
+        let mut next_value: u64 = 0;
+        while next_value < OP_COUNT as u64 {
+            let n = arena::Rc::new(next_value, &memory).unwrap();
+            instances.push(n);
+            next_value += 1;
+        }
+
+        c.bench_function(&format!("arena rc deref x{OP_COUNT}"), |b| {
+            b.iter(|| {
+                for (expected_value, r) in instances.iter().enumerate() {
+                    assert_eq!(*r.get(), expected_value as u64);
+                }
+            })
+        });
+    }
+
+    {
+        // Preallocate the instances
+        let mut instances = Vec::new();
+        let mut next_value: u64 = 0;
+        while next_value < OP_COUNT as u64 {
+            let n = Rc::new(next_value);
+            instances.push(n);
+            next_value += 1;
+        }
+
+        c.bench_function(&format!("std rc deref x{OP_COUNT}"), |b| {
+            b.iter(|| {
+                for (expected_value, r) in instances.iter().enumerate() {
+                    assert_eq!(**r, expected_value as u64);
+                }
+            })
+        });
+    }
+
+    {
+        let memory = Rc::new(arena::RcMemory::new(OP_COUNT));
+        let mut instances = Vec::new();
+
+        c.bench_function(&format!("arena rc new/drop x{OP_COUNT}"), |b| {
+            b.iter(|| {
+                let mut next_value: u64 = 0;
+                while next_value < OP_COUNT as u64 {
+                    let n = arena::Rc::new(next_value, &memory).unwrap();
+                    instances.push(n);
+                    next_value += 1;
+                }
+
+                instances.clear();
+            })
+        });
+    }
+
+    {
+        let mut instances = Vec::new();
+
+        c.bench_function(&format!("std rc new/drop x{OP_COUNT}"), |b| {
+            b.iter(|| {
+                let mut next_value: u64 = 0;
+                while next_value < OP_COUNT as u64 {
+                    let n = Rc::new(next_value);
+                    instances.push(n);
+                    next_value += 1;
+                }
+
+                instances.clear();
+            })
+        });
+    }
+
+    {
+        let memory = Rc::new(arena::RcMemory::new(MEDIUM_ALLOC_OP_COUNT));
+        let mut instances = Vec::with_capacity(MEDIUM_ALLOC_OP_COUNT);
+
+        c.bench_function(
+            &format!("arena rc new/drop medium x{MEDIUM_ALLOC_OP_COUNT}"),
+            |b| {
+                b.iter(|| {
+                    let mut next_value: [u64; 80] = [0; 80];
+                    while next_value[0] < MEDIUM_ALLOC_OP_COUNT as u64 {
+                        let n = arena::Rc::new(next_value, &memory).unwrap();
+                        instances.push(n);
+                        for v in &mut next_value {
+                            *v += 1;
+                        }
+                    }
+
+                    instances.clear();
+                })
+            },
+        );
+    }
+
+    {
+        let mut instances = Vec::with_capacity(MEDIUM_ALLOC_OP_COUNT);
+
+        c.bench_function(
+            &format!("std rc new/drop medium x{MEDIUM_ALLOC_OP_COUNT}"),
+            |b| {
+                b.iter(|| {
+                    let mut next_value: [u64; 80] = [0; 80];
+                    while next_value[0] < MEDIUM_ALLOC_OP_COUNT as u64 {
+                        let n = Rc::new(next_value);
+                        instances.push(n);
+                        for v in &mut next_value {
+                            *v += 1;
+                        }
+                    }
+
+                    instances.clear();
+                })
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/core/arena.rs
+++ b/src/core/arena.rs
@@ -303,7 +303,7 @@ fn unlikely_abort() {
 
 pub struct RcInner<T> {
     refs: Cell<usize>,
-    memory_ptr: *const RcMemory<T>,
+    memory: Cell<Option<std::rc::Rc<RcMemory<T>>>>,
     key: Cell<usize>,
     value: T,
 }
@@ -351,25 +351,14 @@ pub struct Rc<T> {
 impl<T> Rc<T> {
     #[allow(clippy::result_unit_err)]
     pub fn new(v: T, memory: &std::rc::Rc<RcMemory<T>>) -> Result<Self, InsertError<T>> {
-        // SAFETY: This pointer will be placed in an RcInner and remain valid
-        // for the lifetime of the RcInner
-        let memory_ptr = std::rc::Rc::into_raw(std::rc::Rc::clone(memory));
-
         let (key, ptr) = memory
             .insert(RcInner {
                 refs: Cell::new(1),
-                memory_ptr,
+                memory: Cell::new(Some(std::rc::Rc::clone(memory))),
                 key: Cell::new(0),
                 value: v,
             })
-            .map_err(|e| {
-                // Convert this back to an Rc to avoid leaking.
-                // SAFETY: memory_ptr is a valid pointer that was produced
-                // above.
-                unsafe { std::rc::Rc::from_raw(e.0.memory_ptr) };
-
-                InsertError(e.0.value)
-            })?;
+            .map_err(|e| InsertError(e.0.value))?;
 
         // SAFETY: ptr is not null and we promise to only use it immutably
         // despite casting it to *mut in order to construct NonNull
@@ -414,9 +403,12 @@ impl<T> Rc<T> {
     fn drop_slow(&mut self) {
         let key = self.inner().key.get();
 
-        // SAFETY: memory_ptr is guaranteed to be valid for the lifetime of
-        // its owning RcInner
-        let memory = unsafe { std::rc::Rc::from_raw(self.inner().memory_ptr) };
+        // Entries contain a std::rc::Rc to the Memory they are contained in,
+        // and we need to be careful the Memory is not dropped while an entry
+        // is being removed. To ensure this, the Rc is moved out of the entry
+        // and dropped only after the entry is removed.
+
+        let memory = self.inner().memory.take().unwrap();
 
         memory.remove(key);
     }

--- a/src/core/arena.rs
+++ b/src/core/arena.rs
@@ -19,7 +19,7 @@ use slab::Slab;
 use std::cell::{Cell, RefCell};
 use std::fmt;
 use std::marker::PhantomData;
-use std::mem;
+use std::mem::{self, MaybeUninit};
 use std::ops::{Deref, DerefMut};
 use std::process::abort;
 use std::ptr::NonNull;
@@ -37,7 +37,7 @@ impl<T> fmt::Debug for InsertError<T> {
 // Operations are protected by a RefCell, however lookup operations return
 // pointers that can be used without RefCell protection.
 pub struct Memory<T> {
-    entries: RefCell<Slab<T>>,
+    entries: RefCell<Slab<MaybeUninit<T>>>,
 }
 
 impl<T> Memory<T> {
@@ -59,7 +59,10 @@ impl<T> Memory<T> {
     //
     // SAFETY: The returned pointer is guaranteed to be valid until the entry
     // is removed or the Memory is dropped.
-    fn insert(&self, e: T) -> Result<(usize, *const T), InsertError<T>> {
+    fn insert(
+        &self,
+        e: MaybeUninit<T>,
+    ) -> Result<(usize, *const MaybeUninit<T>), InsertError<MaybeUninit<T>>> {
         let mut entries = self.entries.borrow_mut();
 
         // Out of capacity. By preventing inserts beyond the capacity, we
@@ -77,7 +80,7 @@ impl<T> Memory<T> {
         // therefore we can return a pointer to the element and guarantee
         // its validity until the element is removed.
 
-        Ok((key, entry as *const T))
+        Ok((key, entry as *const MaybeUninit<T>))
     }
 
     fn remove(&self, key: usize) {
@@ -89,7 +92,7 @@ impl<T> Memory<T> {
     // SAFETY: The returned pointer is guaranteed to be valid until the entry
     // is removed or the Memory is dropped.
     #[cfg(test)]
-    fn addr_of(&self, key: usize) -> Option<*const T> {
+    fn addr_of(&self, key: usize) -> Option<*const MaybeUninit<T>> {
         let entries = self.entries.borrow();
 
         let entry = entries.get(key)?;
@@ -98,7 +101,7 @@ impl<T> Memory<T> {
         // therefore we can return a pointer to the element and guarantee
         // its validity until the element is removed.
 
-        Some(entry as *const T)
+        Some(entry as *const MaybeUninit<T>)
     }
 }
 
@@ -342,7 +345,7 @@ impl<T> RcInner<T> {
 pub type RcMemory<T> = Memory<RcInner<T>>;
 
 pub struct Rc<T> {
-    ptr: NonNull<RcInner<T>>,
+    ptr: NonNull<MaybeUninit<RcInner<T>>>,
     phantom: PhantomData<RcInner<T>>,
 }
 
@@ -354,27 +357,28 @@ impl<T> Rc<T> {
         let memory_ptr = std::rc::Rc::into_raw(std::rc::Rc::clone(memory));
 
         let (key, ptr) = memory
-            .insert(RcInner {
+            .insert(MaybeUninit::new(RcInner {
                 refs: Cell::new(1),
                 memory_ptr,
                 key: Cell::new(0),
                 value: v,
-            })
+            }))
             .map_err(|e| {
                 // Convert this back to an Rc to avoid leaking.
                 // SAFETY: memory_ptr is a valid pointer that was produced
                 // above.
-                unsafe { std::rc::Rc::from_raw(e.0.memory_ptr) };
+                unsafe { std::rc::Rc::from_raw(e.0.assume_init_ref().memory_ptr) };
 
-                InsertError(e.0.value)
+                // SAFETY: e was initialized above
+                InsertError(unsafe { e.0.assume_init() }.value)
             })?;
 
         // SAFETY: ptr is not null and we promise to only use it immutably
         // despite casting it to *mut in order to construct NonNull
-        let ptr = unsafe { NonNull::new_unchecked(ptr as *mut RcInner<T>) };
+        let ptr = unsafe { NonNull::new_unchecked(ptr as *mut MaybeUninit<RcInner<T>>) };
 
         // SAFETY: ptr is convertible to a reference
-        unsafe { ptr.as_ref().key.set(key) };
+        unsafe { ptr.as_ref().assume_init_ref().key.set(key) };
 
         Ok(Self {
             ptr,
@@ -405,7 +409,7 @@ impl<T> Rc<T> {
         // remove the pointed-to element is in Rc's drop method and only if
         // no other Rc instances are referencing it. Therefore, while this Rc
         // is alive, ptr is always valid.
-        unsafe { self.ptr.as_ref() }
+        unsafe { self.ptr.as_ref().assume_init_ref() }
     }
 
     #[inline(never)]
@@ -415,6 +419,9 @@ impl<T> Rc<T> {
         // SAFETY: memory_ptr is guaranteed to be valid for the lifetime of
         // its owning RcInner
         let memory = unsafe { std::rc::Rc::from_raw(self.inner().memory_ptr) };
+
+        // SAFETY: While this Rc is alive, ptr is always valid
+        unsafe { self.ptr.as_mut().assume_init_drop() };
 
         memory.remove(key);
     }

--- a/src/core/arena.rs
+++ b/src/core/arena.rs
@@ -81,6 +81,7 @@ impl<T> Memory<T> {
         Ok((key, entry as *const T))
     }
 
+    #[allow(clippy::let_unit_value)]
     fn remove(&self, key: usize) {
         // Ensure remove() method doesn't return a value
         let _: () = self.entries.borrow_mut().remove(key);

--- a/src/core/minislab.rs
+++ b/src/core/minislab.rs
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A slab that supports drop-in-place removals.
+// Adapted from https://github.com/tokio-rs/slab (MIT licensed).
+//
+// Changes:
+// * try_remove() returns a Result<(), RemoveError> instead of Option<T>.
+// * remove() returns nothing.
+// * All methods/types we don't use are removed.
+
+#[derive(Debug)]
+pub struct RemoveError;
+
+pub struct MiniSlab<T> {
+    entries: Vec<Entry<T>>,
+    len: usize,
+    next: usize,
+}
+
+#[derive(Clone)]
+enum Entry<T> {
+    Vacant(usize),
+    Occupied(T),
+}
+
+impl<T> MiniSlab<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: Vec::with_capacity(capacity),
+            next: 0,
+            len: 0,
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.entries.capacity()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.len = 0;
+        self.next = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn get(&self, key: usize) -> Option<&T> {
+        match self.entries.get(key) {
+            Some(Entry::Occupied(val)) => Some(val),
+            _ => None,
+        }
+    }
+
+    /// # Safety
+    ///
+    /// The key must be within bounds.
+    pub unsafe fn get_unchecked(&self, key: usize) -> &T {
+        match *self.entries.get_unchecked(key) {
+            Entry::Occupied(ref val) => val,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn insert(&mut self, val: T) -> usize {
+        let key = self.next;
+
+        self.insert_at(key, val);
+
+        key
+    }
+
+    fn insert_at(&mut self, key: usize, val: T) {
+        self.len += 1;
+
+        if key == self.entries.len() {
+            self.entries.push(Entry::Occupied(val));
+            self.next = key + 1;
+        } else {
+            self.next = match self.entries.get(key) {
+                Some(&Entry::Vacant(next)) => next,
+                _ => unreachable!(),
+            };
+            self.entries[key] = Entry::Occupied(val);
+        }
+    }
+
+    pub fn try_remove(&mut self, key: usize) -> Result<(), RemoveError> {
+        if let Some(entry) = self.entries.get_mut(key) {
+            if let Entry::Occupied(_) = entry {
+                *entry = Entry::Vacant(self.next);
+                self.len -= 1;
+                self.next = key;
+                return Ok(());
+            }
+        }
+
+        Err(RemoveError)
+    }
+
+    #[track_caller]
+    pub fn remove(&mut self, key: usize) {
+        self.try_remove(key).expect("invalid key");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -29,6 +29,7 @@ pub mod io;
 pub mod jwt;
 pub mod list;
 pub mod log;
+pub mod minislab;
 pub mod net;
 pub mod reactor;
 pub mod select;


### PR DESCRIPTION
Our `arena::Rc` uses a slab for allocation, which should be algorithmically faster than the general purpose allocator used by `std::rc::Rc`, however much of the absolute performance gains are lost due to the code not being very optimized.

I compared our code to `std::rc::Rc` and found the following differences:

* `arena::Rc` is twice the size (ref+int instead of a single pointer).
* `new`, `clone`, `drop`, and `get` (deref) require borrowing a `RefCell`.
* `clone`, `drop`, and `get` (deref) additionally require indexing into the slab (adding an offset to a pointer).
* No explicit inlining/hinting.

Most of this has to do with the code being written in a mostly safe, straightforward way, leading to a higher instruction count. In general, we don't concern ourselves with instruction count in Pushpin, only algorithmic complexity and conventionally costly operations. However, given how optimized the `std::rc::Rc` pathway is, it seems we do have to concern ourselves with instruction count if we want to justify using arenas.

This PR addresses all of the issues with the current implementation. `arena::Rc` is reduced to just a raw pointer to the slab element. The pointer is used for all operations, bypassing the slab's `RefCell` since slab elements can't move. Explicit inlining is used in an identical manner as `std::rc::Rc`, including splitting `drop` into an inlined part and a non-inlined part. The same compiler hints are also used, except for a call to `std::hint::assert_unchecked` which is left commented-out since it's not available in our MSRV.

The use of raw pointers may seem scary, but the number of `unsafe` blocks is unchanged (by consolidating the pointer deref to one place), and the assumption made by the `unsafe` blocks is also unchanged (that slab elements can't move). The tests pass and valgrind comes up clean.

With these changes, `arena::Rc`'s non-alloc ops (clone/dec/deref) now perform as well as `std::rc::Rc`, as one would expect.

Benchmarks included.

`std::rc::Rc`:

```
std rc clone x100000    time:   [248.95 µs 249.14 µs 249.45 µs]
std rc dec x100000      time:   [140.40 µs 140.46 µs 140.51 µs]
std rc deref x100000    time:   [102.52 µs 102.53 µs 102.56 µs]
std rc new 8b x100000   time:   [1.7904 ms 1.7908 ms 1.7912 ms]
std rc new 640b x100000 time:   [21.150 ms 21.155 ms 21.159 ms]
std rc drop 8b x100000  time:   [1.3785 ms 1.3788 ms 1.3792 ms]
std rc drop 640b x100000
                        time:   [7.3133 ms 7.3174 ms 7.3224 ms]
```

`arena::Rc` before:

```
arena rc clone x100000  time:   [453.07 µs 453.27 µs 453.52 µs]
arena rc dec x100000    time:   [284.09 µs 284.16 µs 284.25 µs]
arena rc deref x100000  time:   [194.81 µs 194.85 µs 194.90 µs]
arena rc new 8b x100000 time:   [691.58 µs 691.75 µs 691.94 µs]
arena rc new 640b x100000
                        time:   [6.8910 ms 6.8969 ms 6.9059 ms]
arena rc drop 8b x100000
                        time:   [324.30 µs 324.35 µs 324.41 µs]
arena rc drop 640b x100000
                        time:   [1.4807 ms 1.4836 ms 1.4876 ms]
```

`arena::Rc` after:

```
arena rc clone x100000  time:   [222.39 µs 222.43 µs 222.47 µs]
arena rc dec x100000    time:   [120.66 µs 120.69 µs 120.71 µs]
arena rc deref x100000  time:   [87.997 µs 88.018 µs 88.043 µs]
arena rc new 8b x100000 time:   [1.0023 ms 1.0025 ms 1.0027 ms]
arena rc new 640b x100000
                        time:   [8.7297 ms 8.7473 ms 8.7696 ms]
arena rc drop 8b x100000
                        time:   [814.41 µs 814.58 µs 814.76 µs]
arena rc drop 640b x100000
                        time:   [6.1289 ms 6.1304 ms 6.1320 ms]
```

I am surprised to see arena's clone/dec/deref ops performing not only as well as std but actually outperforming. These operations are basically the same code as std and I would have expected them to perform the same. Maybe a CPU caching effect since the arena allocations are contiguous.

Optimizing clone/dec/deref caused new/drop to get worse, though still better than std. This is because `Slab`'s insert/remove operations work with keys and now that we've switched to pointers we need to do conversions for these operations. Std's 640b drop performs oddly well and it could be worth investigating why that is.

In any case, hopefully this is good enough to land. If we want to be really serious though, we should consider using a slab that works with pointers, perhaps one from a third party crate.