### PR TITLE
audit: ignore time crate issue which we don't use

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+    # Title: Denial of Service via Stack Exhaustion
+    # Crate: time
+    # SAFETY: We don't use any parsing features
+    "RUSTSEC-2026-0009"
+]

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ moc_*
 target_wrapper.sh
 /target
 **/*.rs.bk
-.cargo
 vendor
 .vscode
 conf.pri


### PR DESCRIPTION
This issue in the time crate has been fixed in a new version but it needs Rust 1.88 and our MSRV is 1.75. Fortunately, it's not an issue that affects us so we can just silence the error.

(Our MSRV policy is to not exceed the version available in the latest Ubuntu LTS, which is currently 1.75 in Ubuntu 24.04.)