### PR TITLE
enforce log level limit in logger rather than globally

### DIFF
--- a/src/bin/pushpin-connmgr.rs
+++ b/src/bin/pushpin-connmgr.rs
@@ -385,9 +385,12 @@ fn main() {
         )
         .get_matches();
 
+    // Allow all log levels globally so individual loggers can limit as they choose
+    log::set_max_level(LevelFilter::Trace);
+
     log::set_logger(get_simple_logger()).unwrap();
 
-    log::set_max_level(LevelFilter::Info);
+    get_simple_logger().set_max_level(LevelFilter::Info);
 
     let level = matches.get_one::<String>("log-level").unwrap();
 
@@ -408,7 +411,7 @@ fn main() {
         _ => unreachable!(),
     };
 
-    log::set_max_level(level);
+    get_simple_logger().set_max_level(level);
 
     local_offset_check();
 


### PR DESCRIPTION
For the upcoming debug socket feature, we'll want to be able to filter by level within our logger rather than by the log crate's global filter. This way, the application can be configured with a low general limit, for example info level, while retaining the ability to log debug or trace level logs to a separate socket if appropriate.

This PR sets the global filter to trace level and then moves the filtering of the configured log level into our logger implementation. For thread safety, the selected level is stored in an `AtomicUsize`, the same way the log crate does for the global filter.