### PR TITLE
update time crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -1833,15 +1833,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ signal-hook = "0.3"
 slab = "0.4"
 socket2 = "0.4"
 thiserror = "1.0"
-time = { version = "0.3.36", features = ["formatting", "local-offset", "macros"] }
+time = { version = "=0.3.41", features = ["formatting", "local-offset", "macros"] }
 url = "2.3"
 zmq = "0.9"
 


### PR DESCRIPTION
I initially wrote this in response to the time crate audit error before deciding to simply ignore the audit error. However, updating the crate is still useful for some changes regarding soundness.

This PR adapts our usage of the time crate to its new behavior which doesn't require toggling a soundness mode. Note that it doesn't seem like much has changed about the thread safety of fetching the timezone or working with environment vars, at least on Linux. As far as I can tell, the crate's API is now considered sound simply because it checks the running thread count and bails out if it's not 1. So we still have to fetch and cache the timezone early on, before spawning threads.