### PR TITLE
use Variant alias types everywhere in place of QVariant

### DIFF
--- a/src/core/inspectdata.h
+++ b/src/core/inspectdata.h
@@ -24,7 +24,7 @@
 #define INSPECTDATA_H
 
 #include <QByteArray>
-#include <QVariant>
+#include "variant.h"
 
 class InspectData
 {
@@ -33,7 +33,7 @@ public:
 	QByteArray sharingKey;
 	QByteArray sid;
 	QHash<QByteArray, QByteArray> lastIds;
-	QVariant userData;
+	Variant userData;
 
 	InspectData() :
 		doProxy(false)

--- a/src/core/jwt.cpp
+++ b/src/core/jwt.cpp
@@ -28,6 +28,7 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include "variant.h"
 
 namespace Jwt {
 
@@ -205,7 +206,7 @@ QByteArray decodeWithAlgorithm(Algorithm alg, const QByteArray &token, const Dec
 	return out;
 }
 
-QByteArray encode(const QVariant &claim, const EncodingKey &key)
+QByteArray encode(const Variant &claim, const EncodingKey &key)
 {
 	Algorithm alg;
 	switch(key.type())
@@ -223,7 +224,7 @@ QByteArray encode(const QVariant &claim, const EncodingKey &key)
 	return encodeWithAlgorithm(alg, claimJson, key);
 }
 
-QVariant decode(const QByteArray &token, const DecodingKey &key)
+Variant decode(const QByteArray &token, const DecodingKey &key)
 {
 	Algorithm alg;
 	switch(key.type())
@@ -231,17 +232,17 @@ QVariant decode(const QByteArray &token, const DecodingKey &key)
 		case Jwt::KeyType::Secret: alg = Jwt::HS256; break;
 		case Jwt::KeyType::Ec: alg = Jwt::ES256; break;
 		case Jwt::KeyType::Rsa: alg = Jwt::RS256; break;
-		default: return QVariant();
+		default: return Variant();
 	}
 
 	QByteArray claimJson = decodeWithAlgorithm(alg, token, key);
 	if(claimJson.isEmpty())
-		return QVariant();
+		return Variant();
 
 	QJsonParseError error;
 	QJsonDocument doc = QJsonDocument::fromJson(claimJson, &error);
 	if(error.error != QJsonParseError::NoError || !doc.isObject())
-		return QVariant();
+		return Variant();
 
 	return doc.object().toVariantMap();
 }

--- a/src/core/jwt.h
+++ b/src/core/jwt.h
@@ -25,7 +25,7 @@
 #define JWT_H
 
 #include <QByteArray>
-#include <QVariant>
+#include "variant.h"
 #include <QSharedData>
 #include <QDir>
 #include "rust/bindings.h"
@@ -109,8 +109,8 @@ QByteArray encodeWithAlgorithm(Algorithm alg, const QByteArray &claim, const Enc
 // Returns claim, null on error
 QByteArray decodeWithAlgorithm(Algorithm alg, const QByteArray &token, const DecodingKey &key);
 
-QByteArray encode(const QVariant &claim, const EncodingKey &key);
-QVariant decode(const QByteArray &token, const DecodingKey &key);
+QByteArray encode(const Variant &claim, const EncodingKey &key);
+Variant decode(const QByteArray &token, const DecodingKey &key);
 
 }
 

--- a/src/core/jwttest.cpp
+++ b/src/core/jwttest.cpp
@@ -25,6 +25,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "qtcompat.h"
+#include "variant.h"
 #include "jwt.h"
 
 static const char *test_ec_private_key_pem =
@@ -83,9 +84,9 @@ static const char *test_rsa_public_key_pem =
 
 static void validToken()
 {
-	QVariant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("secret"));
+	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("secret"));
 	TEST_ASSERT(typeId(vclaim) == QMetaType::QVariantMap);
-	QVariantMap claim = vclaim.toMap();
+	VariantMap claim = vclaim.toMap();
 	TEST_ASSERT(claim.value("foo") == "bar");
 }
 
@@ -96,15 +97,15 @@ static void validTokenBinaryKey()
 	key += 0x61;
 	key += 0x80;
 	key += 0xfe;
-	QVariant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.-eLxyGEITnd6IP4WvGJx9CmIOt--Qcs3LB6wblJ7KXI", Jwt::DecodingKey::fromSecret(key));
+	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.-eLxyGEITnd6IP4WvGJx9CmIOt--Qcs3LB6wblJ7KXI", Jwt::DecodingKey::fromSecret(key));
 	TEST_ASSERT(typeId(vclaim) == QMetaType::QVariantMap);
-	QVariantMap claim = vclaim.toMap();
+	VariantMap claim = vclaim.toMap();
 	TEST_ASSERT(claim.value("foo") == "bar");
 }
 
 static void invalidKey()
 {
-	QVariant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("wrong"));
+	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("wrong"));
 	TEST_ASSERT(vclaim.isNull());
 }
 
@@ -118,7 +119,7 @@ static void es256EncodeDecode()
 	TEST_ASSERT(!publicKey.isNull());
 	TEST_ASSERT_EQ(publicKey.type(), Jwt::KeyType::Ec);
 
-	QVariantMap claim;
+	VariantMap claim;
 	claim["iss"] = "nobody";
 
 	QByteArray claimJson = QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
@@ -135,7 +136,7 @@ static void es256EncodeDecode()
 	TEST_ASSERT(error.error == QJsonParseError::NoError);
 	TEST_ASSERT(doc.isObject());
 
-	QVariantMap result = doc.object().toVariantMap();
+	VariantMap result = doc.object().toVariantMap();
 	TEST_ASSERT_EQ(result["iss"], "nobody");
 }
 
@@ -149,7 +150,7 @@ static void rs256EncodeDecode()
 	TEST_ASSERT(!publicKey.isNull());
 	TEST_ASSERT_EQ(publicKey.type(), Jwt::KeyType::Rsa);
 
-	QVariantMap claim;
+	VariantMap claim;
 	claim["iss"] = "nobody";
 
 	QByteArray claimJson = QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
@@ -166,7 +167,7 @@ static void rs256EncodeDecode()
 	TEST_ASSERT(error.error == QJsonParseError::NoError);
 	TEST_ASSERT(doc.isObject());
 
-	QVariantMap result = doc.object().toVariantMap();
+	VariantMap result = doc.object().toVariantMap();
 	TEST_ASSERT_EQ(result["iss"], "nobody");
 }
 

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include "qtcompat.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "log.h"
 
 #define MAX_DATA_LENGTH 1000
@@ -66,7 +67,7 @@ static QString makeLastIdsStr(const HttpHeaders &headers)
 	return out;
 }
 
-static void logPacket(int level, const QString &message, const QVariant &data = QVariant(), int dataMax = -1, const QByteArray &content = QByteArray(), int contentMax = -1)
+static void logPacket(int level, const QString &message, const Variant &data = Variant(), int dataMax = -1, const QByteArray &content = QByteArray(), int contentMax = -1)
 {
 	QString out = message;
 
@@ -79,31 +80,31 @@ static void logPacket(int level, const QString &message, const QVariant &data = 
 	{
 		out += ' ' + QString::number(content.size()) + ' ';
 		QByteArray buf = trim(content, contentMax);
-		out += TnetString::variantToString(QVariant(buf), -1);
+		out += TnetString::variantToString(Variant(buf), -1);
 	}
 
 	log(level, "%s", qPrintable(out));
 }
 
-static void logPacket(int level, const QVariant &data, const char *fmt, va_list ap)
+static void logPacket(int level, const Variant &data, const char *fmt, va_list ap)
 {
 	logPacket(level, QString::vasprintf(fmt, ap), data, MAX_DATA_LENGTH);
 }
 
 static void logPacket(int level, const QByteArray &content, const char *fmt, va_list ap)
 {
-	logPacket(level, QString::vasprintf(fmt, ap), QVariant(), -1, content, MAX_CONTENT_LENGTH);
+	logPacket(level, QString::vasprintf(fmt, ap), Variant(), -1, content, MAX_CONTENT_LENGTH);
 }
 
-static void logPacket(int level, const QVariant &data, const QString &contentField, const char *fmt, va_list ap)
+static void logPacket(int level, const Variant &data, const QString &contentField, const char *fmt, va_list ap)
 {
-	QVariant meta;
+	Variant meta;
 	QByteArray content;
 
 	if(typeId(data) == QMetaType::QVariantHash)
 	{
 		// Extract content. Meta is the remaining data
-		QVariantHash hdata = data.toHash();
+		VariantHash hdata = data.toHash();
 		content = hdata.value(contentField).toByteArray();
 		hdata.remove(contentField);
 		meta = hdata;
@@ -118,7 +119,7 @@ static void logPacket(int level, const QVariant &data, const QString &contentFie
 	logPacket(level, QString::vasprintf(fmt, ap), meta, MAX_DATA_LENGTH, content, MAX_CONTENT_LENGTH);
 }
 
-void logVariant(int level, const QVariant &data, const char *fmt, ...)
+void logVariant(int level, const Variant &data, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
@@ -134,7 +135,7 @@ void logByteArray(int level, const QByteArray &content, const char *fmt, ...)
 	va_end(ap);
 }
 
-void logVariantWithContent(int level, const QVariant &data, const QString &contentField, const char *fmt, ...)
+void logVariantWithContent(int level, const Variant &data, const QString &contentField, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);

--- a/src/core/logutil.h
+++ b/src/core/logutil.h
@@ -26,6 +26,7 @@
 
 #include <QHostAddress>
 #include "log.h"
+#include "variant.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 
@@ -88,9 +89,9 @@ public:
 	}
 };
 
-void logVariant(int level, const QVariant &data, const char *fmt, ...);
+void logVariant(int level, const Variant &data, const char *fmt, ...);
 void logByteArray(int level, const QByteArray &content, const char *fmt, ...);
-void logVariantWithContent(int level, const QVariant &data, const QString &contentField, const char *fmt, ...);
+void logVariantWithContent(int level, const Variant &data, const QString &contentField, const char *fmt, ...);
 void logRequest(int level, const RequestData &data, const Config &config = Config());
 void logForRoute(const RouteInfo &routeInfo, const char *fmt, ...);
 

--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -24,6 +24,7 @@
 #include "retryrequestpacket.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
 RetryRequestPacket::RetryRequestPacket() :
 	haveInspectInfo(false),
@@ -31,16 +32,16 @@ RetryRequestPacket::RetryRequestPacket() :
 {
 }
 
-QVariant RetryRequestPacket::toVariant() const
+Variant RetryRequestPacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
-	QVariantList vrequests;
+	VariantList vrequests;
 	foreach(const Request &r, requests)
 	{
-		QVariantHash vrequest;
+		VariantHash vrequest;
 
-		QVariantHash vrid;
+		VariantHash vrid;
 		vrid["sender"] = r.rid.first;
 		vrid["id"] = r.rid.second;
 
@@ -82,18 +83,18 @@ QVariant RetryRequestPacket::toVariant() const
 
 	obj["requests"] = vrequests;
 
-	QVariantHash vrequestData;
+	VariantHash vrequestData;
 
 	vrequestData["method"] = requestData.method.toLatin1();
 	vrequestData["uri"] = requestData.uri.toEncoded();
 
-	QVariantList vheaders;
+	VariantList vheaders;
 	foreach(const HttpHeader &h, requestData.headers)
 	{
-		QVariantList vheader;
+		VariantList vheader;
 		vheader += h.first.asQByteArray();
 		vheader += h.second.asQByteArray();
-		vheaders += QVariant(vheader);
+		vheaders += Variant(vheader);
 	}
 	vrequestData["headers"] = vheaders;
 
@@ -103,7 +104,7 @@ QVariant RetryRequestPacket::toVariant() const
 
 	if(haveInspectInfo)
 	{
-		QVariantHash vinspect;
+		VariantHash vinspect;
 
 		vinspect["no-proxy"] = !inspectInfo.doProxy;
 
@@ -115,7 +116,7 @@ QVariant RetryRequestPacket::toVariant() const
 
 		if(!inspectInfo.lastIds.isEmpty())
 		{
-			QVariantHash vlastIds;
+			VariantHash vlastIds;
 
 			QHashIterator<QByteArray, QByteArray> it(inspectInfo.lastIds);
 			while(it.hasNext())
@@ -143,30 +144,30 @@ QVariant RetryRequestPacket::toVariant() const
 	return obj;
 }
 
-bool RetryRequestPacket::fromVariant(const QVariant &in)
+bool RetryRequestPacket::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(!obj.contains("requests") || typeId(obj["requests"]) != QMetaType::QVariantList)
 		return false;
 
 	requests.clear();
-	foreach(const QVariant &i, obj["requests"].toList())
+	foreach(const Variant &i, obj["requests"].toList())
 	{
 		if(typeId(i) != QMetaType::QVariantHash)
 			return false;
 
-		QVariantHash vrequest = i.toHash();
+		VariantHash vrequest = i.toHash();
 
 		Request r;
 
 		if(!vrequest.contains("rid") || typeId(vrequest["rid"]) != QMetaType::QVariantHash)
 			return false;
 
-		QVariantHash vrid = vrequest["rid"].toHash();
+		VariantHash vrid = vrequest["rid"].toHash();
 
 		QByteArray sender, id;
 
@@ -266,7 +267,7 @@ bool RetryRequestPacket::fromVariant(const QVariant &in)
 
 	if(!obj.contains("request-data") || typeId(obj["request-data"]) != QMetaType::QVariantHash)
 		return false;
-	QVariantHash vrequestData = obj["request-data"].toHash();
+	VariantHash vrequestData = obj["request-data"].toHash();
 
 	if(!vrequestData.contains("method") || typeId(vrequestData["method"]) != QMetaType::QByteArray)
 		return false;
@@ -282,9 +283,9 @@ bool RetryRequestPacket::fromVariant(const QVariant &in)
 		if(typeId(vrequestData["headers"]) != QMetaType::QVariantList)
 			return false;
 
-		foreach(const QVariant &i, vrequestData["headers"].toList())
+		foreach(const Variant &i, vrequestData["headers"].toList())
 		{
-			QVariantList list = i.toList();
+			VariantList list = i.toList();
 			if(list.count() != 2)
 				return false;
 
@@ -303,7 +304,7 @@ bool RetryRequestPacket::fromVariant(const QVariant &in)
 	{
 		if(typeId(obj["inspect"]) != QMetaType::QVariantHash)
 			return false;
-		QVariantHash vinspect = obj["inspect"].toHash();
+		VariantHash vinspect = obj["inspect"].toHash();
 
 		if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != QMetaType::Bool)
 			return false;
@@ -331,8 +332,8 @@ bool RetryRequestPacket::fromVariant(const QVariant &in)
 			if(typeId(vinspect["last-ids"]) != QMetaType::QVariantHash)
 				return false;
 
-			QVariantHash vlastIds = vinspect["last-ids"].toHash();
-			QHashIterator<QString, QVariant> it(vlastIds);
+			VariantHash vlastIds = vinspect["last-ids"].toHash();
+			QHashIterator<QString, Variant> it(vlastIds);
 			while(it.hasNext())
 			{
 				it.next();

--- a/src/core/packet/retryrequestpacket.h
+++ b/src/core/packet/retryrequestpacket.h
@@ -24,7 +24,7 @@
 #ifndef RETRYREQUESTPACKET_H
 #define RETRYREQUESTPACKET_H
 
-#include <QVariant>
+#include "variant.h"
 #include <QHostAddress>
 #include "httprequestdata.h"
 
@@ -50,7 +50,7 @@ public:
 		int outSeq;
 		int outCredits;
 		bool routerResp;
-		QVariant userData;
+		Variant userData;
 
 		Request() :
 			https(false),
@@ -73,7 +73,7 @@ public:
 		QByteArray sharingKey;
 		QByteArray sid;
 		QHash<QByteArray, QByteArray> lastIds;
-		QVariant userData;
+		Variant userData;
 
 		InspectInfo() :
 			doProxy(false)
@@ -92,8 +92,8 @@ public:
 
 	RetryRequestPacket();
 
-	QVariant toVariant() const;
-	bool fromVariant(const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/packet/statspacket.cpp
+++ b/src/core/packet/statspacket.cpp
@@ -24,8 +24,9 @@
 #include "statspacket.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
-static bool tryGetInt(const QVariantHash &obj, const QString &name, int *result)
+static bool tryGetInt(const VariantHash &obj, const QString &name, int *result)
 {
 	if(obj.contains(name))
 	{
@@ -38,9 +39,9 @@ static bool tryGetInt(const QVariantHash &obj, const QString &name, int *result)
 	return true;
 }
 
-QVariant StatsPacket::toVariant() const
+Variant StatsPacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	if(!from.isEmpty())
 		obj["from"] = from;
@@ -174,12 +175,12 @@ QVariant StatsPacket::toVariant() const
 	return obj;
 }
 
-bool StatsPacket::fromVariant(const QByteArray &_type, const QVariant &in)
+bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(obj.contains("from"))
 	{

--- a/src/core/packet/statspacket.h
+++ b/src/core/packet/statspacket.h
@@ -25,7 +25,7 @@
 #define STATSPACKET_H
 
 #include <QByteArray>
-#include <QVariant>
+#include "variant.h"
 #include <QHostAddress>
 
 class StatsPacket
@@ -121,8 +121,8 @@ public:
 	{
 	}
 
-	QVariant toVariant() const;
-	bool fromVariant(const QByteArray &type, const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const QByteArray &type, const Variant &in);
 };
 
 #endif

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -25,6 +25,7 @@
 
 #include <assert.h>
 #include "qtcompat.h"
+#include "variant.h"
 
 // FIXME: rewrite packet class using this code?
 /*class WsControlPacket
@@ -50,7 +51,7 @@ public:
 	QString channelPrefix;
 	QList<Message> messages;
 
-	static WsControlPacket fromVariant(const QVariant &in, bool *ok = 0, QString *errorMessage = 0)
+	static WsControlPacket fromVariant(const Variant &in, bool *ok = 0, QString *errorMessage = 0)
 	{
 		QString pn = "wscontrol packet";
 
@@ -63,7 +64,7 @@ public:
 		pn = "wscontrol object";
 
 		bool ok_;
-		QVariantList vitems = getList(in, pn, "items", false, &ok_, errorMessage);
+		VariantList vitems = getList(in, pn, "items", false, &ok_, errorMessage);
 		if(!ok_)
 		{
 			if(ok)
@@ -73,7 +74,7 @@ public:
 
 		WsControlPacket out;
 
-		foreach(const QVariant &vitem, vitems)
+		foreach(const Variant &vitem, vitems)
 		{
 			Message msg;
 
@@ -133,8 +134,8 @@ public:
 					return WsControlPacket();
 				}
 
-				QVariant vmessage = keyedObjectGetValue(vitem, "message");
-				if(vmessage.type() != QVariant::ByteArray)
+				Variant vmessage = keyedObjectGetValue(vitem, "message");
+				if(vmessage.type() != Variant::ByteArray)
 				{
 					setError(ok, errorMessage, QString("'%1' contains 'message' with wrong type").arg(pn));
 					return WsControlPacket();
@@ -151,16 +152,16 @@ public:
 	}
 };*/
 
-QVariant WsControlPacket::toVariant() const
+Variant WsControlPacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	obj["from"] = from;
 
-	QVariantList vitems;
+	VariantList vitems;
 	foreach(const Item &item, items)
 	{
-		QVariantHash vitem;
+		VariantHash vitem;
 
 		vitem["cid"] = item.cid;
 
@@ -243,12 +244,12 @@ QVariant WsControlPacket::toVariant() const
 	return obj;
 }
 
-bool WsControlPacket::fromVariant(const QVariant &in)
+bool WsControlPacket::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(!obj.contains("from") || typeId(obj["from"]) != QMetaType::QByteArray)
 		return false;
@@ -258,15 +259,15 @@ bool WsControlPacket::fromVariant(const QVariant &in)
 	if(!obj.contains("items") || typeId(obj["items"]) != QMetaType::QVariantList)
 		return false;
 
-	QVariantList vitems = obj["items"].toList();
+	VariantList vitems = obj["items"].toList();
 
 	items.clear();
-	foreach(const QVariant &v, vitems)
+	foreach(const Variant &v, vitems)
 	{
 		if(typeId(v) != QMetaType::QVariantHash)
 			return false;
 
-		QVariantHash vitem = v.toHash();
+		VariantHash vitem = v.toHash();
 
 		Item item;
 

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -26,7 +26,7 @@
 
 #include <QByteArray>
 #include <QList>
-#include <QVariant>
+#include "variant.h"
 #include <QUrl>
 
 class WsControlPacket
@@ -89,8 +89,8 @@ public:
 	QByteArray from;
 	QList<Item> items;
 
-	QVariant toVariant() const;
-	bool fromVariant(const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/packet/zrpcrequestpacket.cpp
+++ b/src/core/packet/zrpcrequestpacket.cpp
@@ -24,10 +24,11 @@
 #include "zrpcrequestpacket.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
-QVariant ZrpcRequestPacket::toVariant() const
+Variant ZrpcRequestPacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	if(!from.isEmpty())
 		obj["from"] = from;
@@ -43,12 +44,12 @@ QVariant ZrpcRequestPacket::toVariant() const
 	return obj;
 }
 
-bool ZrpcRequestPacket::fromVariant(const QVariant &in)
+bool ZrpcRequestPacket::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(obj.contains("from"))
 	{

--- a/src/core/packet/zrpcrequestpacket.h
+++ b/src/core/packet/zrpcrequestpacket.h
@@ -25,7 +25,7 @@
 #define ZRPCREQUESTPACKET_H
 
 #include <QByteArray>
-#include <QVariant>
+#include "variant.h"
 
 class ZrpcRequestPacket
 {
@@ -33,10 +33,10 @@ public:
 	QByteArray from;
 	QByteArray id;
 	QString method;
-	QVariantHash args;
+	VariantHash args;
 
-	QVariant toVariant() const;
-	bool fromVariant(const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/packet/zrpcresponsepacket.cpp
+++ b/src/core/packet/zrpcresponsepacket.cpp
@@ -24,10 +24,11 @@
 #include "zrpcresponsepacket.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
-QVariant ZrpcResponsePacket::toVariant() const
+Variant ZrpcResponsePacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	if(!id.isEmpty())
 		obj["id"] = id;
@@ -57,12 +58,12 @@ QVariant ZrpcResponsePacket::toVariant() const
 	return obj;
 }
 
-bool ZrpcResponsePacket::fromVariant(const QVariant &in)
+bool ZrpcResponsePacket::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(obj.contains("id"))
 	{

--- a/src/core/packet/zrpcresponsepacket.h
+++ b/src/core/packet/zrpcresponsepacket.h
@@ -24,14 +24,14 @@
 #define ZRPCRESPONSEPACKET_H
 
 #include <QByteArray>
-#include <QVariant>
+#include "variant.h"
 
 class ZrpcResponsePacket
 {
 public:
 	QByteArray id;
 	bool success;
-	QVariant value;
+	Variant value;
 	QByteArray condition;
 
 	ZrpcResponsePacket() :
@@ -39,8 +39,8 @@ public:
 	{
 	}
 
-	QVariant toVariant() const;
-	bool fromVariant(const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/qtcompat.h
+++ b/src/core/qtcompat.h
@@ -20,6 +20,9 @@
  * $FANOUT_END_LICENSE$
  */
 
+#ifndef QTCOMPAT_H
+#define QTCOMPAT_H
+
 #include <QMetaType>
 #include <QVariant>
 
@@ -40,3 +43,5 @@ inline bool canConvert(const QVariant &v, QMetaType::Type type)
     return v.canConvert(type);
 #endif
 }
+
+#endif

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -28,6 +28,7 @@
 #include <QFileInfo>
 #include <QSettings>
 #include "qtcompat.h"
+#include "variant.h"
 #include "config.h"
 
 Settings::Settings(const QString &fileName) :
@@ -137,7 +138,7 @@ bool Settings::contains(const QString &key) const
 	return false;
 }
 
-QVariant Settings::valueRaw(const QString &key, const QVariant &defaultValue) const
+Variant Settings::valueRaw(const QString &key, const Variant &defaultValue) const
 {
 	if(include_)
 	{
@@ -150,9 +151,9 @@ QVariant Settings::valueRaw(const QString &key, const QVariant &defaultValue) co
 		return main_->value(key, defaultValue);
 }
 
-QVariant Settings::value(const QString &key, const QVariant &defaultValue) const
+Variant Settings::value(const QString &key, const Variant &defaultValue) const
 {
-	QVariant v = valueRaw(key, defaultValue);
+	Variant v = valueRaw(key, defaultValue);
 	if(v.isValid())
 	{
 		if(typeId(v) == QMetaType::QString)
@@ -174,7 +175,7 @@ QVariant Settings::value(const QString &key, const QVariant &defaultValue) const
 
 int Settings::adjustedPort(const QString &key, int defaultValue) const
 {
-	int x = value(key, QVariant(defaultValue)).toInt();
+	int x = value(key, Variant(defaultValue)).toInt();
 	if(x > 0)
 		x += portOffset_;
 	return x;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -24,7 +24,7 @@
 #define SETTINGS_H
 
 #include <QString>
-#include <QVariant>
+#include "variant.h"
 
 class QSettings;
 
@@ -36,8 +36,8 @@ public:
 	~Settings();
 
 	bool contains(const QString &key) const;
-	QVariant valueRaw(const QString &key, const QVariant &defaultValue = QVariant()) const;
-	QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
+	Variant valueRaw(const QString &key, const Variant &defaultValue = Variant()) const;
+	Variant value(const QString &key, const Variant &defaultValue = Variant()) const;
 	int adjustedPort(const QString &key, int defaultValue = -1) const;
 
 	QString ipcPrefix() const;

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -33,6 +33,7 @@
 #include "log.h"
 #include "defercall.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "httpheaders.h"
 #include "simplehttpserver.h"
 #include "zutil.h"
@@ -867,7 +868,7 @@ public:
 		else // ConnectionsMax
 			prefix = "conn-max";
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 
 		QByteArray buf;
 		if(outputFormat == TnetStringFormat)
@@ -1540,15 +1541,15 @@ private:
 
 		foreach(const PrometheusMetric &m, prometheusMetrics)
 		{
-			QVariant value;
+			Variant value;
 
 			switch(m.mtype)
 			{
-				case PrometheusMetric::RequestReceived: value = QVariant(combinedReport.requestsReceived); break;
-				case PrometheusMetric::ConnectionConnected: value = QVariant(combinedReport.connectionsMax); break;
-				case PrometheusMetric::ConnectionMinute: value = QVariant(combinedReport.connectionsMinutes); break;
-				case PrometheusMetric::MessageReceived: value = QVariant(combinedReport.messagesReceived); break;
-				case PrometheusMetric::MessageSent: value = QVariant(combinedReport.messagesSent); break;
+				case PrometheusMetric::RequestReceived: value = Variant(combinedReport.requestsReceived); break;
+				case PrometheusMetric::ConnectionConnected: value = Variant(combinedReport.connectionsMax); break;
+				case PrometheusMetric::ConnectionMinute: value = Variant(combinedReport.connectionsMinutes); break;
+				case PrometheusMetric::MessageReceived: value = Variant(combinedReport.messagesReceived); break;
+				case PrometheusMetric::MessageSent: value = Variant(combinedReport.messagesSent); break;
 			}
 
 			if(value.isNull())

--- a/src/core/statusreasons.cpp
+++ b/src/core/statusreasons.cpp
@@ -23,6 +23,7 @@
 #include "statusreasons.h"
 
 #include <QByteArray>
+#include "variant.h"
 
 namespace StatusReasons {
 

--- a/src/core/tnetstring.cpp
+++ b/src/core/tnetstring.cpp
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include "cowbytearray.h"
 #include "qtcompat.h"
+#include "variant.h"
 
 namespace TnetString {
 
@@ -55,7 +56,7 @@ QByteArray fromNull()
 	return QByteArray("0:~");
 }
 
-QByteArray fromVariant(const QVariant &in)
+QByteArray fromVariant(const Variant &in)
 {
 	switch(typeId(in))
 	{
@@ -81,10 +82,10 @@ QByteArray fromVariant(const QVariant &in)
 	}
 }
 
-QByteArray fromHash(const QVariantHash &in)
+QByteArray fromHash(const VariantHash &in)
 {
 	QByteArray val;
-	QHashIterator<QString, QVariant> it(in);
+	QHashIterator<QString, Variant> it(in);
 	while(it.hasNext())
 	{
 		it.next();
@@ -94,10 +95,10 @@ QByteArray fromHash(const QVariantHash &in)
 	return QByteArray::number(val.size()) + ':' + val + '}';
 }
 
-QByteArray fromList(const QVariantList &in)
+QByteArray fromList(const VariantList &in)
 {
 	QByteArray val;
-	foreach(const QVariant &v, in)
+	foreach(const Variant &v, in)
 		val += fromVariant(v);
 	return QByteArray::number(val.size()) + ':' + val + ']';
 }
@@ -198,9 +199,9 @@ void toNull(const QByteArray &in, int offset, int dataOffset, int dataSize, bool
 	*ok = true;
 }
 
-QVariant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok)
+Variant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok)
 {
-	QVariant val;
+	Variant val;
 	bool ok_ = false;
 	switch(type)
 	{
@@ -231,7 +232,7 @@ QVariant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, 
 	{
 		if(ok)
 			*ok = false;
-		return QVariant();
+		return Variant();
 	}
 
 	if(ok)
@@ -239,7 +240,7 @@ QVariant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, 
 	return val;
 }
 
-QVariant toVariant(const QByteArray &in, int offset, bool *ok)
+Variant toVariant(const QByteArray &in, int offset, bool *ok)
 {
 	Type type;
 	int dataOffset;
@@ -248,22 +249,22 @@ QVariant toVariant(const QByteArray &in, int offset, bool *ok)
 	{
 		if(ok)
 			*ok = false;
-		return QVariant();
+		return Variant();
 	}
 
 	return toVariant(in, offset, type, dataOffset, dataSize, ok);
 }
 
-QVariant toVariant(const CowByteArray &in, int offset, bool *ok)
+Variant toVariant(const CowByteArray &in, int offset, bool *ok)
 {
 	return toVariant(in.asQByteArray(), offset, ok);
 }
 
-QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
+VariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
 {
 	Q_UNUSED(offset);
 
-	QVariantHash out;
+	VariantHash out;
 
 	int at = dataOffset;
 	while(at < dataSize + dataOffset)
@@ -275,14 +276,14 @@ QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSi
 		{
 			if(ok)
 				*ok = false;
-			return QVariantHash();
+			return VariantHash();
 		}
 
 		if(itype != ByteArray)
 		{
 			if(ok)
 				*ok = false;
-			return QVariantHash();
+			return VariantHash();
 		}
 
 		bool ok_;
@@ -291,7 +292,7 @@ QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSi
 		{
 			if(ok)
 				*ok = false;
-			return QVariantHash();
+			return VariantHash();
 		}
 
 		at = ioffset + isize + 1; // Position to value
@@ -300,15 +301,15 @@ QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSi
 		{
 			if(ok)
 				*ok = false;
-			return QVariantHash();
+			return VariantHash();
 		}
 
-		QVariant val = toVariant(in, at, itype, ioffset, isize, &ok_);
+		Variant val = toVariant(in, at, itype, ioffset, isize, &ok_);
 		if(!ok_)
 		{
 			if(ok)
 				*ok = false;
-			return QVariantHash();
+			return VariantHash();
 		}
 
 		out[QString::fromUtf8(key)] = val;
@@ -320,11 +321,11 @@ QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSi
 	return out;
 }
 
-QVariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
+VariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
 {
 	Q_UNUSED(offset);
 
-	QVariantList out;
+	VariantList out;
 
 	int at = dataOffset;
 	while(at < dataOffset + dataSize)
@@ -336,16 +337,16 @@ QVariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSi
 		{
 			if(ok)
 				*ok = false;
-			return QVariantList();
+			return VariantList();
 		}
 
 		bool ok_;
-		QVariant val = toVariant(in, at, itype, ioffset, isize, &ok_);
+		Variant val = toVariant(in, at, itype, ioffset, isize, &ok_);
 		if(!ok_)
 		{
 			if(ok)
 				*ok = false;
-			return QVariantList();
+			return VariantList();
 		}
 
 		out += val;
@@ -377,14 +378,14 @@ QString byteArrayToEscapedString(const QByteArray &in)
 	return out;
 }
 
-QString variantToString(const QVariant &in, int indent)
+QString variantToString(const Variant &in, int indent)
 {
 	QString out;
 
 	QMetaType::Type type = typeId(in);
 	if(type == QMetaType::QVariantHash)
 	{
-		QVariantHash hash = in.toHash();
+		VariantHash hash = in.toHash();
 
 		out += '{';
 		if(indent >= 0)
@@ -392,7 +393,7 @@ QString variantToString(const QVariant &in, int indent)
 		else
 			out += ' ';
 
-		QHashIterator<QString, QVariant> it(hash);
+		QHashIterator<QString, Variant> it(hash);
 		while(it.hasNext())
 		{
 			it.next();
@@ -416,7 +417,7 @@ QString variantToString(const QVariant &in, int indent)
 	}
 	else if(type == QMetaType::QVariantList)
 	{
-		QVariantList list = in.toList();
+		VariantList list = in.toList();
 
 		out += '[';
 		if(indent >= 0)

--- a/src/core/tnetstring.h
+++ b/src/core/tnetstring.h
@@ -21,7 +21,7 @@
 #ifndef TNETSTRING_H
 #define TNETSTRING_H
 
-#include <QVariant>
+#include "variant.h"
 
 class CowByteArray;
 
@@ -43,9 +43,9 @@ QByteArray fromInt(int64_t in);
 QByteArray fromDouble(double in);
 QByteArray fromBool(bool in);
 QByteArray fromNull();
-QByteArray fromHash(const QVariantHash &in);
-QByteArray fromList(const QVariantList &in);
-QByteArray fromVariant(const QVariant &in);
+QByteArray fromHash(const VariantHash &in);
+QByteArray fromList(const VariantList &in);
+QByteArray fromVariant(const Variant &in);
 
 bool check(const QByteArray &in, int offset, Type *type, int *dataOffset, int *dataSize);
 QByteArray toByteArray(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
@@ -53,16 +53,16 @@ int64_t toInt(const QByteArray &in, int offset, int dataOffset, int dataSize, bo
 double toDouble(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 bool toBool(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 void toNull(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
-QVariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
-QVariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
-QVariant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok = 0);
-QVariant toVariant(const QByteArray &in, int offset = 0, bool *ok = 0);
-QVariant toVariant(const CowByteArray &in, int offset = 0, bool *ok = 0);
+VariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
+VariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
+Variant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok = 0);
+Variant toVariant(const QByteArray &in, int offset = 0, bool *ok = 0);
+Variant toVariant(const CowByteArray &in, int offset = 0, bool *ok = 0);
 
 QString byteArrayToEscapedString(const QByteArray &in);
 
 // Pass >= 0 for pretty print, -1 for compact
-QString variantToString(const QVariant &in, int indent = 0);
+QString variantToString(const Variant &in, int indent = 0);
 
 }
 

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -30,6 +30,7 @@
 #include "zmqsocket.h"
 #include "zmqvalve.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
 #include "log.h"
@@ -368,7 +369,7 @@ public:
 		assert(client_out_sock || client_req_sock);
 		const char *logprefix = logPrefixForType(type);
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
 
 		if(client_out_sock)
@@ -392,7 +393,7 @@ public:
 		assert(client_out_stream_sock);
 		const char *logprefix = logPrefixForType(type);
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -410,7 +411,7 @@ public:
 		assert(server_out_sock);
 		const char *logprefix = logPrefixForType(type);
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 
 		if(routerResp)
 		{
@@ -552,7 +553,7 @@ public:
 				continue;
 			}
 
-			QVariant data = TnetString::toVariant(dataRaw.mid(1));
+			Variant data = TnetString::toVariant(dataRaw.mid(1));
 			if(data.isNull())
 			{
 				log_warning("zhttp/zws client req: received message with invalid format (tnetstring parse failed), skipping");
@@ -601,7 +602,7 @@ public:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(msg.mid(1));
+		Variant data = TnetString::toVariant(msg.mid(1));
 		if(data.isNull())
 		{
 			log_warning("zhttp/zws client: received message with invalid format (tnetstring parse failed), skipping");
@@ -705,7 +706,7 @@ public:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(msg[0].mid(1));
+		Variant data = TnetString::toVariant(msg[0].mid(1));
 		if(data.isNull())
 		{
 			log_warning("zhttp/zws server: received message with invalid format (tnetstring parse failed), skipping");
@@ -819,7 +820,7 @@ public:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(msg[2].mid(1));
+		Variant data = TnetString::toVariant(msg[2].mid(1));
 		if(data.isNull())
 		{
 			log_warning("zhttp/zws server: received message with invalid format (tnetstring parse failed), skipping");

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -29,6 +29,7 @@
 #include "bufferlist.h"
 #include "log.h"
 #include "timer.h"
+#include "variant.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
 #include "uuidutil.h"
@@ -75,7 +76,7 @@ public:
 	QString clientCert;
 	QString clientKey;
 	bool sendBodyAfterAck;
-	QVariant passthrough;
+	Variant passthrough;
 	QString requestMethod;
 	QUrl requestUri;
 	HttpHeaders requestHeaders;
@@ -91,7 +92,7 @@ public:
 	QByteArray responseReason;
 	HttpHeaders responseHeaders;
 	BufferList responseBodyBuf;
-	QVariant userData;
+	Variant userData;
 	bool pausing;
 	bool paused;
 	bool pendingUpdate;
@@ -1199,7 +1200,7 @@ ZhttpRequest::Rid ZhttpRequest::rid() const
 	return d->rid;
 }
 
-QVariant ZhttpRequest::passthroughData() const
+Variant ZhttpRequest::passthroughData() const
 {
 	return d->passthrough;
 }
@@ -1255,7 +1256,7 @@ void ZhttpRequest::setSendBodyAfterAcknowledgement(bool on)
 	d->sendBodyAfterAck = on;
 }
 
-void ZhttpRequest::setPassthroughData(const QVariant &data)
+void ZhttpRequest::setPassthroughData(const Variant &data)
 {
 	d->passthrough = data;
 }

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -24,7 +24,7 @@
 #ifndef ZHTTPREQUEST_H
 #define ZHTTPREQUEST_H
 
-#include <QVariant>
+#include "variant.h"
 #include "httprequest.h"
 #include <boost/signals2.hpp>
 
@@ -56,7 +56,7 @@ public:
 		int outSeq;
 		int outCredits;
 		bool routerResp;
-		QVariant userData;
+		Variant userData;
 
 		ServerState() :
 			responseCode(-1),
@@ -71,10 +71,10 @@ public:
 	~ZhttpRequest();
 
 	Rid rid() const;
-	QVariant passthroughData() const;
+	Variant passthroughData() const;
 	void setIsTls(bool on); // Updates scheme
 	void setSendBodyAfterAcknowledgement(bool on); // Only works in push/sub mode
-	void setPassthroughData(const QVariant &data);
+	void setPassthroughData(const Variant &data);
 	void setQuiet(bool on);
 
 	// For server requests only

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -23,11 +23,12 @@
 
 #include <stdio.h>
 #include "qtcompat.h"
+#include "variant.h"
 #include "tnetstring.h"
 
-QVariant ZhttpRequestPacket::toVariant() const
+Variant ZhttpRequestPacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	if(!from.isEmpty())
 		obj["from"] = from.asQByteArray();
@@ -44,10 +45,10 @@ QVariant ZhttpRequestPacket::toVariant() const
 		}
 		else
 		{
-			QVariantList vl;
+			VariantList vl;
 			foreach(const Id &id, ids)
 			{
-				QVariantHash vh;
+				VariantHash vh;
 				if(!id.id.isEmpty())
 					vh["id"] = id.id.asQByteArray();
 				if(id.seq != -1)
@@ -105,13 +106,13 @@ QVariant ZhttpRequestPacket::toVariant() const
 
 	if(!headers.isEmpty())
 	{
-		QVariantList vheaders;
+		VariantList vheaders;
 		foreach(const HttpHeader &h, headers)
 		{
-			QVariantList vheader;
+			VariantList vheader;
 			vheader += h.first.asQByteArray();
 			vheader += h.second.asQByteArray();
-			vheaders += QVariant(vheader);
+			vheaders += Variant(vheader);
 		}
 
 		obj["headers"] = vheaders;
@@ -164,7 +165,7 @@ QVariant ZhttpRequestPacket::toVariant() const
 
 	if(multi || quiet)
 	{
-		QVariantHash ext;
+		VariantHash ext;
 
 		if(multi)
 			ext["multi"] = true;
@@ -178,12 +179,12 @@ QVariant ZhttpRequestPacket::toVariant() const
 	return obj;
 }
 
-bool ZhttpRequestPacket::fromVariant(const QVariant &in)
+bool ZhttpRequestPacket::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	from.clear();
 	if(obj.contains("from"))
@@ -205,15 +206,15 @@ bool ZhttpRequestPacket::fromVariant(const QVariant &in)
 		}
 		else if(typeId(obj["id"]) == QMetaType::QVariantList)
 		{
-			QVariantList vl = obj["id"].toList();
-			foreach(const QVariant &v, vl)
+			VariantList vl = obj["id"].toList();
+			foreach(const Variant &v, vl)
 			{
 				if(typeId(v) != QMetaType::QVariantHash)
 					return false;
 
 				Id id;
 
-				QVariantHash vh = v.toHash();
+				VariantHash vh = v.toHash();
 
 				if(vh.contains("id"))
 				{
@@ -369,9 +370,9 @@ bool ZhttpRequestPacket::fromVariant(const QVariant &in)
 		if(typeId(obj["headers"]) != QMetaType::QVariantList)
 			return false;
 
-		foreach(const QVariant &i, obj["headers"].toList())
+		foreach(const Variant &i, obj["headers"].toList())
 		{
-			QVariantList list = i.toList();
+			VariantList list = i.toList();
 			if(list.count() != 2)
 				return false;
 
@@ -509,7 +510,7 @@ bool ZhttpRequestPacket::fromVariant(const QVariant &in)
 		if(typeId(obj["ext"]) != QMetaType::QVariantHash)
 			return false;
 
-		QVariantHash ext = obj["ext"].toHash();
+		VariantHash ext = obj["ext"].toHash();
 		if(ext.contains("multi") && typeId(ext["multi"]) == QMetaType::Bool)
 		{
 			multi = ext["multi"].toBool();

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -23,11 +23,11 @@
 #define ZHTTPREQUESTPACKET_H
 
 #include <QUrl>
-#include <QVariant>
 #include <QHostAddress>
 #include "cowstring.h"
 #include "cowbytearray.h"
 #include "httpheaders.h"
+#include "variant.h"
 
 class ZhttpRequestPacket
 {
@@ -85,7 +85,7 @@ public:
 	CowByteArray contentType; // WebSocket
 	int code; // WebSocket
 
-	QVariant userData;
+	Variant userData;
 
 	QHostAddress peerAddress;
 	int peerPort;
@@ -98,7 +98,7 @@ public:
 	CowString clientCert;
 	CowString clientKey;
 	bool followRedirects;
-	QVariant passthrough; // If valid, may contain pushpin-specific passthrough info
+	Variant passthrough; // If valid, may contain pushpin-specific passthrough info
 	bool multi;
 	bool quiet;
 
@@ -122,8 +122,8 @@ public:
 	{
 	}
 
-	QVariant toVariant() const;
-	bool fromVariant(const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/zhttpresponsepacket.cpp
+++ b/src/core/zhttpresponsepacket.cpp
@@ -22,10 +22,11 @@
 #include "zhttpresponsepacket.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
-QVariant ZhttpResponsePacket::toVariant() const
+Variant ZhttpResponsePacket::toVariant() const
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	if(!from.isEmpty())
 		obj["from"] = from.asQByteArray();
@@ -42,10 +43,10 @@ QVariant ZhttpResponsePacket::toVariant() const
 		}
 		else
 		{
-			QVariantList vl;
+			VariantList vl;
 			foreach(const Id &id, ids)
 			{
-				QVariantHash vh;
+				VariantHash vh;
 				if(!id.id.isEmpty())
 					vh["id"] = id.id.asQByteArray();
 				if(id.seq != -1)
@@ -90,13 +91,13 @@ QVariant ZhttpResponsePacket::toVariant() const
 		if(type == Data || (type == Error && condition == "rejected"))
 		{
 			obj["reason"] = reason.asQByteArray();
-			QVariantList vheaders;
+			VariantList vheaders;
 			foreach(const HttpHeader &h, headers)
 			{
-				QVariantList vheader;
+				VariantList vheader;
 				vheader += h.first.asQByteArray();
 				vheader += h.second.asQByteArray();
-				vheaders += QVariant(vheader);
+				vheaders += Variant(vheader);
 			}
 			obj["headers"] = vheaders;
 		}
@@ -113,7 +114,7 @@ QVariant ZhttpResponsePacket::toVariant() const
 
 	if(multi)
 	{
-		QVariantHash ext;
+		VariantHash ext;
 		ext["multi"] = true;
 		obj["ext"] = ext;
 	}
@@ -121,12 +122,12 @@ QVariant ZhttpResponsePacket::toVariant() const
 	return obj;
 }
 
-bool ZhttpResponsePacket::fromVariant(const QVariant &in)
+bool ZhttpResponsePacket::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return false;
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	from.clear();
 	if(obj.contains("from"))
@@ -148,15 +149,15 @@ bool ZhttpResponsePacket::fromVariant(const QVariant &in)
 		}
 		else if(typeId(obj["id"]) == QMetaType::QVariantList)
 		{
-			QVariantList vl = obj["id"].toList();
-			foreach(const QVariant &v, vl)
+			VariantList vl = obj["id"].toList();
+			foreach(const Variant &v, vl)
 			{
 				if(typeId(v) != QMetaType::QVariantHash)
 					return false;
 
 				Id id;
 
-				QVariantHash vh = v.toHash();
+				VariantHash vh = v.toHash();
 
 				if(vh.contains("id"))
 				{
@@ -276,9 +277,9 @@ bool ZhttpResponsePacket::fromVariant(const QVariant &in)
 		if(typeId(obj["headers"]) != QMetaType::QVariantList)
 			return false;
 
-		foreach(const QVariant &i, obj["headers"].toList())
+		foreach(const Variant &i, obj["headers"].toList())
 		{
-			QVariantList list = i.toList();
+			VariantList list = i.toList();
 			if(list.count() != 2)
 				return false;
 
@@ -315,7 +316,7 @@ bool ZhttpResponsePacket::fromVariant(const QVariant &in)
 		if(typeId(obj["ext"]) != QMetaType::QVariantHash)
 			return false;
 
-		QVariantHash ext = obj["ext"].toHash();
+		VariantHash ext = obj["ext"].toHash();
 		if(ext.contains("multi") && typeId(ext["multi"]) == QMetaType::Bool)
 		{
 			multi = ext["multi"].toBool();

--- a/src/core/zhttpresponsepacket.h
+++ b/src/core/zhttpresponsepacket.h
@@ -22,7 +22,7 @@
 #ifndef ZHTTPRESPONSEPACKET_H
 #define ZHTTPRESPONSEPACKET_H
 
-#include <QVariant>
+#include "variant.h"
 #include "cowstring.h"
 #include "cowbytearray.h"
 #include "httpheaders.h"
@@ -78,7 +78,7 @@ public:
 
 	CowByteArray contentType; // WebSocket
 
-	QVariant userData;
+	Variant userData;
 
 	bool multi;
 
@@ -91,8 +91,8 @@ public:
 	{
 	}
 
-	QVariant toVariant() const;
-	bool fromVariant(const QVariant &in);
+	Variant toVariant() const;
+	bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/zrpcmanager.cpp
+++ b/src/core/zrpcmanager.cpp
@@ -31,6 +31,7 @@
 #include "zmqreqmessage.h"
 #include "log.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "packet/zrpcrequestpacket.h"
 #include "packet/zrpcresponsepacket.h"
 #include "zrpcrequest.h"
@@ -142,7 +143,7 @@ public:
 		ZrpcRequestPacket p = packet;
 		p.from = instanceId;
 
-		QVariant vpacket = p.toVariant();
+		Variant vpacket = p.toVariant();
 		QByteArray buf = TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -155,7 +156,7 @@ public:
 	{
 		assert(serverSock);
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -182,7 +183,7 @@ public:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(message[1]);
+		Variant data = TnetString::toVariant(message[1]);
 		if(data.isNull())
 		{
 			log_warning("zrpc client: received message with invalid format (tnetstring parse failed), skipping");
@@ -219,7 +220,7 @@ public:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(req.content()[0]);
+		Variant data = TnetString::toVariant(req.content()[0]);
 		if(data.isNull())
 		{
 			log_warning("zrpc server: received message with invalid format (tnetstring parse failed), skipping");

--- a/src/core/zrpcrequest.cpp
+++ b/src/core/zrpcrequest.cpp
@@ -27,6 +27,7 @@
 #include <boost/signals2.hpp>
 #include "packet/zrpcrequestpacket.h"
 #include "packet/zrpcresponsepacket.h"
+#include "variant.h"
 #include "zrpcmanager.h"
 #include "uuidutil.h"
 #include "log.h"
@@ -44,9 +45,9 @@ public:
 	QByteArray from;
 	QByteArray id;
 	QString method;
-	QVariantHash args;
+	VariantHash args;
 	bool success;
-	QVariant result;
+	Variant result;
 	ErrorCondition condition;
 	QByteArray conditionString;
 	std::unique_ptr<Timer> timer;
@@ -81,7 +82,7 @@ public:
 		}
 	}
 
-	void respond(const QVariant &value)
+	void respond(const Variant &value)
 	{
 		ZrpcResponsePacket p;
 		p.id = id;
@@ -90,7 +91,7 @@ public:
 		manager->write(reqHeaders, p);
 	}
 
-	void respondError(const QByteArray &condition, const QVariant &value)
+	void respondError(const QByteArray &condition, const Variant &value)
 	{
 		ZrpcResponsePacket p;
 		p.id = id;
@@ -205,7 +206,7 @@ QString ZrpcRequest::method() const
 	return d->method;
 }
 
-QVariantHash ZrpcRequest::args() const
+VariantHash ZrpcRequest::args() const
 {
 	return d->args;
 }
@@ -215,7 +216,7 @@ bool ZrpcRequest::success() const
 	return d->success;
 }
 
-QVariant ZrpcRequest::result() const
+Variant ZrpcRequest::result() const
 {
 	return d->result;
 }
@@ -230,24 +231,24 @@ QByteArray ZrpcRequest::errorConditionString() const
 	return d->conditionString;
 }
 
-void ZrpcRequest::start(const QString &method, const QVariantHash &args)
+void ZrpcRequest::start(const QString &method, const VariantHash &args)
 {
 	d->method = method;
 	d->args = args;
 	d->deferCall.defer([=] { d->doStart(); });
 }
 
-void ZrpcRequest::respond(const QVariant &result)
+void ZrpcRequest::respond(const Variant &result)
 {
 	d->respond(result);
 }
 
-void ZrpcRequest::respondError(const QByteArray &condition, const QVariant &result)
+void ZrpcRequest::respondError(const QByteArray &condition, const Variant &result)
 {
 	d->respondError(condition, result);
 }
 
-void ZrpcRequest::setError(ErrorCondition condition, const QVariant &result)
+void ZrpcRequest::setError(ErrorCondition condition, const Variant &result)
 {
 	d->success = false;
 	d->condition = condition;

--- a/src/core/zrpcrequest.h
+++ b/src/core/zrpcrequest.h
@@ -24,7 +24,7 @@
 #ifndef ZRPCREQUEST_H
 #define ZRPCREQUEST_H
 
-#include <QVariant>
+#include "variant.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -50,17 +50,17 @@ public:
 	QByteArray from() const;
 	QByteArray id() const;
 	QString method() const;
-	QVariantHash args() const;
+	VariantHash args() const;
 	bool success() const;
-	QVariant result() const;
+	Variant result() const;
 	ErrorCondition errorCondition() const;
 	QByteArray errorConditionString() const;
 
-	void start(const QString &method, const QVariantHash &args = QVariantHash());
-	void respond(const QVariant &result = QVariant());
-	void respondError(const QByteArray &condition, const QVariant &result = QVariant());
+	void start(const QString &method, const VariantHash &args = VariantHash());
+	void respond(const Variant &result = Variant());
+	void respondError(const QByteArray &condition, const Variant &result = Variant());
 
-	void setError(ErrorCondition condition, const QVariant &result = QVariant());
+	void setError(ErrorCondition condition, const Variant &result = Variant());
 
 	Signal finished;
 	Signal destroyed;

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -28,6 +28,7 @@
 #include "zhttpresponsepacket.h"
 #include "log.h"
 #include "timer.h"
+#include "variant.h"
 #include "defercall.h"
 #include "zhttpmanager.h"
 #include "uuidutil.h"
@@ -79,7 +80,7 @@ public:
 	QString closeReason;
 	int peerCloseCode;
 	QString peerCloseReason;
-	QVariant userData;
+	Variant userData;
 	bool pendingUpdate;
 	bool readableChanged;
 	bool writableChanged;

--- a/src/handler/conncheckworker.cpp
+++ b/src/handler/conncheckworker.cpp
@@ -27,11 +27,12 @@
 #include "zrpcrequest.h"
 #include "controlrequest.h"
 #include "statsmanager.h"
+#include "variant.h"
 
 ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats) :
 	req_(req)
 {
-	QVariantHash args = req_->args();
+	VariantHash args = req_->args();
 
 	if(!args.contains("ids") || typeId(args["ids"]) != QMetaType::QVariantList)
 	{
@@ -39,9 +40,9 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 		return;
 	}
 
-	QVariantList vids = args["ids"].toList();
+	VariantList vids = args["ids"].toList();
 
-	foreach(const QVariant &vid, vids)
+	foreach(const Variant &vid, vids)
 	{
 		if(typeId(vid) != QMetaType::QByteArray)
 		{
@@ -80,7 +81,7 @@ void ConnCheckWorker::doFinish()
 	foreach(const QString &cid, missing_)
 		cids_.remove(cid);
 
-	QVariantList result;
+	VariantList result;
 	foreach(const QString &cid, cids_)
 		result += cid.toUtf8();
 

--- a/src/handler/controlrequest.cpp
+++ b/src/handler/controlrequest.cpp
@@ -25,6 +25,7 @@
 
 #include "packet/statspacket.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "deferred.h"
 #include "zrpcrequest.h"
 
@@ -38,11 +39,11 @@ public:
 		req = std::make_unique<ZrpcRequest>(controlClient);
 		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this));
 
-		QVariantList vcids;
+		VariantList vcids;
 		foreach(const QString &cid, cids)
 			vcids += cid.toUtf8();
 
-		QVariantHash args;
+		VariantHash args;
 		args["ids"] = vcids;
 		req->start("conncheck", args);
 	}
@@ -55,17 +56,17 @@ private:
 	{
 		if(req->success())
 		{
-			QVariant vresult = req->result();
+			Variant vresult = req->result();
 			if(typeId(vresult) != QMetaType::QVariantList)
 			{
 				setFinished(false);
 				return;
 			}
 
-			QVariantList result = vresult.toList();
+			VariantList result = vresult.toList();
 
 			CidSet out;
-			foreach(const QVariant &vcid, result)
+			foreach(const Variant &vcid, result)
 			{
 				if(typeId(vcid) != QMetaType::QByteArray)
 				{
@@ -76,7 +77,7 @@ private:
 				out += QString::fromUtf8(vcid.toByteArray());
 			}
 
-			setFinished(true, QVariant::fromValue<CidSet>(out));
+			setFinished(true, Variant::fromValue<CidSet>(out));
 		}
 		else
 		{
@@ -93,7 +94,7 @@ public:
 		req = std::make_unique<ZrpcRequest>(controlClient);
 		finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this));
 
-		QVariantHash args;
+		VariantHash args;
 		args["cid"] = cid;
 		req->start("refresh", args);
 	}

--- a/src/handler/deferred.cpp
+++ b/src/handler/deferred.cpp
@@ -23,6 +23,8 @@
 
 #include "deferred.h"
 
+#include "variant.h"
+
 Deferred::Deferred()
 {
 	qRegisterMetaType<DeferredResult>();
@@ -32,7 +34,7 @@ Deferred::~Deferred()
 {
 }
 
-void Deferred::setFinished(bool ok, const QVariant &value)
+void Deferred::setFinished(bool ok, const Variant &value)
 {
 	result_.success = ok;
 	result_.value = value;

--- a/src/handler/deferred.h
+++ b/src/handler/deferred.h
@@ -24,7 +24,7 @@
 #ifndef DEFERRED_H
 #define DEFERRED_H
 
-#include <QVariant>
+#include "variant.h"
 #include <boost/signals2.hpp>
 #include "defercall.h"
 
@@ -32,14 +32,14 @@ class DeferredResult
 {
 public:
 	bool success;
-	QVariant value;
+	Variant value;
 
 	DeferredResult() :
 		success(false)
 	{
 	}
 
-	DeferredResult(bool _success, const QVariant &_value = QVariant()) :
+	DeferredResult(bool _success, const Variant &_value = Variant()) :
 		success(_success),
 		value(_value)
 	{
@@ -58,7 +58,7 @@ public:
 protected:
 	Deferred();
 
-	void setFinished(bool ok, const QVariant &value = QVariant());
+	void setFinished(bool ok, const Variant &value = Variant());
 
 private:
 	DeferredResult result_;

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -26,6 +26,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "log.h"
+#include "variant.h"
 #include "format.h"
 #include "idformat.h"
 #include "zhttpmanager.h"
@@ -365,7 +366,7 @@ public:
 	{
 	}
 
-	void setup(ZhttpManager *zhttpOut, const QUrl &_uri, const HttpHeaders &_headers, const QVariant &passthroughData, const QByteArray &content, int _responseSizeMax)
+	void setup(ZhttpManager *zhttpOut, const QUrl &_uri, const HttpHeaders &_headers, const Variant &passthroughData, const QByteArray &content, int _responseSizeMax)
 	{
 		uri = _uri;
 		headers = _headers;
@@ -547,7 +548,7 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 	int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
 	int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 
-	QVariantHash passthroughData;
+	VariantHash passthroughData;
 
 	passthroughData["route"] = context.route.toUtf8();
 
@@ -571,7 +572,7 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 	HttpHeaders headers;
 
 	{
-		QVariantMap vmap;
+		VariantMap vmap;
 		QHashIterator<QString, QString> it(context.subscriptionMeta);
 		while(it.hasNext())
 		{
@@ -584,7 +585,7 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 	}
 
 	{
-		QVariantMap vmap;
+		VariantMap vmap;
 		QHashIterator<QString, QString> it(context.publishMeta);
 		while(it.hasNext())
 		{

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -33,6 +33,7 @@
 #include "zmqvalve.h"
 #include "zmqreqmessage.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "tnetstring.h"
 #include "timer.h"
 #include "defercall.h"
@@ -89,11 +90,11 @@
 
 using namespace VariantUtil;
 
-static QList<PublishItem> parseItems(const QVariantList &vitems, bool *ok = 0, QString *errorMessage = 0)
+static QList<PublishItem> parseItems(const VariantList &vitems, bool *ok = 0, QString *errorMessage = 0)
 {
 	QList<PublishItem> out;
 
-	foreach(const QVariant &vitem, vitems)
+	foreach(const Variant &vitem, vitems)
 	{
 		bool ok_;
 		PublishItem item = PublishItem::fromVariant(vitem, QString(), &ok_, errorMessage);
@@ -133,7 +134,7 @@ public:
 	{
 		if(req->method() == "inspect")
 		{
-			QVariantHash args = req->args();
+			VariantHash args = req->args();
 
 			if(!args.contains("method") || typeId(args["method"]) != QMetaType::QByteArray)
 			{
@@ -162,7 +163,7 @@ public:
 				return;
 			}
 
-			foreach(const QVariant &vheader, args["headers"].toList())
+			foreach(const Variant &vheader, args["headers"].toList())
 			{
 				if(typeId(vheader) != QMetaType::QVariantList)
 				{
@@ -170,7 +171,7 @@ public:
 					return;
 				}
 
-				QVariantList vlist = vheader.toList();
+				VariantList vlist = vheader.toList();
 				if(vlist.count() != 2 || typeId(vlist[0]) != QMetaType::QByteArray || typeId(vlist[1]) != QMetaType::QByteArray)
 				{
 					respondError("bad-request");
@@ -254,7 +255,7 @@ private:
 
 	void doFinish()
 	{
-		QVariantHash result;
+		VariantHash result;
 		result["no-proxy"] = false;
 
 		if(autoShare && requestData.method == "GET")
@@ -286,7 +287,7 @@ private:
 
 			if(!lastIds.isEmpty())
 			{
-				QVariantHash vlastIds;
+				VariantHash vlastIds;
 				QHashIterator<QString, QString> it(lastIds);
 				while(it.hasNext())
 				{
@@ -330,7 +331,7 @@ private:
 				if(e.error != QJsonParseError::NoError)
 					continue;
 
-				QVariant vdata;
+				Variant vdata;
 				if(doc.isObject())
 					vdata = doc.object().toVariantMap();
 				else if(doc.isArray())
@@ -474,7 +475,7 @@ public:
 	// asynchronously
 	void start()
 	{
-		QVariantHash args = req->args();
+		VariantHash args = req->args();
 
 		// Process conn-max packets before doing anything else
 		if(args.contains("conn-max"))
@@ -485,9 +486,9 @@ public:
 				return;
 			}
 
-			QVariantList packets = args["conn-max"].toList();
+			VariantList packets = args["conn-max"].toList();
 
-			foreach(const QVariant &data, packets)
+			foreach(const Variant &data, packets)
 			{
 				StatsPacket p;
 				if(!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax)
@@ -555,8 +556,8 @@ public:
 				return;
 			}
 
-			QVariantList vchannels = args["channels"].toList();
-			foreach(const QVariant &v, vchannels)
+			VariantList vchannels = args["channels"].toList();
+			foreach(const Variant &v, vchannels)
 			{
 				if(typeId(v) != QMetaType::QByteArray)
 				{
@@ -587,7 +588,7 @@ public:
 			return;
 		}
 
-		foreach(const QVariant &vr, args["requests"].toList())
+		foreach(const Variant &vr, args["requests"].toList())
 		{
 			RequestState rs = RequestState::fromVariant(vr);
 			if(rs.rid.first.isEmpty())
@@ -625,7 +626,7 @@ public:
 			return;
 		}
 
-		QVariantHash rd = args["response"].toHash();
+		VariantHash rd = args["response"].toHash();
 
 		if(!rd.contains("code") || !canConvert(rd["code"], QMetaType::Int))
 		{
@@ -649,7 +650,7 @@ public:
 			return;
 		}
 
-		foreach(const QVariant &vheader, rd["headers"].toList())
+		foreach(const Variant &vheader, rd["headers"].toList())
 		{
 			if(typeId(vheader) != QMetaType::QVariantList)
 			{
@@ -657,7 +658,7 @@ public:
 				return;
 			}
 
-			QVariantList vlist = vheader.toList();
+			VariantList vlist = vheader.toList();
 			if(vlist.count() != 2 || typeId(vlist[0]) != QMetaType::QByteArray || typeId(vlist[1]) != QMetaType::QByteArray)
 			{
 				respondError("bad-request");
@@ -683,7 +684,7 @@ public:
 				return;
 			}
 
-			QVariantHash vinspect = args["inspect"].toHash();
+			VariantHash vinspect = args["inspect"].toHash();
 
 			if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != QMetaType::Bool)
 			{
@@ -724,8 +725,8 @@ public:
 					return;
 				}
 
-				QVariantHash vlastIds = vinspect["last-ids"].toHash();
-				QHashIterator<QString, QVariant> it(vlastIds);
+				VariantHash vlastIds = vinspect["last-ids"].toHash();
+				QHashIterator<QString, Variant> it(vlastIds);
 				while(it.hasNext())
 				{
 					it.next();
@@ -842,12 +843,12 @@ public:
 	boost::signals2::signal<void(const QByteArray &,const RetryRequestPacket&)> retryPacketReady;
 
 private:
-	static HttpRequestData parseRequestData(const QVariantHash &args, const QString &field)
+	static HttpRequestData parseRequestData(const VariantHash &args, const QString &field)
 	{
 		if(!args.contains(field) || typeId(args[field]) != QMetaType::QVariantHash)
 			return HttpRequestData();
 
-		QVariantHash rd = args[field].toHash();
+		VariantHash rd = args[field].toHash();
 
 		if(!rd.contains("method") || typeId(rd["method"]) != QMetaType::QByteArray)
 			return HttpRequestData();
@@ -865,12 +866,12 @@ private:
 		if(!rd.contains("headers") || typeId(rd["headers"]) != QMetaType::QVariantList)
 			return HttpRequestData();
 
-		foreach(const QVariant &vheader, rd["headers"].toList())
+		foreach(const Variant &vheader, rd["headers"].toList())
 		{
 			if(typeId(vheader) != QMetaType::QVariantList)
 				return HttpRequestData();
 
-			QVariantList vlist = vheader.toList();
+			VariantList vlist = vheader.toList();
 			if(vlist.count() != 2 || typeId(vlist[0]) != QMetaType::QByteArray || typeId(vlist[1]) != QMetaType::QByteArray)
 				return HttpRequestData();
 
@@ -885,7 +886,7 @@ private:
 		return out;
 	}
 
-	void respondError(const QByteArray &condition, const QVariant &result = QVariant())
+	void respondError(const QByteArray &condition, const Variant &result = Variant())
 	{
 		req->respondError(condition, result);
 		setFinished(true);
@@ -928,7 +929,7 @@ private:
 
 		if(instruct.holdMode == Instruct::NoHold && instruct.nextLink.isEmpty())
 		{
-			QVariantHash result;
+			VariantHash result;
 
 			if(!responseSent)
 			{
@@ -958,16 +959,16 @@ private:
 
 				instruct.response.headers.removeAll("Content-Length");
 
-				QVariantHash vresponse;
+				VariantHash vresponse;
 				vresponse["code"] = instruct.response.code;
 				vresponse["reason"] = instruct.response.reason;
-				QVariantList vheaders;
+				VariantList vheaders;
 				foreach(const HttpHeader &h, instruct.response.headers)
 				{
-					QVariantList vheader;
+					VariantList vheader;
 					vheader += h.first.asQByteArray();
 					vheader += h.second.asQByteArray();
-					vheaders += QVariant(vheader);
+					vheaders += Variant(vheader);
 				}
 				vresponse["headers"] = vheaders;
 				vresponse["body"] = body;
@@ -983,7 +984,7 @@ private:
 
 		QByteArray reqFrom = req->from();
 
-		QVariantHash result;
+		VariantHash result;
 		result["accepted"] = true;
 		req->respond(result);
 
@@ -1644,7 +1645,7 @@ private:
 			return;
 		}
 
-		QVariant vout = packet.toVariant();
+		Variant vout = packet.toVariant();
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
 			log_debug("OUT retry: to=%s %s", instanceAddress.data(), qPrintable(TnetString::variantToString(vout, -1)));
@@ -1668,7 +1669,7 @@ private:
 		out.from = config.instanceId;
 		out.items = items;
 
-		QVariant vout = out.toVariant();
+		Variant vout = out.toVariant();
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
 			log_debug("OUT wscontrol: to=%s %s", instanceAddress.data(), qPrintable(TnetString::variantToString(vout, -1)));
@@ -1930,15 +1931,15 @@ private:
 		}
 		else if(req->method() == "conn-max")
 		{
-			QVariantHash args = req->args();
+			VariantHash args = req->args();
 
 			if(args.contains("conn-max"))
 			{
 				if(typeId(args["conn-max"]) == QMetaType::QVariantList)
 				{
-					QVariantList packets = args["conn-max"].toList();
+					VariantList packets = args["conn-max"].toList();
 
-					foreach(const QVariant &data, packets)
+					foreach(const Variant &data, packets)
 					{
 						StatsPacket p;
 						if(!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax)
@@ -1978,7 +1979,7 @@ private:
 		}
 		else if(req->method() == "get-zmq-uris")
 		{
-			QVariantHash out;
+			VariantHash out;
 			if(!config.commandSpec.isEmpty())
 				out["command"] = config.commandSpec.toUtf8();
 			if(!config.pushInSpec.isEmpty())
@@ -2005,7 +2006,7 @@ private:
 		}
 		else if(req->method() == "publish")
 		{
-			QVariantHash args = req->args();
+			VariantHash args = req->args();
 
 			if(!args.contains("items"))
 			{
@@ -2021,7 +2022,7 @@ private:
 				return;
 			}
 
-			QVariantList vitems = args["items"].toList();
+			VariantList vitems = args["items"].toList();
 
 			bool ok;
 			QString errorMessage;
@@ -2388,9 +2389,9 @@ private:
 			removeSub(channel);
 	}
 
-	QVariant parseJsonOrTnetstring(const CowByteArray &message, bool *ok = 0, QString *errorMessage = 0)
+	Variant parseJsonOrTnetstring(const CowByteArray &message, bool *ok = 0, QString *errorMessage = 0)
 	{
-		QVariant data;
+		Variant data;
 		bool ok_;
 		if(message.length() > 0 && message[0] == 'J') {
 			QJsonParseError e;
@@ -2449,7 +2450,7 @@ private:
 
 		bool ok;
 		QString errorMessage;
-		QVariant data = parseJsonOrTnetstring(message[0], &ok, &errorMessage);
+		Variant data = parseJsonOrTnetstring(message[0], &ok, &errorMessage);
 		if(!ok)
 		{
 			log_warning("IN pull: %s, skipping", qPrintable(errorMessage));
@@ -2479,7 +2480,7 @@ private:
 
 		bool ok;
 		QString errorMessage;
-		QVariant data = parseJsonOrTnetstring(message[1], &ok, &errorMessage);
+		Variant data = parseJsonOrTnetstring(message[1], &ok, &errorMessage);
 		if(!ok) {
 			log_warning("IN sub: %s, skipping", qPrintable(errorMessage));
 			return;
@@ -2527,7 +2528,7 @@ private:
 	void wsControlIn_readyRead(const CowByteArray &message)
 	{
 		bool ok;
-		QVariant data = TnetString::toVariant(message, 0, &ok);
+		Variant data = TnetString::toVariant(message, 0, &ok);
 		if(!ok)
 		{
 			log_warning("IN wscontrol: received message with invalid format (tnetstring parse failed), skipping");
@@ -2867,7 +2868,7 @@ private:
 		}
 
 		bool ok;
-		QVariant data = TnetString::toVariant(message[0], at + 2, &ok);
+		Variant data = TnetString::toVariant(message[0], at + 2, &ok);
 		if(!ok)
 		{
 			log_warning("IN proxy stats: received message with invalid format (tnetstring parse failed), skipping");
@@ -2988,8 +2989,8 @@ private:
 					return;
 				}
 
-				QVariantMap mdata = doc.object().toVariantMap();
-				QVariantList vitems;
+				VariantMap mdata = doc.object().toVariantMap();
+				VariantList vitems;
 
 				if(!mdata.contains("items"))
 				{
@@ -3017,7 +3018,7 @@ private:
 				QString message = "Published";
 				if(responseContentType == "application/json")
 				{
-					QVariantMap obj;
+					VariantMap obj;
 					obj["message"] = message;
 					QString body = QJsonDocument(QJsonObject::fromVariantMap(obj)).toJson(QJsonDocument::Compact);
 					httpControlRespond(req, 200, "OK", body + "\n", responseContentType, HttpHeaders(), items.count());
@@ -3044,7 +3045,7 @@ private:
 				QString message = "Updated";
 				if(responseContentType == "application/json")
 				{
-					QVariantMap obj;
+					VariantMap obj;
 					obj["message"] = message;
 					QString body = QJsonDocument(QJsonObject::fromVariantMap(obj)).toJson(QJsonDocument::Compact);
 					httpControlRespond(req, 200, "OK", body + "\n", responseContentType, HttpHeaders());

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -32,6 +32,7 @@
 #include "qtcompat.h"
 #include "log.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
 #include "packet/httpresponsedata.h"
@@ -60,7 +61,7 @@ public:
 
 	QDir workDir;
 	bool acceptSuccess;
-	QVariantHash acceptValue;
+	VariantHash acceptValue;
 	bool finished;
 	QHash<QByteArray, HttpResponseData> responses;
 	int serverReqs;
@@ -162,7 +163,7 @@ public:
 	{
 		log_debug("client in");
 
-		QVariant v = TnetString::toVariant(message);
+		Variant v = TnetString::toVariant(message);
 		ZhttpResponsePacket zresp;
 		zresp.fromVariant(v);
 		if(zresp.type == ZhttpResponsePacket::Data)
@@ -205,7 +206,7 @@ public:
 	{
 		++serverReqs;
 		log_debug("server in");
-		QVariant v = TnetString::toVariant(message[0].mid(1));
+		Variant v = TnetString::toVariant(message[0].mid(1));
 		ZhttpRequestPacket zreq;
 		zreq.fromVariant(v);
 
@@ -215,7 +216,7 @@ public:
 	void zhttpServerInStream_readyRead(const CowByteArrayList &message)
 	{
 		log_debug("server stream in");
-		QVariant v = TnetString::toVariant(message[2].mid(1));
+		Variant v = TnetString::toVariant(message[2].mid(1));
 		ZhttpRequestPacket zreq;
 		zreq.fromVariant(v);
 
@@ -273,10 +274,10 @@ public:
 	void proxyAccept_readyRead(const CowByteArrayList &_message)
 	{
 		ZmqReqMessage message(_message);
-		QVariant v = TnetString::toVariant(message.content()[0]);
+		Variant v = TnetString::toVariant(message.content()[0]);
 
 		TEST_ASSERT(typeId(v) == QMetaType::QVariantHash);
-		QVariantHash vresp = v.toHash();
+		VariantHash vresp = v.toHash();
 
 		TEST_ASSERT(vresp.value("success").toBool());
 
@@ -367,39 +368,39 @@ static void acceptNoHold(Wrapper *wrapper, std::function<void (int)> loop_wait)
 
 	QByteArray id = "1";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
 	reqState["out-credits"] = 1000;
 	reqState["router-resp"] = true;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("hello world\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -419,40 +420,40 @@ static void acceptNoHoldResponseSent(Wrapper *wrapper, std::function<void (int)>
 
 	QByteArray id = "2";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
 	reqState["out-credits"] = 1000;
 	reqState["router-resp"] = true;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("hello world\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 	args["response-sent"] = true;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -472,40 +473,40 @@ static void acceptNoHoldNext(Wrapper *wrapper, std::function<void (int)> loop_wa
 
 	QByteArray id = "3";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
 	reqState["out-credits"] = 1000;
 	reqState["router-resp"] = true;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("hello world\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -530,11 +531,11 @@ static void acceptNoHoldNextResponseSent(Wrapper *wrapper, std::function<void (i
 
 	QByteArray id = "4";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
@@ -542,30 +543,30 @@ static void acceptNoHoldNextResponseSent(Wrapper *wrapper, std::function<void (i
 	reqState["router-resp"] = true;
 	reqState["response-code"] = 200;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("hello world\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 	args["response-sent"] = true;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -590,41 +591,41 @@ static void publishResponse(Wrapper *wrapper, std::function<void (int)> loop_wai
 
 	QByteArray id = "5";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
 	reqState["out-credits"] = 1000;
 	reqState["router-resp"] = true;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Hold") << QByteArray("response"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("response"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("timeout\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -636,10 +637,10 @@ static void publishResponse(Wrapper *wrapper, std::function<void (int)> loop_wai
 
 	data.clear();
 
-	QVariantHash hr;
+	VariantHash hr;
 	hr["body"] = QByteArray("hello world\n");
 
-	QVariantHash formats;
+	VariantHash formats;
 	formats["http-response"] = hr;
 
 	data["channel"] = QByteArray("apple");
@@ -660,41 +661,41 @@ static void publishStream(Wrapper *wrapper, std::function<void (int)> loop_wait)
 
 	QByteArray id = "6";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
 	reqState["out-credits"] = 1000;
 	reqState["router-resp"] = true;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("stream open\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -707,10 +708,10 @@ static void publishStream(Wrapper *wrapper, std::function<void (int)> loop_wait)
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["content"] = QByteArray("hello world\n");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");
@@ -723,10 +724,10 @@ static void publishStream(Wrapper *wrapper, std::function<void (int)> loop_wait)
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["action"] = QByteArray("close");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");
@@ -749,41 +750,41 @@ static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loo
 
 	QByteArray id = "7";
 
-	QVariantHash rid;
+	VariantHash rid;
 	rid["sender"] = QByteArray("test-client");
 	rid["id"] = id;
 
-	QVariantHash reqState;
+	VariantHash reqState;
 	reqState["rid"] = rid;
 	reqState["in-seq"] = 1;
 	reqState["out-seq"] = 1;
 	reqState["out-credits"] = 1000;
 	reqState["router-resp"] = true;
 
-	QVariantHash req;
+	VariantHash req;
 	req["method"] = QByteArray("GET");
 	req["uri"] = QByteArray("http://example.com/path");
-	QVariantList reqHeaders;
+	VariantList reqHeaders;
 	req["headers"] = reqHeaders;
 	req["body"] = QByteArray();
 
-	QVariantHash resp;
+	VariantHash resp;
 	resp["code"] = 200;
 	resp["reason"] = QByteArray("OK");
-	QVariantList respHeaders;
-	respHeaders += QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
-	respHeaders += QVariant(QVariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
+	VariantList respHeaders;
+	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
+	respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
 	resp["headers"] = respHeaders;
 	resp["body"] = QByteArray("stream open\n");
 
-	QVariantHash args;
-	args["requests"] = QVariantList() << reqState;
+	VariantHash args;
+	args["requests"] = VariantList() << reqState;
 	args["request-data"] = req;
 	args["orig-request-data"] = req;
 	args["response"] = resp;
 
-	QVariantHash data;
+	VariantHash data;
 	data["id"] = id;
 	data["method"] = QByteArray("accept");
 	data["args"] = args;
@@ -796,10 +797,10 @@ static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loo
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["content"] = QByteArray("one\n");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");
@@ -813,10 +814,10 @@ static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loo
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["action"] = QByteArray("close");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");
@@ -831,10 +832,10 @@ static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loo
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["content"] = QByteArray("four\n");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");
@@ -849,10 +850,10 @@ static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loo
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["content"] = QByteArray("three\n");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");
@@ -867,10 +868,10 @@ static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loo
 	data.clear();
 
 	{
-		QVariantHash hs;
+		VariantHash hs;
 		hs["content"] = QByteArray("two\n");
 
-		QVariantHash formats;
+		VariantHash formats;
 		formats["http-stream"] = hs;
 
 		data["channel"] = QByteArray("apple");

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -29,6 +29,7 @@
 #include <QJsonArray>
 #include <QRandomGenerator>
 #include "qtcompat.h"
+#include "variant.h"
 #include "timer.h"
 #include "defercall.h"
 #include "log.h"
@@ -55,7 +56,7 @@
 #define UPDATES_PER_ACTION_MAX 100
 #define PUBLISH_QUEUE_MAX 100
 
-static QByteArray applyBodyPatch(const QByteArray &in, const QVariantList &bodyPatch)
+static QByteArray applyBodyPatch(const QByteArray &in, const VariantList &bodyPatch)
 {
 	QByteArray body;
 
@@ -63,7 +64,7 @@ static QByteArray applyBodyPatch(const QByteArray &in, const QVariantList &bodyP
 	QJsonDocument doc = QJsonDocument::fromJson(in, &e);
 	if(e.error == QJsonParseError::NoError && (doc.isObject() || doc.isArray()))
 	{
-		QVariant vbody;
+		Variant vbody;
 		if(doc.isObject())
 			vbody = doc.object().toVariantMap();
 		else // IsArray
@@ -908,17 +909,17 @@ private:
 			{
 				if(adata.jsonpExtendedResponse)
 				{
-					QVariantMap result;
+					VariantMap result;
 					result["code"] = code;
 					result["reason"] = QString::fromUtf8(reason);
 
 					// Need to compact headers into a map
-					QVariantMap vheaders;
+					VariantMap vheaders;
 					foreach(const HttpHeader &h, headers)
 					{
 						// Don't add the same header name twice. We'll collect all values for a single header
 						bool found = false;
-						QMapIterator<QString, QVariant> it(vheaders);
+						QMapIterator<QString, Variant> it(vheaders);
 						while(it.hasNext())
 						{
 							it.next();
@@ -1147,7 +1148,7 @@ private:
 		int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
 		int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 
-		QVariantHash passthroughData;
+		VariantHash passthroughData;
 
 		passthroughData["route"] = adata.route.toUtf8();
 

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -23,10 +23,10 @@
 
 #include "instruct.h"
 
-#include <QVariant>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "qtcompat.h"
+#include "variant.h"
 #include "variantutil.h"
 #include "statusreasons.h"
 #include "filter.h"
@@ -395,7 +395,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			return Instruct();
 		}
 
-		QVariantMap minstruct = doc.object().toVariantMap();
+		VariantMap minstruct = doc.object().toVariantMap();
 
 		bool ok_;
 
@@ -409,7 +409,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 			QString pn = "hold";
 
-			QVariant vhold = minstruct["hold"];
+			Variant vhold = minstruct["hold"];
 
 			QString modeStr = getString(vhold, pn, "mode", false, &ok_, errorMessage);
 			if(!ok_)
@@ -440,7 +440,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				holdMode = ResponseHold;
 			}
 
-			QVariantList vchannels = getList(vhold, pn, "channels", true, &ok_, errorMessage);
+			VariantList vchannels = getList(vhold, pn, "channels", true, &ok_, errorMessage);
 			if(!ok_)
 			{
 				if(ok)
@@ -448,7 +448,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				return Instruct();
 			}
 
-			foreach(const QVariant &vchannel, vchannels)
+			foreach(const Variant &vchannel, vchannels)
 			{
 				QString cpn = "channel";
 				Channel c;
@@ -469,7 +469,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 					return Instruct();
 				}
 
-				QVariantList vfilters = getList(vchannel, cpn, "filters", false, &ok_, errorMessage);
+				VariantList vfilters = getList(vchannel, cpn, "filters", false, &ok_, errorMessage);
 				if(!ok_)
 				{
 					if(ok)
@@ -477,7 +477,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 					return Instruct();
 				}
 
-				foreach(const QVariant &vfilter, vfilters)
+				foreach(const Variant &vfilter, vfilters)
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -494,7 +494,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 			if(keyedObjectContains(vhold, "timeout"))
 			{
-				QVariant vtimeout = keyedObjectGetValue(vhold, "timeout");
+				Variant vtimeout = keyedObjectGetValue(vhold, "timeout");
 				if(!canConvert(vtimeout, QMetaType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(pn));
@@ -510,7 +510,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				}
 			}
 
-			QVariant vka = getKeyedObject(vhold, pn, "keep-alive", false, &ok_, errorMessage);
+			Variant vka = getKeyedObject(vhold, pn, "keep-alive", false, &ok_, errorMessage);
 			if(!ok_)
 			{
 				if(ok)
@@ -536,7 +536,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				}
 				else if(keyedObjectContains(vka, "content"))
 				{
-					QVariant vcontent = keyedObjectGetValue(vka, "content");
+					Variant vcontent = keyedObjectGetValue(vka, "content");
 					if(typeId(vcontent) == QMetaType::QByteArray)
 						keepAliveData = vcontent.toByteArray();
 					else if(typeId(vcontent) == QMetaType::QString)
@@ -550,7 +550,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 				if(keyedObjectContains(vka, "timeout"))
 				{
-					QVariant vtimeout = keyedObjectGetValue(vka, "timeout");
+					Variant vtimeout = keyedObjectGetValue(vka, "timeout");
 					if(!canConvert(vtimeout, QMetaType::Int))
 					{
 						setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(kpn));
@@ -571,7 +571,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				}
 			}
 
-			QVariant vmeta = getKeyedObject(vhold, pn, "meta", false, &ok_, errorMessage);
+			Variant vmeta = getKeyedObject(vhold, pn, "meta", false, &ok_, errorMessage);
 			if(!ok_)
 			{
 				if(ok)
@@ -583,14 +583,14 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			{
 				if(typeId(vmeta) == QMetaType::QVariantHash)
 				{
-					QVariantHash hmeta = vmeta.toHash();
+					VariantHash hmeta = vmeta.toHash();
 
-					QHashIterator<QString, QVariant> it(hmeta);
+					QHashIterator<QString, Variant> it(hmeta);
 					while(it.hasNext())
 					{
 						it.next();
 						const QString &key = it.key();
-						const QVariant &vval = it.value();
+						const Variant &vval = it.value();
 
 						QString val = getString(vval, &ok_);
 						if(!ok_)
@@ -604,14 +604,14 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				}
 				else // Map
 				{
-					QVariantMap mmeta = vmeta.toMap();
+					VariantMap mmeta = vmeta.toMap();
 
-					QMapIterator<QString, QVariant> it(mmeta);
+					QMapIterator<QString, Variant> it(mmeta);
 					while(it.hasNext())
 					{
 						it.next();
 						const QString &key = it.key();
-						const QVariant &vval = it.value();
+						const Variant &vval = it.value();
 
 						QString val = getString(vval, &ok_);
 						if(!ok_)
@@ -638,13 +638,13 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				return Instruct();
 			}
 
-			QVariant in = minstruct["response"];
+			Variant in = minstruct["response"];
 
 			QString pn = "response";
 
 			if(keyedObjectContains(in, "code"))
 			{
-				QVariant vcode = keyedObjectGetValue(in, "code");
+				Variant vcode = keyedObjectGetValue(in, "code");
 				if(!canConvert(vcode, QMetaType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
@@ -677,10 +677,10 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 			if(keyedObjectContains(in, "headers"))
 			{
-				QVariant vheaders = keyedObjectGetValue(in, "headers");
+				Variant vheaders = keyedObjectGetValue(in, "headers");
 				if(typeId(vheaders) == QMetaType::QVariantList)
 				{
-					foreach(const QVariant &vheader, vheaders.toList())
+					foreach(const Variant &vheader, vheaders.toList())
 					{
 						if(typeId(vheader) != QMetaType::QVariantList)
 						{
@@ -688,7 +688,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 							return Instruct();
 						}
 
-						QVariantList lheader = vheader.toList();
+						VariantList lheader = vheader.toList();
 						if(lheader.count() != 2)
 						{
 							setError(ok, errorMessage, "headers contains list with wrong number of elements");
@@ -716,14 +716,14 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				{
 					if(typeId(vheaders) == QMetaType::QVariantHash)
 					{
-						QVariantHash hheaders = vheaders.toHash();
+						VariantHash hheaders = vheaders.toHash();
 
-						QHashIterator<QString, QVariant> it(hheaders);
+						QHashIterator<QString, Variant> it(hheaders);
 						while(it.hasNext())
 						{
 							it.next();
 							const QString &key = it.key();
-							const QVariant &vval = it.value();
+							const Variant &vval = it.value();
 
 							QString val = getString(vval, &ok_);
 							if(!ok_)
@@ -737,14 +737,14 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 					}
 					else // Map
 					{
-						QVariantMap mheaders = vheaders.toMap();
+						VariantMap mheaders = vheaders.toMap();
 
-						QMapIterator<QString, QVariant> it(mheaders);
+						QMapIterator<QString, Variant> it(mheaders);
 						while(it.hasNext())
 						{
 							it.next();
 							const QString &key = it.key();
-							const QVariant &vval = it.value();
+							const Variant &vval = it.value();
 
 							QString val = getString(vval, &ok_);
 							if(!ok_)
@@ -778,7 +778,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			}
 			else if(keyedObjectContains(in, "body"))
 			{
-				QVariant vcontent = keyedObjectGetValue(in, "body");
+				Variant vcontent = keyedObjectGetValue(in, "body");
 				if(typeId(vcontent) == QMetaType::QByteArray)
 					newResponse.body = vcontent.toByteArray();
 				else if(typeId(vcontent) == QMetaType::QString)

--- a/src/handler/jsonpatch.cpp
+++ b/src/handler/jsonpatch.cpp
@@ -25,6 +25,7 @@
 
 #include <assert.h>
 #include "qtcompat.h"
+#include "variant.h"
 #include "jsonpointer.h"
 
 namespace JsonPatch {
@@ -45,12 +46,12 @@ static void setError(bool *ok, QString *errorMessage, const QString &msg)
 		*errorMessage = msg;
 }
 
-static bool isKeyedObject(const QVariant &in)
+static bool isKeyedObject(const Variant &in)
 {
 	return (typeId(in) == QMetaType::QVariantHash || typeId(in) == QMetaType::QVariantMap);
 }
 
-static bool keyedObjectContains(const QVariant &in, const QString &name)
+static bool keyedObjectContains(const Variant &in, const QString &name)
 {
 	if(typeId(in) == QMetaType::QVariantHash)
 		return in.toHash().contains(name);
@@ -60,31 +61,31 @@ static bool keyedObjectContains(const QVariant &in, const QString &name)
 		return false;
 }
 
-static QVariant keyedObjectGetValue(const QVariant &in, const QString &name)
+static Variant keyedObjectGetValue(const Variant &in, const QString &name)
 {
 	if(typeId(in) == QMetaType::QVariantHash)
 		return in.toHash().value(name);
 	else if(typeId(in) == QMetaType::QVariantMap)
 		return in.toMap().value(name);
 	else
-		return QVariant();
+		return Variant();
 }
 
-static QVariant getChild(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0)
+static Variant getChild(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0)
 {
 	if(!isKeyedObject(in))
 	{
 		QString pn = !parentName.isEmpty() ? parentName : QString("value");
 		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return QVariant();
+		return Variant();
 	}
 
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	QVariant v;
+	Variant v;
 	if(typeId(in) == QMetaType::QVariantHash)
 	{
-		QVariantHash h = in.toHash();
+		VariantHash h = in.toHash();
 
 		if(!h.contains(childName))
 		{
@@ -93,14 +94,14 @@ static QVariant getChild(const QVariant &in, const QString &parentName, const QS
 			else
 				setSuccess(ok, errorMessage);
 
-			return QVariant();
+			return Variant();
 		}
 
 		v = h[childName];
 	}
 	else // Map
 	{
-		QVariantMap m = in.toMap();
+		VariantMap m = in.toMap();
 
 		if(!m.contains(childName))
 		{
@@ -109,7 +110,7 @@ static QVariant getChild(const QVariant &in, const QString &parentName, const QS
 			else
 				setSuccess(ok, errorMessage);
 
-			return QVariant();
+			return Variant();
 		}
 
 		v = m[childName];
@@ -119,7 +120,7 @@ static QVariant getChild(const QVariant &in, const QString &parentName, const QS
 	return v;
 }
 
-static QString getString(const QVariant &in, bool *ok = 0)
+static QString getString(const Variant &in, bool *ok = 0)
 {
 	if(typeId(in) == QMetaType::QString)
 	{
@@ -141,10 +142,10 @@ static QString getString(const QVariant &in, bool *ok = 0)
 	}
 }
 
-static QString getString(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0)
+static QString getString(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0)
 {
 	bool ok_;
-	QVariant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
 	if(!ok_)
 	{
 		if(ok)
@@ -172,7 +173,7 @@ static QString getString(const QVariant &in, const QString &parentName, const QS
 }
 
 // Return true if item modified
-static bool convertToJsonStyleInPlace(QVariant *in)
+static bool convertToJsonStyleInPlace(Variant *in)
 {
 	// Hash -> Map
 	// ByteArray (UTF-8) -> String
@@ -182,13 +183,13 @@ static bool convertToJsonStyleInPlace(QVariant *in)
 	QMetaType::Type type = typeId(*in);
 	if(type == QMetaType::QVariantHash)
 	{
-		QVariantMap vmap;
-		QVariantHash vhash = in->toHash();
-		QHashIterator<QString, QVariant> it(vhash);
+		VariantMap vmap;
+		VariantHash vhash = in->toHash();
+		QHashIterator<QString, Variant> it(vhash);
 		while(it.hasNext())
 		{
 			it.next();
-			QVariant i = it.value();
+			Variant i = it.value();
 			convertToJsonStyleInPlace(&i);
 			vmap[it.key()] = i;
 		}
@@ -198,10 +199,10 @@ static bool convertToJsonStyleInPlace(QVariant *in)
 	}
 	else if(type == QMetaType::QVariantList)
 	{
-		QVariantList vlist = in->toList();
+		VariantList vlist = in->toList();
 		for(int n = 0; n < vlist.count(); ++n)
 		{
-			QVariant i = vlist.at(n);
+			Variant i = vlist.at(n);
 			convertToJsonStyleInPlace(&i);
 			vlist[n] = i;
 		}
@@ -211,36 +212,36 @@ static bool convertToJsonStyleInPlace(QVariant *in)
 	}
 	else if(type == QMetaType::QByteArray)
 	{
-		*in = QVariant(QString::fromUtf8(in->toByteArray()));
+		*in = Variant(QString::fromUtf8(in->toByteArray()));
 		changed = true;
 	}
 
 	return changed;
 }
 
-static QVariant convertToJsonStyle(const QVariant &in)
+static Variant convertToJsonStyle(const Variant &in)
 {
-	QVariant v = in;
+	Variant v = in;
 	convertToJsonStyleInPlace(&v);
 	return v;
 }
 
-static bool _compareJsonValues(const QVariant &a, const QVariant &b)
+static bool _compareJsonValues(const Variant &a, const Variant &b)
 {
 	if(typeId(a) == QMetaType::QVariantMap && typeId(b) == QMetaType::QVariantMap)
 	{
-		QVariantMap am = a.toMap();
-		QVariantMap bm = b.toMap();
+		VariantMap am = a.toMap();
+		VariantMap bm = b.toMap();
 
 		if(am.count() != bm.count())
 			return false;
 
-		QMapIterator<QString, QVariant> it(am);
+		QMapIterator<QString, Variant> it(am);
 		while(it.hasNext())
 		{
 			it.next();
 			const QString &key = it.key();
-			const QVariant &val = it.value();
+			const Variant &val = it.value();
 
 			if(!bm.contains(key))
 				return false;
@@ -252,8 +253,8 @@ static bool _compareJsonValues(const QVariant &a, const QVariant &b)
 	}
 	else if(typeId(a) == QMetaType::QVariantList && typeId(b) == QMetaType::QVariantList)
 	{
-		QVariantList al = a.toList();
-		QVariantList bl = b.toList();
+		VariantList al = a.toList();
+		VariantList bl = b.toList();
 
 		if(al.count() != bl.count())
 			return false;
@@ -286,25 +287,25 @@ static bool _compareJsonValues(const QVariant &a, const QVariant &b)
 		return false;
 }
 
-static bool compareJsonValues(const QVariant &a, const QVariant &b)
+static bool compareJsonValues(const Variant &a, const Variant &b)
 {
-	QVariant ca = convertToJsonStyle(a);
-	QVariant cb = convertToJsonStyle(b);
+	Variant ca = convertToJsonStyle(a);
+	Variant cb = convertToJsonStyle(b);
 
 	return _compareJsonValues(ca, cb);
 }
 
-QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMessage)
+Variant patch(const Variant &data, const VariantList &ops, QString *errorMessage)
 {
-	QVariant out = data;
+	Variant out = data;
 
-	foreach(const QVariant &vop, ops)
+	foreach(const Variant &vop, ops)
 	{
 		if(!isKeyedObject(vop))
 		{
 			if(errorMessage)
 				*errorMessage = "invalid op";
-			return QVariant();
+			return Variant();
 		}
 
 		QString pn = "op";
@@ -312,11 +313,11 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 		bool ok;
 		QString type = getString(vop, pn, "op", true, &ok, errorMessage);
 		if(!ok)
-			return QVariant();
+			return Variant();
 
 		QString path = getString(vop, pn, "path", true, &ok, errorMessage);
 		if(!ok)
-			return QVariant();
+			return Variant();
 
 		JsonPointer ptr;
 
@@ -325,7 +326,7 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 		{
 			ptr = JsonPointer::resolve(&out, path, errorMessage);
 			if(ptr.isNull())
-				return QVariant();
+				return Variant();
 		}
 
 		if(type == "add")
@@ -334,10 +335,10 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 			{
 				if(errorMessage)
 					*errorMessage = "op does not contain 'value'";
-				return QVariant();
+				return Variant();
 			}
 
-			QVariant value = keyedObjectGetValue(vop, "value");
+			Variant value = keyedObjectGetValue(vop, "value");
 			ptr.setValue(value);
 		}
 		else if(type == "remove")
@@ -346,11 +347,11 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 			{
 				if(errorMessage)
 					*errorMessage = "location does not exist";
-				return QVariant();
+				return Variant();
 			}
 
 			if(!ptr.remove())
-				return QVariant();
+				return Variant();
 		}
 		else if(type == "replace")
 		{
@@ -358,16 +359,16 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 			{
 				if(errorMessage)
 					*errorMessage = "op does not contain 'value'";
-				return QVariant();
+				return Variant();
 			}
 
-			QVariant value = keyedObjectGetValue(vop, "value");
+			Variant value = keyedObjectGetValue(vop, "value");
 
 			if(!ptr.exists())
 			{
 				if(errorMessage)
 					*errorMessage = "location does not exist";
-				return QVariant();
+				return Variant();
 			}
 
 			ptr.setValue(value);
@@ -376,31 +377,31 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 		{
 			QString from = getString(vop, pn, "from", true, &ok, errorMessage);
 			if(!ok)
-				return QVariant();
+				return Variant();
 
 			if(JsonPointer::isWithin(path, from))
 			{
 				if(errorMessage)
 					*errorMessage = "cannot move location into itself";
-				return QVariant();
+				return Variant();
 			}
 
 			JsonPointer fromPtr = JsonPointer::resolve(&out, from, errorMessage);
 			if(fromPtr.isNull())
-				return QVariant();
+				return Variant();
 
 			if(!fromPtr.exists())
 			{
 				if(errorMessage)
 					*errorMessage = "location does not exist";
-				return QVariant();
+				return Variant();
 			}
 
-			QVariant value = fromPtr.take();
+			Variant value = fromPtr.take();
 
 			ptr = JsonPointer::resolve(&out, path, errorMessage);
 			if(ptr.isNull())
-				return QVariant();
+				return Variant();
 
 			ptr.setValue(value);
 		}
@@ -408,22 +409,22 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 		{
 			QString from = getString(vop, pn, "from", true, &ok, errorMessage);
 			if(!ok)
-				return QVariant();
+				return Variant();
 
 			JsonPointer fromPtr = JsonPointer::resolve(&out, from, errorMessage);
 			if(fromPtr.isNull())
-				return QVariant();
+				return Variant();
 
 			if(!fromPtr.exists())
 			{
 				if(errorMessage)
 					*errorMessage = "location does not exist";
-				return QVariant();
+				return Variant();
 			}
 
 			ptr = JsonPointer::resolve(&out, path, errorMessage);
 			if(ptr.isNull())
-				return QVariant();
+				return Variant();
 
 			ptr.setValue(fromPtr.value());
 		}
@@ -433,24 +434,24 @@ QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMess
 			{
 				if(errorMessage)
 					*errorMessage = "op does not contain 'value'";
-				return QVariant();
+				return Variant();
 			}
 
-			QVariant value = keyedObjectGetValue(vop, "value");
-			QVariant cur = ptr.value();
+			Variant value = keyedObjectGetValue(vop, "value");
+			Variant cur = ptr.value();
 
 			if(!compareJsonValues(cur, value))
 			{
 				if(errorMessage)
 					*errorMessage = "tested values are not equal";
-				return QVariant();
+				return Variant();
 			}
 		}
 		else
 		{
 			if(errorMessage)
 				*errorMessage = QString("unsupported op: %1").arg(type);
-			return QVariant();
+			return Variant();
 		}
 	}
 

--- a/src/handler/jsonpatch.h
+++ b/src/handler/jsonpatch.h
@@ -23,11 +23,11 @@
 #ifndef JSONPATCH_H
 #define JSONPATCH_H
 
-#include <QVariant>
+#include "variant.h"
 
 namespace JsonPatch {
 
-QVariant patch(const QVariant &data, const QVariantList &ops, QString *errorMessage = 0);
+Variant patch(const Variant &data, const VariantList &ops, QString *errorMessage = 0);
 
 }
 

--- a/src/handler/jsonpatchtest.cpp
+++ b/src/handler/jsonpatchtest.cpp
@@ -23,27 +23,28 @@
 
 #include "test.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "jsonpatch.h"
 
 static void patch()
 {
-	QVariantMap data;
+	VariantMap data;
 	data["foo"] = "bar";
 
-	QVariantMap op;
+	VariantMap op;
 	op["op"] = "test";
 	op["path"] = "/foo";
 	op["value"] = "bar";
 	QString msg;
-	QVariant ret = JsonPatch::patch(data, QVariantList() << op, &msg);
+	Variant ret = JsonPatch::patch(data, VariantList() << op, &msg);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
 
 	op.clear();
 	op["op"] = "add";
 	op["path"] = "/fruit";
-	op["value"] = QVariantList() << "apple";
-	ret = JsonPatch::patch(data, QVariantList() << op);
+	op["value"] = VariantList() << "apple";
+	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
 	TEST_ASSERT_EQ(typeId(data["fruit"]), QMetaType::QVariantList);
@@ -53,7 +54,7 @@ static void patch()
 	op["op"] = "copy";
 	op["from"] = "/foo";
 	op["path"] = "/fruit/-";
-	ret = JsonPatch::patch(data, QVariantList() << op);
+	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
 	TEST_ASSERT_EQ(data["fruit"].toList()[1].toString(), QString("bar"));
@@ -61,11 +62,11 @@ static void patch()
 	op.clear();
 	op["op"] = "replace";
 	op["path"] = "/fruit/1";
-	QVariantMap bowl;
+	VariantMap bowl;
 	bowl["cherries"] = true;
 	bowl["grapes"] = 5;
 	op["value"] = bowl;
-	ret = JsonPatch::patch(data, QVariantList() << op);
+	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
 	TEST_ASSERT_EQ(typeId(data["fruit"].toList()[1]), QMetaType::QVariantMap);
@@ -75,7 +76,7 @@ static void patch()
 	op.clear();
 	op["op"] = "remove";
 	op["path"] = "/fruit/1/cherries";
-	ret = JsonPatch::patch(data, QVariantList() << op);
+	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
 	TEST_ASSERT(!data["fruit"].toList()[1].toMap().contains("cherries"));
@@ -85,7 +86,7 @@ static void patch()
 	op["op"] = "move";
 	op["from"] = "/fruit/0";
 	op["path"] = "/foo";
-	ret = JsonPatch::patch(data, QVariantList() << op);
+	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
 	TEST_ASSERT_EQ(data["foo"].toString(), QString("apple"));

--- a/src/handler/jsonpointer.cpp
+++ b/src/handler/jsonpointer.cpp
@@ -26,18 +26,19 @@
 #include <assert.h>
 #include <QStringList>
 #include "qtcompat.h"
+#include "variant.h"
 
 JsonPointer::JsonPointer() :
 	isNull_(true)
 {
 }
 
-QVariant *JsonPointer::root()
+Variant *JsonPointer::root()
 {
 	return root_;
 }
 
-JsonPointer::ExecStatus JsonPointer::execute(const QVariant *i, int refIndex, ConstFunc func, void *data) const
+JsonPointer::ExecStatus JsonPointer::execute(const Variant *i, int refIndex, ConstFunc func, void *data) const
 {
 	// If there are more refs after current ref, step into current
 	if(refIndex + 1 < refs_.count())
@@ -50,7 +51,7 @@ JsonPointer::ExecStatus JsonPointer::execute(const QVariant *i, int refIndex, Co
 		{
 			if(typeId(*i) == QMetaType::QVariantHash)
 			{
-				QVariantHash h = i->toHash();
+				VariantHash h = i->toHash();
 				if(!h.contains(ref.name))
 					return ExecError;
 
@@ -58,7 +59,7 @@ JsonPointer::ExecStatus JsonPointer::execute(const QVariant *i, int refIndex, Co
 			}
 			else // Map
 			{
-				QVariantMap m = i->toMap();
+				VariantMap m = i->toMap();
 				if(!m.contains(ref.name))
 					return ExecError;
 
@@ -67,7 +68,7 @@ JsonPointer::ExecStatus JsonPointer::execute(const QVariant *i, int refIndex, Co
 		}
 		else // Array
 		{
-			QVariantList l = i->toList();
+			VariantList l = i->toList();
 			if(ref.index < 0 || ref.index >= l.count())
 				return ExecError;
 
@@ -86,7 +87,7 @@ JsonPointer::ExecStatus JsonPointer::execute(const QVariant *i, int refIndex, Co
 	return ExecContinue;
 }
 
-JsonPointer::ExecStatus JsonPointer::execute(QVariant *i, int refIndex, Func func, void *data)
+JsonPointer::ExecStatus JsonPointer::execute(Variant *i, int refIndex, Func func, void *data)
 {
 	// If there are more refs after current ref, step into current
 	if(refIndex + 1 < refs_.count())
@@ -96,7 +97,7 @@ JsonPointer::ExecStatus JsonPointer::execute(QVariant *i, int refIndex, Func fun
 		{
 			if(typeId(*i) == QMetaType::QVariantHash)
 			{
-				QVariantHash h = i->toHash();
+				VariantHash h = i->toHash();
 				if(!h.contains(ref.name))
 					return ExecError;
 
@@ -107,7 +108,7 @@ JsonPointer::ExecStatus JsonPointer::execute(QVariant *i, int refIndex, Func fun
 			}
 			else // Map
 			{
-				QVariantMap m = i->toMap();
+				VariantMap m = i->toMap();
 				if(!m.contains(ref.name))
 					return ExecError;
 
@@ -119,7 +120,7 @@ JsonPointer::ExecStatus JsonPointer::execute(QVariant *i, int refIndex, Func fun
 		}
 		else if(ref.type == Ref::Array)
 		{
-			QVariantList l = i->toList();
+			VariantList l = i->toList();
 			if(ref.index < 0 || ref.index >= l.count())
 				return ExecError;
 
@@ -169,9 +170,9 @@ bool JsonPointer::execute(Func func, void *data)
 	}
 }
 
-static void existsFunc(const QVariant *v, const JsonPointer::Ref &ref, void *data)
+static void existsFunc(const Variant *v, const JsonPointer::Ref &ref, void *data)
 {
-	QVariant &ret = *((QVariant *)data);
+	Variant &ret = *((Variant *)data);
 
 	if(ref.type == JsonPointer::Ref::Self)
 	{
@@ -186,23 +187,23 @@ static void existsFunc(const QVariant *v, const JsonPointer::Ref &ref, void *dat
 	}
 	else // Array
 	{
-		QVariantList l = v->toList();
+		VariantList l = v->toList();
 		ret = (ref.index >= 0 && ref.index < l.count());
 	}
 }
 
 bool JsonPointer::exists() const
 {
-	QVariant ret;
+	Variant ret;
 	if(execute(existsFunc, &ret))
 		return ret.toBool();
 	else
 		return false;
 }
 
-static void valueFunc(const QVariant *v, const JsonPointer::Ref &ref, void *data)
+static void valueFunc(const Variant *v, const JsonPointer::Ref &ref, void *data)
 {
-	QVariant &ret = *((QVariant *)data);
+	Variant &ret = *((Variant *)data);
 
 	if(ref.type == JsonPointer::Ref::Self)
 	{
@@ -217,24 +218,24 @@ static void valueFunc(const QVariant *v, const JsonPointer::Ref &ref, void *data
 	}
 	else // Array
 	{
-		QVariantList l = v->toList();
+		VariantList l = v->toList();
 		if(ref.index >= 0 && ref.index < l.count())
 			ret = l[ref.index];
 	}
 }
 
-QVariant JsonPointer::value() const
+Variant JsonPointer::value() const
 {
-	QVariant ret;
+	Variant ret;
 	if(execute(valueFunc, &ret))
 		return ret;
 	else
-		return QVariant();
+		return Variant();
 }
 
-static bool removeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
+static bool removeFunc(Variant *v, const JsonPointer::Ref &ref, void *data)
 {
-	QVariant &ret = *((QVariant *)data);
+	Variant &ret = *((Variant *)data);
 
 	if(ref.type == JsonPointer::Ref::Self)
 	{
@@ -245,7 +246,7 @@ static bool removeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 	{
 		if(typeId(*v) == QMetaType::QVariantHash)
 		{
-			QVariantHash h = v->toHash();
+			VariantHash h = v->toHash();
 			if(h.contains(ref.name))
 			{
 				ret = true;
@@ -258,7 +259,7 @@ static bool removeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 		}
 		else // Map
 		{
-			QVariantMap m = v->toMap();
+			VariantMap m = v->toMap();
 			if(m.contains(ref.name))
 			{
 				ret = true;
@@ -272,7 +273,7 @@ static bool removeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 	}
 	else // Array
 	{
-		QVariantList l = v->toList();
+		VariantList l = v->toList();
 		if(ref.index >= 0 && ref.index < l.count())
 		{
 			ret = true;
@@ -287,16 +288,16 @@ static bool removeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 
 bool JsonPointer::remove()
 {
-	QVariant ret;
+	Variant ret;
 	if(execute(removeFunc, &ret))
 		return ret.toBool();
 	else
 		return false;
 }
 
-static bool takeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
+static bool takeFunc(Variant *v, const JsonPointer::Ref &ref, void *data)
 {
-	QVariant &ret = *((QVariant *)data);
+	Variant &ret = *((Variant *)data);
 
 	if(ref.type == JsonPointer::Ref::Self)
 	{
@@ -307,7 +308,7 @@ static bool takeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 	{
 		if(typeId(*v) == QMetaType::QVariantHash)
 		{
-			QVariantHash h = v->toHash();
+			VariantHash h = v->toHash();
 			if(h.contains(ref.name))
 			{
 				ret = h.value(ref.name);
@@ -320,7 +321,7 @@ static bool takeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 		}
 		else // Map
 		{
-			QVariantMap m = v->toMap();
+			VariantMap m = v->toMap();
 			if(m.contains(ref.name))
 			{
 				ret = m.value(ref.name);
@@ -334,7 +335,7 @@ static bool takeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 	}
 	else // Array
 	{
-		QVariantList l = v->toList();
+		VariantList l = v->toList();
 		if(ref.index >= 0 && ref.index < l.count())
 		{
 			ret = l[ref.index];
@@ -347,18 +348,18 @@ static bool takeFunc(QVariant *v, const JsonPointer::Ref &ref, void *data)
 	}
 }
 
-QVariant JsonPointer::take()
+Variant JsonPointer::take()
 {
-	QVariant ret;
+	Variant ret;
 	if(execute(takeFunc, &ret))
 		return ret;
 	else
-		return QVariant();
+		return Variant();
 }
 
-static bool setValueFunc(QVariant *v, const JsonPointer::Ref &ref, void *_data)
+static bool setValueFunc(Variant *v, const JsonPointer::Ref &ref, void *_data)
 {
-	QPair<QVariant, QVariant> &data = *((QPair<QVariant, QVariant> *)_data);
+	QPair<Variant, Variant> &data = *((QPair<Variant, Variant> *)_data);
 
 	if(ref.type == JsonPointer::Ref::Self)
 	{
@@ -370,7 +371,7 @@ static bool setValueFunc(QVariant *v, const JsonPointer::Ref &ref, void *_data)
 	{
 		if(typeId(*v) == QMetaType::QVariantHash)
 		{
-			QVariantHash h = v->toHash();
+			VariantHash h = v->toHash();
 			h[ref.name] = data.first;
 			*v = h;
 			data.second = true;
@@ -378,7 +379,7 @@ static bool setValueFunc(QVariant *v, const JsonPointer::Ref &ref, void *_data)
 		}
 		else // Map
 		{
-			QVariantMap m = v->toMap();
+			VariantMap m = v->toMap();
 			m[ref.name] = data.first;
 			*v = m;
 			data.second = true;
@@ -387,7 +388,7 @@ static bool setValueFunc(QVariant *v, const JsonPointer::Ref &ref, void *_data)
 	}
 	else // Array
 	{
-		QVariantList l = v->toList();
+		VariantList l = v->toList();
 		if(ref.index == -1)
 		{
 			// Append
@@ -408,9 +409,9 @@ static bool setValueFunc(QVariant *v, const JsonPointer::Ref &ref, void *_data)
 	}
 }
 
-bool JsonPointer::setValue(const QVariant &value)
+bool JsonPointer::setValue(const Variant &value)
 {
-	QPair<QVariant, QVariant> data;
+	QPair<Variant, Variant> data;
 	data.first = value;
 	if(execute(setValueFunc, &data))
 		return data.second.toBool();
@@ -438,7 +439,7 @@ bool JsonPointer::isWithin(const QString &bPointerStr, const QString &aPointerSt
 	return true;
 }
 
-JsonPointer JsonPointer::resolve(QVariant *data, const QString &pointerStr, QString *errorMessage)
+JsonPointer JsonPointer::resolve(Variant *data, const QString &pointerStr, QString *errorMessage)
 {
 	if(!pointerStr.startsWith('/'))
 	{
@@ -455,7 +456,7 @@ JsonPointer JsonPointer::resolve(QVariant *data, const QString &pointerStr, QStr
 	if(pointerStr.length() == 1)
 		return ptr;
 
-	QVariant i = *ptr.root_;
+	Variant i = *ptr.root_;
 	QStringList parts = pointerStr.split('/').mid(1);
 	foreach(const QString &part, parts)
 	{
@@ -481,7 +482,7 @@ JsonPointer JsonPointer::resolve(QVariant *data, const QString &pointerStr, QStr
 
 				if(typeId(i) == QMetaType::QVariantHash)
 				{
-					QVariantHash h = i.toHash();
+					VariantHash h = i.toHash();
 					if(!h.contains(prevRef.name))
 					{
 						if(errorMessage)
@@ -493,7 +494,7 @@ JsonPointer JsonPointer::resolve(QVariant *data, const QString &pointerStr, QStr
 				}
 				else // Map
 				{
-					QVariantMap m = i.toMap();
+					VariantMap m = i.toMap();
 					if(!m.contains(prevRef.name))
 					{
 						if(errorMessage)
@@ -506,7 +507,7 @@ JsonPointer JsonPointer::resolve(QVariant *data, const QString &pointerStr, QStr
 			}
 			else // Array
 			{
-				QVariantList l = i.toList();
+				VariantList l = i.toList();
 				if(prevRef.index < 0 || prevRef.index >= l.count())
 				{
 					if(errorMessage)
@@ -524,7 +525,7 @@ JsonPointer JsonPointer::resolve(QVariant *data, const QString &pointerStr, QStr
 		}
 		else if(typeId(i) == QMetaType::QVariantList)
 		{
-			QVariantList l = i.toList();
+			VariantList l = i.toList();
 			if(p == "-")
 			{
 				ptr.refs_ += Ref(-1);

--- a/src/handler/jsonpointer.h
+++ b/src/handler/jsonpointer.h
@@ -24,8 +24,8 @@
 #define JSONPOINTER_H
 
 #include <QString>
-#include <QVariant>
 #include <QVarLengthArray>
+#include "variant.h"
 
 class JsonPointer
 {
@@ -64,26 +64,26 @@ public:
 		}
 	};
 
-	typedef void (*ConstFunc)(const QVariant *v, const Ref &ref, void *data);
+	typedef void (*ConstFunc)(const Variant *v, const Ref &ref, void *data);
 
 	// Return true if data was modified
-	typedef bool (*Func)(QVariant *v, const Ref &ref, void *data);
+	typedef bool (*Func)(Variant *v, const Ref &ref, void *data);
 
 	JsonPointer();
 
 	inline bool isNull() const { return isNull_; }
 
-	QVariant *root();
+	Variant *root();
 	bool execute(ConstFunc func, void *data) const;
 	bool execute(Func func, void *data);
 	bool exists() const;
-	QVariant value() const;
-	QVariant take();
+	Variant value() const;
+	Variant take();
 	bool remove();
-	bool setValue(const QVariant &value);
+	bool setValue(const Variant &value);
 
 	static bool isWithin(const QString &bPointerStr, const QString &aPointerStr);
-	static JsonPointer resolve(QVariant *data, const QString &pointerStr, QString *errorMessage = 0);
+	static JsonPointer resolve(Variant *data, const QString &pointerStr, QString *errorMessage = 0);
 
 private:
 	enum ExecStatus
@@ -94,11 +94,11 @@ private:
 	};
 
 	bool isNull_;
-	QVariant *root_;
+	Variant *root_;
 	QVarLengthArray<Ref, 16> refs_;
 
-	ExecStatus execute(const QVariant *i, int refIndex, ConstFunc func, void *data) const;
-	ExecStatus execute(QVariant *i, int refIndex, Func func, void *data);
+	ExecStatus execute(const Variant *i, int refIndex, ConstFunc func, void *data) const;
+	ExecStatus execute(Variant *i, int refIndex, Func func, void *data);
 };
 
 #endif

--- a/src/handler/publishformat.cpp
+++ b/src/handler/publishformat.cpp
@@ -24,12 +24,13 @@
 #include "publishformat.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 #include "variantutil.h"
 #include "statusreasons.h"
 
 using namespace VariantUtil;
 
-PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok, QString *errorMessage)
+PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok, QString *errorMessage)
 {
 	QString pn;
 	if(type == HttpResponse)
@@ -85,7 +86,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 		{
 			if(keyedObjectContains(in, "code"))
 			{
-				QVariant vcode = keyedObjectGetValue(in, "code");
+				Variant vcode = keyedObjectGetValue(in, "code");
 				if(!canConvert(vcode, QMetaType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
@@ -118,10 +119,10 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 
 			if(keyedObjectContains(in, "headers"))
 			{
-				QVariant vheaders = keyedObjectGetValue(in, "headers");
+				Variant vheaders = keyedObjectGetValue(in, "headers");
 				if(typeId(vheaders) == QMetaType::QVariantList)
 				{
-					foreach(const QVariant &vheader, vheaders.toList())
+					foreach(const Variant &vheader, vheaders.toList())
 					{
 						if(typeId(vheader) != QMetaType::QVariantList)
 						{
@@ -129,7 +130,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 							return PublishFormat();
 						}
 
-						QVariantList lheader = vheader.toList();
+						VariantList lheader = vheader.toList();
 						if(lheader.count() != 2)
 						{
 							setError(ok, errorMessage, "headers contains list with wrong number of elements");
@@ -157,14 +158,14 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 				{
 					if(typeId(vheaders) == QMetaType::QVariantHash)
 					{
-						QVariantHash hheaders = vheaders.toHash();
+						VariantHash hheaders = vheaders.toHash();
 
-						QHashIterator<QString, QVariant> it(hheaders);
+						QHashIterator<QString, Variant> it(hheaders);
 						while(it.hasNext())
 						{
 							it.next();
 							const QString &key = it.key();
-							const QVariant &vval = it.value();
+							const Variant &vval = it.value();
 
 							QString val = getString(vval, &ok_);
 							if(!ok_)
@@ -178,14 +179,14 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 					}
 					else // Map
 					{
-						QVariantMap mheaders = vheaders.toMap();
+						VariantMap mheaders = vheaders.toMap();
 
-						QMapIterator<QString, QVariant> it(mheaders);
+						QMapIterator<QString, Variant> it(mheaders);
 						while(it.hasNext())
 						{
 							it.next();
 							const QString &key = it.key();
-							const QVariant &vval = it.value();
+							const Variant &vval = it.value();
 
 							QString val = getString(vval, &ok_);
 							if(!ok_)
@@ -207,7 +208,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 
 			if(keyedObjectContains(in, "content-filters"))
 			{
-				QVariant vfilters = keyedObjectGetValue(in, "content-filters");
+				Variant vfilters = keyedObjectGetValue(in, "content-filters");
 				if(typeId(vfilters) != QMetaType::QVariantList)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
@@ -215,7 +216,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 				}
 
 				QStringList filters;
-				foreach(const QVariant &vfilter, vfilters.toList())
+				foreach(const Variant &vfilter, vfilters.toList())
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -245,7 +246,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 			}
 			else if(keyedObjectContains(in, "body"))
 			{
-				QVariant vcontent = keyedObjectGetValue(in, "body");
+				Variant vcontent = keyedObjectGetValue(in, "body");
 				if(typeId(vcontent) == QMetaType::QByteArray)
 					out.body = vcontent.toByteArray();
 				else if(typeId(vcontent) == QMetaType::QString)
@@ -284,7 +285,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 		{
 			if(keyedObjectContains(in, "content-filters"))
 			{
-				QVariant vfilters = keyedObjectGetValue(in, "content-filters");
+				Variant vfilters = keyedObjectGetValue(in, "content-filters");
 				if(typeId(vfilters) != QMetaType::QVariantList)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
@@ -292,7 +293,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 				}
 
 				QStringList filters;
-				foreach(const QVariant &vfilter, vfilters.toList())
+				foreach(const Variant &vfilter, vfilters.toList())
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -322,7 +323,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 			}
 			else if(keyedObjectContains(in, "content"))
 			{
-				QVariant vcontent = keyedObjectGetValue(in, "content");
+				Variant vcontent = keyedObjectGetValue(in, "content");
 				if(typeId(vcontent) == QMetaType::QByteArray)
 					out.body = vcontent.toByteArray();
 				else if(typeId(vcontent) == QMetaType::QString)
@@ -374,7 +375,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 
 			if(keyedObjectContains(in, "content-filters"))
 			{
-				QVariant vfilters = keyedObjectGetValue(in, "content-filters");
+				Variant vfilters = keyedObjectGetValue(in, "content-filters");
 				if(typeId(vfilters) != QMetaType::QVariantList)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
@@ -382,7 +383,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 				}
 
 				QStringList filters;
-				foreach(const QVariant &vfilter, vfilters.toList())
+				foreach(const Variant &vfilter, vfilters.toList())
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -400,7 +401,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 
 			if(keyedObjectContains(in, "content-bin"))
 			{
-				QVariant vcontentBin = keyedObjectGetValue(in, "content-bin");
+				Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
 
 				if(typeId(in) == QMetaType::QVariantMap) // JSON input
 				{
@@ -428,7 +429,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 			}
 			else if(keyedObjectContains(in, "content"))
 			{
-				QVariant vcontent = keyedObjectGetValue(in, "content");
+				Variant vcontent = keyedObjectGetValue(in, "content");
 				if(typeId(vcontent) == QMetaType::QByteArray)
 					out.body = vcontent.toByteArray();
 				else if(typeId(vcontent) == QMetaType::QString)
@@ -452,7 +453,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const QVariant &in, bool *ok
 		{
 			if(keyedObjectContains(in, "code"))
 			{
-				QVariant vcode = keyedObjectGetValue(in, "code");
+				Variant vcode = keyedObjectGetValue(in, "code");
 				if(!canConvert(vcode, QMetaType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));

--- a/src/handler/publishformat.h
+++ b/src/handler/publishformat.h
@@ -25,7 +25,7 @@
 
 #include <QByteArray>
 #include <QString>
-#include <QVariant>
+#include "variant.h"
 #include "httpheaders.h"
 
 class PublishFormat
@@ -61,7 +61,7 @@ public:
 	HttpHeaders headers; // Response
 	QByteArray body; // Response/stream/ws
 	bool haveBodyPatch; // Response
-	QVariantList bodyPatch; // Response
+	VariantList bodyPatch; // Response
 	MessageType messageType; // Ws
 	bool haveContentFilters;
 	QStringList contentFilters; // Response/stream/ws
@@ -86,7 +86,7 @@ public:
 	{
 	}
 
-	static PublishFormat fromVariant(Type type, const QVariant &in, bool *ok = 0, QString *errorMessage = 0);
+	static PublishFormat fromVariant(Type type, const Variant &in, bool *ok = 0, QString *errorMessage = 0);
 };
 
 #endif

--- a/src/handler/publishformattest.cpp
+++ b/src/handler/publishformattest.cpp
@@ -22,15 +22,15 @@
  */
 
 #include "test.h"
-#include <QVariant>
+#include "variant.h"
 #include "publishformat.h"
 
 static void responseFormat()
 {
-	QVariantHash data;
+	VariantHash data;
 	data["code"] = 200;
 	data["reason"] = QByteArray("OK");
-	data["headers"] = QVariantList() << QVariant(QVariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+	data["headers"] = VariantList() << Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
 	data["body"] = QByteArray("hello world");
 
 	bool ok;
@@ -56,7 +56,7 @@ static void responseFormat()
 
 static void streamFormat()
 {
-	QVariantHash data;
+	VariantHash data;
 	data["content"] = QByteArray("hello world");
 
 	bool ok;
@@ -76,7 +76,7 @@ static void streamFormat()
 
 static void webSocketMessageFormat()
 {
-	QVariantHash data;
+	VariantHash data;
 	data["content"] = QByteArray("hello world");
 
 	bool ok;

--- a/src/handler/publishitem.cpp
+++ b/src/handler/publishitem.cpp
@@ -24,11 +24,12 @@
 #include "publishitem.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 #include "variantutil.h"
 
 using namespace VariantUtil;
 
-PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &channel, bool *ok, QString *errorMessage)
+PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channel, bool *ok, QString *errorMessage)
 {
 	QString pn = "publish item object";
 
@@ -72,7 +73,7 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 		return PublishItem();
 	}
 
-	QVariant vformats = getKeyedObject(vitem, pn, "formats", false, &ok_, errorMessage);
+	Variant vformats = getKeyedObject(vitem, pn, "formats", false, &ok_, errorMessage);
 	if(!ok_)
 	{
 		if(ok)
@@ -84,7 +85,7 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 	{
 		vformats = createSameKeyedObject(vitem);
 
-		QVariant v = keyedObjectGetValue(vitem, "http-response");
+		Variant v = keyedObjectGetValue(vitem, "http-response");
 		if(v.isValid())
 			keyedObjectInsert(&vformats, "http-response", v);
 
@@ -142,7 +143,7 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 		item.formats.insert(f.type, f);
 	}
 
-	QVariant vmeta = getKeyedObject(vitem, pn, "meta", false, &ok_, errorMessage);
+	Variant vmeta = getKeyedObject(vitem, pn, "meta", false, &ok_, errorMessage);
 	if(!ok_)
 	{
 		if(ok)
@@ -154,14 +155,14 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 	{
 		if(typeId(vmeta) == QMetaType::QVariantHash)
 		{
-			QVariantHash hmeta = vmeta.toHash();
+			VariantHash hmeta = vmeta.toHash();
 
-			QHashIterator<QString, QVariant> it(hmeta);
+			QHashIterator<QString, Variant> it(hmeta);
 			while(it.hasNext())
 			{
 				it.next();
 				const QString &key = it.key();
-				const QVariant &vval = it.value();
+				const Variant &vval = it.value();
 
 				QString val = getString(vval, &ok_);
 				if(!ok_)
@@ -175,14 +176,14 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 		}
 		else // Map
 		{
-			QVariantMap mmeta = vmeta.toMap();
+			VariantMap mmeta = vmeta.toMap();
 
-			QMapIterator<QString, QVariant> it(mmeta);
+			QMapIterator<QString, Variant> it(mmeta);
 			while(it.hasNext())
 			{
 				it.next();
 				const QString &key = it.key();
-				const QVariant &vval = it.value();
+				const Variant &vval = it.value();
 
 				QString val = getString(vval, &ok_);
 				if(!ok_)
@@ -198,7 +199,7 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 
 	if(keyedObjectContains(vitem, "size"))
 	{
-		QVariant vsize = keyedObjectGetValue(vitem, "size");
+		Variant vsize = keyedObjectGetValue(vitem, "size");
 		if(!canConvert(vsize, QMetaType::Int))
 		{
 			setError(ok, errorMessage, QString("%1 contains 'size' with wrong type").arg(pn));
@@ -216,7 +217,7 @@ PublishItem PublishItem::fromVariant(const QVariant &vitem, const QString &chann
 
 	if(keyedObjectContains(vitem, "no-seq"))
 	{
-		QVariant vnoSeq = keyedObjectGetValue(vitem, "no-seq");
+		Variant vnoSeq = keyedObjectGetValue(vitem, "no-seq");
 		if(typeId(vnoSeq) != QMetaType::Bool)
 		{
 			setError(ok, errorMessage, QString("%1 contains 'no-seq' with wrong type").arg(pn));

--- a/src/handler/publishitem.h
+++ b/src/handler/publishitem.h
@@ -25,7 +25,7 @@
 
 #include <QString>
 #include <QHash>
-#include <QVariant>
+#include "variant.h"
 #include "publishformat.h"
 
 class PublishItem
@@ -47,7 +47,7 @@ public:
 	{
 	}
 
-	static PublishItem fromVariant(const QVariant &vitem, const QString &channel = QString(), bool *ok = 0, QString *errorMessage = 0);
+	static PublishItem fromVariant(const Variant &vitem, const QString &channel = QString(), bool *ok = 0, QString *errorMessage = 0);
 };
 
 #endif

--- a/src/handler/publishitemtest.cpp
+++ b/src/handler/publishitemtest.cpp
@@ -24,20 +24,21 @@
 #include "test.h"
 #include "publishformat.h"
 #include "publishitem.h"
+#include "variant.h"
 
 static void parseItem()
 {
-	QVariantHash meta;
+	VariantHash meta;
 	meta["foo"] = QByteArray("bar");
 	meta["bar"] = QByteArray("baz");
 
-	QVariantHash hs;
+	VariantHash hs;
 	hs["content"] = QByteArray("hello world");
 
-	QVariantHash formats;
+	VariantHash formats;
 	formats["http-stream"] = hs;
 
-	QVariantHash data;
+	VariantHash data;
 	data["channel"] = QByteArray("apple");
 	data["id"] = QByteArray("item1");
 	data["prev-id"] = QByteArray("item0");
@@ -59,17 +60,17 @@ static void parseItem()
 
 static void parseItemJsonStyle()
 {
-	QVariantMap meta;
+	VariantMap meta;
 	meta["foo"] = QString("bar");
 	meta["bar"] = QString("baz");
 
-	QVariantMap hs;
+	VariantMap hs;
 	hs["content"] = QString("hello world");
 
-	QVariantMap formats;
+	VariantMap formats;
 	formats["http-stream"] = hs;
 
-	QVariantMap data;
+	VariantMap data;
 	data["channel"] = QString("apple");
 	data["id"] = QString("item1");
 	data["prev-id"] = QString("item0");

--- a/src/handler/refreshworker.cpp
+++ b/src/handler/refreshworker.cpp
@@ -28,13 +28,14 @@
 #include "controlrequest.h"
 #include "statsmanager.h"
 #include "wssession.h"
+#include "variant.h"
 
 RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel) :
 	ignoreErrors_(false),
 	proxyControlClient_(proxyControlClient),
 	req_(req)
 {
-	QVariantHash args = req_->args();
+	VariantHash args = req_->args();
 
 	if(args.contains("cid"))
 	{

--- a/src/handler/requeststate.cpp
+++ b/src/handler/requeststate.cpp
@@ -24,19 +24,20 @@
 #include "requeststate.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
-RequestState RequestState::fromVariant(const QVariant &in)
+RequestState RequestState::fromVariant(const Variant &in)
 {
 	if(typeId(in) != QMetaType::QVariantHash)
 		return RequestState();
 
-	QVariantHash r = in.toHash();
+	VariantHash r = in.toHash();
 	RequestState rs;
 
 	if(!r.contains("rid") || typeId(r["rid"]) != QMetaType::QVariantHash)
 		return RequestState();
 
-	QVariantHash vrid = r["rid"].toHash();
+	VariantHash vrid = r["rid"].toHash();
 
 	if(!vrid.contains("sender") || typeId(vrid["sender"]) != QMetaType::QByteArray)
 		return RequestState();

--- a/src/handler/requeststate.h
+++ b/src/handler/requeststate.h
@@ -25,7 +25,7 @@
 #define REQUESTSTATE_H
 
 #include <QByteArray>
-#include <QVariant>
+#include "variant.h"
 #include <QHostAddress>
 #include "zhttprequest.h"
 
@@ -47,7 +47,7 @@ public:
 	QByteArray jsonpCallback;
 	bool jsonpExtendedResponse;
 	int unreportedTime;
-	QVariant userData;
+	Variant userData;
 
 	RequestState() :
 		responseCode(-1),
@@ -64,7 +64,7 @@ public:
 	{
 	}
 
-	static RequestState fromVariant(const QVariant &in);
+	static RequestState fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/handler/sessionrequest.cpp
+++ b/src/handler/sessionrequest.cpp
@@ -23,8 +23,8 @@
 
 #include "sessionrequest.h"
 
-#include <QVariant>
 #include "qtcompat.h"
+#include "variant.h"
 #include "zrpcmanager.h"
 #include "zrpcrequest.h"
 #include "deferred.h"
@@ -40,10 +40,10 @@ public:
 		req = std::make_unique<ZrpcRequest>(stateClient);
 		finishedConnection = req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this));
 
-		QVariantList rlist;
+		VariantList rlist;
 		foreach(const DetectRule &rule, rules)
 		{
-			QVariantHash i;
+			VariantHash i;
 			i["domain"] = rule.domain.toUtf8();
 			i["path-prefix"] = rule.pathPrefix;
 			i["sid-ptr"] = rule.sidPtr.toUtf8();
@@ -52,7 +52,7 @@ public:
 			rlist += i;
 		}
 
-		QVariantHash args;
+		VariantHash args;
 		args["rules"] = rlist;
 		req->start("session-detect-rules-set", args);
 	}
@@ -82,7 +82,7 @@ public:
 		req = std::make_unique<ZrpcRequest>(stateClient);
 		finishedConnection = req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this));
 
-		QVariantHash args;
+		VariantHash args;
 		args["domain"] = domain.toUtf8();
 		args["path"] = path;
 		req->start("session-detect-rules-get", args);
@@ -96,17 +96,17 @@ private:
 	{
 		if(req->success())
 		{
-			QVariant vresult = req->result();
+			Variant vresult = req->result();
 			if(typeId(vresult) != QMetaType::QVariantList)
 			{
 				setFinished(false);
 				return;
 			}
 
-			QVariantList result = vresult.toList();
+			VariantList result = vresult.toList();
 
 			QList<DetectRule> rules;
-			foreach(const QVariant &vr, result)
+			foreach(const Variant &vr, result)
 			{
 				if(typeId(vr) != QMetaType::QVariantHash)
 				{
@@ -114,7 +114,7 @@ private:
 					return;
 				}
 
-				QVariantHash r = vr.toHash();
+				VariantHash r = vr.toHash();
 
 				DetectRule rule;
 
@@ -156,7 +156,7 @@ private:
 				rules += rule;
 			}
 
-			setFinished(true, QVariant::fromValue<DetectRuleList>(rules));
+			setFinished(true, Variant::fromValue<DetectRuleList>(rules));
 		}
 		else
 		{
@@ -173,11 +173,11 @@ public:
 		req = std::make_unique<ZrpcRequest>(stateClient);
 		finishedConnection = req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this));
 
-		QVariantHash args;
+		VariantHash args;
 
 		args["sid"] = sid.toUtf8();
 
-		QVariantHash vlastIds;
+		VariantHash vlastIds;
 		QHashIterator<QString, QString> it(lastIds);
 		while(it.hasNext())
 		{
@@ -214,7 +214,7 @@ public:
 		req = std::make_unique<ZrpcRequest>(stateClient);
 		finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this));
 
-		QVariantHash vsidLastIds;
+		VariantHash vsidLastIds;
 
 		QHashIterator<QString, LastIds> it(sidLastIds);
 		while(it.hasNext())
@@ -223,7 +223,7 @@ public:
 			const QString &sid = it.key();
 			const LastIds &lastIds = it.value();
 
-			QVariantHash vlastIds;
+			VariantHash vlastIds;
 
 			QHashIterator<QString, QString> it(lastIds);
 			while(it.hasNext())
@@ -235,7 +235,7 @@ public:
 			vsidLastIds.insert(sid, vlastIds);
 		}
 
-		QVariantHash args;
+		VariantHash args;
 		args["sid-last-ids"] = vsidLastIds;
 		req->start("session-update-many", args);
 	}
@@ -265,7 +265,7 @@ public:
 		req = std::make_unique<ZrpcRequest>(stateClient);
 		finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this));
 
-		QVariantHash args;
+		VariantHash args;
 		args["sid"] = sid.toUtf8();
 		req->start("session-get-last-ids", args);
 	}
@@ -278,21 +278,21 @@ private:
 	{
 		if(req->success())
 		{
-			QVariant vresult = req->result();
+			Variant vresult = req->result();
 			if(typeId(vresult) != QMetaType::QVariantHash)
 			{
 				setFinished(false);
 				return;
 			}
 
-			QVariantHash result = vresult.toHash();
+			VariantHash result = vresult.toHash();
 
 			QHash<QString, QString> out;
-			QHashIterator<QString, QVariant> it(result);
+			QHashIterator<QString, Variant> it(result);
 			while(it.hasNext())
 			{
 				it.next();
-				const QVariant &i = it.value();
+				const Variant &i = it.value();
 				if(typeId(i) != QMetaType::QByteArray)
 				{
 					setFinished(false);
@@ -302,7 +302,7 @@ private:
 				out.insert(it.key(), QString::fromUtf8(i.toByteArray()));
 			}
 
-			setFinished(true, QVariant::fromValue<LastIds>(out));
+			setFinished(true, Variant::fromValue<LastIds>(out));
 		}
 		else
 		{

--- a/src/handler/variantutil.cpp
+++ b/src/handler/variantutil.cpp
@@ -24,6 +24,7 @@
 #include "variantutil.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 
 namespace VariantUtil {
 
@@ -43,22 +44,22 @@ void setError(bool *ok, QString *errorMessage, const QString &msg)
 		*errorMessage = msg;
 }
 
-bool isKeyedObject(const QVariant &in)
+bool isKeyedObject(const Variant &in)
 {
 	return (typeId(in) == QMetaType::QVariantHash || typeId(in) == QMetaType::QVariantMap);
 }
 
-QVariant createSameKeyedObject(const QVariant &in)
+Variant createSameKeyedObject(const Variant &in)
 {
 	if(typeId(in) == QMetaType::QVariantHash)
-		return QVariantHash();
+		return VariantHash();
 	else if(typeId(in) == QMetaType::QVariantMap)
-		return QVariantMap();
+		return VariantMap();
 	else
-		return QVariant();
+		return Variant();
 }
 
-bool keyedObjectIsEmpty(const QVariant &in)
+bool keyedObjectIsEmpty(const Variant &in)
 {
 	if(typeId(in) == QMetaType::QVariantHash)
 		return in.toHash().isEmpty();
@@ -68,7 +69,7 @@ bool keyedObjectIsEmpty(const QVariant &in)
 		return true;
 }
 
-bool keyedObjectContains(const QVariant &in, const QString &name)
+bool keyedObjectContains(const Variant &in, const QString &name)
 {
 	if(typeId(in) == QMetaType::QVariantHash)
 		return in.toHash().contains(name);
@@ -78,47 +79,47 @@ bool keyedObjectContains(const QVariant &in, const QString &name)
 		return false;
 }
 
-QVariant keyedObjectGetValue(const QVariant &in, const QString &name)
+Variant keyedObjectGetValue(const Variant &in, const QString &name)
 {
 	if(typeId(in) == QMetaType::QVariantHash)
 		return in.toHash().value(name);
 	else if(typeId(in) == QMetaType::QVariantMap)
 		return in.toMap().value(name);
 	else
-		return QVariant();
+		return Variant();
 }
 
-void keyedObjectInsert(QVariant *in, const QString &name, const QVariant &value)
+void keyedObjectInsert(Variant *in, const QString &name, const Variant &value)
 {
 	if(typeId(*in) == QMetaType::QVariantHash)
 	{
-		QVariantHash h = in->toHash();
+		VariantHash h = in->toHash();
 		h.insert(name, value);
 		*in = h;
 	}
 	else if(typeId(*in) == QMetaType::QVariantMap)
 	{
-		QVariantMap h = in->toMap();
+		VariantMap h = in->toMap();
 		h.insert(name, value);
 		*in = h;
 	}
 }
 
-QVariant getChild(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
+Variant getChild(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
 {
 	if(!isKeyedObject(in))
 	{
 		QString pn = !parentName.isEmpty() ? parentName : QString("value");
 		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return QVariant();
+		return Variant();
 	}
 
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	QVariant v;
+	Variant v;
 	if(typeId(in) == QMetaType::QVariantHash)
 	{
-		QVariantHash h = in.toHash();
+		VariantHash h = in.toHash();
 
 		if(!h.contains(childName))
 		{
@@ -127,14 +128,14 @@ QVariant getChild(const QVariant &in, const QString &parentName, const QString &
 			else
 				setSuccess(ok, errorMessage);
 
-			return QVariant();
+			return Variant();
 		}
 
 		v = h[childName];
 	}
 	else // Map
 	{
-		QVariantMap m = in.toMap();
+		VariantMap m = in.toMap();
 
 		if(!m.contains(childName))
 		{
@@ -143,7 +144,7 @@ QVariant getChild(const QVariant &in, const QString &parentName, const QString &
 			else
 				setSuccess(ok, errorMessage);
 
-			return QVariant();
+			return Variant();
 		}
 
 		v = m[childName];
@@ -153,21 +154,21 @@ QVariant getChild(const QVariant &in, const QString &parentName, const QString &
 	return v;
 }
 
-QVariant getKeyedObject(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
+Variant getKeyedObject(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
 {
 	bool ok_;
-	QVariant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
 	if(!ok_)
 	{
 		if(ok)
 			*ok = false;
-		return QVariant();
+		return Variant();
 	}
 
 	if(!v.isValid() && !required)
 	{
 		setSuccess(ok, errorMessage);
-		return QVariant();
+		return Variant();
 	}
 
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
@@ -175,28 +176,28 @@ QVariant getKeyedObject(const QVariant &in, const QString &parentName, const QSt
 	if(!isKeyedObject(v))
 	{
 		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
-		return QVariant();
+		return Variant();
 	}
 
 	setSuccess(ok, errorMessage);
 	return v;
 }
 
-QVariantList getList(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
+VariantList getList(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
 {
 	bool ok_;
-	QVariant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
 	if(!ok_)
 	{
 		if(ok)
 			*ok = false;
-		return QVariantList();
+		return VariantList();
 	}
 
 	if(!v.isValid() && !required)
 	{
 		setSuccess(ok, errorMessage);
-		return QVariantList();
+		return VariantList();
 	}
 
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
@@ -204,14 +205,14 @@ QVariantList getList(const QVariant &in, const QString &parentName, const QStrin
 	if(typeId(v) != QMetaType::QVariantList)
 	{
 		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
-		return QVariantList();
+		return VariantList();
 	}
 
 	setSuccess(ok, errorMessage);
 	return v.toList();
 }
 
-QString getString(const QVariant &in, bool *ok)
+QString getString(const Variant &in, bool *ok)
 {
 	if(typeId(in) == QMetaType::QString)
 	{
@@ -237,10 +238,10 @@ QString getString(const QVariant &in, bool *ok)
 	}
 }
 
-QString getString(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
+QString getString(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
 {
 	bool ok_;
-	QVariant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
 	if(!ok_)
 	{
 		if(ok)
@@ -267,7 +268,7 @@ QString getString(const QVariant &in, const QString &parentName, const QString &
 	return str;
 }
 
-bool convertToJsonStyleInPlace(QVariant *in)
+bool convertToJsonStyleInPlace(Variant *in)
 {
 	// Hash -> Map
 	// ByteArray (UTF-8) -> String
@@ -277,13 +278,13 @@ bool convertToJsonStyleInPlace(QVariant *in)
 	QMetaType::Type type = typeId(*in);
 	if(type == QMetaType::QVariantHash)
 	{
-		QVariantMap vmap;
-		QVariantHash vhash = in->toHash();
-		QHashIterator<QString, QVariant> it(vhash);
+		VariantMap vmap;
+		VariantHash vhash = in->toHash();
+		QHashIterator<QString, Variant> it(vhash);
 		while(it.hasNext())
 		{
 			it.next();
-			QVariant i = it.value();
+			Variant i = it.value();
 			convertToJsonStyleInPlace(&i);
 			vmap[it.key()] = i;
 		}
@@ -293,10 +294,10 @@ bool convertToJsonStyleInPlace(QVariant *in)
 	}
 	else if(type == QMetaType::QVariantList)
 	{
-		QVariantList vlist = in->toList();
+		VariantList vlist = in->toList();
 		for(int n = 0; n < vlist.count(); ++n)
 		{
-			QVariant i = vlist.at(n);
+			Variant i = vlist.at(n);
 			convertToJsonStyleInPlace(&i);
 			vlist[n] = i;
 		}
@@ -317,9 +318,9 @@ bool convertToJsonStyleInPlace(QVariant *in)
 	return changed;
 }
 
-QVariant convertToJsonStyle(const QVariant &in)
+Variant convertToJsonStyle(const Variant &in)
 {
-	QVariant v = in;
+	Variant v = in;
 	convertToJsonStyleInPlace(&v);
 	return v;
 }

--- a/src/handler/variantutil.h
+++ b/src/handler/variantutil.h
@@ -23,30 +23,30 @@
 #ifndef VARIANTUTIL_H
 #define VARIANTUTIL_H
 
-#include <QVariant>
+#include "variant.h"
 
 namespace VariantUtil {
 
 void setSuccess(bool *ok, QString *errorMessage);
 void setError(bool *ok, QString *errorMessage, const QString &msg);
 
-bool isKeyedObject(const QVariant &in);
-QVariant createSameKeyedObject(const QVariant &in);
-bool keyedObjectIsEmpty(const QVariant &in);
-bool keyedObjectContains(const QVariant &in, const QString &name);
-QVariant keyedObjectGetValue(const QVariant &in, const QString &name);
-void keyedObjectInsert(QVariant *in, const QString &name, const QVariant &value);
+bool isKeyedObject(const Variant &in);
+Variant createSameKeyedObject(const Variant &in);
+bool keyedObjectIsEmpty(const Variant &in);
+bool keyedObjectContains(const Variant &in, const QString &name);
+Variant keyedObjectGetValue(const Variant &in, const QString &name);
+void keyedObjectInsert(Variant *in, const QString &name, const Variant &value);
 
-QVariant getChild(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
-QVariant getKeyedObject(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
-QVariantList getList(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
-QString getString(const QVariant &in, bool *ok = 0);
-QString getString(const QVariant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
+Variant getChild(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
+Variant getKeyedObject(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
+VariantList getList(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
+QString getString(const Variant &in, bool *ok = 0);
+QString getString(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
 
 // Return true if item modified
-bool convertToJsonStyleInPlace(QVariant *in);
+bool convertToJsonStyleInPlace(Variant *in);
 
-QVariant convertToJsonStyle(const QVariant &in);
+Variant convertToJsonStyle(const Variant &in);
 
 }
 

--- a/src/handler/wscontrolmessage.cpp
+++ b/src/handler/wscontrolmessage.cpp
@@ -23,13 +23,13 @@
 
 #include "wscontrolmessage.h"
 
-#include <QVariant>
 #include "qtcompat.h"
+#include "variant.h"
 #include "variantutil.h"
 
 using namespace VariantUtil;
 
-WsControlMessage WsControlMessage::fromVariant(const QVariant &in, bool *ok, QString *errorMessage)
+WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QString *errorMessage)
 {
 	QString pn = "grip control packet";
 
@@ -92,7 +92,7 @@ WsControlMessage WsControlMessage::fromVariant(const QVariant &in, bool *ok, QSt
 
 		if(out.type == Subscribe)
 		{
-			QVariantList vfilters = getList(in, pn, "filters", false, &ok_, errorMessage);
+			VariantList vfilters = getList(in, pn, "filters", false, &ok_, errorMessage);
 			if(!ok_)
 			{
 				if(ok)
@@ -100,7 +100,7 @@ WsControlMessage WsControlMessage::fromVariant(const QVariant &in, bool *ok, QSt
 				return WsControlMessage();
 			}
 
-			foreach(const QVariant &vfilter, vfilters)
+			foreach(const Variant &vfilter, vfilters)
 			{
 				QString filter = getString(vfilter, &ok_);
 				if(!ok_)
@@ -181,7 +181,7 @@ WsControlMessage WsControlMessage::fromVariant(const QVariant &in, bool *ok, QSt
 
 		if(keyedObjectContains(in, "content-bin"))
 		{
-			QVariant vcontentBin = keyedObjectGetValue(in, "content-bin");
+			Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
 
 			if(typeId(in) == QMetaType::QVariantMap) // JSON input
 			{
@@ -209,7 +209,7 @@ WsControlMessage WsControlMessage::fromVariant(const QVariant &in, bool *ok, QSt
 		}
 		else if(keyedObjectContains(in, "content"))
 		{
-			QVariant vcontent = keyedObjectGetValue(in, "content");
+			Variant vcontent = keyedObjectGetValue(in, "content");
 			if(typeId(vcontent) == QMetaType::QByteArray)
 				out.content = vcontent.toByteArray();
 			else if(typeId(vcontent) == QMetaType::QString)
@@ -228,7 +228,7 @@ WsControlMessage WsControlMessage::fromVariant(const QVariant &in, bool *ok, QSt
 		{
 			if(keyedObjectContains(in, "timeout"))
 			{
-				QVariant vtimeout = keyedObjectGetValue(in, "timeout");
+				Variant vtimeout = keyedObjectGetValue(in, "timeout");
 				if(!canConvert(vtimeout, QMetaType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(pn));

--- a/src/handler/wscontrolmessage.h
+++ b/src/handler/wscontrolmessage.h
@@ -25,8 +25,7 @@
 
 #include <QString>
 #include <QStringList>
-
-class QVariant;
+#include "variant.h"
 
 class WsControlMessage
 {
@@ -69,7 +68,7 @@ public:
 	{
 	}
 
-	static WsControlMessage fromVariant(const QVariant &in, bool *ok = 0, QString *errorMessage = 0);
+	static WsControlMessage fromVariant(const Variant &in, bool *ok = 0, QString *errorMessage = 0);
 };
 
 #endif

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -38,6 +38,7 @@
 #include "zmqsocket.h"
 #include "zmqvalve.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "processquit.h"
 #include "tnetstring.h"
 #include "m2requestpacket.h"
@@ -942,9 +943,9 @@ public:
 		m2_out_sock->write(QList<QByteArray>() << buf);
 	}
 
-	void m2_control_write(int index, const QByteArray &cmd, const QVariantHash &args)
+	void m2_control_write(int index, const QByteArray &cmd, const VariantHash &args)
 	{
-		QVariantList vlist;
+		VariantList vlist;
 		vlist += cmd;
 		vlist += args;
 
@@ -960,19 +961,19 @@ public:
 		controlPorts[index].sock->write(message);
 	}
 
-	void m2_writeCtl(M2Connection *conn, const QVariant &args)
+	void m2_writeCtl(M2Connection *conn, const Variant &args)
 	{
 		M2ResponsePacket mresp;
 		mresp.sender = m2_send_idents[conn->identIndex];
 		mresp.id = "X " + conn->id;
-		QVariantList parts;
+		VariantList parts;
 		parts += QByteArray("ctl");
 		parts += args;
 		mresp.data = TnetString::fromVariant(parts);
 		m2_out_write(mresp);
 	}
 
-	void m2_writeCtlMany(const QByteArray &sender, const QList<QByteArray> &connIds, const QVariant &args)
+	void m2_writeCtlMany(const QByteArray &sender, const QList<QByteArray> &connIds, const Variant &args)
 	{
 		assert(!connIds.isEmpty());
 
@@ -981,7 +982,7 @@ public:
 		mresp.id = "X";
 		foreach(const QByteArray &id, connIds)
 			mresp.id += " " + id;
-		QVariantList parts;
+		VariantList parts;
 		parts += QByteArray("ctl");
 		parts += args;
 		mresp.data = TnetString::fromVariant(parts);
@@ -993,9 +994,9 @@ public:
 		M2ResponsePacket mresp;
 		mresp.sender = sender;
 		mresp.id = "X " + id;
-		QVariantHash args;
+		VariantHash args;
 		args["cancel"] = true;
-		QVariantList parts;
+		VariantList parts;
 		parts += QByteArray("ctl");
 		parts += args;
 		mresp.data = TnetString::fromVariant(parts);
@@ -1217,7 +1218,7 @@ public:
 	{
 		const char *logprefix = (mode == Http ? "zhttp" : "zws");
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -1233,7 +1234,7 @@ public:
 	{
 		const char *logprefix = (mode == Http ? "zhttp" : "zws");
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -1268,7 +1269,7 @@ public:
 		zhttp_out_write(s->mode, out, s->zhttpAddress);
 	}
 
-	void handleControlResponse(int index, const QVariant &data)
+	void handleControlResponse(int index, const Variant &data)
 	{
 #ifdef CONTROL_PORT_DEBUG
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -1278,12 +1279,12 @@ public:
 		if(typeId(data) != QMetaType::QVariantHash)
 			return;
 
-		QVariantHash vhash = data.toHash();
+		VariantHash vhash = data.toHash();
 
 		if(!vhash.contains("rows"))
 			return;
 
-		QVariant rows = vhash["rows"];
+		Variant rows = vhash["rows"];
 
 		// Once we get at least one successful response then we flag the port as working
 		if(!controlPorts[index].works)
@@ -1293,12 +1294,12 @@ public:
 		}
 
 		QSet<QByteArray> ids;
-		foreach(const QVariant &row, rows.toList())
+		foreach(const Variant &row, rows.toList())
 		{
 			if(typeId(row) != QMetaType::QVariantList)
 				break;
 
-			QVariantList vlist = row.toList();
+			VariantList vlist = row.toList();
 			QByteArray id = vlist[0].toByteArray();
 			int bytes_written = vlist[7].toInt();
 
@@ -1462,7 +1463,7 @@ public:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(dataRaw.mid(1));
+		Variant data = TnetString::toVariant(dataRaw.mid(1));
 		if(data.isNull())
 		{
 			log_warning("%s: received message with invalid format (tnetstring parse failed), skipping", logprefix);
@@ -1713,7 +1714,7 @@ public:
 			// Data packet may have credits
 			if(zresp.credits > 0)
 			{
-				QVariantHash args;
+				VariantHash args;
 				args["credits"] = zresp.credits;
 				m2_writeCtl(s->conn, args);
 			}
@@ -1931,7 +1932,7 @@ public:
 		{
 			if(zresp.credits > 0)
 			{
-				QVariantHash args;
+				VariantHash args;
 				args["credits"] = zresp.credits;
 				m2_writeCtl(s->conn, args);
 			}
@@ -2024,7 +2025,7 @@ public:
 			// If we're at max, send out now
 			if(connIdList.count() >= M2_HANDLER_TARGETS_MAX)
 			{
-				QVariantHash args;
+				VariantHash args;
 				args["keep-alive"] = true;
 				m2_writeCtlMany(m2_send_idents[conn->identIndex], connIdList, args);
 
@@ -2057,7 +2058,7 @@ public:
 			// If we're at max, send out now
 			if(connIdList.count() >= M2_HANDLER_TARGETS_MAX)
 			{
-				QVariantHash args;
+				VariantHash args;
 				args["keep-alive"] = true;
 				m2_writeCtlMany(m2_send_idents[conn->identIndex], connIdList, args);
 
@@ -2076,7 +2077,7 @@ public:
 
 			if(!connIdList.isEmpty())
 			{
-				QVariantHash args;
+				VariantHash args;
 				args["keep-alive"] = true;
 				m2_writeCtlMany(m2_send_idents[index], connIdList, args);
 			}
@@ -2763,7 +2764,7 @@ public:
 				continue;
 			}
 
-			QVariant data = TnetString::toVariant(message[1]);
+			Variant data = TnetString::toVariant(message[1]);
 			if(data.isNull())
 			{
 				log_warning("m2: received control response with invalid format (tnetstring parse failed), skipping");
@@ -2840,7 +2841,7 @@ private slots:
 			if(c.state == ControlPort::Idle || (c.state == ControlPort::ExpectingResponse && c.reqStartTime + CONTROL_REQUEST_EXPIRE <= now))
 			{
 				// Query m2 for connection info (to track bytes written)
-				QVariantHash cmdArgs;
+				VariantHash cmdArgs;
 				cmdArgs["what"] = QByteArray("net");
 				c.state = ControlPort::ExpectingResponse;
 				c.reqStartTime = now;

--- a/src/m2adapter/m2requestpacket.cpp
+++ b/src/m2adapter/m2requestpacket.cpp
@@ -27,6 +27,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "qtcompat.h"
+#include "variant.h"
 #include "tnetstring.h"
 
 static bool isAllCaps(const QString &s)
@@ -100,7 +101,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 		return false;
 
 	bool ok;
-	QVariant vheaders = TnetString::toVariant(in, start, htype, offset, size, &ok);
+	Variant vheaders = TnetString::toVariant(in, start, htype, offset, size, &ok);
 	if(!ok)
 		return false;
 
@@ -112,14 +113,14 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 	QMap<QString, QByteArray> m2headers; // Single-value map for easy processing
 	if(htype == TnetString::Hash)
 	{
-		QVariantMap headersMap = vheaders.toMap();
-		QMapIterator<QString, QVariant> vit(headersMap);
+		VariantMap headersMap = vheaders.toMap();
+		QMapIterator<QString, Variant> vit(headersMap);
 		while(vit.hasNext())
 		{
 			vit.next();
 
 			QString key = vit.key();
-			QVariant val = vit.value();
+			Variant val = vit.value();
 
 			if(typeId(val) == QMetaType::QByteArray)
 			{
@@ -132,7 +133,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 			}
 			else if(typeId(val) == QMetaType::QVariantList)
 			{
-				QVariantList vl = val.toList();
+				VariantList vl = val.toList();
 				if(vl.isEmpty())
 					return false;
 
@@ -145,7 +146,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 				{
 					QByteArray name = makeMixedCaseHeader(key).toLatin1();
 
-					foreach(const QVariant &v, vl)
+					foreach(const Variant &v, vl)
 					{
 						if(typeId(v) != QMetaType::QByteArray)
 							return false;
@@ -165,14 +166,14 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 		if(error.error != QJsonParseError::NoError || !doc.isObject())
 			return false;
 
-		QVariantMap headersMap = doc.object().toVariantMap();
-		QMapIterator<QString, QVariant> vit(headersMap);
+		VariantMap headersMap = doc.object().toVariantMap();
+		QMapIterator<QString, Variant> vit(headersMap);
 		while(vit.hasNext())
 		{
 			vit.next();
 
 			QString key = vit.key();
-			QVariant val = vit.value();
+			Variant val = vit.value();
 
 			if(typeId(val) == QMetaType::QString)
 			{
@@ -185,7 +186,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 			}
 			else if(typeId(val) == QMetaType::QVariantList)
 			{
-				QVariantList vl = val.toList();
+				VariantList vl = val.toList();
 				if(vl.isEmpty())
 					return false;
 
@@ -198,7 +199,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 				{
 					QByteArray name = makeMixedCaseHeader(key).toLatin1();
 
-					foreach(const QVariant &v, vl)
+					foreach(const Variant &v, vl)
 					{
 						if(typeId(v) != QMetaType::QString)
 							return false;
@@ -239,7 +240,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 		if(error.error != QJsonParseError::NoError || !doc.isObject())
 			return false;
 
-		QVariantMap data = doc.object().toVariantMap();
+		VariantMap data = doc.object().toVariantMap();
 		if(!data.contains("type") || typeId(data["type"]) != QMetaType::QString)
 			return false;
 

--- a/src/m2adapter/m2requestpacket.h
+++ b/src/m2adapter/m2requestpacket.h
@@ -23,7 +23,6 @@
 #ifndef M2REQUESTPACKET_H
 #define M2REQUESTPACKET_H
 
-#include <QVariant>
 #include <QHostAddress>
 #include "httpheaders.h"
 

--- a/src/m2adapter/m2responsepacket.h
+++ b/src/m2adapter/m2responsepacket.h
@@ -23,7 +23,7 @@
 #ifndef M2RESPONSEPACKET_H
 #define M2RESPONSEPACKET_H
 
-#include <QVariant>
+#include <QByteArray>
 
 class M2ResponsePacket
 {

--- a/src/proxy/acceptdata.h
+++ b/src/proxy/acceptdata.h
@@ -25,6 +25,7 @@
 #define ACCEPTDATA_H
 
 #include <QList>
+#include "variant.h"
 #include "httpheaders.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
@@ -55,7 +56,7 @@ public:
 		int outSeq;
 		int outCredits;
 		bool routerResp;
-		QVariant userData;
+		Variant userData;
 
 		Request() :
 			https(false),
@@ -91,7 +92,7 @@ public:
 	bool trusted; // Whether a trusted target was used
 	bool useSession;
 	bool responseSent;
-	QVariantList connMaxPackets;
+	VariantList connMaxPackets;
 
 	AcceptData() :
 		haveInspectData(false),

--- a/src/proxy/acceptrequest.cpp
+++ b/src/proxy/acceptrequest.cpp
@@ -24,19 +24,20 @@
 #include "acceptrequest.h"
 
 #include "qtcompat.h"
+#include "variant.h"
 #include "acceptdata.h"
 
-static QVariant acceptDataToVariant(const AcceptData &adata)
+static Variant acceptDataToVariant(const AcceptData &adata)
 {
-	QVariantHash obj;
+	VariantHash obj;
 
 	{
-		QVariantList vrequests;
+		VariantList vrequests;
 		foreach(const AcceptData::Request &r, adata.requests)
 		{
-			QVariantHash vrequest;
+			VariantHash vrequest;
 
-			QVariantHash vrid;
+			VariantHash vrid;
 			vrid["sender"] = r.rid.first;
 			vrid["id"] = r.rid.second;
 
@@ -92,18 +93,18 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 
 	{
 		const HttpRequestData &requestData = adata.requestData;
-		QVariantHash vrequestData;
+		VariantHash vrequestData;
 
 		vrequestData["method"] = requestData.method.toLatin1();
 		vrequestData["uri"] = requestData.uri.toEncoded();
 
-		QVariantList vheaders;
+		VariantList vheaders;
 		foreach(const HttpHeader &h, requestData.headers)
 		{
-			QVariantList vheader;
+			VariantList vheader;
 			vheader += h.first.asQByteArray();
 			vheader += h.second.asQByteArray();
-			vheaders += QVariant(vheader);
+			vheaders += Variant(vheader);
 		}
 
 		vrequestData["headers"] = vheaders;
@@ -115,18 +116,18 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 
 	{
 		const HttpRequestData &requestData = adata.origRequestData;
-		QVariantHash vrequestData;
+		VariantHash vrequestData;
 
 		vrequestData["method"] = requestData.method.toLatin1();
 		vrequestData["uri"] = requestData.uri.toEncoded();
 
-		QVariantList vheaders;
+		VariantList vheaders;
 		foreach(const HttpHeader &h, requestData.headers)
 		{
-			QVariantList vheader;
+			VariantList vheader;
 			vheader += h.first.asQByteArray();
 			vheader += h.second.asQByteArray();
-			vheaders += QVariant(vheader);
+			vheaders += Variant(vheader);
 		}
 
 		vrequestData["headers"] = vheaders;
@@ -138,7 +139,7 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 
 	if(adata.haveInspectData)
 	{
-		QVariantHash vinspect;
+		VariantHash vinspect;
 
 		vinspect["no-proxy"] = !adata.inspectData.doProxy;
 
@@ -150,7 +151,7 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 
 		if(!adata.inspectData.lastIds.isEmpty())
 		{
-			QVariantHash vlastIds;
+			VariantHash vlastIds;
 			QHashIterator<QByteArray, QByteArray> it(adata.inspectData.lastIds);
 			while(it.hasNext())
 			{
@@ -169,18 +170,18 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 
 	if(adata.haveResponse)
 	{
-		QVariantHash vresponse;
+		VariantHash vresponse;
 
 		vresponse["code"] = adata.response.code;
 		vresponse["reason"] = adata.response.reason;
 
-		QVariantList vheaders;
+		VariantList vheaders;
 		foreach(const HttpHeader &h, adata.response.headers)
 		{
-			QVariantList vheader;
+			VariantList vheader;
 			vheader += h.first.asQByteArray();
 			vheader += h.second.asQByteArray();
-			vheaders += QVariant(vheader);
+			vheaders += Variant(vheader);
 		}
 		vresponse["headers"] = vheaders;
 
@@ -203,7 +204,7 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 
 	if(!adata.channels.isEmpty())
 	{
-		QVariantList vchannels;
+		VariantList vchannels;
 		foreach(const QByteArray &channel, adata.channels)
 			vchannels += channel;
 		obj["channels"] = vchannels;
@@ -224,7 +225,7 @@ static QVariant acceptDataToVariant(const AcceptData &adata)
 	return obj;
 }
 
-static AcceptRequest::ResponseData convertResult(const QVariant &in, bool *ok)
+static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 {
 	AcceptRequest::ResponseData out;
 
@@ -234,7 +235,7 @@ static AcceptRequest::ResponseData convertResult(const QVariant &in, bool *ok)
 		return AcceptRequest::ResponseData();
 	}
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(obj.contains("accepted"))
 	{
@@ -255,7 +256,7 @@ static AcceptRequest::ResponseData convertResult(const QVariant &in, bool *ok)
 			return AcceptRequest::ResponseData();
 		}
 
-		QVariantHash vresponse = obj["response"].toHash();
+		VariantHash vresponse = obj["response"].toHash();
 
 		if(vresponse.contains("code"))
 		{
@@ -287,9 +288,9 @@ static AcceptRequest::ResponseData convertResult(const QVariant &in, bool *ok)
 				return AcceptRequest::ResponseData();
 			}
 
-			foreach(const QVariant &i, vresponse["headers"].toList())
+			foreach(const Variant &i, vresponse["headers"].toList())
 			{
-				QVariantList list = i.toList();
+				VariantList list = i.toList();
 				if(list.count() != 2)
 				{
 					*ok = false;

--- a/src/proxy/inspectrequest.cpp
+++ b/src/proxy/inspectrequest.cpp
@@ -25,9 +25,10 @@
 
 #include "packet/httprequestdata.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "inspectdata.h"
 
-static InspectData resultToData(const QVariant &in, bool *ok)
+static InspectData resultToData(const Variant &in, bool *ok)
 {
 	InspectData out;
 
@@ -37,7 +38,7 @@ static InspectData resultToData(const QVariant &in, bool *ok)
 		return InspectData();
 	}
 
-	QVariantHash obj = in.toHash();
+	VariantHash obj = in.toHash();
 
 	if(!obj.contains("no-proxy") || typeId(obj["no-proxy"]) != QMetaType::Bool)
 	{
@@ -79,8 +80,8 @@ static InspectData resultToData(const QVariant &in, bool *ok)
 			return InspectData();
 		}
 
-		QVariantHash vlastIds = obj["last-ids"].toHash();
-		QHashIterator<QString, QVariant> it(vlastIds);
+		VariantHash vlastIds = obj["last-ids"].toHash();
+		QHashIterator<QString, Variant> it(vlastIds);
 		while(it.hasNext())
 		{
 			it.next();
@@ -133,18 +134,18 @@ InspectData InspectRequest::result() const
 
 void InspectRequest::start(const HttpRequestData &hdata, bool truncated, bool getSession, bool autoShare)
 {
-	QVariantHash args;
+	VariantHash args;
 
 	args["method"] = hdata.method.toLatin1();
 	args["uri"] = hdata.uri.toEncoded();
 
-	QVariantList vheaders;
+	VariantList vheaders;
 	foreach(const HttpHeader &h, hdata.headers)
 	{
-		QVariantList vheader;
+		VariantList vheader;
 		vheader += h.first.asQByteArray();
 		vheader += h.second.asQByteArray();
-		vheaders += QVariant(vheader);
+		vheaders += Variant(vheader);
 	}
 
 	args["headers"] = vheaders;

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -33,6 +33,7 @@
 #include "packet/statspacket.h"
 #include "packet/zrpcrequestpacket.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "timer.h"
 #include "defercall.h"
 #include "log.h"
@@ -509,12 +510,12 @@ public:
 		bool preferInternal = false;
 		bool autoShare = false;
 
-		QVariant passthroughData = req->passthroughData();
+		Variant passthroughData = req->passthroughData();
 		if(passthroughData.isValid())
 		{
 			// Passthrough request, from handler
 
-			const QVariantHash data = passthroughData.toHash();
+			const VariantHash data = passthroughData.toHash();
 
 			// There is always a route
 			routeId = QString::fromUtf8(data["route"].toByteArray());
@@ -548,7 +549,7 @@ public:
 			if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
 				originalRoute = domainMap->entry(routeId);
 
-			const QVariantHash data = passthroughData.toHash();
+			const VariantHash data = passthroughData.toHash();
 
 			DomainMap::Entry route;
 
@@ -841,7 +842,7 @@ private:
 		}
 
 		bool ok;
-		QVariant data = TnetString::toVariant(req.content()[0], 0, &ok);
+		Variant data = TnetString::toVariant(req.content()[0], 0, &ok);
 		if(!ok)
 		{
 			log_warning("retry: received message with invalid format (tnetstring parse failed), skipping");
@@ -914,7 +915,7 @@ private:
 		{
 			ZrpcRequestPacket p;
 			p.method = "conn-max";
-			p.args["conn-max"] = QVariantList() << packet.toVariant();
+			p.args["conn-max"] = VariantList() << packet.toVariant();
 
 			accept->write(p);
 		}
@@ -932,7 +933,7 @@ private:
 				return;
 			}
 
-			QVariantHash args = req->args();
+			VariantHash args = req->args();
 			if(!args.contains("ids") || typeId(args["ids"]) != QMetaType::QVariantList)
 			{
 				req->respondError("bad-format");
@@ -940,11 +941,11 @@ private:
 				return;
 			}
 
-			QVariantList vids = args["ids"].toList();
+			VariantList vids = args["ids"].toList();
 
 			bool ok = true;
 			QList<QByteArray> ids;
-			foreach(const QVariant &vid, vids)
+			foreach(const Variant &vid, vids)
 			{
 				if(typeId(vid) != QMetaType::QByteArray)
 				{
@@ -961,7 +962,7 @@ private:
 				return;
 			}
 
-			QVariantList out;
+			VariantList out;
 			foreach(const QByteArray &id, ids)
 			{
 				if(stats->checkConnection(id))
@@ -972,7 +973,7 @@ private:
 		}
 		else if(req->method() == "refresh")
 		{
-			QVariantHash args = req->args();
+			VariantHash args = req->args();
 			if(!args.contains("cid") || typeId(args["cid"]) != QMetaType::QByteArray)
 			{
 				req->respondError("bad-format");

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -35,6 +35,7 @@
 #include "zmqreqmessage.h"
 #include "log.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
 #include "packet/httprequestdata.h"
@@ -201,7 +202,7 @@ private:
 	void processClientIn(const CowByteArray &message)
 	{
 		log_debug("client in");
-		QVariant v = TnetString::toVariant(message);
+		Variant v = TnetString::toVariant(message);
 		ZhttpResponsePacket zresp;
 		zresp.fromVariant(v);
 		if(zresp.type == ZhttpResponsePacket::Data)
@@ -266,7 +267,7 @@ private:
 	void zhttpServerIn_readyRead(const CowByteArrayList &message)
 	{
 		log_debug("server in");
-		QVariant v = TnetString::toVariant(message[0].mid(1));
+		Variant v = TnetString::toVariant(message[0].mid(1));
 		ZhttpRequestPacket zreq;
 		zreq.fromVariant(v);
 
@@ -282,7 +283,7 @@ private:
 	void zhttpServerInStream_readyRead(const CowByteArrayList &message)
 	{
 		log_debug("server stream in");
-		QVariant v = TnetString::toVariant(message[2].mid(1));
+		Variant v = TnetString::toVariant(message[2].mid(1));
 		ZhttpRequestPacket zreq;
 		zreq.fromVariant(v);
 
@@ -471,20 +472,20 @@ private:
 	void handlerInspect_readyRead(const CowByteArrayList &_message)
 	{
 		ZmqReqMessage message(_message);
-		QVariant v = TnetString::toVariant(message.content()[0]);
+		Variant v = TnetString::toVariant(message.content()[0]);
 		log_debug("inspect: %s", qPrintable(TnetString::variantToString(v, -1)));
 
 		inspected = true;
 
 		if(inspectEnabled)
 		{
-			QVariantHash vreq = v.toHash();
-			QVariantHash args = vreq["args"].toHash();
-			QVariantHash respValue;
+			VariantHash vreq = v.toHash();
+			VariantHash args = vreq["args"].toHash();
+			VariantHash respValue;
 			respValue["no-proxy"] = false;
 			if(!sharingKey.isEmpty())
 				respValue["sharing-key"] = sharingKey;
-			QVariantHash vresp;
+			VariantHash vresp;
 			vresp["id"] = vreq["id"];
 			vresp["success"] = true;
 			vresp["value"] = respValue;
@@ -496,27 +497,27 @@ private:
 	void handlerAccept_readyRead(const CowByteArrayList &_message)
 	{
 		ZmqReqMessage message(_message);
-		QVariant v = TnetString::toVariant(message.content()[0]);
+		Variant v = TnetString::toVariant(message.content()[0]);
 		log_debug("accept: %s", qPrintable(TnetString::variantToString(v, -1)));
 
-		QVariantHash vreq = v.toHash();
+		VariantHash vreq = v.toHash();
 
 		if(vreq["method"].toString() != "accept")
 			return;
 
-		QVariantHash vaccept = vreq["args"].toHash();
-		QVariantHash vresponse = vaccept["response"].toHash();
+		VariantHash vaccept = vreq["args"].toHash();
+		VariantHash vresponse = vaccept["response"].toHash();
 
 		acceptHeaders.clear();
-		foreach(const QVariant &vheader, vresponse["headers"].toList())
+		foreach(const Variant &vheader, vresponse["headers"].toList())
 		{
-			QVariantList h = vheader.toList();
+			VariantList h = vheader.toList();
 			acceptHeaders += HttpHeader(h[0].toByteArray(), h[1].toByteArray());
 		}
 
 		acceptIn = vresponse["body"].toByteArray();
 
-		QVariantMap jsonInstruct;
+		VariantMap jsonInstruct;
 		QByteArray hold;
 
 		if(acceptHeaders.get("Content-Type") == "application/grip-instruct")
@@ -536,10 +537,10 @@ private:
 			hold = acceptHeaders.get("Grip-Hold").asQByteArray();
 		}
 
-		QVariantList vheaders = vresponse["headers"].toList();
+		VariantList vheaders = vresponse["headers"].toList();
 		for(int n = 0; n < vheaders.count(); ++n)
 		{
-			QVariantList h = vheaders[n].toList();
+			VariantList h = vheaders[n].toList();
 			if(h[0].toByteArray().startsWith("Grip-"))
 			{
 				vheaders.removeAt(n);
@@ -548,10 +549,10 @@ private:
 		}
 		vresponse["headers"] = vheaders;
 
-		QVariantHash vresp;
+		VariantHash vresp;
 		vresp["id"] = vreq["id"];
 		vresp["success"] = true;
-		QVariantHash respValue;
+		VariantHash respValue;
 		if(!hold.isEmpty())
 			respValue["accepted"] = true;
 		else if(!vaccept.value("response-sent").toBool())
@@ -566,7 +567,7 @@ private:
 			if(jsonInstruct.contains("hold") && jsonInstruct["hold"].toMap()["channels"].toList()[0].toMap().contains("prev-id"))
 			{
 				retried = true;
-				QVariantHash vretry;
+				VariantHash vretry;
 				vretry["requests"] = vaccept["requests"];
 				vretry["request-data"] = vaccept["request-data"];
 				QByteArray buf = TnetString::fromVariant(vretry);
@@ -772,7 +773,7 @@ static void passthroughJsonp(TestState &state, std::function<void (int)> loop_wa
 	TEST_ASSERT(e.error == QJsonParseError::NoError);
 	TEST_ASSERT(doc.isObject());
 
-	QVariantMap data = doc.object().toVariantMap();
+	VariantMap data = doc.object().toVariantMap();
 
 	TEST_ASSERT_EQ(data["code"].toInt(), 200);
 	TEST_ASSERT_EQ(data["body"].toByteArray(), QByteArray("{\"hello\": \"world\"}"));

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -31,6 +31,7 @@
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "bufferlist.h"
 #include "log.h"
 #include "jwt.h"

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -27,13 +27,14 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include "qtcompat.h"
+#include "variant.h"
 #include "log.h"
 #include "jwt.h"
 #include "inspectdata.h"
 
 static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key)
 {
-	QVariantMap claim;
+	VariantMap claim;
 	claim["iss"] = QString::fromUtf8(iss);
 	claim["exp"] = QDateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600;
 	return Jwt::encode(claim, key);
@@ -41,11 +42,11 @@ static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key)
 
 static bool validate_token(const QByteArray &token, const Jwt::DecodingKey &key)
 {
-	QVariant claimObj = Jwt::decode(token, key);
+	Variant claimObj = Jwt::decode(token, key);
 	if(!claimObj.isValid() || typeId(claimObj) != QMetaType::QVariantMap)
 		return false;
 
-	QVariantMap claim = claimObj.toMap();
+	VariantMap claim = claimObj.toMap();
 
 	int exp = claim.value("exp").toInt();
 	if(exp <= 0 || (int)QDateTime::currentDateTimeUtc().toSecsSinceEpoch() >= exp)

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -33,6 +33,7 @@
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "qtcompat.h"
+#include "variant.h"
 #include "bufferlist.h"
 #include "log.h"
 #include "defercall.h"
@@ -114,7 +115,7 @@ static bool validMethod(const QString &in)
 
 static QByteArray serializeJsonString(const QString &s)
 {
-	QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(QVariantList() << s)).toJson(QJsonDocument::Compact);
+	QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s)).toJson(QJsonDocument::Compact);
 
 	assert(tmp.length() >= 4);
 	assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
@@ -570,7 +571,7 @@ public:
 			if(reasonJson.isNull())
 				return QByteArray();
 
-			QVariantMap vheaders;
+			VariantMap vheaders;
 			foreach(const HttpHeader h, headers)
 			{
 				if(!vheaders.contains(h.first.asQByteArray()))
@@ -686,9 +687,9 @@ public:
 				return false;
 			}
 
-			QVariantMap headersMap = doc.object().toVariantMap();
+			VariantMap headersMap = doc.object().toVariantMap();
 
-			QMapIterator<QString, QVariant> vit(headersMap);
+			QMapIterator<QString, Variant> vit(headersMap);
 			while(vit.hasNext())
 			{
 				vit.next();

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -32,6 +32,7 @@
 #include <QCryptographicHash>
 #include <QRandomGenerator>
 #include "qtcompat.h"
+#include "variant.h"
 #include "log.h"
 #include "bufferlist.h"
 #include "timer.h"
@@ -63,7 +64,7 @@ const char *iframeHtmlTemplate =
 
 static QByteArray serializeJsonString(const QString &s)
 {
-	QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(QVariantList() << s)).toJson(QJsonDocument::Compact);
+	QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s)).toJson(QJsonDocument::Compact);
 
 	assert(tmp.length() >= 4);
 	assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
@@ -98,7 +99,7 @@ public:
 		bool pending;
 		SockJsSession *ext;
 		std::unique_ptr<Timer> timer;
-		QVariant closeValue;
+		Variant closeValue;
 		Connection timerConnection;
 
 		Session(Private *_owner) :
@@ -206,7 +207,7 @@ public:
 			removeSession(s);
 	}
 
-	void setLinger(SockJsSession *ext, const QVariant &closeValue)
+	void setLinger(SockJsSession *ext, const Variant &closeValue)
 	{
 		Session *s = sessionsByExt.value(ext);
 		assert(s);
@@ -317,7 +318,7 @@ public:
 		respond(req, 204, "No Content", headers, QByteArray());
 	}
 
-	void respondOk(ZhttpRequest *req, const QVariant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray())
+	void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray())
 	{
 		HttpHeaders headers;
 		if(!jsonpCallback.isEmpty())
@@ -422,9 +423,9 @@ public:
 		{
 			uint32_t x = QRandomGenerator::global()->generate();
 
-			QVariantMap out;
+			VariantMap out;
 			out["websocket"] = true;
-			out["origins"] = QVariantList() << QString("*:*");
+			out["origins"] = VariantList() << QString("*:*");
 			out["cookie_needed"] = false;
 			out["entropy"] = x;
 			respondOk(s->req, out);
@@ -477,7 +478,7 @@ public:
 						}
 						else
 						{
-							QVariantList out;
+							VariantList out;
 							out += 2010;
 							out += QString("Another connection still open");
 							respondOk(s->req, out, "c", s->jsonpCallback);
@@ -711,12 +712,12 @@ void SockJsManager::unlink(SockJsSession *sess)
 	d->unlink(sess);
 }
 
-void SockJsManager::setLinger(SockJsSession *ext, const QVariant &closeValue)
+void SockJsManager::setLinger(SockJsSession *ext, const Variant &closeValue)
 {
 	d->setLinger(ext, closeValue);
 }
 
-void SockJsManager::respondOk(ZhttpRequest *req, const QVariant &data, const QByteArray &prefix, const QByteArray &jsonpCallback)
+void SockJsManager::respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix, const QByteArray &jsonpCallback)
 {
 	d->respondOk(req, data, prefix, jsonpCallback);
 }

--- a/src/proxy/sockjsmanager.h
+++ b/src/proxy/sockjsmanager.h
@@ -24,6 +24,7 @@
 #ifndef SOCKJSMANAGER_H
 #define SOCKJSMANAGER_H
 
+#include "variant.h"
 #include "domainmap.h"
 #include <boost/signals2.hpp>
 #include <boost/signals2.hpp>
@@ -57,8 +58,8 @@ private:
 
 	friend class SockJsSession;
 	void unlink(SockJsSession *sess);
-	void setLinger(SockJsSession *sess, const QVariant &closeValue);
-	void respondOk(ZhttpRequest *req, const QVariant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray());
+	void setLinger(SockJsSession *sess, const Variant &closeValue);
+	void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray());
 	void respondOk(ZhttpRequest *req, const QString &str, const QByteArray &jsonpCallback = QByteArray());
 	void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message, bool discard = false);
 	void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -29,6 +29,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include "qtcompat.h"
+#include "variant.h"
 #include "log.h"
 #include "bufferlist.h"
 #include "packet/httprequestdata.h"
@@ -294,7 +295,7 @@ public:
 		state = Connecting;
 	}
 
-	void respondOk(ZhttpRequest *req, const QVariant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray())
+	void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray())
 	{
 		manager->respondOk(req, data, prefix, jsonpCallback);
 	}
@@ -325,7 +326,7 @@ public:
 		{
 			if(req)
 			{
-				QVariantList out;
+				VariantList out;
 				out += 2010;
 				out += QString("Another connection still open");
 
@@ -336,7 +337,7 @@ public:
 
 			if(peerClosed)
 			{
-				QVariantList out;
+				VariantList out;
 				out += 3000;
 				out += QString("Client already closed connection");
 
@@ -402,11 +403,11 @@ public:
 				return;
 			}
 
-			QVariantList messages = doc.array().toVariantList();
+			VariantList messages = doc.array().toVariantList();
 
 			QList<Frame> frames;
 			int bytes = 0;
-			foreach(const QVariant &vmessage, messages)
+			foreach(const Variant &vmessage, messages)
 			{
 				if(typeId(vmessage) != QMetaType::QString)
 				{
@@ -463,7 +464,7 @@ public:
 
 			ri->type = RequestItem::Accept;
 			ri->responded = true;
-			respondOk(req, QVariant(), "o", ri->jsonpCallback);
+			respondOk(req, Variant(), "o", ri->jsonpCallback);
 		}
 		else
 		{
@@ -545,7 +546,7 @@ public:
 			}
 			else // WebSocketFramed
 			{
-				QVariantList messages;
+				VariantList messages;
 				messages += QString::fromUtf8(frame.data);
 
 				QByteArray arrayJson = QJsonDocument(QJsonArray::fromVariantList(messages)).toJson(QJsonDocument::Compact);
@@ -611,7 +612,7 @@ public:
 		if(ri->responded)
 			return;
 
-		QVariantList messages;
+		VariantList messages;
 
 		int frames = 0;
 		int bytes = 0;
@@ -666,7 +667,7 @@ public:
 		else if(state == Closing)
 		{
 			closeSent = true;
-			QVariant closeValue = applyLinger();
+			Variant closeValue = applyLinger();
 
 			ri->type = RequestItem::ReceiveClose;
 			ri->responded = true;
@@ -788,11 +789,11 @@ public:
 					break;
 				}
 
-				QVariantList messages = doc.array().toVariantList();
+				VariantList messages = doc.array().toVariantList();
 
 				QList<Frame> frames;
 				int bytes = 0;
-				foreach(const QVariant &vmessage, messages)
+				foreach(const Variant &vmessage, messages)
 				{
 					if(typeId(vmessage) != QMetaType::QString)
 					{
@@ -880,9 +881,9 @@ public:
 		q->framesWritten(count, contentBytes);
 	}
 
-	QVariant applyLinger()
+	Variant applyLinger()
 	{
-		QVariantList closeValue;
+		VariantList closeValue;
 
 		if(closeCode != -1)
 			closeValue += closeCode;
@@ -1088,7 +1089,7 @@ public:
 				assert(ri && !ri->responded);
 
 				ri->responded = true;
-				respondOk(req, QVariant(), "h", ri->jsonpCallback);
+				respondOk(req, Variant(), "h", ri->jsonpCallback);
 			}
 			else
 			{

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -32,6 +32,7 @@
 #include "log.h"
 #include "timer.h"
 #include "tnetstring.h"
+#include "variant.h"
 #include "zutil.h"
 #include "logutil.h"
 #include "wscontrolsession.h"
@@ -164,7 +165,7 @@ public:
 	{
 		assert(streamSock);
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -177,7 +178,7 @@ public:
 	{
 		assert(streamSock);
 
-		QVariant vpacket = packet.toVariant();
+		Variant vpacket = packet.toVariant();
 		QByteArray buf = TnetString::fromVariant(vpacket);
 
 		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
@@ -262,7 +263,7 @@ private:
 			return;
 		}
 
-		QVariant data = TnetString::toVariant(req.content()[0]);
+		Variant data = TnetString::toVariant(req.content()[0]);
 		if(data.isNull())
 		{
 			log_warning("wscontrol: received message with invalid format (tnetstring parse failed), skipping");

--- a/src/runner/connmgrservice.cpp
+++ b/src/runner/connmgrservice.cpp
@@ -23,7 +23,6 @@
 #include "connmgrservice.h"
 
 #include <QDir>
-#include <QVariantList>
 #include <QProcess>
 #include <QUrl>
 #include "log.h"

--- a/src/runner/m2adapterservice.cpp
+++ b/src/runner/m2adapterservice.cpp
@@ -23,10 +23,10 @@
 #include "m2adapterservice.h"
 
 #include <QDir>
-#include <QVariantList>
 #include <QProcess>
 #include "log.h"
 #include "template.h"
+#include "variant.h"
 
 M2AdapterService::M2AdapterService(
 	const QString &binFile,
@@ -72,11 +72,11 @@ bool M2AdapterService::acceptSighup() const
 
 bool M2AdapterService::preStart()
 {
-	QVariantList portStrs;
+	VariantList portStrs;
 	foreach(int port, ports_)
 		portStrs += QString::number(port);
 
-	QVariantMap context;
+	VariantMap context;
 	context["ports"] = portStrs;
 	context["rundir"] = runDir_;
 	context["ipc_prefix"] = ipcPrefix_;

--- a/src/runner/mongrel2service.cpp
+++ b/src/runner/mongrel2service.cpp
@@ -25,10 +25,9 @@
 
 #include <QDateTime>
 #include <QDir>
-#include <QVariant>
-#include <QVariantList>
 #include <QProcess>
 #include "log.h"
+#include "variant.h"
 #include "template.h"
 
 Mongrel2Service::Mongrel2Service(
@@ -61,7 +60,7 @@ Mongrel2Service::Mongrel2Service(
 
 bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, int maxconn, const QList<ListenPort> &ports, int logLevel)
 {
-	QVariantList vinterfaces;
+	VariantList vinterfaces;
 
 	foreach(const ListenPort &p, ports)
 	{
@@ -71,14 +70,14 @@ bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile, const QStri
 			return false;
 		}
 
-		QVariantMap v;
+		VariantMap v;
 		v["addr"] = (!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
 		v["port"] = p.port;
 		v["ssl"] = p.ssl;
 		vinterfaces += v;
 	}
 
-	QVariantMap context;
+	VariantMap context;
 	context["interfaces"] = vinterfaces;
 	context["rundir"] = runDir;
 	context["logdir"] = logDir;

--- a/src/runner/template.cpp
+++ b/src/runner/template.cpp
@@ -28,9 +28,9 @@
 
 #include "template.h"
 
-#include <QVariantMap>
 #include <QFile>
 #include "qtcompat.h"
+#include "variant.h"
 #include "log.h"
 
 namespace Template {
@@ -239,7 +239,7 @@ static QList<TemplateItem> parseContent(const QString &content, int *pos, Contro
 }
 
 // Handles lookup by exact name or dot-notation for children
-static QVariant getVar(const QString &s, const QVariantMap &context)
+static Variant getVar(const QString &s, const VariantMap &context)
 {
 	int at = s.indexOf('.');
 	if(at != -1)
@@ -247,35 +247,35 @@ static QVariant getVar(const QString &s, const QVariantMap &context)
 		QString parent = s.mid(0, at);
 		QString member = s.mid(at + 1);
 		if(parent.isEmpty() || !context.contains(parent))
-			return QVariant();
+			return Variant();
 
-		QVariant subContext = context[parent];
+		Variant subContext = context[parent];
 		if(typeId(subContext) != QMetaType::QVariantMap)
-			return QVariant();
+			return Variant();
 
 		return getVar(member, subContext.toMap());
 	}
 	else
 	{
 		if(!context.contains(s))
-			return QVariant();
+			return Variant();
 
 		return context[s];
 	}
 }
 
-static QString renderExpression(const QString &exp, const QVariantMap &context)
+static QString renderExpression(const QString &exp, const VariantMap &context)
 {
 	// For now all we support is variable lookups. No fancy expressions
 
-	QVariant val = getVar(exp, context);
+	Variant val = getVar(exp, context);
 	if(!val.isValid())
 		return QString();
 
 	return val.toString();
 }
 
-static bool evalCondition(const QString &s, const QVariantMap &context)
+static bool evalCondition(const QString &s, const VariantMap &context)
 {
 	// For now all we support is variable test with optional negation
 
@@ -285,7 +285,7 @@ static bool evalCondition(const QString &s, const QVariantMap &context)
 	}
 	else
 	{
-		QVariant val = getVar(s, context);
+		Variant val = getVar(s, context);
 		if(typeId(val) == QMetaType::QString)
 			return !val.toString().isEmpty();
 		else if(typeId(val) == QMetaType::Bool)
@@ -297,7 +297,7 @@ static bool evalCondition(const QString &s, const QVariantMap &context)
 	}
 }
 
-static QVariantList parseFor(const QString &s, QString *iterVarName, const QVariantMap &context, QString *error)
+static VariantList parseFor(const QString &s, QString *iterVarName, const VariantMap &context, QString *error)
 {
 	// For now all we support is "varname in map"
 
@@ -305,23 +305,23 @@ static QVariantList parseFor(const QString &s, QString *iterVarName, const QVari
 	if(at == -1)
 	{
 		*error = "\"for\" directive must be of the form: \"for variable in container\"";
-		return QVariantList();
+		return VariantList();
 	}
 
 	*iterVarName = s.mid(0, at);
 	QString containerName = s.mid(at + 4);
 
-	QVariant container = getVar(containerName, context);
+	Variant container = getVar(containerName, context);
 	if(typeId(container) != QMetaType::QVariantList)
 	{
 		*error = "\"for\" container must be a list";
-		return QVariantList();
+		return VariantList();
 	}
 
 	return container.toList();
 }
 
-static QString renderInternal(const TemplateItem &item, const QVariantMap &context, QString *error)
+static QString renderInternal(const TemplateItem &item, const VariantMap &context, QString *error)
 {
 	QString out;
 
@@ -357,19 +357,19 @@ static QString renderInternal(const TemplateItem &item, const QVariantMap &conte
 	else if(item.type == TemplateItem::For)
 	{
 		QString iterVarName;
-		QVariantList forItems = parseFor(item.data, &iterVarName, context, error);
+		VariantList forItems = parseFor(item.data, &iterVarName, context, error);
 		if(!error->isEmpty())
 			return QString();
 
 		for(int n = 0; n < forItems.count(); ++n)
 		{
-			const QVariant &forItem = forItems[n];
+			const Variant &forItem = forItems[n];
 
-			QVariantMap loop;
+			VariantMap loop;
 			loop["first"] = (n == 0);
 			loop["last"] = (n == forItems.count() - 1);
 
-			QVariantMap tmp = context;
+			VariantMap tmp = context;
 			tmp[iterVarName] = forItem;
 			tmp["loop"] = loop;
 
@@ -418,7 +418,7 @@ static void dumpItem(const TemplateItem &item, int depth = 0)
 	}
 }
 
-QString render(const QString &content, const QVariantMap &context, QString *error)
+QString render(const QString &content, const VariantMap &context, QString *error)
 {
 	TemplateItem root;
 	root.type = TemplateItem::Root;
@@ -443,7 +443,7 @@ QString render(const QString &content, const QVariantMap &context, QString *erro
 	return result;
 }
 
-bool renderFile(const QString &inFile, const QString &outFile, const QVariantMap &context, QString *error)
+bool renderFile(const QString &inFile, const QString &outFile, const VariantMap &context, QString *error)
 {
 	QFile in(inFile);
 	if(!in.open(QFile::ReadOnly | QFile::Text))

--- a/src/runner/template.h
+++ b/src/runner/template.h
@@ -24,12 +24,12 @@
 #define TEMPLATE_H
 
 #include <QString>
-#include <QVariantMap>
+#include "variant.h"
 
 namespace Template {
 
-QString render(const QString &content, const QVariantMap &context, QString *error = 0);
-bool renderFile(const QString &inFile, const QString &outFile, const QVariantMap &context, QString *error = 0);
+QString render(const QString &content, const VariantMap &context, QString *error = 0);
+bool renderFile(const QString &inFile, const QString &outFile, const VariantMap &context, QString *error = 0);
 
 void dumpTemplate(const QString &content);
 

--- a/src/runner/templatetest.cpp
+++ b/src/runner/templatetest.cpp
@@ -22,19 +22,20 @@
  */
 
 #include "test.h"
+#include "variant.h"
 #include "template.h"
 
 static void render()
 {
-	QVariantMap context;
+	VariantMap context;
 	context["place"] = "world";
 
-	QVariantMap user;
+	VariantMap user;
 	user["first"] = "john";
 	user["last"] = "smith";
 	context["user"] = user;
 
-	QVariantList fruits;
+	VariantList fruits;
 	fruits.append("apple");
 	fruits.append("banana");
 	context["fruits"] = fruits;

--- a/src/runner/zurlservice.cpp
+++ b/src/runner/zurlservice.cpp
@@ -26,6 +26,7 @@
 #include <QProcess>
 #include "log.h"
 #include "template.h"
+#include "variant.h"
 
 ZurlService::ZurlService(
 	const QString &binFile,
@@ -71,7 +72,7 @@ bool ZurlService::acceptSighup() const
 
 bool ZurlService::preStart()
 {
-	QVariantMap context;
+	VariantMap context;
 	context["rundir"] = runDir_;
 	context["ipc_prefix"] = ipcPrefix_;
 


### PR DESCRIPTION
This follows up on #48319 by updating the whole codebase to use the aliases. This PR includes the following changes:

* Use `Variant` everywhere instead of `QVariant`.
* Use `VariantHash` everywhere instead of `QVariantHash`.
* Use `VariantMap` everywhere instead of `QVariantMap`.
* Use `VariantList` everywhere instead of `QVariantList`.
* Replace all `#include <QVariant*>` directives with `#include "variant.h"`.
* Add an include guard to `qtcompat.h`.

Since the types are aliases to the Qt types, the code still actually uses the Qt types and compiles to the same thing, so there should be no change in behavior.

Note that even with these changes, call sites are not fully Qt-free. For example, the `QHashIterator` type is used to iterate `VariantHash`, and variant types are compared against enum values like `QMetaType::QVariantHash`. These will be addressed later.