### PR TITLE
proxy: ensure fresh grip-sig used for disconnect events

### DIFF
--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -348,10 +348,8 @@ public:
 		cleanupKeepAliveTimer();
 
 		cleanupInSock();
+		cleanupOutSock();
 		
-		outWSConnection = WSConnections();
-		outSock.reset();
-
 		wsProxyConnectionMap.erase(wsControl);
 		delete wsControl;
 		wsControl = 0;
@@ -370,6 +368,19 @@ public:
 			connectionManager->removeConnection(inSock.get());
 			inWSConnection = InWSConnections();
 			inSock.reset();
+		}
+	}
+
+	void cleanupOutSock()
+	{
+		if(outSock)
+		{
+			// Ensure the socket has an updated Grip-Sig to use during its
+			// destruction process
+			updateGripSig();
+
+			outWSConnection = WSConnections();
+			outSock.reset();
 		}
 	}
 
@@ -554,7 +565,7 @@ public:
 				if(target.oneEvent)
 					woh->setMaxEventsPerRequest(1);
 
-				aboutToSendRequestConnection = woh->aboutToSendRequest.connect(boost::bind(&Private::out_aboutToSendRequest, this, woh.get()));
+				aboutToSendRequestConnection = woh->aboutToSendRequest.connect(boost::bind(&Private::out_aboutToSendRequest, this));
 				outSock = std::move(woh);
 			}
 			else
@@ -807,6 +818,17 @@ public:
 			setupKeepAlive();
 	}
 
+	void updateGripSig()
+	{
+		WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp*>(outSock.get());
+		if(!woh)
+			return;
+
+		ProxyUtil::applyGripSig("wsproxysession", q, &requestData.headers, sigIss, sigKey);
+
+		woh->setHeaders(requestData.headers);
+	}
+
 	void incCounter(Stats::Counter c, int count = 1)
 	{
 		if(statsManager)
@@ -849,9 +871,7 @@ public:
 			{
 				if(outSock->state() == WebSocket::Connecting)
 				{
-					outWSConnection = WSConnections();
-					outSock.reset();
-
+					cleanupOutSock();
 					inSock->close();
 				}
 				else if(outSock->state() == WebSocket::Connected)
@@ -879,10 +899,7 @@ public:
 		cleanupInSock();
 
 		if(!detached)
-		{
-			outWSConnection = WSConnections();
-			outSock.reset();
-		}
+			cleanupOutSock();
 
 		tryFinish();
 	}
@@ -976,8 +993,7 @@ public:
 	{
 		int code = outSock->peerCloseCode();
 		QString reason = outSock->peerCloseReason();
-		outWSConnection = WSConnections();
-		outSock.reset();
+		cleanupOutSock();
 
 		if(!detached && inSock && inSock->state() != WebSocket::Closing)
 			inSock->close(code, reason);
@@ -992,9 +1008,7 @@ public:
 
 		if(detached)
 		{
-			outWSConnection = WSConnections();
-			outSock.reset();
-
+			cleanupOutSock();
 			tryFinish();
 			return;
 		}
@@ -1018,8 +1032,7 @@ public:
 					break;
 			}
 
-			outWSConnection = WSConnections();
-			outSock.reset();
+			cleanupOutSock();
 
 			if(tryAgain)
 				tryNextTarget();
@@ -1027,22 +1040,17 @@ public:
 		else
 		{
 			cleanupInSock();
-
-			outWSConnection = WSConnections();
-			outSock.reset();
+			cleanupOutSock();
 
 			tryFinish();
 		}
 	}
 
-	void out_aboutToSendRequest(WebSocketOverHttp *woh)
+	void out_aboutToSendRequest()
 	{
-		ProxyUtil::applyGripSig("wsproxysession", q, &requestData.headers, sigIss, sigKey);
-
-		woh->setHeaders(requestData.headers);
+		updateGripSig();
 	}
 
-private:
 	void wsControl_sendEventReceived(WebSocket::Frame::Type type, const QByteArray &message, bool queue)
 	{
 		// This method accepts a full message, which must be typed
@@ -1136,13 +1144,8 @@ private:
 
 	void wsControl_cancelEventReceived()
 	{
-		if(outSock)
-		{
-			outWSConnection = WSConnections();
-			outSock.reset();
-		}
-
 		cleanupInSock();
+		cleanupOutSock();
 
 		tryFinish();
 	}


### PR DESCRIPTION
Currently, whenever `WebSocketOverHttp` is about to make a new outbound HTTP request for its session, it emits the `aboutToSendRequest` signal which `WsProxySession` reacts to by applying a `Grip-Sig` header to it. This ensures the outbound request not only has that header but also that it gets a new one for every request. However, this mechanism doesn't work for requests containing `DISCONNECT` events since they are sent after the `aboutToSendRequest` signal is disconnected. In that case, the request uses the most recently applied `Grip-Sig` header, which depending on the frequency of outbound requests could contain an old/expired token.

This PR updates `WebSocketOverHttp`'s `Grip-Sig` header just prior to destruction, in case it is needed for a `DISCONNECT` event.