### PR TITLE
list: add head/tail methods for use instead of direct fields

### DIFF
--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -316,7 +316,7 @@ impl Connections {
         let items = &mut *self.items.borrow_mut();
         let cinner = &*self.inner.borrow_mut();
 
-        let mut next = cinner.active.head;
+        let mut next = cinner.active.head();
         while let Some(nkey) = next {
             let n = &mut items.nodes[nkey];
             let ci = &mut n.value;

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -421,7 +421,7 @@ impl Connections {
         let items = &mut *self.items.borrow_mut();
         let cinner = &*self.inner.borrow_mut();
 
-        let mut next = cinner.active.head;
+        let mut next = cinner.active.head();
         while let Some(nkey) = next {
             let n = &mut items.nodes[nkey];
             let ci = &mut n.value;

--- a/src/connmgr/zhttpsocket.rs
+++ b/src/connmgr/zhttpsocket.rs
@@ -586,7 +586,7 @@ impl ReqHandles {
 
         let (mut tasks, slice_scratch) = scratch.get();
 
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -620,7 +620,7 @@ impl ReqHandles {
     }
 
     async fn send(&self, msg: &Arc<zmq::Message>, ids: &[Id<'_>]) {
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -660,7 +660,7 @@ impl ReqHandles {
     where
         F: Fn(&ReqPipe),
     {
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &mut self.nodes[nkey];
@@ -721,7 +721,7 @@ impl StreamHandles {
 
         let (mut tasks, slice_scratch) = scratch.get();
 
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -760,7 +760,7 @@ impl StreamHandles {
 
         let (mut tasks, slice_scratch) = scratch.get();
 
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -794,7 +794,7 @@ impl StreamHandles {
     }
 
     async fn send(&self, msg: &Arc<zmq::Message>, ids: &[Id<'_>], from_router: bool) {
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -834,7 +834,7 @@ impl StreamHandles {
     where
         F: Fn(&StreamPipe),
     {
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &mut self.nodes[nkey];
@@ -898,7 +898,7 @@ impl ServerReqHandles {
 
         let (mut tasks, slice_scratch) = scratch.get();
 
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -1035,7 +1035,7 @@ impl ServerReqHandles {
     where
         F: Fn(&ServerReqPipe),
     {
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &mut self.nodes[nkey];
@@ -1108,7 +1108,7 @@ impl ServerStreamHandles {
 
         let (mut tasks, slice_scratch) = scratch.get();
 
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &self.nodes[nkey];
@@ -1313,7 +1313,7 @@ impl ServerStreamHandles {
     where
         F: Fn(&ServerStreamPipe),
     {
-        let mut next = self.list.head;
+        let mut next = self.list.head();
 
         while let Some(nkey) = next {
             let n = &mut self.nodes[nkey];

--- a/src/core/channel.rs
+++ b/src/core/channel.rs
@@ -268,7 +268,7 @@ impl<T> LocalChannel<T> {
         let senders = &mut *self.senders.borrow_mut();
 
         // Add if not already present
-        if senders.nodes[key].prev.is_none() && senders.waiting.head != Some(key) {
+        if senders.nodes[key].prev.is_none() && senders.waiting.head() != Some(key) {
             senders.waiting.push_back(&mut senders.nodes, key);
         }
     }

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -198,7 +198,7 @@ impl Tasks {
     }
 
     fn take_task(&self, l: &mut list::List) -> Option<(usize, BoxFuture, Waker)> {
-        let nkey = l.head?;
+        let nkey = l.head()?;
 
         let data = &mut *self.data.borrow_mut();
 

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -34,13 +34,21 @@ impl<T> Node<T> {
 
 #[derive(Default, Clone, Copy)]
 pub struct List {
-    pub head: Option<usize>,
-    pub tail: Option<usize>,
+    head: Option<usize>,
+    tail: Option<usize>,
 }
 
 impl List {
     pub fn is_empty(&self) -> bool {
         self.head.is_none()
+    }
+
+    pub fn head(&self) -> Option<usize> {
+        self.head
+    }
+
+    pub fn tail(&self) -> Option<usize> {
+        self.tail
     }
 
     pub fn insert<T, S>(&mut self, nodes: &mut S, after: Option<usize>, key: usize)
@@ -217,21 +225,21 @@ mod tests {
 
         let mut l = List::default();
         assert_eq!(l.is_empty(), true);
-        assert_eq!(l.head, None);
-        assert_eq!(l.tail, None);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
         assert_eq!(l.pop_front(&mut nodes), None);
 
         l.push_back(&mut nodes, n1);
         assert_eq!(l.is_empty(), false);
-        assert_eq!(l.head, Some(n1));
-        assert_eq!(l.tail, Some(n1));
+        assert_eq!(l.head(), Some(n1));
+        assert_eq!(l.tail(), Some(n1));
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, None);
 
         l.push_back(&mut nodes, n2);
         assert_eq!(l.is_empty(), false);
-        assert_eq!(l.head, Some(n1));
-        assert_eq!(l.tail, Some(n2));
+        assert_eq!(l.head(), Some(n1));
+        assert_eq!(l.tail(), Some(n2));
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, Some(n2));
         assert_eq!(nodes[n2].prev, Some(n1));
@@ -239,8 +247,8 @@ mod tests {
 
         l.push_back(&mut nodes, n3);
         assert_eq!(l.is_empty(), false);
-        assert_eq!(l.head, Some(n1));
-        assert_eq!(l.tail, Some(n3));
+        assert_eq!(l.head(), Some(n1));
+        assert_eq!(l.tail(), Some(n3));
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, Some(n2));
         assert_eq!(nodes[n2].prev, Some(n1));
@@ -251,8 +259,8 @@ mod tests {
         let key = l.pop_front(&mut nodes);
         assert_eq!(key, Some(n1));
         assert_eq!(l.is_empty(), false);
-        assert_eq!(l.head, Some(n2));
-        assert_eq!(l.tail, Some(n3));
+        assert_eq!(l.head(), Some(n2));
+        assert_eq!(l.tail(), Some(n3));
         assert_eq!(nodes[n2].prev, None);
         assert_eq!(nodes[n2].next, Some(n3));
         assert_eq!(nodes[n3].prev, Some(n2));
@@ -261,16 +269,16 @@ mod tests {
         let key = l.pop_front(&mut nodes);
         assert_eq!(key, Some(n2));
         assert_eq!(l.is_empty(), false);
-        assert_eq!(l.head, Some(n3));
-        assert_eq!(l.tail, Some(n3));
+        assert_eq!(l.head(), Some(n3));
+        assert_eq!(l.tail(), Some(n3));
         assert_eq!(nodes[n3].prev, None);
         assert_eq!(nodes[n3].next, None);
 
         let key = l.pop_front(&mut nodes);
         assert_eq!(key, Some(n3));
         assert_eq!(l.is_empty(), true);
-        assert_eq!(l.head, None);
-        assert_eq!(l.tail, None);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
 
         assert_eq!(l.pop_front(&mut nodes), None);
     }
@@ -285,28 +293,28 @@ mod tests {
 
         let mut l = List::default();
         assert_eq!(l.is_empty(), true);
-        assert_eq!(l.head, None);
-        assert_eq!(l.tail, None);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
 
         l.push_back(&mut nodes, n1);
         assert_eq!(l.is_empty(), false);
-        assert_eq!(l.head, Some(n1));
-        assert_eq!(l.tail, Some(n1));
+        assert_eq!(l.head(), Some(n1));
+        assert_eq!(l.tail(), Some(n1));
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, None);
 
         l.remove(&mut nodes, n1);
         assert_eq!(l.is_empty(), true);
-        assert_eq!(l.head, None);
-        assert_eq!(l.tail, None);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, None);
 
         // Already removed
         l.remove(&mut nodes, n1);
         assert_eq!(l.is_empty(), true);
-        assert_eq!(l.head, None);
-        assert_eq!(l.tail, None);
+        assert_eq!(l.head(), None);
+        assert_eq!(l.tail(), None);
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, None);
     }
@@ -322,22 +330,22 @@ mod tests {
 
         a.concat(&mut nodes, &mut b);
         assert_eq!(a.is_empty(), true);
-        assert_eq!(a.head, None);
-        assert_eq!(a.tail, None);
+        assert_eq!(a.head(), None);
+        assert_eq!(a.tail(), None);
         assert_eq!(b.is_empty(), true);
-        assert_eq!(b.head, None);
-        assert_eq!(b.tail, None);
+        assert_eq!(b.head(), None);
+        assert_eq!(b.tail(), None);
 
         a.push_back(&mut nodes, n1);
         b.push_back(&mut nodes, n2);
 
         a.concat(&mut nodes, &mut b);
         assert_eq!(a.is_empty(), false);
-        assert_eq!(a.head, Some(n1));
-        assert_eq!(a.tail, Some(n2));
+        assert_eq!(a.head(), Some(n1));
+        assert_eq!(a.tail(), Some(n2));
         assert_eq!(b.is_empty(), true);
-        assert_eq!(b.head, None);
-        assert_eq!(b.tail, None);
+        assert_eq!(b.head(), None);
+        assert_eq!(b.tail(), None);
         assert_eq!(nodes[n1].prev, None);
         assert_eq!(nodes[n1].next, Some(n2));
         assert_eq!(nodes[n2].prev, Some(n1));

--- a/src/core/timer.rs
+++ b/src/core/timer.rs
@@ -256,7 +256,7 @@ impl TimerWheel {
 
         self.curtime = curtime;
 
-        while let Some(key) = l.head {
+        while let Some(key) = l.head() {
             l.remove(&mut self.nodes, key);
 
             let n = &mut self.nodes[key];
@@ -489,12 +489,12 @@ mod tests {
         // Wheel 3 slot 63
         let t6 = w.add(0b1_000000_000000_000000_000000, 1).unwrap();
 
-        assert_eq!(w.expired.head, Some(t1));
-        assert_eq!(w.wheel[0][8].head, Some(t2));
-        assert_eq!(w.wheel[0][63].head, Some(t3));
-        assert_eq!(w.wheel[0][0].head, Some(t4));
-        assert_eq!(w.wheel[1][0].head, Some(t5));
-        assert_eq!(w.wheel[3][63].head, Some(t6));
+        assert_eq!(w.expired.head(), Some(t1));
+        assert_eq!(w.wheel[0][8].head(), Some(t2));
+        assert_eq!(w.wheel[0][63].head(), Some(t3));
+        assert_eq!(w.wheel[0][0].head(), Some(t4));
+        assert_eq!(w.wheel[1][0].head(), Some(t5));
+        assert_eq!(w.wheel[3][63].head(), Some(t6));
     }
 
     #[test]


### PR DESCRIPTION
The new list implementation planned in #48291 will expose head/tail as methods in order to make their behavior generic. This PR adapts to that change in advance by adding such methods to the current list implementation, so that there will be less code to change when we move to the new one.