### PR TITLE
add option to send debug logs to a unix socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,9 +980,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"

--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -200,7 +200,10 @@ impl App {
                 }
             }
 
-            debug_logger = Some(DebugLogger::new(l));
+            // Scale the log queue with the number of workers
+            let queue_max = (config.workers * 1000) + 1000;
+
+            debug_logger = Some(DebugLogger::new(l, queue_max));
         }
 
         let zmq_context = Arc::new(zmq::Context::new());


### PR DESCRIPTION
This adds an option to connmgr for sending debug logs to a unix socket. The `--debug-socket` arg can be used to specify a unix socket path to serve logs from. Any clients connected to that path receive all logs regardless of the configured log level limit.

The debug logger is invoked from the global logger so that all logs can be sent through it. However, the debug logger also implements the `Log` trait, in case we ever want to log to it explicitly.

To ensure the mechanism doesn't introduce too much overhead when it is unused, the `Log::enabled` trait method skips logging when no clients are connected. This means expensive logging code guarded by `log_enabled!` should get skipped appropriately.

Broadcasting to clients is done from a separate thread to avoid tying up callers. When a logging call is made, the logger simply sends the log message to a channel and returns. A separate thread then reads from the channel, handling the rest of the pipeline. The channel is bounded and the send is best-effort using non-blocking `try_send()` calls, so if the channel is full then logs are dropped.