### PR TITLE
memorypool: make rc's api like std

### DIFF
--- a/benches/memorypool.rs
+++ b/benches/memorypool.rs
@@ -33,7 +33,7 @@ fn bench_memorypool_rc_new<const N: usize>(c: &mut Criterion, op_kcount: usize) 
                 let instances = &mut *instances.borrow_mut();
                 let mut next_value: [u64; N] = [0; N];
                 while next_value[0] < op_count as u64 {
-                    let n = memorypool::Rc::new(next_value, &memory).unwrap();
+                    let n = memorypool::Rc::try_new_in(next_value, &memory).unwrap();
                     instances.push(n);
                     next_value[0] += 1;
                 }
@@ -77,7 +77,7 @@ fn bench_memorypool_rc_drop<const N: usize>(c: &mut Criterion, op_kcount: usize)
                 let instances = &mut *instances.borrow_mut();
                 let mut next_value: [u64; N] = [0; N];
                 while next_value[0] < op_count as u64 {
-                    let n = memorypool::Rc::new(next_value, &memory).unwrap();
+                    let n = memorypool::Rc::try_new_in(next_value, &memory).unwrap();
                     instances.push(n);
                     next_value[0] += 1;
                 }
@@ -120,7 +120,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut instances = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < OP_COUNT as u64 {
-            let n = memorypool::Rc::new(next_value, &memory).unwrap();
+            let n = memorypool::Rc::try_new_in(next_value, &memory).unwrap();
             instances.push(n);
             next_value += 1;
         }
@@ -173,7 +173,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut instances = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < OP_COUNT as u64 {
-            let n = memorypool::Rc::new(next_value, &memory).unwrap();
+            let n = memorypool::Rc::try_new_in(next_value, &memory).unwrap();
             instances.push(n);
             next_value += 1;
         }
@@ -226,7 +226,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut instances = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < OP_COUNT as u64 {
-            let n = memorypool::Rc::new(next_value, &memory).unwrap();
+            let n = memorypool::Rc::try_new_in(next_value, &memory).unwrap();
             instances.push(n);
             next_value += 1;
         }
@@ -234,7 +234,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("mp-rc-deref-x{OP_KCOUNT}k"), |b| {
             b.iter(|| {
                 for (expected_value, r) in instances.iter().enumerate() {
-                    assert_eq!(*r.get(), expected_value as u64);
+                    assert_eq!(**r, expected_value as u64);
                 }
             })
         });

--- a/src/connmgr/zhttppacket.rs
+++ b/src/connmgr/zhttppacket.rs
@@ -1751,7 +1751,7 @@ where
         // into scratch_mut, because src_ref and scratch_mut have the same
         // Lifetime
         let scratch_mut: &'static mut ParseScratch<'static> =
-            unsafe { scratch.get().as_ptr().as_mut().unwrap() };
+            unsafe { scratch.as_ptr().as_mut().unwrap() };
 
         let inner = T::parse(src_ref, scratch_mut)?;
 
@@ -2046,7 +2046,7 @@ mod tests {
 
         let msg = Arc::new(zmq::Message::from(data));
         let scratch =
-            memorypool::Rc::new(RefCell::new(ParseScratch::new()), &scratch_memory).unwrap();
+            memorypool::Rc::try_new_in(RefCell::new(ParseScratch::new()), &scratch_memory).unwrap();
 
         let req = OwnedRequest::parse(msg, 0, scratch).unwrap();
 
@@ -2072,7 +2072,7 @@ mod tests {
 
         let msg = Arc::new(zmq::Message::from(data));
         let scratch =
-            memorypool::Rc::new(RefCell::new(ParseScratch::new()), &scratch_memory).unwrap();
+            memorypool::Rc::try_new_in(RefCell::new(ParseScratch::new()), &scratch_memory).unwrap();
 
         let resp = OwnedResponse::parse(msg, 5, scratch).unwrap();
 

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -285,7 +285,7 @@ impl CustomSources {
         subtoken: Token,
         interests: Interest,
     ) -> Result<(), io::Error> {
-        let mut reg = registration.entry.get().data.borrow_mut();
+        let mut reg = registration.entry.data.borrow_mut();
 
         if reg.data.is_none() {
             let key = self.local.register(subtoken, interests)?;
@@ -303,7 +303,7 @@ impl CustomSources {
     }
 
     fn deregister_local(&self, registration: &LocalRegistration) -> Result<(), io::Error> {
-        let mut reg = registration.entry.get().data.borrow_mut();
+        let mut reg = registration.entry.data.borrow_mut();
 
         if let Some((key, _)) = reg.data {
             self.local.deregister(key)?;
@@ -452,7 +452,7 @@ impl LocalRegistration {
     pub fn new(
         memory: &Rc<memorypool::RcMemory<LocalRegistrationEntry>>,
     ) -> (Self, LocalSetReadiness) {
-        let reg = memorypool::Rc::new(
+        let reg = memorypool::Rc::try_new_in(
             LocalRegistrationEntry {
                 data: RefCell::new(LocalRegistrationData {
                     data: None,
@@ -475,7 +475,7 @@ impl LocalRegistration {
 
 impl Drop for LocalRegistration {
     fn drop(&mut self) {
-        let mut reg = self.entry.get().data.borrow_mut();
+        let mut reg = self.entry.data.borrow_mut();
 
         if let Some((key, sources)) = &reg.data {
             sources.deregister(*key).unwrap();
@@ -491,7 +491,7 @@ pub struct LocalSetReadiness {
 
 impl LocalSetReadiness {
     pub fn set_readiness(&self, readiness: Interest) -> Result<(), io::Error> {
-        let mut reg = self.entry.get().data.borrow_mut();
+        let mut reg = self.entry.data.borrow_mut();
 
         match &reg.data {
             Some((key, sources)) => sources.set_readiness(*key, readiness)?,

--- a/src/core/memorypool.rs
+++ b/src/core/memorypool.rs
@@ -26,6 +26,9 @@ use std::process::abort;
 use std::ptr::NonNull;
 use std::sync::Mutex;
 
+#[derive(Debug)]
+pub struct AllocError;
+
 pub struct InsertError<T>(pub T);
 
 impl<T> fmt::Debug for InsertError<T> {
@@ -254,8 +257,7 @@ pub struct Rc<T> {
 }
 
 impl<T> Rc<T> {
-    #[allow(clippy::result_unit_err)]
-    pub fn new(v: T, memory: &std::rc::Rc<RcMemory<T>>) -> Result<Self, InsertError<T>> {
+    pub fn try_new_in(v: T, memory: &std::rc::Rc<RcMemory<T>>) -> Result<Self, AllocError> {
         let (key, ptr) = memory
             .insert(RcInner {
                 refs: Cell::new(1),
@@ -263,7 +265,7 @@ impl<T> Rc<T> {
                 key: Cell::new(0),
                 value: v,
             })
-            .map_err(|e| InsertError(e.0.value))?;
+            .map_err(|_| AllocError)?;
 
         // SAFETY: ptr is not null and we promise to only use it immutably
         // despite casting it to *mut in order to construct NonNull
@@ -276,22 +278,6 @@ impl<T> Rc<T> {
             ptr,
             phantom: PhantomData,
         })
-    }
-
-    #[allow(clippy::should_implement_trait)]
-    #[inline]
-    pub fn clone(rc: &Rc<T>) -> Self {
-        rc.inner().inc();
-
-        Self {
-            ptr: rc.ptr,
-            phantom: rc.phantom,
-        }
-    }
-
-    #[inline(always)]
-    pub fn get(&self) -> &T {
-        &self.inner().value
     }
 
     #[inline(always)]
@@ -316,6 +302,27 @@ impl<T> Rc<T> {
         let memory = self.inner().memory.take().unwrap();
 
         memory.remove(key);
+    }
+}
+
+impl<T> Clone for Rc<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.inner().inc();
+
+        Self {
+            ptr: self.ptr,
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<T> Deref for Rc<T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.inner().value
     }
 }
 
@@ -456,7 +463,7 @@ mod tests {
         let memory = std::rc::Rc::new(RcMemory::new(2));
         assert_eq!(memory.len(), 0);
 
-        let e0a = Rc::new(123 as i32, &memory).unwrap();
+        let e0a = Rc::try_new_in(123 as i32, &memory).unwrap();
         assert_eq!(memory.len(), 1);
         let p = memory.addr_of(0).unwrap();
 
@@ -464,16 +471,16 @@ mod tests {
         assert_eq!(memory.len(), 1);
         assert_eq!(memory.addr_of(0).unwrap(), p);
 
-        let e1a = Rc::new(456 as i32, &memory).unwrap();
+        let e1a = Rc::try_new_in(456 as i32, &memory).unwrap();
         assert_eq!(memory.len(), 2);
         assert_eq!(memory.addr_of(0).unwrap(), p);
 
         // No room
-        assert!(Rc::new(789 as i32, &memory).is_err());
+        assert!(Rc::try_new_in(789 as i32, &memory).is_err());
 
-        assert_eq!(*e0a.get(), 123);
-        assert_eq!(*e0b.get(), 123);
-        assert_eq!(*e1a.get(), 456);
+        assert_eq!(*e0a, 123);
+        assert_eq!(*e0b, 123);
+        assert_eq!(*e1a, 456);
 
         mem::drop(e0b);
         assert_eq!(memory.len(), 2);


### PR DESCRIPTION
This renames the constructor from `new` to `try_new_in`, and impls `Deref` and `Clone`, to match how std's API works. This does a few things for us:

* Frees up `new` which we can reintroduce after this lands for using the system allocator instead of a memory pool. Having a single `Rc` type able to work with both kinds of memory sources is the optimal approach for supporting both in our linked list nodes (as opposed to wrapping two different `Rc` types in an `enum` and using that for links).
* Once we have both `new` and `try_new_in`, our `Rc` basically becomes a [mirror of std](https://doc.rust-lang.org/stable/std/rc/struct.Rc.html#method.try_new_in) while we wait for the allocator API to stabilize.
* Tracking std makes it easier to swap between our type and std, for benchmarks or possible removal.