### PR TITLE
use new slab list

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -15,7 +15,7 @@
  */
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use pushpin::core::list;
+use pushpin::core::list::{List, Node, RcList, RcNode, SlabList, SlabNode};
 use pushpin::core::memorypool;
 use slab::Slab;
 use std::rc::Rc;
@@ -30,11 +30,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("slab-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
                 let mut nodes = nodes_slab.take().unwrap();
-                let mut l = list::List::default();
+                let mut l = List::default();
 
                 let mut next_value: u64 = 0;
                 while nodes.len() < nodes.capacity() {
-                    let n = nodes.insert(list::Node::new(next_value));
+                    let n = nodes.insert(Node::new(next_value));
                     l.push_back(&mut nodes, n);
                     next_value += 1;
                 }
@@ -59,11 +59,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("gen-slab-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
                 let mut nodes = nodes_slab.take().unwrap();
-                let mut l = list::SlabList::default();
+                let mut l = SlabList::default();
 
                 let mut next_value: u64 = 0;
                 while nodes.len() < nodes.capacity() {
-                    let n = nodes.insert(list::SlabNode::new(next_value));
+                    let n = nodes.insert(SlabNode::new(next_value));
                     l.push_back(&mut nodes, n);
                     next_value += 1;
                 }
@@ -89,11 +89,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function(&format!("mp-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut l = list::RcList::default();
+                let mut l = RcList::default();
 
                 let mut next_value: u64 = 0;
                 while next_value < node_count as u64 {
-                    let n = list::RcNode::new(next_value, Some(&nodes_memory));
+                    let n = RcNode::new(next_value, Some(&nodes_memory));
                     l.push_back(n);
                     next_value += 1;
                 }
@@ -113,11 +113,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function(&format!("sys-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut l = list::RcList::default();
+                let mut l = RcList::default();
 
                 let mut next_value: u64 = 0;
                 while next_value < node_count as u64 {
-                    let n = list::RcNode::new(next_value, None);
+                    let n = RcNode::new(next_value, None);
                     l.push_back(n);
                     next_value += 1;
                 }
@@ -140,14 +140,14 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut nodes = Vec::new();
         let mut next_value: u64 = 0;
         while nodes_memory.len() < nodes_memory.capacity() {
-            let n = list::RcNode::new(next_value, Some(&nodes_memory));
+            let n = RcNode::new(next_value, Some(&nodes_memory));
             nodes.push(n);
             next_value += 1;
         }
 
         c.bench_function(&format!("pre-mp-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut l = list::RcList::default();
+                let mut l = RcList::default();
 
                 for n in &nodes {
                     l.push_back(n.clone());
@@ -170,14 +170,14 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut nodes = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < node_count as u64 {
-            let n = list::RcNode::new(next_value, None);
+            let n = RcNode::new(next_value, None);
             nodes.push(n);
             next_value += 1;
         }
 
         c.bench_function(&format!("pre-sys-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
-                let mut l = list::RcList::default();
+                let mut l = RcList::default();
 
                 for n in &nodes {
                     l.push_back(n.clone());

--- a/src/connmgr/batch.rs
+++ b/src/connmgr/batch.rs
@@ -17,7 +17,7 @@
 
 use crate::connmgr::zhttppacket;
 use crate::connmgr::zhttpsocket::FROM_MAX;
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::memorypool;
 use arrayvec::ArrayVec;
 use slab::Slab;
@@ -81,11 +81,11 @@ impl<'a, 'b> BatchGroupWithIds<'a, 'b> {
 struct AddrItem {
     addr: ArrayVec<u8, FROM_MAX>,
     use_router: bool,
-    keys: list::List,
+    keys: SlabList<usize>,
 }
 
 pub struct Batch {
-    nodes: Slab<list::Node<usize>>,
+    nodes: Slab<SlabNode<usize>>,
     addrs: Vec<AddrItem>,
     addr_index: usize,
     group_ids: memorypool::ReusableVec,
@@ -152,7 +152,7 @@ impl Batch {
             self.addrs.push(AddrItem {
                 addr,
                 use_router,
-                keys: list::List::default(),
+                keys: SlabList::default(),
             });
         } else {
             // adding not allowed if take_group() has already moved past the index
@@ -161,7 +161,7 @@ impl Batch {
             }
         }
 
-        let nkey = self.nodes.insert(list::Node::new(ckey));
+        let nkey = self.nodes.insert(SlabNode::new(ckey));
         self.addrs[pos].keys.push_back(&mut self.nodes, nkey);
 
         Ok(BatchKey {

--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -29,7 +29,7 @@ use crate::core::buffer::TmpBuffer;
 use crate::core::channel::{self, AsyncLocalReceiver, AsyncLocalSender, AsyncReceiver};
 use crate::core::event;
 use crate::core::executor::{Executor, Spawner};
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::memorypool;
 use crate::core::reactor::Reactor;
 use crate::core::select::{select_2, select_5, select_6, select_option, Select2, Select5, Select6};
@@ -183,7 +183,7 @@ struct ConnectionItem {
 }
 
 struct ConnectionItems {
-    nodes: Slab<list::Node<ConnectionItem>>,
+    nodes: Slab<SlabNode<ConnectionItem>>,
     nodes_by_id: HashMap<SessionKey, usize>,
     batch: Batch,
 }
@@ -199,7 +199,7 @@ impl ConnectionItems {
 }
 
 struct ConnectionsInner {
-    active: list::List,
+    active: SlabList<ConnectionItem>,
     count: usize,
     max: usize,
 }
@@ -214,7 +214,7 @@ impl Connections {
         Self {
             items,
             inner: RefCell::new(ConnectionsInner {
-                active: list::List::default(),
+                active: SlabList::default(),
                 count: 0,
                 max,
             }),
@@ -244,7 +244,7 @@ impl Connections {
             return Err(());
         }
 
-        let nkey = items.nodes.insert(list::Node::new(ConnectionItem {
+        let nkey = items.nodes.insert(SlabNode::new(ConnectionItem {
             id: None,
             stop: Some(stop),
             zreceiver_sender,

--- a/src/connmgr/pool.rs
+++ b/src/connmgr/pool.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  * limitations under the License.
  */
 
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::timer::TimerWheel;
 use slab::Slab;
 use std::borrow::Borrow;
@@ -35,8 +36,8 @@ struct PoolItem<K, V> {
 }
 
 pub struct Pool<K, V> {
-    nodes: Slab<list::SlabNode<PoolItem<K, V>>>,
-    by_key: HashMap<K, list::SlabList<PoolItem<K, V>>>,
+    nodes: Slab<SlabNode<PoolItem<K, V>>>,
+    by_key: HashMap<K, SlabList<PoolItem<K, V>>>,
     wheel: TimerWheel,
     start: Instant,
     current_ticks: u64,
@@ -69,7 +70,7 @@ where
 
             let timer_id = self.wheel.add(expires, nkey).unwrap();
 
-            entry.insert(list::SlabNode::new(PoolItem {
+            entry.insert(SlabNode::new(PoolItem {
                 key: key.clone(),
                 value,
                 timer_id,

--- a/src/connmgr/resolver.rs
+++ b/src/connmgr/resolver.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
  */
 
 use crate::core::event;
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::reactor::CustomEvented;
 use crate::core::task::get_reactor;
 use arrayvec::{ArrayString, ArrayVec};
@@ -54,8 +55,8 @@ struct QueryItem {
 
 struct QueriesInner {
     stop: bool,
-    nodes: Slab<list::Node<QueryItem>>,
-    next: list::List,
+    nodes: Slab<SlabNode<QueryItem>>,
+    next: SlabList<QueryItem>,
     registrations: VecDeque<(event::Registration, event::SetReadiness)>,
     invalidated_count: u32,
 }
@@ -76,7 +77,7 @@ impl Queries {
         let inner = QueriesInner {
             stop: false,
             nodes: Slab::with_capacity(queries_max),
-            next: list::List::default(),
+            next: SlabList::default(),
             registrations,
             invalidated_count: 0,
         };
@@ -108,7 +109,7 @@ impl Queries {
 
         let nkey = match Hostname::from(host) {
             Ok(host) => {
-                let nkey = queries.nodes.insert(list::Node::new(QueryItem {
+                let nkey = queries.nodes.insert(SlabNode::new(QueryItem {
                     host,
                     result: None,
                     set_readiness: sr,
@@ -124,7 +125,7 @@ impl Queries {
             Err(_) => {
                 sr.set_readiness(Interest::READABLE).unwrap();
 
-                queries.nodes.insert(list::Node::new(QueryItem {
+                queries.nodes.insert(SlabNode::new(QueryItem {
                     host: Hostname::new(),
                     result: Some(Err(io::Error::from(io::ErrorKind::InvalidInput))),
                     set_readiness: sr,

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -30,7 +30,7 @@ use crate::core::channel::{self, AsyncLocalReceiver, AsyncLocalSender, AsyncRece
 use crate::core::event;
 use crate::core::executor::{Executor, Spawner};
 use crate::core::fs::{set_group, set_user};
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::memorypool;
 use crate::core::net::{
     set_socket_opts, AsyncTcpStream, AsyncUnixStream, NetListener, NetStream, SocketAddr,
@@ -297,7 +297,7 @@ struct ConnectionItem {
 }
 
 struct ConnectionItems {
-    nodes: Slab<list::Node<ConnectionItem>>,
+    nodes: Slab<SlabNode<ConnectionItem>>,
     next_cid: u32,
     batch: Batch,
 }
@@ -313,7 +313,7 @@ impl ConnectionItems {
 }
 
 struct ConnectionsInner {
-    active: list::List,
+    active: SlabList<ConnectionItem>,
     count: usize,
     max: usize,
 }
@@ -328,7 +328,7 @@ impl Connections {
         Self {
             items,
             inner: RefCell::new(ConnectionsInner {
-                active: list::List::default(),
+                active: SlabList::default(),
                 count: 0,
                 max,
             }),
@@ -357,7 +357,7 @@ impl Connections {
             return Err(());
         }
 
-        let nkey = items.nodes.insert(list::Node::new(ConnectionItem {
+        let nkey = items.nodes.insert(SlabNode::new(ConnectionItem {
             id: ArrayString::new(),
             stop: Some(stop),
             zreceiver_sender,

--- a/src/connmgr/zhttpsocket.rs
+++ b/src/connmgr/zhttpsocket.rs
@@ -22,7 +22,7 @@ use crate::core::channel::{
 };
 use crate::core::event;
 use crate::core::executor::Executor;
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::memorypool;
 use crate::core::reactor::Reactor;
 use crate::core::select::{select_10, select_option, select_slice, Select10};
@@ -548,8 +548,8 @@ impl<T> CheckSendScratch<T> {
 }
 
 struct ReqHandles {
-    nodes: Slab<list::Node<ReqPipe>>,
-    list: list::List,
+    nodes: Slab<SlabNode<ReqPipe>>,
+    list: SlabList<ReqPipe>,
     recv_scratch: RefCell<RecvScratch<zmq::Message>>,
     need_cleanup: Cell<bool>,
 }
@@ -558,7 +558,7 @@ impl ReqHandles {
     fn new(capacity: usize) -> Self {
         Self {
             nodes: Slab::with_capacity(capacity),
-            list: list::List::default(),
+            list: SlabList::default(),
             recv_scratch: RefCell::new(RecvScratch::new(capacity)),
             need_cleanup: Cell::new(false),
         }
@@ -571,7 +571,7 @@ impl ReqHandles {
     fn add(&mut self, pe: AsyncReqPipeEnd, filter: ArrayString<8>) {
         assert!(self.nodes.len() < self.nodes.capacity());
 
-        let key = self.nodes.insert(list::Node::new(ReqPipe {
+        let key = self.nodes.insert(SlabNode::new(ReqPipe {
             pe,
             filter,
             valid: Cell::new(true),
@@ -681,8 +681,8 @@ impl ReqHandles {
 }
 
 struct StreamHandles {
-    nodes: Slab<list::Node<StreamPipe>>,
-    list: list::List,
+    nodes: Slab<SlabNode<StreamPipe>>,
+    list: SlabList<StreamPipe>,
     recv_any_scratch: RefCell<RecvScratch<zmq::Message>>,
     recv_addr_scratch: RefCell<RecvScratch<(ArrayVec<u8, 64>, zmq::Message)>>,
     need_cleanup: Cell<bool>,
@@ -692,7 +692,7 @@ impl StreamHandles {
     fn new(capacity: usize) -> Self {
         Self {
             nodes: Slab::with_capacity(capacity),
-            list: list::List::default(),
+            list: SlabList::default(),
             recv_any_scratch: RefCell::new(RecvScratch::new(capacity)),
             recv_addr_scratch: RefCell::new(RecvScratch::new(capacity)),
             need_cleanup: Cell::new(false),
@@ -706,7 +706,7 @@ impl StreamHandles {
     fn add(&mut self, pe: AsyncStreamPipeEnd, filter: ArrayString<8>) {
         assert!(self.nodes.len() < self.nodes.capacity());
 
-        let key = self.nodes.insert(list::Node::new(StreamPipe {
+        let key = self.nodes.insert(SlabNode::new(StreamPipe {
             pe,
             filter,
             valid: Cell::new(true),
@@ -857,8 +857,8 @@ impl StreamHandles {
 struct ReqHandlesSendError(MultipartHeader);
 
 struct ServerReqHandles {
-    nodes: Slab<list::Node<ServerReqPipe>>,
-    list: list::List,
+    nodes: Slab<SlabNode<ServerReqPipe>>,
+    list: SlabList<ServerReqPipe>,
     recv_scratch: RefCell<RecvScratch<(MultipartHeader, zmq::Message)>>,
     check_send_scratch: RefCell<CheckSendScratch<(MultipartHeader, Arc<zmq::Message>)>>,
     need_cleanup: Cell<bool>,
@@ -869,7 +869,7 @@ impl ServerReqHandles {
     fn new(capacity: usize) -> Self {
         Self {
             nodes: Slab::with_capacity(capacity),
-            list: list::List::default(),
+            list: SlabList::default(),
             recv_scratch: RefCell::new(RecvScratch::new(capacity)),
             check_send_scratch: RefCell::new(CheckSendScratch::new(capacity)),
             need_cleanup: Cell::new(false),
@@ -884,7 +884,7 @@ impl ServerReqHandles {
     fn add(&mut self, pe: AsyncServerReqPipeEnd) {
         assert!(self.nodes.len() < self.nodes.capacity());
 
-        let key = self.nodes.insert(list::Node::new(ServerReqPipe {
+        let key = self.nodes.insert(SlabNode::new(ServerReqPipe {
             pe,
             valid: Cell::new(true),
         }));
@@ -937,7 +937,9 @@ impl ServerReqHandles {
         let mut any_valid = false;
         let mut any_writable = false;
 
-        for (_, p) in self.list.iter(&self.nodes) {
+        for nkey in self.list.iter(&self.nodes) {
+            let p = &self.nodes[nkey].value;
+
             if p.valid.get() {
                 any_valid = true;
 
@@ -963,7 +965,9 @@ impl ServerReqHandles {
         let mut scratch = self.check_send_scratch.borrow_mut();
         let (mut tasks, slice_scratch) = scratch.get();
 
-        for (_, p) in self.list.iter(&self.nodes) {
+        for nkey in self.list.iter(&self.nodes) {
+            let p = &self.nodes[nkey].value;
+
             if p.valid.get() {
                 assert!(tasks.len() < tasks.capacity());
 
@@ -989,7 +993,9 @@ impl ServerReqHandles {
 
         // Select the nth ready node, else the latest ready node
         let mut selected = None;
-        for (nkey, p) in self.list.iter(&self.nodes) {
+        for nkey in self.list.iter(&self.nodes) {
+            let p = &self.nodes[nkey].value;
+
             if p.valid.get() && p.pe.sender.is_writable() {
                 selected = Some(nkey);
             }
@@ -1063,8 +1069,8 @@ enum StreamHandlesSendError {
 }
 
 struct ServerStreamHandles {
-    nodes: Slab<list::Node<ServerStreamPipe>>,
-    list: list::List,
+    nodes: Slab<SlabNode<ServerStreamPipe>>,
+    list: SlabList<ServerStreamPipe>,
     recv_scratch: RefCell<RecvScratch<(Option<ArrayVec<u8, 64>>, zmq::Message)>>,
     check_send_any_scratch: RefCell<CheckSendScratch<(Arc<zmq::Message>, Session)>>,
     send_direct_scratch: RefCell<Vec<bool>>,
@@ -1077,7 +1083,7 @@ impl ServerStreamHandles {
     fn new(capacity: usize, sessions_capacity: usize) -> Self {
         Self {
             nodes: Slab::with_capacity(capacity),
-            list: list::List::default(),
+            list: SlabList::default(),
             recv_scratch: RefCell::new(RecvScratch::new(capacity)),
             check_send_any_scratch: RefCell::new(CheckSendScratch::new(capacity)),
             send_direct_scratch: RefCell::new(Vec::with_capacity(capacity)),
@@ -1094,7 +1100,7 @@ impl ServerStreamHandles {
     fn add(&mut self, pe: AsyncServerStreamPipeEnd) {
         assert!(self.nodes.len() < self.nodes.capacity());
 
-        let key = self.nodes.insert(list::Node::new(ServerStreamPipe {
+        let key = self.nodes.insert(SlabNode::new(ServerStreamPipe {
             pe,
             valid: Cell::new(true),
         }));
@@ -1147,7 +1153,9 @@ impl ServerStreamHandles {
         let mut any_valid = false;
         let mut any_writable = false;
 
-        for (_, p) in self.list.iter(&self.nodes) {
+        for nkey in self.list.iter(&self.nodes) {
+            let p = &self.nodes[nkey].value;
+
             if p.valid.get() {
                 any_valid = true;
 
@@ -1173,7 +1181,9 @@ impl ServerStreamHandles {
         let mut scratch = self.check_send_any_scratch.borrow_mut();
         let (mut tasks, slice_scratch) = scratch.get();
 
-        for (_, p) in self.list.iter(&self.nodes) {
+        for nkey in self.list.iter(&self.nodes) {
+            let p = &self.nodes[nkey].value;
+
             if p.valid.get() {
                 assert!(tasks.len() < tasks.capacity());
 
@@ -1204,7 +1214,9 @@ impl ServerStreamHandles {
 
         // Select the nth ready node, else the latest ready node
         let mut selected = None;
-        for (nkey, p) in self.list.iter(&self.nodes) {
+        for nkey in self.list.iter(&self.nodes) {
+            let p = &self.nodes[nkey].value;
+
             if p.valid.get() && p.pe.sender_any.is_writable() {
                 selected = Some(nkey);
             }

--- a/src/core/channel.rs
+++ b/src/core/channel.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
  */
 
 use crate::core::event;
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::memorypool;
 use crate::core::reactor::CustomEvented;
 use crate::core::task::get_reactor;
@@ -220,8 +221,8 @@ struct LocalSenderData {
 }
 
 struct LocalSenders {
-    nodes: Slab<list::Node<LocalSenderData>>,
-    waiting: list::List,
+    nodes: Slab<SlabNode<LocalSenderData>>,
+    waiting: SlabList<LocalSenderData>,
 }
 
 struct LocalChannel<T> {
@@ -242,7 +243,7 @@ impl<T> LocalChannel<T> {
             return Err(());
         }
 
-        let key = senders.nodes.insert(list::Node::new(LocalSenderData {
+        let key = senders.nodes.insert(SlabNode::new(LocalSenderData {
             notified: false,
             write_set_readiness: write_sr,
         }));
@@ -468,7 +469,7 @@ pub fn local_channel<T>(
         queue: RefCell::new(VecDeque::with_capacity(bound)),
         senders: RefCell::new(LocalSenders {
             nodes: Slab::with_capacity(max_senders),
-            waiting: list::List::default(),
+            waiting: SlabList::default(),
         }),
         read_set_readiness: RefCell::new(Some(read_sr)),
     });

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021-2023 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  * limitations under the License.
  */
 
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::memorypool;
 use mio::event::Source;
 use mio::{Events, Interest, Poll, Token, Waker};
@@ -68,8 +69,8 @@ struct SourceItem {
 }
 
 struct RegisteredSources {
-    nodes: Slab<list::Node<SourceItem>>,
-    ready: list::List,
+    nodes: Slab<SlabNode<SourceItem>>,
+    ready: SlabList<SourceItem>,
 }
 
 struct LocalSources {
@@ -81,7 +82,7 @@ impl LocalSources {
         Self {
             registered_sources: RefCell::new(RegisteredSources {
                 nodes: Slab::with_capacity(max_sources),
-                ready: list::List::default(),
+                ready: SlabList::default(),
             }),
         }
     }
@@ -93,7 +94,7 @@ impl LocalSources {
             return Err(io::Error::from(io::ErrorKind::WriteZero));
         }
 
-        Ok(sources.nodes.insert(list::Node::new(SourceItem {
+        Ok(sources.nodes.insert(SlabNode::new(SourceItem {
             subtoken,
             interests,
             readiness: None,
@@ -171,7 +172,7 @@ impl SyncSources {
         Self {
             registered_sources: Mutex::new(RegisteredSources {
                 nodes: Slab::with_capacity(max_sources),
-                ready: list::List::default(),
+                ready: SlabList::default(),
             }),
             waker,
         }
@@ -184,7 +185,7 @@ impl SyncSources {
             return Err(io::Error::from(io::ErrorKind::WriteZero));
         }
 
-        Ok(sources.nodes.insert(list::Node::new(SourceItem {
+        Ok(sources.nodes.insert(SlabNode::new(SourceItem {
             subtoken,
             interests,
             readiness: None,

--- a/src/core/eventloop.rs
+++ b/src/core/eventloop.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Fastly, Inc.
+ * Copyright (C) 2025-2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 use crate::core::event::{self, ReadinessExt};
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::reactor;
 use crate::core::waker;
 use slab::Slab;
@@ -71,8 +71,8 @@ struct Registration<C> {
 }
 
 struct RegistrationsData<C> {
-    nodes: Slab<list::Node<Registration<C>>>,
-    activated: list::List,
+    nodes: Slab<SlabNode<Registration<C>>>,
+    activated: SlabList<Registration<C>>,
     waker: Option<Waker>,
 }
 
@@ -88,7 +88,7 @@ impl<C: Callback> Registrations<C> {
         Self {
             data: RefCell::new(RegistrationsData {
                 nodes: Slab::with_capacity(capacity),
-                activated: list::List::default(),
+                activated: SlabList::default(),
                 waker: None,
             }),
         }
@@ -123,7 +123,7 @@ impl<C: Callback> Registrations<C> {
             callback: Some(callback),
         };
 
-        entry.insert(list::Node::new(reg));
+        entry.insert(SlabNode::new(reg));
 
         Ok(nkey)
     }

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2023 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
  */
 
 use crate::core::future::SizedFuture;
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use crate::core::waker;
 use log::debug;
 use slab::Slab;
@@ -76,9 +77,9 @@ struct Task {
 }
 
 struct TasksData {
-    nodes: Slab<list::Node<Task>>,
-    next: list::List,
-    next_low: list::List,
+    nodes: Slab<SlabNode<Task>>,
+    next: SlabList<Task>,
+    next_low: SlabList<Task>,
     wakers: Vec<Rc<TaskWaker>>,
     current_task: Option<usize>,
 }
@@ -92,8 +93,8 @@ impl Tasks {
     fn new(max: usize) -> Rc<Self> {
         let data = TasksData {
             nodes: Slab::with_capacity(max),
-            next: list::List::default(),
-            next_low: list::List::default(),
+            next: SlabList::default(),
+            next_low: SlabList::default(),
             wakers: Vec::with_capacity(max),
             current_task: None,
         };
@@ -146,7 +147,7 @@ impl Tasks {
             low: false,
         };
 
-        entry.insert(list::Node::new(task));
+        entry.insert(SlabNode::new(task));
 
         data.next.push_back(&mut data.nodes, nkey);
 
@@ -183,10 +184,10 @@ impl Tasks {
         self.data.borrow_mut().current_task = task_id;
     }
 
-    fn take_next_list(&self, low: bool) -> list::List {
+    fn take_next_list(&self, low: bool) -> SlabList<Task> {
         let data = &mut *self.data.borrow_mut();
 
-        let mut l = list::List::default();
+        let mut l = SlabList::default();
 
         if low {
             l.concat(&mut data.nodes, &mut data.next_low);
@@ -197,7 +198,7 @@ impl Tasks {
         l
     }
 
-    fn take_task(&self, l: &mut list::List) -> Option<(usize, BoxFuture, Waker)> {
+    fn take_task(&self, l: &mut SlabList<Task>) -> Option<(usize, BoxFuture, Waker)> {
         let nkey = l.head()?;
 
         let data = &mut *self.data.borrow_mut();

--- a/src/core/timer.rs
+++ b/src/core/timer.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2021 Fanout, Inc.
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +17,7 @@
 
 // adapted from http://25thandclement.com/~william/projects/timeout.c.html (MIT licensed)
 
-use crate::core::list;
+use crate::core::list::{SlabList, SlabNode};
 use slab::Slab;
 use std::array;
 use std::cmp;
@@ -133,9 +134,9 @@ struct Timer {
 }
 
 pub struct TimerWheel {
-    nodes: Slab<list::SlabNode<Timer>>,
-    wheel: [[list::SlabList<Timer>; WHEEL_LEN]; WHEEL_NUM],
-    expired: list::SlabList<Timer>,
+    nodes: Slab<SlabNode<Timer>>,
+    wheel: [[SlabList<Timer>; WHEEL_LEN]; WHEEL_NUM],
+    expired: SlabList<Timer>,
     pending: [u64; WHEEL_NUM],
     curtime: u64,
 }
@@ -144,8 +145,8 @@ impl TimerWheel {
     pub fn new(capacity: usize) -> Self {
         Self {
             nodes: Slab::with_capacity(capacity),
-            wheel: array::from_fn(|_| array::from_fn(|_| list::SlabList::default())),
-            expired: list::SlabList::default(),
+            wheel: array::from_fn(|_| array::from_fn(|_| SlabList::default())),
+            expired: SlabList::default(),
             pending: [0; WHEEL_NUM],
             curtime: 0,
         }
@@ -163,7 +164,7 @@ impl TimerWheel {
             user_data,
         };
 
-        let key = self.nodes.insert(list::SlabNode::new(t));
+        let key = self.nodes.insert(SlabNode::new(t));
 
         self.sched(key);
 
@@ -241,7 +242,7 @@ impl TimerWheel {
 
         let need = need_resched(self.curtime, curtime);
 
-        let mut l = list::SlabList::default();
+        let mut l = SlabList::default();
 
         for (wheel, &pending) in need.iter().enumerate() {
             // Loop as long as we still have slots to process


### PR DESCRIPTION
This replaces all uses of our original Slab-based `List` with its generics-based replacement, `SlabList`.

As discussed earlier, the implementation is nearly the same and it performs similarly:

```
slab-push-pop-x10k      time:   [86.493 µs 86.659 µs 86.870 µs]
gen-slab-push-pop-x10k  time:   [83.906 µs 83.918 µs 83.931 µs]
```