### PR TITLE
pushpin-publish: support bearer auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,28 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,8 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -301,15 +277,6 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -515,12 +482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,12 +574,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -933,15 +888,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1563,8 +1509,6 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1609,7 +1553,6 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ mio = { version = "1", features = ["os-poll", "os-ext", "net"] }
 notify = "7"
 openssl = "=0.10.72"
 paste = "1.0"
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-native-certs = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/bin/pushpin-publish.rs
+++ b/src/bin/pushpin-publish.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2023 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * This file is part of Pushpin.
  *
@@ -22,7 +23,7 @@
 
 use clap::{Arg, ArgAction, Command};
 use pushpin::core::version;
-use pushpin::publish::{run, Action, Config, Content, Message};
+use pushpin::publish::{run, Action, AuthType, Config, Content, Message};
 use std::env;
 use std::error::Error;
 use std::process;
@@ -45,7 +46,7 @@ struct Args {
     no_seq: bool,
     no_eol: bool,
     spec: String,
-    user: Option<String>,
+    auth: Option<(AuthType, String)>,
 }
 
 fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
@@ -112,7 +113,7 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
 
     let config = Config {
         spec: args.spec,
-        basic_auth: args.user,
+        auth: args.auth,
         channel: args.channel,
         id: args.id,
         prev_id: args.prev_id,
@@ -242,6 +243,14 @@ fn main() {
                 .value_name("user:pass")
                 .help("Authenticate using basic auth"),
         )
+        .arg(
+            Arg::new("bearer")
+                .short('B')
+                .long("bearer")
+                .num_args(1)
+                .value_name("token")
+                .help("Authenticate using bearer auth"),
+        )
         .get_matches();
 
     let channel = matches.get_one::<String>("channel").unwrap().clone();
@@ -289,6 +298,17 @@ fn main() {
     let spec = matches.get_one::<String>("spec").unwrap().clone();
 
     let user = matches.get_one::<String>("user").cloned();
+    let bearer = matches.get_one::<String>("bearer").cloned();
+
+    let auth = match (user, bearer) {
+        (Some(_), Some(_)) => {
+            eprintln!("Error: only one authentication method can be specified");
+            process::exit(1);
+        }
+        (Some(user), None) => Some((AuthType::Basic, user)),
+        (None, Some(bearer)) => Some((AuthType::Bearer, bearer)),
+        (None, None) => None,
+    };
 
     let args = Args {
         channel,
@@ -305,7 +325,7 @@ fn main() {
         no_seq,
         no_eol,
         spec,
-        user,
+        auth,
     };
 
     if let Err(e) = process_args_and_run(args) {

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -309,9 +309,15 @@ impl Write for Stream {
     }
 }
 
+#[derive(Copy, Clone)]
+pub enum AuthType {
+    Basic,
+    Bearer,
+}
+
 fn publish_http(
     base_url: &str,
-    basic_auth: Option<&str>,
+    auth: Option<(AuthType, &str)>,
     item: &serde_json::Value,
 ) -> Result<(), Box<dyn Error>> {
     let parsed_url = match parse_url(base_url) {
@@ -340,12 +346,17 @@ fn publish_http(
         body.len()
     );
 
-    if let Some(s) = basic_auth {
+    if let Some((auth_type, value)) = auth {
         if parsed_url.scheme != "https" {
             return Err("Authentication requires https".into());
         }
 
-        req.push_str(&format!("Authorization: Basic {}\r\n", base64::encode(s)));
+        let header_value = match auth_type {
+            AuthType::Basic => format!("Basic {}", base64::encode(value)),
+            AuthType::Bearer => format!("Bearer {value}"),
+        };
+
+        req.push_str(&format!("Authorization: {header_value}\r\n"));
     }
 
     req += "\r\n";
@@ -391,7 +402,7 @@ fn publish_http(
 
             let pos = match rest.find(' ') {
                 Some(pos) => pos,
-                None => return Err(io::Error::from(io::ErrorKind::InvalidData).into()),
+                None => rest.len(),
             };
 
             let code = &rest[..pos];
@@ -451,7 +462,7 @@ pub enum Action {
 
 pub struct Config {
     pub spec: String,
-    pub basic_auth: Option<String>,
+    pub auth: Option<(AuthType, String)>,
     pub channel: String,
     pub id: String,
     pub prev_id: String,
@@ -609,9 +620,9 @@ pub fn run(config: &Config) -> Result<(), Box<dyn Error>> {
     if config.spec.starts_with("https:") || config.spec.starts_with("http:") {
         let item = tnet_to_json(&item)?;
 
-        let basic_auth = config.basic_auth.as_deref();
+        let auth = config.auth.as_ref().map(|(t, v)| (*t, v.as_str()));
 
-        publish_http(&config.spec, basic_auth, &item)?;
+        publish_http(&config.spec, auth, &item)?;
     } else {
         publish_zmq(&config.spec, &item)?;
     }


### PR DESCRIPTION
This makes it so `pushpin-publish` works with Fastly:

```
pushpin-publish --spec https://api.fastly.com/service/SERVICE_ID --bearer API_TOKEN ...`
```