### PR TITLE
use short hyphenated names for benchmarks

### DIFF
--- a/benches/memorypool.rs
+++ b/benches/memorypool.rs
@@ -20,12 +20,13 @@ use std::cell::RefCell;
 use std::mem;
 use std::rc::Rc;
 
-fn bench_mp_rc_new<const N: usize>(c: &mut Criterion, op_count: usize) {
+fn bench_memorypool_rc_new<const N: usize>(c: &mut Criterion, op_kcount: usize) {
+    let op_count = op_kcount * 1000;
     let bytes = mem::size_of::<[u64; N]>();
     let memory = Rc::new(memorypool::RcMemory::new(op_count));
     let instances = RefCell::new(Vec::with_capacity(op_count));
 
-    c.bench_function(&format!("mp rc new {bytes}b x{op_count}"), |b| {
+    c.bench_function(&format!("mp-rc-new-{bytes}b-x{op_kcount}k"), |b| {
         b.iter_batched_ref(
             || instances.borrow_mut().clear(),
             |_| {
@@ -42,11 +43,12 @@ fn bench_mp_rc_new<const N: usize>(c: &mut Criterion, op_count: usize) {
     });
 }
 
-fn bench_std_rc_new<const N: usize>(c: &mut Criterion, op_count: usize) {
+fn bench_std_rc_new<const N: usize>(c: &mut Criterion, op_kcount: usize) {
+    let op_count = op_kcount * 1000;
     let bytes = mem::size_of::<[u64; N]>();
     let instances = RefCell::new(Vec::with_capacity(op_count));
 
-    c.bench_function(&format!("std rc new {bytes}b x{op_count}"), |b| {
+    c.bench_function(&format!("std-rc-new-{bytes}b-x{op_kcount}k"), |b| {
         b.iter_batched_ref(
             || instances.borrow_mut().clear(),
             |_| {
@@ -63,12 +65,13 @@ fn bench_std_rc_new<const N: usize>(c: &mut Criterion, op_count: usize) {
     });
 }
 
-fn bench_mp_rc_drop<const N: usize>(c: &mut Criterion, op_count: usize) {
+fn bench_memorypool_rc_drop<const N: usize>(c: &mut Criterion, op_kcount: usize) {
+    let op_count = op_kcount * 1000;
     let bytes = mem::size_of::<[u64; N]>();
     let memory = Rc::new(memorypool::RcMemory::new(op_count));
     let instances = RefCell::new(Vec::with_capacity(op_count));
 
-    c.bench_function(&format!("mp rc drop {bytes}b x{op_count}"), |b| {
+    c.bench_function(&format!("mp-rc-drp-{bytes}b-x{op_kcount}k"), |b| {
         b.iter_batched_ref(
             || {
                 let instances = &mut *instances.borrow_mut();
@@ -85,11 +88,12 @@ fn bench_mp_rc_drop<const N: usize>(c: &mut Criterion, op_count: usize) {
     });
 }
 
-fn bench_std_rc_drop<const N: usize>(c: &mut Criterion, op_count: usize) {
+fn bench_std_rc_drop<const N: usize>(c: &mut Criterion, op_kcount: usize) {
+    let op_count = op_kcount * 1000;
     let bytes = mem::size_of::<[u64; N]>();
     let instances = RefCell::new(Vec::with_capacity(op_count));
 
-    c.bench_function(&format!("std rc drop {bytes}b x{op_count}"), |b| {
+    c.bench_function(&format!("std-rc-drp-{bytes}b-x{op_kcount}k"), |b| {
         b.iter_batched_ref(
             || {
                 let instances = &mut *instances.borrow_mut();
@@ -107,7 +111,8 @@ fn bench_std_rc_drop<const N: usize>(c: &mut Criterion, op_count: usize) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    const OP_COUNT: usize = 100000;
+    const OP_KCOUNT: usize = 100;
+    const OP_COUNT: usize = OP_KCOUNT * 1000;
 
     {
         // Preallocate the instances
@@ -122,7 +127,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let clones = RefCell::new(Vec::with_capacity(instances.len()));
 
-        c.bench_function(&format!("mp rc clone x{OP_COUNT}"), |b| {
+        c.bench_function(&format!("mp-rc-clone-x{OP_KCOUNT}k"), |b| {
             b.iter_batched_ref(
                 || clones.borrow_mut().clear(),
                 |_| {
@@ -148,7 +153,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let clones = RefCell::new(Vec::with_capacity(instances.len()));
 
-        c.bench_function(&format!("std rc clone x{OP_COUNT}"), |b| {
+        c.bench_function(&format!("std-rc-clone-x{OP_KCOUNT}k"), |b| {
             b.iter_batched_ref(
                 || clones.borrow_mut().clear(),
                 |_| {
@@ -175,7 +180,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let clones = RefCell::new(Vec::with_capacity(instances.len()));
 
-        c.bench_function(&format!("mp rc dec x{OP_COUNT}"), |b| {
+        c.bench_function(&format!("mp-rc-dec-x{OP_KCOUNT}k"), |b| {
             b.iter_batched_ref(
                 || {
                     let clones = &mut *clones.borrow_mut();
@@ -201,7 +206,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let clones = RefCell::new(Vec::with_capacity(instances.len()));
 
-        c.bench_function(&format!("std rc dec x{OP_COUNT}"), |b| {
+        c.bench_function(&format!("std-rc-dec-x{OP_KCOUNT}k"), |b| {
             b.iter_batched_ref(
                 || {
                     let clones = &mut *clones.borrow_mut();
@@ -226,7 +231,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             next_value += 1;
         }
 
-        c.bench_function(&format!("mp rc deref x{OP_COUNT}"), |b| {
+        c.bench_function(&format!("mp-rc-deref-x{OP_KCOUNT}k"), |b| {
             b.iter(|| {
                 for (expected_value, r) in instances.iter().enumerate() {
                     assert_eq!(*r.get(), expected_value as u64);
@@ -245,7 +250,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             next_value += 1;
         }
 
-        c.bench_function(&format!("std rc deref x{OP_COUNT}"), |b| {
+        c.bench_function(&format!("std-rc-deref-x{OP_KCOUNT}k"), |b| {
             b.iter(|| {
                 for (expected_value, r) in instances.iter().enumerate() {
                     assert_eq!(**r, expected_value as u64);
@@ -254,23 +259,23 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
     }
 
-    bench_mp_rc_new::<1>(c, OP_COUNT);
-    bench_std_rc_new::<1>(c, OP_COUNT);
+    bench_memorypool_rc_new::<1>(c, OP_KCOUNT);
+    bench_std_rc_new::<1>(c, OP_KCOUNT);
 
-    bench_mp_rc_drop::<1>(c, OP_COUNT);
-    bench_std_rc_drop::<1>(c, OP_COUNT);
+    bench_memorypool_rc_drop::<1>(c, OP_KCOUNT);
+    bench_std_rc_drop::<1>(c, OP_KCOUNT);
 
-    bench_mp_rc_new::<80>(c, OP_COUNT);
-    bench_std_rc_new::<80>(c, OP_COUNT);
+    bench_memorypool_rc_new::<80>(c, OP_KCOUNT);
+    bench_std_rc_new::<80>(c, OP_KCOUNT);
 
-    bench_mp_rc_drop::<80>(c, OP_COUNT);
-    bench_std_rc_drop::<80>(c, OP_COUNT);
+    bench_memorypool_rc_drop::<80>(c, OP_KCOUNT);
+    bench_std_rc_drop::<80>(c, OP_KCOUNT);
 
-    bench_mp_rc_new::<160>(c, OP_COUNT);
-    bench_std_rc_new::<160>(c, OP_COUNT);
+    bench_memorypool_rc_new::<160>(c, OP_KCOUNT);
+    bench_std_rc_new::<160>(c, OP_KCOUNT);
 
-    bench_mp_rc_drop::<160>(c, OP_COUNT);
-    bench_std_rc_drop::<160>(c, OP_COUNT);
+    bench_memorypool_rc_drop::<160>(c, OP_KCOUNT);
+    bench_std_rc_drop::<160>(c, OP_KCOUNT);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -74,7 +74,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchServerReqHandler::new();
 
-        c.bench_function("req_handler", |b| {
+        c.bench_function("server-req-handler", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -82,7 +82,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchServerStreamHandler::new();
 
-        c.bench_function("stream_handler", |b| {
+        c.bench_function("server-stream-handler", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -90,7 +90,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchServerReqConnection::new();
 
-        c.bench_function("req_connection", |b| {
+        c.bench_function("server-req-connection", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -98,7 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchServerStreamConnection::new();
 
-        c.bench_function("stream_connection", |b| {
+        c.bench_function("server-stream-connection", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -106,7 +106,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchSendMessage::new(false);
 
-        c.bench_function("ws_send", |b| {
+        c.bench_function("ws-send", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -114,7 +114,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchSendMessage::new(true);
 
-        c.bench_function("ws_send_deflate", |b| {
+        c.bench_function("ws-send-deflate", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -122,7 +122,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchRecvMessage::new(false);
 
-        c.bench_function("ws_recv", |b| {
+        c.bench_function("ws-recv", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -130,27 +130,25 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchRecvMessage::new(true);
 
-        c.bench_function("ws_recv_deflate", |b| {
+        c.bench_function("ws-recv-deflate", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
 
-    {
-        let server = TestServer::new(1);
+    for worker_count in [1, 2] {
+        let server = TestServer::new(worker_count);
         let req_addr = server.req_addr();
         let stream_addr = server.stream_addr();
 
-        c.bench_function("req_server workers=1", |b| b.iter(|| req(req_addr)));
-        c.bench_function("stream_server workers=1", |b| b.iter(|| req(stream_addr)));
-    }
+        c.bench_function(
+            &format!("server-req-{worker_count}w-x{REQS_PER_ITER}"),
+            |b| b.iter(|| req(req_addr)),
+        );
 
-    {
-        let server = TestServer::new(2);
-        let req_addr = server.req_addr();
-        let stream_addr = server.stream_addr();
-
-        c.bench_function("req_server workers=2", |b| b.iter(|| req(req_addr)));
-        c.bench_function("stream_server workers=2", |b| b.iter(|| req(stream_addr)));
+        c.bench_function(
+            &format!("server-stream-{worker_count}w-x{REQS_PER_ITER}"),
+            |b| b.iter(|| req(stream_addr)),
+        );
     }
 }
 

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -90,7 +90,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchServerReqConnection::new();
 
-        c.bench_function("server-req-connection", |b| {
+        c.bench_function("server-req-conn", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }
@@ -98,7 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let t = BenchServerStreamConnection::new();
 
-        c.bench_function("server-stream-connection", |b| {
+        c.bench_function("server-stream-conn", |b| {
             b.iter_batched_ref(|| t.init(), |i| t.run(i), criterion::BatchSize::SmallInput)
         });
     }


### PR DESCRIPTION
This ensures uniform output (no long names causing some results to be pushed to the next line) and removes the need for quotes when filtering (`cargo bench rc-drop` instead of `cargo bench "rc drop"`).

```
% cargo bench --bench client 2>&1 | grep time:              
client-req-1w-x10       time:   [1.0755 ms 1.1279 ms 1.1881 ms]
client-stream-1w-x10    time:   [1.7949 ms 1.8457 ms 1.9040 ms]
client-req-2w-x10       time:   [1.0841 ms 1.1416 ms 1.1986 ms]
client-stream-2w-x10    time:   [2.0524 ms 2.1434 ms 2.2477 ms]
```