### PR TITLE
add variant type aliases, as preparation to migrate away from QVariant

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,6 +1,7 @@
 HEADERS += \
 	$$PWD/cowbytearray.h \
-	$$PWD/cowstring.h
+	$$PWD/cowstring.h \
+	$$PWD/variant.h
 
 HEADERS += \
 	$$PWD/zmqcontext.h \

--- a/src/core/variant.h
+++ b/src/core/variant.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
+
+#ifndef VARIANT_H
+#define VARIANT_H
+
+#include <QVariant>
+#include <QHash>
+#include <QMap>
+#include <QList>
+#include "qtcompat.h"
+
+using Variant = QVariant;
+using VariantHash = QVariantHash;
+using VariantMap = QVariantMap;
+using VariantList = QVariantList;
+
+// Note: typeId() and canConvert() functions are already provided by qtcompat.h
+// Since Variant = QVariant (alias), those functions work directly with our types
+
+#endif


### PR DESCRIPTION
As part of our ongoing process of migrating away from Qt types, this PR is the first in a series for addressing `QVariant`.

The plan is to do something similar to what we're doing with the Cow types, by introducing a replacement type, `Variant`, that behaves exactly the same way as `QVariant` and is initially a wrapper around it. Later, the implementation can be substituted with something else, likely `std::variant`. Unlike the Cow types, however, which are being slowly rolled out throughout the project, for `Variant` the plan will be to roll it out to the whole project in one shot via a type alias. The reason for doing it this way is to avoid deep copy conversions between our `Variant` and `QVariant`, which are hard to avoid when the types are distinct and variants are nested within variants.

Steps:

1. Add `Variant*` type aliases (this PR). Easy change, nothing using it yet.
2. Change all mentions of `QVariant*` in the whole project to `Variant*`. The actual types would still be `QVariant*` so this should be completely safe with no worry about behavioral changes.
3. Replace `Variant*` type aliases with `Variant*` classes that wrap `QVariant*`, forwarding to an inner instance. No change to the call sites.
4. Eventually, change the implementation of the `Variant*` classes with something not Qt-based.