### PR TITLE
add VariantType::Type to replace direct use of QMetaType::Type

### DIFF
--- a/src/core/jwttest.cpp
+++ b/src/core/jwttest.cpp
@@ -85,7 +85,7 @@ static const char *test_rsa_public_key_pem =
 static void validToken()
 {
 	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("secret"));
-	TEST_ASSERT(typeId(vclaim) == QMetaType::QVariantMap);
+	TEST_ASSERT(typeId(vclaim) == VariantType::Map);
 	VariantMap claim = vclaim.toMap();
 	TEST_ASSERT(claim.value("foo") == "bar");
 }
@@ -98,7 +98,7 @@ static void validTokenBinaryKey()
 	key += 0x80;
 	key += 0xfe;
 	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.-eLxyGEITnd6IP4WvGJx9CmIOt--Qcs3LB6wblJ7KXI", Jwt::DecodingKey::fromSecret(key));
-	TEST_ASSERT(typeId(vclaim) == QMetaType::QVariantMap);
+	TEST_ASSERT(typeId(vclaim) == VariantType::Map);
 	VariantMap claim = vclaim.toMap();
 	TEST_ASSERT(claim.value("foo") == "bar");
 }

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -101,7 +101,7 @@ static void logPacket(int level, const Variant &data, const QString &contentFiel
 	Variant meta;
 	QByteArray content;
 
-	if(typeId(data) == QMetaType::QVariantHash)
+	if(typeId(data) == VariantType::Hash)
 	{
 		// Extract content. Meta is the remaining data
 		VariantHash hdata = data.toHash();

--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -146,37 +146,37 @@ Variant RetryRequestPacket::toVariant() const
 
 bool RetryRequestPacket::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
 
-	if(!obj.contains("requests") || typeId(obj["requests"]) != QMetaType::QVariantList)
+	if(!obj.contains("requests") || typeId(obj["requests"]) != VariantType::List)
 		return false;
 
 	requests.clear();
 	foreach(const Variant &i, obj["requests"].toList())
 	{
-		if(typeId(i) != QMetaType::QVariantHash)
+		if(typeId(i) != VariantType::Hash)
 			return false;
 
 		VariantHash vrequest = i.toHash();
 
 		Request r;
 
-		if(!vrequest.contains("rid") || typeId(vrequest["rid"]) != QMetaType::QVariantHash)
+		if(!vrequest.contains("rid") || typeId(vrequest["rid"]) != VariantType::Hash)
 			return false;
 
 		VariantHash vrid = vrequest["rid"].toHash();
 
 		QByteArray sender, id;
 
-		if(!vrid.contains("sender") || typeId(vrid["sender"]) != QMetaType::QByteArray)
+		if(!vrid.contains("sender") || typeId(vrid["sender"]) != VariantType::ByteArray)
 			return false;
 
 		sender = vrid["sender"].toByteArray();
 
-		if(!vrid.contains("id") || typeId(vrid["id"]) != QMetaType::QByteArray)
+		if(!vrid.contains("id") || typeId(vrid["id"]) != VariantType::ByteArray)
 			return false;
 
 		id = vrid["id"].toByteArray();
@@ -185,7 +185,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vrequest.contains("https"))
 		{
-			if(typeId(vrequest["https"]) != QMetaType::Bool)
+			if(typeId(vrequest["https"]) != VariantType::Bool)
 				return false;
 
 			r.https = vrequest["https"].toBool();
@@ -193,7 +193,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vrequest.contains("peer-address"))
 		{
-			if(typeId(vrequest["peer-address"]) != QMetaType::QByteArray)
+			if(typeId(vrequest["peer-address"]) != VariantType::ByteArray)
 				return false;
 
 			r.peerAddress = QHostAddress(QString::fromUtf8(vrequest["peer-address"].toByteArray()));
@@ -201,7 +201,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vrequest.contains("debug"))
 		{
-			if(typeId(vrequest["debug"]) != QMetaType::Bool)
+			if(typeId(vrequest["debug"]) != VariantType::Bool)
 				return false;
 
 			r.debug = vrequest["debug"].toBool();
@@ -209,7 +209,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vrequest.contains("auto-cross-origin"))
 		{
-			if(typeId(vrequest["auto-cross-origin"]) != QMetaType::Bool)
+			if(typeId(vrequest["auto-cross-origin"]) != VariantType::Bool)
 				return false;
 
 			r.autoCrossOrigin = vrequest["auto-cross-origin"].toBool();
@@ -217,14 +217,14 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vrequest.contains("jsonp-callback"))
 		{
-			if(typeId(vrequest["jsonp-callback"]) != QMetaType::QByteArray)
+			if(typeId(vrequest["jsonp-callback"]) != VariantType::ByteArray)
 				return false;
 
 			r.jsonpCallback = vrequest["jsonp-callback"].toByteArray();
 
 			if(vrequest.contains("jsonp-extended-response"))
 			{
-				if(typeId(vrequest["jsonp-extended-response"]) != QMetaType::Bool)
+				if(typeId(vrequest["jsonp-extended-response"]) != VariantType::Bool)
 					return false;
 
 				r.jsonpExtendedResponse = vrequest["jsonp-extended-response"].toBool();
@@ -233,27 +233,27 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vrequest.contains("unreported-time"))
 		{
-			if(!canConvert(vrequest["unreported-time"], QMetaType::Int))
+			if(!canConvert(vrequest["unreported-time"], VariantType::Int))
 				return false;
 
 			r.unreportedTime = vrequest["unreported-time"].toInt();
 		}
 
-		if(!vrequest.contains("in-seq") || !canConvert(vrequest["in-seq"], QMetaType::Int))
+		if(!vrequest.contains("in-seq") || !canConvert(vrequest["in-seq"], VariantType::Int))
 			return false;
 		r.inSeq = vrequest["in-seq"].toInt();
 
-		if(!vrequest.contains("out-seq") || !canConvert(vrequest["out-seq"], QMetaType::Int))
+		if(!vrequest.contains("out-seq") || !canConvert(vrequest["out-seq"], VariantType::Int))
 			return false;
 		r.outSeq = vrequest["out-seq"].toInt();
 
-		if(!vrequest.contains("out-credits") || !canConvert(vrequest["out-credits"], QMetaType::Int))
+		if(!vrequest.contains("out-credits") || !canConvert(vrequest["out-credits"], VariantType::Int))
 			return false;
 		r.outCredits = vrequest["out-credits"].toInt();
 
 		if(vrequest.contains("router-resp"))
 		{
-			if(typeId(vrequest["router-resp"]) != QMetaType::Bool)
+			if(typeId(vrequest["router-resp"]) != VariantType::Bool)
 				return false;
 
 			r.routerResp = vrequest["router-resp"].toBool();
@@ -265,22 +265,22 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 		requests += r;
 	}
 
-	if(!obj.contains("request-data") || typeId(obj["request-data"]) != QMetaType::QVariantHash)
+	if(!obj.contains("request-data") || typeId(obj["request-data"]) != VariantType::Hash)
 		return false;
 	VariantHash vrequestData = obj["request-data"].toHash();
 
-	if(!vrequestData.contains("method") || typeId(vrequestData["method"]) != QMetaType::QByteArray)
+	if(!vrequestData.contains("method") || typeId(vrequestData["method"]) != VariantType::ByteArray)
 		return false;
 	requestData.method = QString::fromLatin1(vrequestData["method"].toByteArray());
 
-	if(!vrequestData.contains("uri") || typeId(vrequestData["uri"]) != QMetaType::QByteArray)
+	if(!vrequestData.contains("uri") || typeId(vrequestData["uri"]) != VariantType::ByteArray)
 		return false;
 	requestData.uri = QUrl::fromEncoded(vrequestData["uri"].toByteArray(), QUrl::StrictMode);
 
 	requestData.headers.clear();
 	if(vrequestData.contains("headers"))
 	{
-		if(typeId(vrequestData["headers"]) != QMetaType::QVariantList)
+		if(typeId(vrequestData["headers"]) != VariantType::List)
 			return false;
 
 		foreach(const Variant &i, vrequestData["headers"].toList())
@@ -289,31 +289,31 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 			if(list.count() != 2)
 				return false;
 
-			if(typeId(list[0]) != QMetaType::QByteArray || typeId(list[1]) != QMetaType::QByteArray)
+			if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
 				return false;
 
 			requestData.headers += QPair<QByteArray, QByteArray>(list[0].toByteArray(), list[1].toByteArray());
 		}
 	}
 
-	if(!vrequestData.contains("body") || typeId(vrequestData["body"]) != QMetaType::QByteArray)
+	if(!vrequestData.contains("body") || typeId(vrequestData["body"]) != VariantType::ByteArray)
 		return false;
 	requestData.body = vrequestData["body"].toByteArray();
 
 	if(obj.contains("inspect"))
 	{
-		if(typeId(obj["inspect"]) != QMetaType::QVariantHash)
+		if(typeId(obj["inspect"]) != VariantType::Hash)
 			return false;
 		VariantHash vinspect = obj["inspect"].toHash();
 
-		if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != QMetaType::Bool)
+		if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != VariantType::Bool)
 			return false;
 		inspectInfo.doProxy = !vinspect["no-proxy"].toBool();
 
 		inspectInfo.sharingKey.clear();
 		if(vinspect.contains("sharing-key"))
 		{
-			if(typeId(vinspect["sharing-key"]) != QMetaType::QByteArray)
+			if(typeId(vinspect["sharing-key"]) != VariantType::ByteArray)
 				return false;
 
 			inspectInfo.sharingKey = vinspect["sharing-key"].toByteArray();
@@ -321,7 +321,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vinspect.contains("sid"))
 		{
-			if(typeId(vinspect["sid"]) != QMetaType::QByteArray)
+			if(typeId(vinspect["sid"]) != VariantType::ByteArray)
 				return false;
 
 			inspectInfo.sid = vinspect["sid"].toByteArray();
@@ -329,7 +329,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 		if(vinspect.contains("last-ids"))
 		{
-			if(typeId(vinspect["last-ids"]) != QMetaType::QVariantHash)
+			if(typeId(vinspect["last-ids"]) != VariantType::Hash)
 				return false;
 
 			VariantHash vlastIds = vinspect["last-ids"].toHash();
@@ -338,7 +338,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 			{
 				it.next();
 
-				if(typeId(it.value()) != QMetaType::QByteArray)
+				if(typeId(it.value()) != VariantType::ByteArray)
 					return false;
 
 				QByteArray key = it.key().toUtf8();
@@ -354,7 +354,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 	if(obj.contains("route"))
 	{
-		if(typeId(obj["route"]) != QMetaType::QByteArray)
+		if(typeId(obj["route"]) != VariantType::ByteArray)
 			return false;
 
 		route = obj["route"].toByteArray();
@@ -362,7 +362,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 	if(obj.contains("retry-seq"))
 	{
-		if(!canConvert(obj["retry-seq"], QMetaType::Int))
+		if(!canConvert(obj["retry-seq"], VariantType::Int))
 			return false;
 
 		retrySeq = obj["retry-seq"].toInt();

--- a/src/core/packet/statspacket.cpp
+++ b/src/core/packet/statspacket.cpp
@@ -30,7 +30,7 @@ static bool tryGetInt(const VariantHash &obj, const QString &name, int *result)
 {
 	if(obj.contains(name))
 	{
-		if(!canConvert(obj[name], QMetaType::Int))
+		if(!canConvert(obj[name], VariantType::Int))
 			return false;
 
 		*result = obj[name].toInt();
@@ -177,14 +177,14 @@ Variant StatsPacket::toVariant() const
 
 bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
 
 	if(obj.contains("from"))
 	{
-		if(typeId(obj["from"]) != QMetaType::QByteArray)
+		if(typeId(obj["from"]) != VariantType::ByteArray)
 			return false;
 
 		from = obj["from"].toByteArray();
@@ -192,7 +192,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 	if(obj.contains("route"))
 	{
-		if(typeId(obj["route"]) != QMetaType::QByteArray)
+		if(typeId(obj["route"]) != VariantType::ByteArray)
 			return false;
 
 		route = obj["route"].toByteArray();
@@ -202,7 +202,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 	{
 		type = Activity;
 
-		if(!obj.contains("count") || !canConvert(obj["count"], QMetaType::Int))
+		if(!obj.contains("count") || !canConvert(obj["count"], VariantType::Int))
 			return false;
 
 		count = obj["count"].toInt();
@@ -213,20 +213,20 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 	{
 		type = Message;
 
-		if(!obj.contains("channel") || typeId(obj["channel"]) != QMetaType::QByteArray)
+		if(!obj.contains("channel") || typeId(obj["channel"]) != VariantType::ByteArray)
 			return false;
 
 		channel = obj["channel"].toByteArray();
 
 		if(obj.contains("item-id"))
 		{
-			if(typeId(obj["item-id"]) != QMetaType::QByteArray)
+			if(typeId(obj["item-id"]) != VariantType::ByteArray)
 				return false;
 
 			itemId = obj["item-id"].toByteArray();
 		}
 
-		if(!obj.contains("count") || !canConvert(obj["count"], QMetaType::Int))
+		if(!obj.contains("count") || !canConvert(obj["count"], VariantType::Int))
 			return false;
 
 		count = obj["count"].toInt();
@@ -235,20 +235,20 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("blocks"))
 		{
-			if(!canConvert(obj["blocks"], QMetaType::Int))
+			if(!canConvert(obj["blocks"], VariantType::Int))
 				return false;
 
 			blocks = obj["blocks"].toInt();
 		}
 
-		if(!obj.contains("transport") || typeId(obj["transport"]) != QMetaType::QByteArray)
+		if(!obj.contains("transport") || typeId(obj["transport"]) != VariantType::ByteArray)
 			return false;
 
 		transport = obj["transport"].toByteArray();
 	}
 	else if(_type == "conn")
 	{
-		if(!obj.contains("id") || typeId(obj["id"]) != QMetaType::QByteArray)
+		if(!obj.contains("id") || typeId(obj["id"]) != VariantType::ByteArray)
 			return false;
 
 		connectionId = obj["id"].toByteArray();
@@ -256,7 +256,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 		type = Connected;
 		if(obj.contains("unavailable"))
 		{
-			if(typeId(obj["unavailable"]) != QMetaType::Bool)
+			if(typeId(obj["unavailable"]) != VariantType::Bool)
 				return false;
 
 			if(obj["unavailable"].toBool())
@@ -265,7 +265,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(type == Connected)
 		{
-			if(!obj.contains("type") || typeId(obj["type"]) != QMetaType::QByteArray)
+			if(!obj.contains("type") || typeId(obj["type"]) != VariantType::ByteArray)
 				return false;
 
 			QByteArray typeStr = obj["type"].toByteArray();
@@ -278,7 +278,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 			if(obj.contains("peer-address"))
 			{
-				if(typeId(obj["peer-address"]) != QMetaType::QByteArray)
+				if(typeId(obj["peer-address"]) != VariantType::ByteArray)
 					return false;
 
 				QByteArray peerAddressStr = obj["peer-address"].toByteArray();
@@ -288,13 +288,13 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 			if(obj.contains("ssl"))
 			{
-				if(typeId(obj["ssl"]) != QMetaType::Bool)
+				if(typeId(obj["ssl"]) != VariantType::Bool)
 					return false;
 
 				ssl = obj["ssl"].toBool();
 			}
 
-			if(!obj.contains("ttl") || !canConvert(obj["ttl"], QMetaType::Int))
+			if(!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
 				return false;
 
 			ttl = obj["ttl"].toInt();
@@ -304,12 +304,12 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 	}
 	else if(_type == "sub")
 	{
-		if(!obj.contains("mode") || typeId(obj["mode"]) != QMetaType::QByteArray)
+		if(!obj.contains("mode") || typeId(obj["mode"]) != VariantType::ByteArray)
 			return false;
 
 		mode = obj["mode"].toByteArray();
 
-		if(!obj.contains("channel") || typeId(obj["channel"]) != QMetaType::QByteArray)
+		if(!obj.contains("channel") || typeId(obj["channel"]) != VariantType::ByteArray)
 			return false;
 
 		channel = obj["channel"].toByteArray();
@@ -317,7 +317,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 		type = Subscribed;
 		if(obj.contains("unavailable"))
 		{
-			if(typeId(obj["unavailable"]) != QMetaType::Bool)
+			if(typeId(obj["unavailable"]) != VariantType::Bool)
 				return false;
 
 			if(obj["unavailable"].toBool())
@@ -326,7 +326,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(type == Subscribed)
 		{
-			if(!obj.contains("ttl") || !canConvert(obj["ttl"], QMetaType::Int))
+			if(!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
 				return false;
 
 			ttl = obj["ttl"].toInt();
@@ -335,7 +335,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 			if(obj.contains("subscribers"))
 			{
-				if(!canConvert(obj["subscribers"], QMetaType::Int))
+				if(!canConvert(obj["subscribers"], VariantType::Int))
 					return false;
 
 				subscribers = obj["subscribers"].toInt();
@@ -350,7 +350,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("connections"))
 		{
-			if(!canConvert(obj["connections"], QMetaType::Int))
+			if(!canConvert(obj["connections"], VariantType::Int))
 				return false;
 
 			connectionsMax = obj["connections"].toInt();
@@ -358,7 +358,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("minutes"))
 		{
-			if(!canConvert(obj["minutes"], QMetaType::Int))
+			if(!canConvert(obj["minutes"], VariantType::Int))
 				return false;
 
 			connectionsMinutes = obj["minutes"].toInt();
@@ -366,7 +366,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("received"))
 		{
-			if(!canConvert(obj["received"], QMetaType::Int))
+			if(!canConvert(obj["received"], VariantType::Int))
 				return false;
 
 			messagesReceived = obj["received"].toInt();
@@ -374,7 +374,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("sent"))
 		{
-			if(!canConvert(obj["sent"], QMetaType::Int))
+			if(!canConvert(obj["sent"], VariantType::Int))
 				return false;
 
 			messagesSent = obj["sent"].toInt();
@@ -382,7 +382,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("http-response-sent"))
 		{
-			if(!canConvert(obj["http-response-sent"], QMetaType::Int))
+			if(!canConvert(obj["http-response-sent"], VariantType::Int))
 				return false;
 
 			httpResponseMessagesSent = obj["http-response-sent"].toInt();
@@ -390,7 +390,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("blocks-received"))
 		{
-			if(!canConvert(obj["blocks-received"], QMetaType::Int))
+			if(!canConvert(obj["blocks-received"], VariantType::Int))
 				return false;
 
 			blocksReceived = obj["blocks-received"].toInt();
@@ -398,7 +398,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("blocks-sent"))
 		{
-			if(!canConvert(obj["blocks-sent"], QMetaType::Int))
+			if(!canConvert(obj["blocks-sent"], VariantType::Int))
 				return false;
 
 			blocksSent = obj["blocks-sent"].toInt();
@@ -406,7 +406,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("duration"))
 		{
-			if(!canConvert(obj["duration"], QMetaType::Int))
+			if(!canConvert(obj["duration"], VariantType::Int))
 				return false;
 
 			duration = obj["duration"].toInt();
@@ -443,7 +443,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("requests-received"))
 		{
-			if(!canConvert(obj["requests-received"], QMetaType::Int))
+			if(!canConvert(obj["requests-received"], VariantType::Int))
 				return false;
 
 			int x = obj["requests-received"].toInt();
@@ -457,7 +457,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 	{
 		type = ConnectionsMax;
 
-		if(!obj.contains("max") || !canConvert(obj["max"], QMetaType::Int))
+		if(!obj.contains("max") || !canConvert(obj["max"], VariantType::Int))
 			return false;
 
 		int x = obj["max"].toInt();
@@ -466,7 +466,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		connectionsMax = x;
 
-		if(!obj.contains("ttl") || !canConvert(obj["ttl"], QMetaType::Int))
+		if(!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
 			return false;
 
 		x = obj["ttl"].toInt();
@@ -477,7 +477,7 @@ bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
 
 		if(obj.contains("retry-seq"))
 		{
-			if(!canConvert(obj["retry-seq"], QMetaType::LongLong))
+			if(!canConvert(obj["retry-seq"], VariantType::LongLong))
 				return false;
 
 			int x = obj["retry-seq"].toLongLong();

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -135,7 +135,7 @@ public:
 				}
 
 				Variant vmessage = keyedObjectGetValue(vitem, "message");
-				if(vmessage.type() != Variant::ByteArray)
+				if(vmessage.type() != VariantType::ByteArray)
 				{
 					setError(ok, errorMessage, QString("'%1' contains 'message' with wrong type").arg(pn));
 					return WsControlPacket();
@@ -246,17 +246,17 @@ Variant WsControlPacket::toVariant() const
 
 bool WsControlPacket::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
 
-	if(!obj.contains("from") || typeId(obj["from"]) != QMetaType::QByteArray)
+	if(!obj.contains("from") || typeId(obj["from"]) != VariantType::ByteArray)
 		return false;
 
 	from = obj["from"].toByteArray();
 
-	if(!obj.contains("items") || typeId(obj["items"]) != QMetaType::QVariantList)
+	if(!obj.contains("items") || typeId(obj["items"]) != VariantType::List)
 		return false;
 
 	VariantList vitems = obj["items"].toList();
@@ -264,18 +264,18 @@ bool WsControlPacket::fromVariant(const Variant &in)
 	items.clear();
 	foreach(const Variant &v, vitems)
 	{
-		if(typeId(v) != QMetaType::QVariantHash)
+		if(typeId(v) != VariantType::Hash)
 			return false;
 
 		VariantHash vitem = v.toHash();
 
 		Item item;
 
-		if(!vitem.contains("cid") || typeId(vitem["cid"]) != QMetaType::QByteArray)
+		if(!vitem.contains("cid") || typeId(vitem["cid"]) != VariantType::ByteArray)
 			return false;
 		item.cid = vitem["cid"].toByteArray();
 
-		if(!vitem.contains("type") || typeId(vitem["type"]) != QMetaType::QByteArray)
+		if(!vitem.contains("type") || typeId(vitem["type"]) != VariantType::ByteArray)
 			return false;
 		QByteArray typeStr = vitem["type"].toByteArray();
 
@@ -310,7 +310,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("req-id"))
 		{
-			if(typeId(vitem["req-id"]) != QMetaType::QByteArray)
+			if(typeId(vitem["req-id"]) != VariantType::ByteArray)
 				return false;
 
 			item.requestId = vitem["req-id"].toByteArray();
@@ -318,7 +318,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("uri"))
 		{
-			if(typeId(vitem["uri"]) != QMetaType::QByteArray)
+			if(typeId(vitem["uri"]) != VariantType::ByteArray)
 				return false;
 
 			item.uri = QUrl::fromEncoded(vitem["uri"].toByteArray(), QUrl::StrictMode);
@@ -326,7 +326,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("content-type"))
 		{
-			if(typeId(vitem["content-type"]) != QMetaType::QByteArray)
+			if(typeId(vitem["content-type"]) != VariantType::ByteArray)
 				return false;
 
 			QByteArray contentType = vitem["content-type"].toByteArray();
@@ -336,7 +336,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("message"))
 		{
-			if(typeId(vitem["message"]) != QMetaType::QByteArray)
+			if(typeId(vitem["message"]) != VariantType::ByteArray)
 				return false;
 
 			item.message = vitem["message"].toByteArray();
@@ -344,7 +344,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("queue"))
 		{
-			if(typeId(vitem["queue"]) != QMetaType::Bool)
+			if(typeId(vitem["queue"]) != VariantType::Bool)
 				return false;
 
 			item.queue = vitem["queue"].toBool();
@@ -352,7 +352,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("code"))
 		{
-			if(!canConvert(vitem["code"], QMetaType::Int))
+			if(!canConvert(vitem["code"], VariantType::Int))
 				return false;
 
 			item.code = vitem["code"].toInt();
@@ -360,7 +360,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("reason"))
 		{
-			if(typeId(vitem["reason"]) != QMetaType::QByteArray)
+			if(typeId(vitem["reason"]) != VariantType::ByteArray)
 				return false;
 
 			item.reason = vitem["reason"].toByteArray();
@@ -368,7 +368,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("debug"))
 		{
-			if(typeId(vitem["debug"]) != QMetaType::Bool)
+			if(typeId(vitem["debug"]) != VariantType::Bool)
 				return false;
 
 			item.debug = vitem["debug"].toBool();
@@ -376,7 +376,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("route"))
 		{
-			if(typeId(vitem["route"]) != QMetaType::QByteArray)
+			if(typeId(vitem["route"]) != VariantType::ByteArray)
 				return false;
 
 			QByteArray route = vitem["route"].toByteArray();
@@ -386,7 +386,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("separate-stats"))
 		{
-			if(typeId(vitem["separate-stats"]) != QMetaType::Bool)
+			if(typeId(vitem["separate-stats"]) != VariantType::Bool)
 				return false;
 
 			item.separateStats = vitem["separate-stats"].toBool();
@@ -394,7 +394,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("channel-prefix"))
 		{
-			if(typeId(vitem["channel-prefix"]) != QMetaType::QByteArray)
+			if(typeId(vitem["channel-prefix"]) != VariantType::ByteArray)
 				return false;
 
 			QByteArray channelPrefix = vitem["channel-prefix"].toByteArray();
@@ -404,7 +404,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("log-level"))
 		{
-			if(!canConvert(vitem["log-level"], QMetaType::Int))
+			if(!canConvert(vitem["log-level"], VariantType::Int))
 				return false;
 
 			item.logLevel = vitem["log-level"].toInt();
@@ -412,7 +412,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("trusted"))
 		{
-			if(typeId(vitem["trusted"]) != QMetaType::Bool)
+			if(typeId(vitem["trusted"]) != VariantType::Bool)
 				return false;
 
 			item.trusted = vitem["trusted"].toBool();
@@ -420,7 +420,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("channel"))
 		{
-			if(typeId(vitem["channel"]) != QMetaType::QByteArray)
+			if(typeId(vitem["channel"]) != VariantType::ByteArray)
 				return false;
 
 			QByteArray channel = vitem["channel"].toByteArray();
@@ -430,7 +430,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("ttl"))
 		{
-			if(!canConvert(vitem["ttl"], QMetaType::Int))
+			if(!canConvert(vitem["ttl"], VariantType::Int))
 				return false;
 
 			item.ttl = vitem["ttl"].toInt();
@@ -440,7 +440,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("timeout"))
 		{
-			if(!canConvert(vitem["timeout"], QMetaType::Int))
+			if(!canConvert(vitem["timeout"], VariantType::Int))
 				return false;
 
 			item.timeout = vitem["timeout"].toInt();
@@ -450,7 +450,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 
 		if(vitem.contains("keep-alive-mode"))
 		{
-			if(!canConvert(vitem["keep-alive-mode"], QMetaType::QByteArray))
+			if(!canConvert(vitem["keep-alive-mode"], VariantType::ByteArray))
 				return false;
 
 			QByteArray keepAliveMode = vitem["keep-alive-mode"].toByteArray();

--- a/src/core/packet/zrpcrequestpacket.cpp
+++ b/src/core/packet/zrpcrequestpacket.cpp
@@ -46,14 +46,14 @@ Variant ZrpcRequestPacket::toVariant() const
 
 bool ZrpcRequestPacket::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
 
 	if(obj.contains("from"))
 	{
-		if(typeId(obj["from"]) != QMetaType::QByteArray)
+		if(typeId(obj["from"]) != VariantType::ByteArray)
 			return false;
 
 		from = obj["from"].toByteArray();
@@ -61,19 +61,19 @@ bool ZrpcRequestPacket::fromVariant(const Variant &in)
 
 	if(obj.contains("id"))
 	{
-		if(typeId(obj["id"]) != QMetaType::QByteArray)
+		if(typeId(obj["id"]) != VariantType::ByteArray)
 			return false;
 
 		id = obj["id"].toByteArray();
 	}
 
-	if(!obj.contains("method") || typeId(obj["method"]) != QMetaType::QByteArray)
+	if(!obj.contains("method") || typeId(obj["method"]) != VariantType::ByteArray)
 		return false;
 	method = QString::fromUtf8(obj["method"].toByteArray());
 
 	if(obj.contains("args"))
 	{
-		if(typeId(obj["args"]) != QMetaType::QVariantHash)
+		if(typeId(obj["args"]) != VariantType::Hash)
 			return false;
 
 		args = obj["args"].toHash();

--- a/src/core/packet/zrpcresponsepacket.cpp
+++ b/src/core/packet/zrpcresponsepacket.cpp
@@ -37,7 +37,7 @@ Variant ZrpcResponsePacket::toVariant() const
 
 	if(success)
 	{
-		if(typeId(value) == QMetaType::QString)
+		if(typeId(value) == VariantType::String)
 			obj["value"] = value.toString().toUtf8();
 		else
 			obj["value"] = value;
@@ -48,7 +48,7 @@ Variant ZrpcResponsePacket::toVariant() const
 
 		if(value.isValid())
 		{
-			if(typeId(value) == QMetaType::QString)
+			if(typeId(value) == VariantType::String)
 				obj["value"] = value.toString().toUtf8();
 			else
 				obj["value"] = value;
@@ -60,20 +60,20 @@ Variant ZrpcResponsePacket::toVariant() const
 
 bool ZrpcResponsePacket::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
 
 	if(obj.contains("id"))
 	{
-		if(typeId(obj["id"]) != QMetaType::QByteArray)
+		if(typeId(obj["id"]) != VariantType::ByteArray)
 			return false;
 
 		id = obj["id"].toByteArray();
 	}
 
-	if(!obj.contains("success") || typeId(obj["success"]) != QMetaType::Bool)
+	if(!obj.contains("success") || typeId(obj["success"]) != VariantType::Bool)
 		return false;
 	success = obj["success"].toBool();
 
@@ -87,7 +87,7 @@ bool ZrpcResponsePacket::fromVariant(const Variant &in)
 	}
 	else
 	{
-		if(!obj.contains("condition") || typeId(obj["condition"]) != QMetaType::QByteArray)
+		if(!obj.contains("condition") || typeId(obj["condition"]) != VariantType::ByteArray)
 			return false;
 		condition = obj["condition"].toByteArray();
 

--- a/src/core/qtcompat.h
+++ b/src/core/qtcompat.h
@@ -26,21 +26,36 @@
 #include <QMetaType>
 #include <QVariant>
 
-inline QMetaType::Type typeId(const QVariant &v)
+namespace VariantType {
+	enum Type {
+		Invalid = QMetaType::UnknownType,
+		Bool = QMetaType::Bool,
+		Int = QMetaType::Int,
+		Double = QMetaType::Double,
+		LongLong = QMetaType::LongLong,
+		String = QMetaType::QString,
+		ByteArray = QMetaType::QByteArray,
+		Hash = QMetaType::QVariantHash,
+		Map = QMetaType::QVariantMap,
+		List = QMetaType::QVariantList
+	};
+}
+
+inline VariantType::Type typeId(const QVariant &v)
 {
 #if QT_VERSION >= 0x060000
-	return (QMetaType::Type)v.typeId();
+	return (VariantType::Type)v.typeId();
 #else
-	return (QMetaType::Type)v.type();
+	return (VariantType::Type)v.type();
 #endif
 }
 
-inline bool canConvert(const QVariant &v, QMetaType::Type type)
+inline bool canConvert(const QVariant &v, VariantType::Type type)
 {
 #if QT_VERSION >= 0x060000
-    return v.canConvert(QMetaType(type));
+    return v.canConvert(QMetaType((QMetaType::Type)type));
 #else
-    return v.canConvert(type);
+    return v.canConvert((QMetaType::Type)type);
 #endif
 }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -156,11 +156,11 @@ Variant Settings::value(const QString &key, const Variant &defaultValue) const
 	Variant v = valueRaw(key, defaultValue);
 	if(v.isValid())
 	{
-		if(typeId(v) == QMetaType::QString)
+		if(typeId(v) == VariantType::String)
 		{
 			v = resolveVars(v.toString());
 		}
-		else if(typeId(v) == QMetaType::QStringList)
+		else if(typeId(v) == VariantType::List)
 		{
 			QStringList oldList = v.toStringList();
 			QStringList newList;

--- a/src/core/tnetstring.cpp
+++ b/src/core/tnetstring.cpp
@@ -60,20 +60,20 @@ QByteArray fromVariant(const Variant &in)
 {
 	switch(typeId(in))
 	{
-		case QMetaType::QByteArray:
+		case VariantType::ByteArray:
 			return fromByteArray(in.toByteArray());
-		case QMetaType::Double:
+		case VariantType::Double:
 			return fromDouble(in.toDouble());
-		case QMetaType::Bool:
+		case VariantType::Bool:
 			return fromBool(in.toBool());
-		case QMetaType::UnknownType:
+		case VariantType::Invalid:
 			return fromNull();
-		case QMetaType::QVariantHash:
+		case VariantType::Hash:
 			return fromHash(in.toHash());
-		case QMetaType::QVariantList:
+		case VariantType::List:
 			return fromList(in.toList());
 		default:
-			if(canConvert(in, QMetaType::LongLong))
+			if(canConvert(in, VariantType::LongLong))
 				return fromInt(in.toLongLong());
 
 			// Unsupported type
@@ -382,8 +382,8 @@ QString variantToString(const Variant &in, int indent)
 {
 	QString out;
 
-	QMetaType::Type type = typeId(in);
-	if(type == QMetaType::QVariantHash)
+	VariantType::Type type = typeId(in);
+	if(type == VariantType::Hash)
 	{
 		VariantHash hash = in.toHash();
 
@@ -415,7 +415,7 @@ QString variantToString(const Variant &in, int indent)
 			out += QString(indent, ' ');
 		out += '}';
 	}
-	else if(type == QMetaType::QVariantList)
+	else if(type == VariantType::List)
 	{
 		VariantList list = in.toList();
 
@@ -444,18 +444,18 @@ QString variantToString(const Variant &in, int indent)
 			out += QString(indent, ' ');
 		out += ']';
 	}
-	else if(type == QMetaType::QByteArray)
+	else if(type == VariantType::ByteArray)
 	{
 		QByteArray val = in.toByteArray();
 		out += '\"' + byteArrayToEscapedString(val) + '\"';
 	}
-	else if(type == QMetaType::Double)
+	else if(type == VariantType::Double)
 		out += QString::number(in.toDouble());
-	else if(type == QMetaType::Bool)
+	else if(type == VariantType::Bool)
 		out += in.toBool() ? "true" : "false";
-	else if(type == QMetaType::UnknownType)
+	else if(type == VariantType::Invalid)
 		out += "null";
-	else if(canConvert(in, QMetaType::LongLong))
+	else if(canConvert(in, VariantType::LongLong))
 		out += QString::number(in.toLongLong());
 	else
 		out += QString("<unknown: %1>").arg((int)type);

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -181,7 +181,7 @@ Variant ZhttpRequestPacket::toVariant() const
 
 bool ZhttpRequestPacket::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
@@ -189,7 +189,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	from.clear();
 	if(obj.contains("from"))
 	{
-		if(typeId(obj["from"]) != QMetaType::QByteArray)
+		if(typeId(obj["from"]) != VariantType::ByteArray)
 			return false;
 
 		from = obj["from"].toByteArray();
@@ -198,18 +198,18 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	ids.clear();
 	if(obj.contains("id"))
 	{
-		if(typeId(obj["id"]) == QMetaType::QByteArray)
+		if(typeId(obj["id"]) == VariantType::ByteArray)
 		{
 			Id id;
 			id.id = obj["id"].toByteArray();
 			ids += id;
 		}
-		else if(typeId(obj["id"]) == QMetaType::QVariantList)
+		else if(typeId(obj["id"]) == VariantType::List)
 		{
 			VariantList vl = obj["id"].toList();
 			foreach(const Variant &v, vl)
 			{
-				if(typeId(v) != QMetaType::QVariantHash)
+				if(typeId(v) != VariantType::Hash)
 					return false;
 
 				Id id;
@@ -218,7 +218,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 
 				if(vh.contains("id"))
 				{
-					if(typeId(vh["id"]) != QMetaType::QByteArray)
+					if(typeId(vh["id"]) != VariantType::ByteArray)
 						return false;
 
 					id.id = vh["id"].toByteArray();
@@ -226,7 +226,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 
 				if(vh.contains("seq"))
 				{
-					if(!canConvert(vh["seq"], QMetaType::Int))
+					if(!canConvert(vh["seq"], VariantType::Int))
 						return false;
 
 					id.seq = vh["seq"].toInt();
@@ -241,7 +241,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 
 	if(obj.contains("seq"))
 	{
-		if(!canConvert(obj["seq"], QMetaType::Int))
+		if(!canConvert(obj["seq"], VariantType::Int))
 			return false;
 
 		if(ids.isEmpty())
@@ -253,7 +253,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	type = Data;
 	if(obj.contains("type"))
 	{
-		if(typeId(obj["type"]) != QMetaType::QByteArray)
+		if(typeId(obj["type"]) != VariantType::ByteArray)
 			return false;
 
 		QByteArray typeStr = obj["type"].toByteArray();
@@ -285,7 +285,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 		condition.clear();
 		if(obj.contains("condition"))
 		{
-			if(typeId(obj["condition"]) != QMetaType::QByteArray)
+			if(typeId(obj["condition"]) != VariantType::ByteArray)
 				return false;
 
 			condition = obj["condition"].toByteArray();
@@ -295,7 +295,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	credits = -1;
 	if(obj.contains("credits"))
 	{
-		if(!canConvert(obj["credits"], QMetaType::Int))
+		if(!canConvert(obj["credits"], VariantType::Int))
 			return false;
 
 		credits = obj["credits"].toInt();
@@ -304,7 +304,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	more = false;
 	if(obj.contains("more"))
 	{
-		if(typeId(obj["more"]) != QMetaType::Bool)
+		if(typeId(obj["more"]) != VariantType::Bool)
 			return false;
 
 		more = obj["more"].toBool();
@@ -313,7 +313,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	stream = false;
 	if(obj.contains("stream"))
 	{
-		if(typeId(obj["stream"]) != QMetaType::Bool)
+		if(typeId(obj["stream"]) != VariantType::Bool)
 			return false;
 
 		stream = obj["stream"].toBool();
@@ -322,7 +322,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	routerResp = false;
 	if(obj.contains("router-resp"))
 	{
-		if(typeId(obj["router-resp"]) != QMetaType::Bool)
+		if(typeId(obj["router-resp"]) != VariantType::Bool)
 			return false;
 
 		routerResp = obj["router-resp"].toBool();
@@ -331,7 +331,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	maxSize = -1;
 	if(obj.contains("max-size"))
 	{
-		if(!canConvert(obj["max-size"], QMetaType::Int))
+		if(!canConvert(obj["max-size"], VariantType::Int))
 			return false;
 
 		maxSize = obj["max-size"].toInt();
@@ -340,7 +340,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	timeout = -1;
 	if(obj.contains("timeout"))
 	{
-		if(!canConvert(obj["timeout"], QMetaType::Int))
+		if(!canConvert(obj["timeout"], VariantType::Int))
 			return false;
 
 		timeout = obj["timeout"].toInt();
@@ -349,7 +349,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	method.clear();
 	if(obj.contains("method"))
 	{
-		if(typeId(obj["method"]) != QMetaType::QByteArray)
+		if(typeId(obj["method"]) != VariantType::ByteArray)
 			return false;
 
 		method = QString::fromLatin1(obj["method"].toByteArray());
@@ -358,7 +358,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	uri.clear();
 	if(obj.contains("uri"))
 	{
-		if(typeId(obj["uri"]) != QMetaType::QByteArray)
+		if(typeId(obj["uri"]) != VariantType::ByteArray)
 			return false;
 
 		uri = QUrl::fromEncoded(obj["uri"].toByteArray(), QUrl::StrictMode);
@@ -367,7 +367,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	headers.clear();
 	if(obj.contains("headers"))
 	{
-		if(typeId(obj["headers"]) != QMetaType::QVariantList)
+		if(typeId(obj["headers"]) != VariantType::List)
 			return false;
 
 		foreach(const Variant &i, obj["headers"].toList())
@@ -376,7 +376,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 			if(list.count() != 2)
 				return false;
 
-			if(typeId(list[0]) != QMetaType::QByteArray || typeId(list[1]) != QMetaType::QByteArray)
+			if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
 				return false;
 
 			headers += HttpHeader(list[0].toByteArray(), list[1].toByteArray());
@@ -386,7 +386,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	body.clear();
 	if(obj.contains("body"))
 	{
-		if(typeId(obj["body"]) != QMetaType::QByteArray)
+		if(typeId(obj["body"]) != VariantType::ByteArray)
 			return false;
 
 		body = obj["body"].toByteArray();
@@ -395,7 +395,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	contentType.clear();
 	if(obj.contains("content-type"))
 	{
-		if(typeId(obj["content-type"]) != QMetaType::QByteArray)
+		if(typeId(obj["content-type"]) != VariantType::ByteArray)
 			return false;
 
 		contentType = obj["content-type"].toByteArray();
@@ -404,7 +404,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	code = -1;
 	if(obj.contains("code"))
 	{
-		if(!canConvert(obj["code"], QMetaType::Int))
+		if(!canConvert(obj["code"], VariantType::Int))
 			return false;
 
 		code = obj["code"].toInt();
@@ -415,7 +415,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	peerAddress = QHostAddress();
 	if(obj.contains("peer-address"))
 	{
-		if(typeId(obj["peer-address"]) != QMetaType::QByteArray)
+		if(typeId(obj["peer-address"]) != VariantType::ByteArray)
 			return false;
 
 		peerAddress = QHostAddress(QString::fromUtf8(obj["peer-address"].toByteArray()));
@@ -424,7 +424,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	peerPort = -1;
 	if(obj.contains("peer-port"))
 	{
-		if(!canConvert(obj["peer-port"], QMetaType::Int))
+		if(!canConvert(obj["peer-port"], VariantType::Int))
 			return false;
 
 		peerPort = obj["peer-port"].toInt();
@@ -433,7 +433,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	connectHost.clear();
 	if(obj.contains("connect-host"))
 	{
-		if(typeId(obj["connect-host"]) != QMetaType::QByteArray)
+		if(typeId(obj["connect-host"]) != VariantType::ByteArray)
 			return false;
 
 		connectHost = QString::fromUtf8(obj["connect-host"].toByteArray());
@@ -442,7 +442,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	connectPort = -1;
 	if(obj.contains("connect-port"))
 	{
-		if(!canConvert(obj["connect-port"], QMetaType::Int))
+		if(!canConvert(obj["connect-port"], VariantType::Int))
 			return false;
 
 		connectPort = obj["connect-port"].toInt();
@@ -451,7 +451,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	ignorePolicies = false;
 	if(obj.contains("ignore-policies"))
 	{
-		if(typeId(obj["ignore-policies"]) != QMetaType::Bool)
+		if(typeId(obj["ignore-policies"]) != VariantType::Bool)
 			return false;
 
 		ignorePolicies = obj["ignore-policies"].toBool();
@@ -460,7 +460,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	trustConnectHost = false;
 	if(obj.contains("trust-connect-host"))
 	{
-		if(typeId(obj["trust-connect-host"]) != QMetaType::Bool)
+		if(typeId(obj["trust-connect-host"]) != VariantType::Bool)
 			return false;
 
 		trustConnectHost = obj["trust-connect-host"].toBool();
@@ -469,7 +469,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	ignoreTlsErrors = false;
 	if(obj.contains("ignore-tls-errors"))
 	{
-		if(typeId(obj["ignore-tls-errors"]) != QMetaType::Bool)
+		if(typeId(obj["ignore-tls-errors"]) != VariantType::Bool)
 			return false;
 
 		ignoreTlsErrors = obj["ignore-tls-errors"].toBool();
@@ -478,7 +478,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	clientCert.clear();
 	if(obj.contains("client-cert"))
 	{
-		if(typeId(obj["client-cert"]) != QMetaType::QByteArray)
+		if(typeId(obj["client-cert"]) != VariantType::ByteArray)
 			return false;
 
 		clientCert = QString::fromUtf8(obj["client-cert"].toByteArray());
@@ -487,7 +487,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	clientKey.clear();
 	if(obj.contains("client-key"))
 	{
-		if(typeId(obj["client-key"]) != QMetaType::QByteArray)
+		if(typeId(obj["client-key"]) != VariantType::ByteArray)
 			return false;
 
 		clientKey = QString::fromUtf8(obj["client-key"].toByteArray());
@@ -496,7 +496,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	followRedirects = false;
 	if(obj.contains("follow-redirects"))
 	{
-		if(typeId(obj["follow-redirects"]) != QMetaType::Bool)
+		if(typeId(obj["follow-redirects"]) != VariantType::Bool)
 			return false;
 
 		followRedirects = obj["follow-redirects"].toBool();
@@ -507,16 +507,16 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 	multi = false;
 	if(obj.contains("ext"))
 	{
-		if(typeId(obj["ext"]) != QMetaType::QVariantHash)
+		if(typeId(obj["ext"]) != VariantType::Hash)
 			return false;
 
 		VariantHash ext = obj["ext"].toHash();
-		if(ext.contains("multi") && typeId(ext["multi"]) == QMetaType::Bool)
+		if(ext.contains("multi") && typeId(ext["multi"]) == VariantType::Bool)
 		{
 			multi = ext["multi"].toBool();
 		}
 
-		if(ext.contains("quiet") && typeId(ext["quiet"]) == QMetaType::Bool)
+		if(ext.contains("quiet") && typeId(ext["quiet"]) == VariantType::Bool)
 		{
 			quiet = ext["quiet"].toBool();
 		}

--- a/src/core/zhttpresponsepacket.cpp
+++ b/src/core/zhttpresponsepacket.cpp
@@ -124,7 +124,7 @@ Variant ZhttpResponsePacket::toVariant() const
 
 bool ZhttpResponsePacket::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return false;
 
 	VariantHash obj = in.toHash();
@@ -132,7 +132,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	from.clear();
 	if(obj.contains("from"))
 	{
-		if(typeId(obj["from"]) != QMetaType::QByteArray)
+		if(typeId(obj["from"]) != VariantType::ByteArray)
 			return false;
 
 		from = obj["from"].toByteArray();
@@ -141,18 +141,18 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	ids.clear();
 	if(obj.contains("id"))
 	{
-		if(typeId(obj["id"]) == QMetaType::QByteArray)
+		if(typeId(obj["id"]) == VariantType::ByteArray)
 		{
 			Id id;
 			id.id = obj["id"].toByteArray();
 			ids += id;
 		}
-		else if(typeId(obj["id"]) == QMetaType::QVariantList)
+		else if(typeId(obj["id"]) == VariantType::List)
 		{
 			VariantList vl = obj["id"].toList();
 			foreach(const Variant &v, vl)
 			{
-				if(typeId(v) != QMetaType::QVariantHash)
+				if(typeId(v) != VariantType::Hash)
 					return false;
 
 				Id id;
@@ -161,7 +161,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 
 				if(vh.contains("id"))
 				{
-					if(typeId(vh["id"]) != QMetaType::QByteArray)
+					if(typeId(vh["id"]) != VariantType::ByteArray)
 						return false;
 
 					id.id = vh["id"].toByteArray();
@@ -169,7 +169,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 
 				if(vh.contains("seq"))
 				{
-					if(!canConvert(vh["seq"], QMetaType::Int))
+					if(!canConvert(vh["seq"], VariantType::Int))
 						return false;
 
 					id.seq = vh["seq"].toInt();
@@ -184,7 +184,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 
 	if(obj.contains("seq"))
 	{
-		if(!canConvert(obj["seq"], QMetaType::Int))
+		if(!canConvert(obj["seq"], VariantType::Int))
 			return false;
 
 		if(ids.isEmpty())
@@ -196,7 +196,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	type = Data;
 	if(obj.contains("type"))
 	{
-		if(typeId(obj["type"]) != QMetaType::QByteArray)
+		if(typeId(obj["type"]) != VariantType::ByteArray)
 			return false;
 
 		QByteArray typeStr = obj["type"].toByteArray();
@@ -228,7 +228,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 		condition.clear();
 		if(obj.contains("condition"))
 		{
-			if(typeId(obj["condition"]) != QMetaType::QByteArray)
+			if(typeId(obj["condition"]) != VariantType::ByteArray)
 				return false;
 
 			condition = obj["condition"].toByteArray();
@@ -238,7 +238,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	credits = -1;
 	if(obj.contains("credits"))
 	{
-		if(!canConvert(obj["credits"], QMetaType::Int))
+		if(!canConvert(obj["credits"], VariantType::Int))
 			return false;
 
 		credits = obj["credits"].toInt();
@@ -247,7 +247,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	more = false;
 	if(obj.contains("more"))
 	{
-		if(typeId(obj["more"]) != QMetaType::Bool)
+		if(typeId(obj["more"]) != VariantType::Bool)
 			return false;
 
 		more = obj["more"].toBool();
@@ -256,7 +256,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	code = -1;
 	if(obj.contains("code"))
 	{
-		if(!canConvert(obj["code"], QMetaType::Int))
+		if(!canConvert(obj["code"], VariantType::Int))
 			return false;
 
 		code = obj["code"].toInt();
@@ -265,7 +265,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	reason.clear();
 	if(obj.contains("reason"))
 	{
-		if(typeId(obj["reason"]) != QMetaType::QByteArray)
+		if(typeId(obj["reason"]) != VariantType::ByteArray)
 			return false;
 
 		reason = obj["reason"].toByteArray();
@@ -274,7 +274,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	headers.clear();
 	if(obj.contains("headers"))
 	{
-		if(typeId(obj["headers"]) != QMetaType::QVariantList)
+		if(typeId(obj["headers"]) != VariantType::List)
 			return false;
 
 		foreach(const Variant &i, obj["headers"].toList())
@@ -283,7 +283,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 			if(list.count() != 2)
 				return false;
 
-			if(typeId(list[0]) != QMetaType::QByteArray || typeId(list[1]) != QMetaType::QByteArray)
+			if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
 				return false;
 
 			headers += HttpHeader(list[0].toByteArray(), list[1].toByteArray());
@@ -293,7 +293,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	body.clear();
 	if(obj.contains("body"))
 	{
-		if(typeId(obj["body"]) != QMetaType::QByteArray)
+		if(typeId(obj["body"]) != VariantType::ByteArray)
 			return false;
 
 		body = obj["body"].toByteArray();
@@ -302,7 +302,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	contentType.clear();
 	if(obj.contains("content-type"))
 	{
-		if(typeId(obj["content-type"]) != QMetaType::QByteArray)
+		if(typeId(obj["content-type"]) != VariantType::ByteArray)
 			return false;
 
 		contentType = obj["content-type"].toByteArray();
@@ -313,11 +313,11 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 	multi = false;
 	if(obj.contains("ext"))
 	{
-		if(typeId(obj["ext"]) != QMetaType::QVariantHash)
+		if(typeId(obj["ext"]) != VariantType::Hash)
 			return false;
 
 		VariantHash ext = obj["ext"].toHash();
-		if(ext.contains("multi") && typeId(ext["multi"]) == QMetaType::Bool)
+		if(ext.contains("multi") && typeId(ext["multi"]) == VariantType::Bool)
 		{
 			multi = ext["multi"].toBool();
 		}

--- a/src/handler/conncheckworker.cpp
+++ b/src/handler/conncheckworker.cpp
@@ -34,7 +34,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 {
 	VariantHash args = req_->args();
 
-	if(!args.contains("ids") || typeId(args["ids"]) != QMetaType::QVariantList)
+	if(!args.contains("ids") || typeId(args["ids"]) != VariantType::List)
 	{
 		respondError("bad-request");
 		return;
@@ -44,7 +44,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 
 	foreach(const Variant &vid, vids)
 	{
-		if(typeId(vid) != QMetaType::QByteArray)
+		if(typeId(vid) != VariantType::ByteArray)
 		{
 			respondError("bad-request");
 			return;

--- a/src/handler/controlrequest.cpp
+++ b/src/handler/controlrequest.cpp
@@ -57,7 +57,7 @@ private:
 		if(req->success())
 		{
 			Variant vresult = req->result();
-			if(typeId(vresult) != QMetaType::QVariantList)
+			if(typeId(vresult) != VariantType::List)
 			{
 				setFinished(false);
 				return;
@@ -68,7 +68,7 @@ private:
 			CidSet out;
 			foreach(const Variant &vcid, result)
 			{
-				if(typeId(vcid) != QMetaType::QByteArray)
+				if(typeId(vcid) != VariantType::ByteArray)
 				{
 					setFinished(false);
 					return;

--- a/src/handler/detectrule.h
+++ b/src/handler/detectrule.h
@@ -25,7 +25,6 @@
 
 #include <QByteArray>
 #include <QString>
-#include <QMetaType>
 
 class DetectRule
 {

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -27,7 +27,6 @@
 #include <QString>
 #include <QStringList>
 #include <QHash>
-#include <QMetaType>
 #include <QUrl>
 #include <boost/signals2.hpp>
 #include "zhttprequest.h"

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -136,7 +136,7 @@ public:
 		{
 			VariantHash args = req->args();
 
-			if(!args.contains("method") || typeId(args["method"]) != QMetaType::QByteArray)
+			if(!args.contains("method") || typeId(args["method"]) != VariantType::ByteArray)
 			{
 				respondError("bad-request");
 				return;
@@ -144,7 +144,7 @@ public:
 
 			requestData.method = QString::fromLatin1(args["method"].toByteArray());
 
-			if(!args.contains("uri") || typeId(args["uri"]) != QMetaType::QByteArray)
+			if(!args.contains("uri") || typeId(args["uri"]) != VariantType::ByteArray)
 			{
 				respondError("bad-request");
 				return;
@@ -157,7 +157,7 @@ public:
 				return;
 			}
 
-			if(!args.contains("headers") || typeId(args["headers"]) != QMetaType::QVariantList)
+			if(!args.contains("headers") || typeId(args["headers"]) != VariantType::List)
 			{
 				respondError("bad-request");
 				return;
@@ -165,14 +165,14 @@ public:
 
 			foreach(const Variant &vheader, args["headers"].toList())
 			{
-				if(typeId(vheader) != QMetaType::QVariantList)
+				if(typeId(vheader) != VariantType::List)
 				{
 					respondError("bad-request");
 					return;
 				}
 
 				VariantList vlist = vheader.toList();
-				if(vlist.count() != 2 || typeId(vlist[0]) != QMetaType::QByteArray || typeId(vlist[1]) != QMetaType::QByteArray)
+				if(vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray || typeId(vlist[1]) != VariantType::ByteArray)
 				{
 					respondError("bad-request");
 					return;
@@ -181,7 +181,7 @@ public:
 				requestData.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
 			}
 
-			if(!args.contains("body") || typeId(args["body"]) != QMetaType::QByteArray)
+			if(!args.contains("body") || typeId(args["body"]) != VariantType::ByteArray)
 			{
 				respondError("bad-request");
 				return;
@@ -192,7 +192,7 @@ public:
 			truncated = false;
 			if(args.contains("truncated"))
 			{
-				if(typeId(args["truncated"]) != QMetaType::Bool)
+				if(typeId(args["truncated"]) != VariantType::Bool)
 				{
 					respondError("bad-request");
 					return;
@@ -204,7 +204,7 @@ public:
 			bool getSession = false;
 			if(args.contains("get-session"))
 			{
-				if(typeId(args["get-session"]) != QMetaType::Bool)
+				if(typeId(args["get-session"]) != VariantType::Bool)
 				{
 					respondError("bad-request");
 					return;
@@ -216,7 +216,7 @@ public:
 			autoShare = false;
 			if(args.contains("auto-share"))
 			{
-				if(typeId(args["auto-share"]) != QMetaType::Bool)
+				if(typeId(args["auto-share"]) != VariantType::Bool)
 				{
 					respondError("bad-request");
 					return;
@@ -480,7 +480,7 @@ public:
 		// Process conn-max packets before doing anything else
 		if(args.contains("conn-max"))
 		{
-			if(typeId(args["conn-max"]) != QMetaType::QVariantList)
+			if(typeId(args["conn-max"]) != VariantType::List)
 			{
 				respondError("bad-request");
 				return;
@@ -503,7 +503,7 @@ public:
 
 		if(args.contains("route"))
 		{
-			if(typeId(args["route"]) != QMetaType::QByteArray)
+			if(typeId(args["route"]) != VariantType::ByteArray)
 			{
 				respondError("bad-request");
 				return;
@@ -514,7 +514,7 @@ public:
 
 		if(args.contains("separate-stats"))
 		{
-			if(typeId(args["separate-stats"]) != QMetaType::Bool)
+			if(typeId(args["separate-stats"]) != VariantType::Bool)
 			{
 				respondError("bad-request");
 				return;
@@ -528,7 +528,7 @@ public:
 
 		if(args.contains("channel-prefix"))
 		{
-			if(typeId(args["channel-prefix"]) != QMetaType::QByteArray)
+			if(typeId(args["channel-prefix"]) != VariantType::ByteArray)
 			{
 				respondError("bad-request");
 				return;
@@ -539,7 +539,7 @@ public:
 
 		if(args.contains("log-level"))
 		{
-			if(!canConvert(args["log-level"], QMetaType::Int))
+			if(!canConvert(args["log-level"], VariantType::Int))
 			{
 				respondError("bad-request");
 				return;
@@ -550,7 +550,7 @@ public:
 
 		if(args.contains("channels"))
 		{
-			if(typeId(args["channels"]) != QMetaType::QVariantList)
+			if(typeId(args["channels"]) != VariantType::List)
 			{
 				respondError("bad-request");
 				return;
@@ -559,7 +559,7 @@ public:
 			VariantList vchannels = args["channels"].toList();
 			foreach(const Variant &v, vchannels)
 			{
-				if(typeId(v) != QMetaType::QByteArray)
+				if(typeId(v) != VariantType::ByteArray)
 				{
 					respondError("bad-request");
 					return;
@@ -571,7 +571,7 @@ public:
 
 		if(args.contains("trusted"))
 		{
-			if(typeId(args["trusted"]) != QMetaType::Bool)
+			if(typeId(args["trusted"]) != VariantType::Bool)
 			{
 				respondError("bad-request");
 				return;
@@ -582,7 +582,7 @@ public:
 
 		// Parse requests
 
-		if(!args.contains("requests") || typeId(args["requests"]) != QMetaType::QVariantList)
+		if(!args.contains("requests") || typeId(args["requests"]) != VariantType::List)
 		{
 			respondError("bad-request");
 			return;
@@ -620,7 +620,7 @@ public:
 
 		// Parse response
 
-		if(!args.contains("response") || typeId(args["response"]) != QMetaType::QVariantHash)
+		if(!args.contains("response") || typeId(args["response"]) != VariantType::Hash)
 		{
 			respondError("bad-request");
 			return;
@@ -628,7 +628,7 @@ public:
 
 		VariantHash rd = args["response"].toHash();
 
-		if(!rd.contains("code") || !canConvert(rd["code"], QMetaType::Int))
+		if(!rd.contains("code") || !canConvert(rd["code"], VariantType::Int))
 		{
 			respondError("bad-request");
 			return;
@@ -636,7 +636,7 @@ public:
 
 		responseData.code = rd["code"].toInt();
 
-		if(!rd.contains("reason") || typeId(rd["reason"]) != QMetaType::QByteArray)
+		if(!rd.contains("reason") || typeId(rd["reason"]) != VariantType::ByteArray)
 		{
 			respondError("bad-request");
 			return;
@@ -644,7 +644,7 @@ public:
 
 		responseData.reason = rd["reason"].toByteArray();
 
-		if(!rd.contains("headers") || typeId(rd["headers"]) != QMetaType::QVariantList)
+		if(!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List)
 		{
 			respondError("bad-request");
 			return;
@@ -652,14 +652,14 @@ public:
 
 		foreach(const Variant &vheader, rd["headers"].toList())
 		{
-			if(typeId(vheader) != QMetaType::QVariantList)
+			if(typeId(vheader) != VariantType::List)
 			{
 				respondError("bad-request");
 				return;
 			}
 
 			VariantList vlist = vheader.toList();
-			if(vlist.count() != 2 || typeId(vlist[0]) != QMetaType::QByteArray || typeId(vlist[1]) != QMetaType::QByteArray)
+			if(vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray || typeId(vlist[1]) != VariantType::ByteArray)
 			{
 				respondError("bad-request");
 				return;
@@ -668,7 +668,7 @@ public:
 			responseData.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
 		}
 
-		if(!rd.contains("body") || typeId(rd["body"]) != QMetaType::QByteArray)
+		if(!rd.contains("body") || typeId(rd["body"]) != VariantType::ByteArray)
 		{
 			respondError("bad-request");
 			return;
@@ -678,7 +678,7 @@ public:
 
 		if(args.contains("inspect"))
 		{
-			if(typeId(args["inspect"]) != QMetaType::QVariantHash)
+			if(typeId(args["inspect"]) != VariantType::Hash)
 			{
 				respondError("bad-request");
 				return;
@@ -686,7 +686,7 @@ public:
 
 			VariantHash vinspect = args["inspect"].toHash();
 
-			if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != QMetaType::Bool)
+			if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != VariantType::Bool)
 			{
 				respondError("bad-request");
 				return;
@@ -697,7 +697,7 @@ public:
 			inspectInfo.sharingKey.clear();
 			if(vinspect.contains("sharing-key"))
 			{
-				if(typeId(vinspect["sharing-key"]) != QMetaType::QByteArray)
+				if(typeId(vinspect["sharing-key"]) != VariantType::ByteArray)
 				{
 					respondError("bad-request");
 					return;
@@ -708,7 +708,7 @@ public:
 
 			if(vinspect.contains("sid"))
 			{
-				if(typeId(vinspect["sid"]) != QMetaType::QByteArray)
+				if(typeId(vinspect["sid"]) != VariantType::ByteArray)
 				{
 					respondError("bad-request");
 					return;
@@ -719,7 +719,7 @@ public:
 
 			if(vinspect.contains("last-ids"))
 			{
-				if(typeId(vinspect["last-ids"]) != QMetaType::QVariantHash)
+				if(typeId(vinspect["last-ids"]) != VariantType::Hash)
 				{
 					respondError("bad-request");
 					return;
@@ -731,7 +731,7 @@ public:
 				{
 					it.next();
 
-					if(typeId(it.value()) != QMetaType::QByteArray)
+					if(typeId(it.value()) != VariantType::ByteArray)
 					{
 						respondError("bad-request");
 						return;
@@ -750,7 +750,7 @@ public:
 
 		if(args.contains("response-sent"))
 		{
-			if(typeId(args["response-sent"]) != QMetaType::Bool)
+			if(typeId(args["response-sent"]) != VariantType::Bool)
 			{
 				respondError("bad-request");
 				return;
@@ -762,7 +762,7 @@ public:
 		bool useSession = false;
 		if(args.contains("use-session"))
 		{
-			if(typeId(args["use-session"]) != QMetaType::Bool)
+			if(typeId(args["use-session"]) != VariantType::Bool)
 			{
 				respondError("bad-request");
 				return;
@@ -845,40 +845,40 @@ public:
 private:
 	static HttpRequestData parseRequestData(const VariantHash &args, const QString &field)
 	{
-		if(!args.contains(field) || typeId(args[field]) != QMetaType::QVariantHash)
+		if(!args.contains(field) || typeId(args[field]) != VariantType::Hash)
 			return HttpRequestData();
 
 		VariantHash rd = args[field].toHash();
 
-		if(!rd.contains("method") || typeId(rd["method"]) != QMetaType::QByteArray)
+		if(!rd.contains("method") || typeId(rd["method"]) != VariantType::ByteArray)
 			return HttpRequestData();
 
 		HttpRequestData out;
 		out.method = QString::fromLatin1(rd["method"].toByteArray());
 
-		if(!rd.contains("uri") || typeId(rd["uri"]) != QMetaType::QByteArray)
+		if(!rd.contains("uri") || typeId(rd["uri"]) != VariantType::ByteArray)
 			return HttpRequestData();
 
 		out.uri = QUrl(rd["uri"].toString(), QUrl::StrictMode);
 		if(!out.uri.isValid())
 			return HttpRequestData();
 
-		if(!rd.contains("headers") || typeId(rd["headers"]) != QMetaType::QVariantList)
+		if(!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List)
 			return HttpRequestData();
 
 		foreach(const Variant &vheader, rd["headers"].toList())
 		{
-			if(typeId(vheader) != QMetaType::QVariantList)
+			if(typeId(vheader) != VariantType::List)
 				return HttpRequestData();
 
 			VariantList vlist = vheader.toList();
-			if(vlist.count() != 2 || typeId(vlist[0]) != QMetaType::QByteArray || typeId(vlist[1]) != QMetaType::QByteArray)
+			if(vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray || typeId(vlist[1]) != VariantType::ByteArray)
 				return HttpRequestData();
 
 			out.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
 		}
 
-		if(!rd.contains("body") || typeId(rd["body"]) != QMetaType::QByteArray)
+		if(!rd.contains("body") || typeId(rd["body"]) != VariantType::ByteArray)
 			return HttpRequestData();
 
 		out.body = rd["body"].toByteArray();
@@ -1935,7 +1935,7 @@ private:
 
 			if(args.contains("conn-max"))
 			{
-				if(typeId(args["conn-max"]) == QMetaType::QVariantList)
+				if(typeId(args["conn-max"]) == VariantType::List)
 				{
 					VariantList packets = args["conn-max"].toList();
 
@@ -2015,7 +2015,7 @@ private:
 				return;
 			}
 
-			if(typeId(args["items"]) != QMetaType::QVariantList)
+			if(typeId(args["items"]) != VariantType::List)
 			{
 				req->respondError("bad-request", "Invalid format: object contains 'items' with wrong type");
 				delete req;
@@ -2998,7 +2998,7 @@ private:
 					return;
 				}
 
-				if(typeId(mdata["items"]) != QMetaType::QVariantList)
+				if(typeId(mdata["items"]) != VariantType::List)
 				{
 					httpControlRespond(req, 400, "Bad Request", "Invalid format: object contains 'items' with wrong type\n");
 					return;

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -276,7 +276,7 @@ public:
 		ZmqReqMessage message(_message);
 		Variant v = TnetString::toVariant(message.content()[0]);
 
-		TEST_ASSERT(typeId(v) == QMetaType::QVariantHash);
+		TEST_ASSERT(typeId(v) == VariantType::Hash);
 		VariantHash vresp = v.toHash();
 
 		TEST_ASSERT(vresp.value("success").toBool());
@@ -284,7 +284,7 @@ public:
 		acceptSuccess = true;
 
 		v = vresp.value("value");
-		TEST_ASSERT(typeId(v) == QMetaType::QVariantHash);
+		TEST_ASSERT(typeId(v) == VariantType::Hash);
 		acceptValue = v.toHash();
 	}
 };

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -74,10 +74,10 @@ static QByteArray applyBodyPatch(const QByteArray &in, const VariantList &bodyPa
 		vbody = JsonPatch::patch(vbody, bodyPatch, &errorMessage);
 		if(vbody.isValid())
 			vbody = VariantUtil::convertToJsonStyle(vbody);
-		if(vbody.isValid() && (typeId(vbody) == QMetaType::QVariantMap || typeId(vbody) == QMetaType::QVariantList))
+		if(vbody.isValid() && (typeId(vbody) == VariantType::Map || typeId(vbody) == VariantType::List))
 		{
 			QJsonDocument doc;
-			if(typeId(vbody) == QMetaType::QVariantMap)
+			if(typeId(vbody) == VariantType::Map)
 				doc = QJsonDocument(QJsonObject::fromVariantMap(vbody.toMap()));
 			else // List
 				doc = QJsonDocument(QJsonArray::fromVariantList(vbody.toList()));

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -401,7 +401,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 		if(minstruct.contains("hold"))
 		{
-			if(typeId(minstruct["hold"]) != QMetaType::QVariantMap)
+			if(typeId(minstruct["hold"]) != VariantType::Map)
 			{
 				setError(ok, errorMessage, "instruct contains 'hold' with wrong type");
 				return Instruct();
@@ -495,7 +495,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			if(keyedObjectContains(vhold, "timeout"))
 			{
 				Variant vtimeout = keyedObjectGetValue(vhold, "timeout");
-				if(!canConvert(vtimeout, QMetaType::Int))
+				if(!canConvert(vtimeout, VariantType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(pn));
 					return Instruct();
@@ -537,9 +537,9 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				else if(keyedObjectContains(vka, "content"))
 				{
 					Variant vcontent = keyedObjectGetValue(vka, "content");
-					if(typeId(vcontent) == QMetaType::QByteArray)
+					if(typeId(vcontent) == VariantType::ByteArray)
 						keepAliveData = vcontent.toByteArray();
-					else if(typeId(vcontent) == QMetaType::QString)
+					else if(typeId(vcontent) == VariantType::String)
 						keepAliveData = vcontent.toString().toUtf8();
 					else
 					{
@@ -551,7 +551,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				if(keyedObjectContains(vka, "timeout"))
 				{
 					Variant vtimeout = keyedObjectGetValue(vka, "timeout");
-					if(!canConvert(vtimeout, QMetaType::Int))
+					if(!canConvert(vtimeout, VariantType::Int))
 					{
 						setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(kpn));
 						return Instruct();
@@ -581,7 +581,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 			if(vmeta.isValid())
 			{
-				if(typeId(vmeta) == QMetaType::QVariantHash)
+				if(typeId(vmeta) == VariantType::Hash)
 				{
 					VariantHash hmeta = vmeta.toHash();
 
@@ -631,7 +631,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 
 		if(minstruct.contains("response"))
 		{
-			if(typeId(minstruct["response"]) != QMetaType::QVariantMap)
+			if(typeId(minstruct["response"]) != VariantType::Map)
 			{
 				if(ok)
 					*ok = false;
@@ -645,7 +645,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			if(keyedObjectContains(in, "code"))
 			{
 				Variant vcode = keyedObjectGetValue(in, "code");
-				if(!canConvert(vcode, QMetaType::Int))
+				if(!canConvert(vcode, VariantType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
 					return Instruct();
@@ -678,11 +678,11 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			if(keyedObjectContains(in, "headers"))
 			{
 				Variant vheaders = keyedObjectGetValue(in, "headers");
-				if(typeId(vheaders) == QMetaType::QVariantList)
+				if(typeId(vheaders) == VariantType::List)
 				{
 					foreach(const Variant &vheader, vheaders.toList())
 					{
-						if(typeId(vheader) != QMetaType::QVariantList)
+						if(typeId(vheader) != VariantType::List)
 						{
 							setError(ok, errorMessage, "headers contains element with wrong type");
 							return Instruct();
@@ -714,7 +714,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				}
 				else if(isKeyedObject(vheaders))
 				{
-					if(typeId(vheaders) == QMetaType::QVariantHash)
+					if(typeId(vheaders) == VariantType::Hash)
 					{
 						VariantHash hheaders = vheaders.toHash();
 
@@ -779,9 +779,9 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			else if(keyedObjectContains(in, "body"))
 			{
 				Variant vcontent = keyedObjectGetValue(in, "body");
-				if(typeId(vcontent) == QMetaType::QByteArray)
+				if(typeId(vcontent) == VariantType::ByteArray)
 					newResponse.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == QMetaType::QString)
+				else if(typeId(vcontent) == VariantType::String)
 					newResponse.body = vcontent.toString().toUtf8();
 				else
 				{

--- a/src/handler/jsonpatch.cpp
+++ b/src/handler/jsonpatch.cpp
@@ -48,14 +48,14 @@ static void setError(bool *ok, QString *errorMessage, const QString &msg)
 
 static bool isKeyedObject(const Variant &in)
 {
-	return (typeId(in) == QMetaType::QVariantHash || typeId(in) == QMetaType::QVariantMap);
+	return (typeId(in) == VariantType::Hash || typeId(in) == VariantType::Map);
 }
 
 static bool keyedObjectContains(const Variant &in, const QString &name)
 {
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 		return in.toHash().contains(name);
-	else if(typeId(in) == QMetaType::QVariantMap)
+	else if(typeId(in) == VariantType::Map)
 		return in.toMap().contains(name);
 	else
 		return false;
@@ -63,9 +63,9 @@ static bool keyedObjectContains(const Variant &in, const QString &name)
 
 static Variant keyedObjectGetValue(const Variant &in, const QString &name)
 {
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 		return in.toHash().value(name);
-	else if(typeId(in) == QMetaType::QVariantMap)
+	else if(typeId(in) == VariantType::Map)
 		return in.toMap().value(name);
 	else
 		return Variant();
@@ -83,7 +83,7 @@ static Variant getChild(const Variant &in, const QString &parentName, const QStr
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
 	Variant v;
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 	{
 		VariantHash h = in.toHash();
 
@@ -122,13 +122,13 @@ static Variant getChild(const Variant &in, const QString &parentName, const QStr
 
 static QString getString(const Variant &in, bool *ok = 0)
 {
-	if(typeId(in) == QMetaType::QString)
+	if(typeId(in) == VariantType::String)
 	{
 		if(ok)
 			*ok = true;
 		return in.toString();
 	}
-	else if(typeId(in) == QMetaType::QByteArray)
+	else if(typeId(in) == VariantType::ByteArray)
 	{
 		if(ok)
 			*ok = true;
@@ -180,8 +180,8 @@ static bool convertToJsonStyleInPlace(Variant *in)
 
 	bool changed = false;
 
-	QMetaType::Type type = typeId(*in);
-	if(type == QMetaType::QVariantHash)
+	VariantType::Type type = typeId(*in);
+	if(type == VariantType::Hash)
 	{
 		VariantMap vmap;
 		VariantHash vhash = in->toHash();
@@ -197,7 +197,7 @@ static bool convertToJsonStyleInPlace(Variant *in)
 		*in = vmap;
 		changed = true;
 	}
-	else if(type == QMetaType::QVariantList)
+	else if(type == VariantType::List)
 	{
 		VariantList vlist = in->toList();
 		for(int n = 0; n < vlist.count(); ++n)
@@ -210,7 +210,7 @@ static bool convertToJsonStyleInPlace(Variant *in)
 		*in = vlist;
 		changed = true;
 	}
-	else if(type == QMetaType::QByteArray)
+	else if(type == VariantType::ByteArray)
 	{
 		*in = Variant(QString::fromUtf8(in->toByteArray()));
 		changed = true;
@@ -228,7 +228,7 @@ static Variant convertToJsonStyle(const Variant &in)
 
 static bool _compareJsonValues(const Variant &a, const Variant &b)
 {
-	if(typeId(a) == QMetaType::QVariantMap && typeId(b) == QMetaType::QVariantMap)
+	if(typeId(a) == VariantType::Map && typeId(b) == VariantType::Map)
 	{
 		VariantMap am = a.toMap();
 		VariantMap bm = b.toMap();
@@ -251,7 +251,7 @@ static bool _compareJsonValues(const Variant &a, const Variant &b)
 
 		return true;
 	}
-	else if(typeId(a) == QMetaType::QVariantList && typeId(b) == QMetaType::QVariantList)
+	else if(typeId(a) == VariantType::List && typeId(b) == VariantType::List)
 	{
 		VariantList al = a.toList();
 		VariantList bl = b.toList();
@@ -267,19 +267,19 @@ static bool _compareJsonValues(const Variant &a, const Variant &b)
 
 		return true;
 	}
-	else if(typeId(a) == QMetaType::QString && typeId(b) == QMetaType::QString)
+	else if(typeId(a) == VariantType::String && typeId(b) == VariantType::String)
 	{
 		return (a.toString() == b.toString());
 	}
-	else if(typeId(a) == QMetaType::Bool && typeId(b) == QMetaType::Bool)
+	else if(typeId(a) == VariantType::Bool && typeId(b) == VariantType::Bool)
 	{
 		return (a.toBool() == b.toBool());
 	}
-	else if(typeId(a) == QMetaType::UnknownType && typeId(b) == QMetaType::UnknownType)
+	else if(typeId(a) == VariantType::Invalid && typeId(b) == VariantType::Invalid)
 	{
 		return true;
 	}
-	else if(canConvert(a, QMetaType::Int) && canConvert(b, QMetaType::Int))
+	else if(canConvert(a, VariantType::Int) && canConvert(b, VariantType::Int))
 	{
 		return (a.toInt() == b.toInt());
 	}

--- a/src/handler/jsonpatchtest.cpp
+++ b/src/handler/jsonpatchtest.cpp
@@ -47,7 +47,7 @@ static void patch()
 	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
-	TEST_ASSERT_EQ(typeId(data["fruit"]), QMetaType::QVariantList);
+	TEST_ASSERT_EQ(typeId(data["fruit"]), VariantType::List);
 	TEST_ASSERT_EQ(data["fruit"].toList()[0].toString(), QString("apple"));
 
 	op.clear();
@@ -69,7 +69,7 @@ static void patch()
 	ret = JsonPatch::patch(data, VariantList() << op);
 	TEST_ASSERT(ret.isValid());
 	data = ret.toMap();
-	TEST_ASSERT_EQ(typeId(data["fruit"].toList()[1]), QMetaType::QVariantMap);
+	TEST_ASSERT_EQ(typeId(data["fruit"].toList()[1]), VariantType::Map);
 	TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("cherries").toBool(), true);
 	TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("grapes").toInt(), 5);
 

--- a/src/handler/jsonpointer.cpp
+++ b/src/handler/jsonpointer.cpp
@@ -49,7 +49,7 @@ JsonPointer::ExecStatus JsonPointer::execute(const Variant *i, int refIndex, Con
 
 		if(ref.type == Ref::Object)
 		{
-			if(typeId(*i) == QMetaType::QVariantHash)
+			if(typeId(*i) == VariantType::Hash)
 			{
 				VariantHash h = i->toHash();
 				if(!h.contains(ref.name))
@@ -78,9 +78,9 @@ JsonPointer::ExecStatus JsonPointer::execute(const Variant *i, int refIndex, Con
 
 	// Ensure ref is correct type
 	const Ref &ref = refs_[refIndex];
-	if(ref.type == Ref::Object && (typeId(*i) != QMetaType::QVariantHash && typeId(*i) != QMetaType::QVariantMap))
+	if(ref.type == Ref::Object && (typeId(*i) != VariantType::Hash && typeId(*i) != VariantType::Map))
 		return ExecError;
-	else if(ref.type == Ref::Array && typeId(*i) != QMetaType::QVariantList)
+	else if(ref.type == Ref::Array && typeId(*i) != VariantType::List)
 		return ExecError;
 
 	func(i, refs_[refIndex], data);
@@ -95,7 +95,7 @@ JsonPointer::ExecStatus JsonPointer::execute(Variant *i, int refIndex, Func func
 		const Ref &ref = refs_[refIndex];
 		if(ref.type == Ref::Object)
 		{
-			if(typeId(*i) == QMetaType::QVariantHash)
+			if(typeId(*i) == VariantType::Hash)
 			{
 				VariantHash h = i->toHash();
 				if(!h.contains(ref.name))
@@ -133,9 +133,9 @@ JsonPointer::ExecStatus JsonPointer::execute(Variant *i, int refIndex, Func func
 
 	// Ensure ref is correct type
 	const Ref &ref = refs_[refIndex];
-	if(ref.type == Ref::Object && (typeId(*i) != QMetaType::QVariantHash && typeId(*i) != QMetaType::QVariantMap))
+	if(ref.type == Ref::Object && (typeId(*i) != VariantType::Hash && typeId(*i) != VariantType::Map))
 		return ExecError;
-	else if(ref.type == Ref::Array && typeId(*i) != QMetaType::QVariantList)
+	else if(ref.type == Ref::Array && typeId(*i) != VariantType::List)
 		return ExecError;
 
 	if(func(i, refs_[refIndex], data))
@@ -180,7 +180,7 @@ static void existsFunc(const Variant *v, const JsonPointer::Ref &ref, void *data
 	}
 	else if(ref.type == JsonPointer::Ref::Object)
 	{
-		if(typeId(*v) == QMetaType::QVariantHash)
+		if(typeId(*v) == VariantType::Hash)
 			ret = v->toHash().contains(ref.name);
 		else // Map
 			ret = v->toMap().contains(ref.name);
@@ -211,7 +211,7 @@ static void valueFunc(const Variant *v, const JsonPointer::Ref &ref, void *data)
 	}
 	else if(ref.type == JsonPointer::Ref::Object)
 	{
-		if(typeId(*v) == QMetaType::QVariantHash)
+		if(typeId(*v) == VariantType::Hash)
 			ret = v->toHash().value(ref.name);
 		else // Map
 			ret = v->toMap().value(ref.name);
@@ -244,7 +244,7 @@ static bool removeFunc(Variant *v, const JsonPointer::Ref &ref, void *data)
 	}
 	else if(ref.type == JsonPointer::Ref::Object)
 	{
-		if(typeId(*v) == QMetaType::QVariantHash)
+		if(typeId(*v) == VariantType::Hash)
 		{
 			VariantHash h = v->toHash();
 			if(h.contains(ref.name))
@@ -306,7 +306,7 @@ static bool takeFunc(Variant *v, const JsonPointer::Ref &ref, void *data)
 	}
 	else if(ref.type == JsonPointer::Ref::Object)
 	{
-		if(typeId(*v) == QMetaType::QVariantHash)
+		if(typeId(*v) == VariantType::Hash)
 		{
 			VariantHash h = v->toHash();
 			if(h.contains(ref.name))
@@ -369,7 +369,7 @@ static bool setValueFunc(Variant *v, const JsonPointer::Ref &ref, void *_data)
 	}
 	else if(ref.type == JsonPointer::Ref::Object)
 	{
-		if(typeId(*v) == QMetaType::QVariantHash)
+		if(typeId(*v) == VariantType::Hash)
 		{
 			VariantHash h = v->toHash();
 			h[ref.name] = data.first;
@@ -478,9 +478,9 @@ JsonPointer JsonPointer::resolve(Variant *data, const QString &pointerStr, QStri
 
 			if(prevRef.type == Ref::Object)
 			{
-				assert(typeId(i) == QMetaType::QVariantHash || typeId(i) == QMetaType::QVariantMap);
+				assert(typeId(i) == VariantType::Hash || typeId(i) == VariantType::Map);
 
-				if(typeId(i) == QMetaType::QVariantHash)
+				if(typeId(i) == VariantType::Hash)
 				{
 					VariantHash h = i.toHash();
 					if(!h.contains(prevRef.name))
@@ -519,11 +519,11 @@ JsonPointer JsonPointer::resolve(Variant *data, const QString &pointerStr, QStri
 			}
 		}
 
-		if(typeId(i) == QMetaType::QVariantHash || typeId(i) == QMetaType::QVariantMap)
+		if(typeId(i) == VariantType::Hash || typeId(i) == VariantType::Map)
 		{
 			ptr.refs_ += Ref(p);
 		}
-		else if(typeId(i) == QMetaType::QVariantList)
+		else if(typeId(i) == VariantType::List)
 		{
 			VariantList l = i.toList();
 			if(p == "-")

--- a/src/handler/publishformat.cpp
+++ b/src/handler/publishformat.cpp
@@ -87,7 +87,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			if(keyedObjectContains(in, "code"))
 			{
 				Variant vcode = keyedObjectGetValue(in, "code");
-				if(!canConvert(vcode, QMetaType::Int))
+				if(!canConvert(vcode, VariantType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
 					return PublishFormat();
@@ -120,11 +120,11 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			if(keyedObjectContains(in, "headers"))
 			{
 				Variant vheaders = keyedObjectGetValue(in, "headers");
-				if(typeId(vheaders) == QMetaType::QVariantList)
+				if(typeId(vheaders) == VariantType::List)
 				{
 					foreach(const Variant &vheader, vheaders.toList())
 					{
-						if(typeId(vheader) != QMetaType::QVariantList)
+						if(typeId(vheader) != VariantType::List)
 						{
 							setError(ok, errorMessage, "headers contains element with wrong type");
 							return PublishFormat();
@@ -156,7 +156,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				}
 				else if(isKeyedObject(vheaders))
 				{
-					if(typeId(vheaders) == QMetaType::QVariantHash)
+					if(typeId(vheaders) == VariantType::Hash)
 					{
 						VariantHash hheaders = vheaders.toHash();
 
@@ -209,7 +209,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			if(keyedObjectContains(in, "content-filters"))
 			{
 				Variant vfilters = keyedObjectGetValue(in, "content-filters");
-				if(typeId(vfilters) != QMetaType::QVariantList)
+				if(typeId(vfilters) != VariantType::List)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
 					return PublishFormat();
@@ -232,7 +232,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				out.contentFilters = filters;
 			}
 
-			if(typeId(in) == QMetaType::QVariantMap && keyedObjectContains(in, "body-bin")) // JSON input
+			if(typeId(in) == VariantType::Map && keyedObjectContains(in, "body-bin")) // JSON input
 			{
 				QString bodyBin = getString(in, pn, "body-bin", false, &ok_, errorMessage);
 				if(!ok_)
@@ -247,9 +247,9 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			else if(keyedObjectContains(in, "body"))
 			{
 				Variant vcontent = keyedObjectGetValue(in, "body");
-				if(typeId(vcontent) == QMetaType::QByteArray)
+				if(typeId(vcontent) == VariantType::ByteArray)
 					out.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == QMetaType::QString)
+				else if(typeId(vcontent) == VariantType::String)
 					out.body = vcontent.toString().toUtf8();
 				else
 				{
@@ -271,7 +271,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			}
 			else
 			{
-				if(typeId(in) == QMetaType::QVariantMap) // JSON input
+				if(typeId(in) == VariantType::Map) // JSON input
 					setError(ok, errorMessage, QString("%1 does not contain 'body', 'body-bin', or 'body-patch'").arg(pn));
 				else
 					setError(ok, errorMessage, QString("%1 does not contain 'body' or 'body-patch'").arg(pn));
@@ -286,7 +286,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			if(keyedObjectContains(in, "content-filters"))
 			{
 				Variant vfilters = keyedObjectGetValue(in, "content-filters");
-				if(typeId(vfilters) != QMetaType::QVariantList)
+				if(typeId(vfilters) != VariantType::List)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
 					return PublishFormat();
@@ -309,7 +309,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				out.contentFilters = filters;
 			}
 
-			if(typeId(in) == QMetaType::QVariantMap && keyedObjectContains(in, "content-bin")) // JSON input
+			if(typeId(in) == VariantType::Map && keyedObjectContains(in, "content-bin")) // JSON input
 			{
 				QString contentBin = getString(in, pn, "content-bin", false, &ok_, errorMessage);
 				if(!ok_)
@@ -324,9 +324,9 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			else if(keyedObjectContains(in, "content"))
 			{
 				Variant vcontent = keyedObjectGetValue(in, "content");
-				if(typeId(vcontent) == QMetaType::QByteArray)
+				if(typeId(vcontent) == VariantType::ByteArray)
 					out.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == QMetaType::QString)
+				else if(typeId(vcontent) == VariantType::String)
 					out.body = vcontent.toString().toUtf8();
 				else
 				{
@@ -336,7 +336,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			}
 			else
 			{
-				if(typeId(in) == QMetaType::QVariantMap) // JSON input
+				if(typeId(in) == VariantType::Map) // JSON input
 					setError(ok, errorMessage, QString("%1 does not contain 'content' or 'content-bin'").arg(pn));
 				else
 					setError(ok, errorMessage, QString("%1 does not contain 'content'").arg(pn));
@@ -376,7 +376,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			if(keyedObjectContains(in, "content-filters"))
 			{
 				Variant vfilters = keyedObjectGetValue(in, "content-filters");
-				if(typeId(vfilters) != QMetaType::QVariantList)
+				if(typeId(vfilters) != VariantType::List)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
 					return PublishFormat();
@@ -403,9 +403,9 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			{
 				Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
 
-				if(typeId(in) == QMetaType::QVariantMap) // JSON input
+				if(typeId(in) == VariantType::Map) // JSON input
 				{
-					if(typeId(vcontentBin) != QMetaType::QString)
+					if(typeId(vcontentBin) != VariantType::String)
 					{
 						setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
 						return PublishFormat();
@@ -415,7 +415,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				}
 				else
 				{
-					if(typeId(vcontentBin) != QMetaType::QByteArray)
+					if(typeId(vcontentBin) != VariantType::ByteArray)
 					{
 						setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
 						return PublishFormat();
@@ -430,9 +430,9 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			else if(keyedObjectContains(in, "content"))
 			{
 				Variant vcontent = keyedObjectGetValue(in, "content");
-				if(typeId(vcontent) == QMetaType::QByteArray)
+				if(typeId(vcontent) == VariantType::ByteArray)
 					out.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == QMetaType::QString)
+				else if(typeId(vcontent) == VariantType::String)
 					out.body = vcontent.toString().toUtf8();
 				else
 				{
@@ -454,7 +454,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 			if(keyedObjectContains(in, "code"))
 			{
 				Variant vcode = keyedObjectGetValue(in, "code");
-				if(!canConvert(vcode, QMetaType::Int))
+				if(!canConvert(vcode, VariantType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
 					return PublishFormat();

--- a/src/handler/publishitem.cpp
+++ b/src/handler/publishitem.cpp
@@ -153,7 +153,7 @@ PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channe
 
 	if(vmeta.isValid())
 	{
-		if(typeId(vmeta) == QMetaType::QVariantHash)
+		if(typeId(vmeta) == VariantType::Hash)
 		{
 			VariantHash hmeta = vmeta.toHash();
 
@@ -200,7 +200,7 @@ PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channe
 	if(keyedObjectContains(vitem, "size"))
 	{
 		Variant vsize = keyedObjectGetValue(vitem, "size");
-		if(!canConvert(vsize, QMetaType::Int))
+		if(!canConvert(vsize, VariantType::Int))
 		{
 			setError(ok, errorMessage, QString("%1 contains 'size' with wrong type").arg(pn));
 			return PublishItem();
@@ -218,7 +218,7 @@ PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channe
 	if(keyedObjectContains(vitem, "no-seq"))
 	{
 		Variant vnoSeq = keyedObjectGetValue(vitem, "no-seq");
-		if(typeId(vnoSeq) != QMetaType::Bool)
+		if(typeId(vnoSeq) != VariantType::Bool)
 		{
 			setError(ok, errorMessage, QString("%1 contains 'no-seq' with wrong type").arg(pn));
 			return PublishItem();

--- a/src/handler/refreshworker.cpp
+++ b/src/handler/refreshworker.cpp
@@ -39,7 +39,7 @@ RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, 
 
 	if(args.contains("cid"))
 	{
-		if(typeId(args["cid"]) != QMetaType::QByteArray)
+		if(typeId(args["cid"]) != VariantType::ByteArray)
 		{
 			respondError("bad-request");
 			return;
@@ -51,7 +51,7 @@ RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, 
 	}
 	else if(args.contains("channel"))
 	{
-		if(typeId(args["channel"]) != QMetaType::QByteArray)
+		if(typeId(args["channel"]) != VariantType::ByteArray)
 		{
 			respondError("bad-request");
 			return;

--- a/src/handler/requeststate.cpp
+++ b/src/handler/requeststate.cpp
@@ -28,43 +28,43 @@
 
 RequestState RequestState::fromVariant(const Variant &in)
 {
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 		return RequestState();
 
 	VariantHash r = in.toHash();
 	RequestState rs;
 
-	if(!r.contains("rid") || typeId(r["rid"]) != QMetaType::QVariantHash)
+	if(!r.contains("rid") || typeId(r["rid"]) != VariantType::Hash)
 		return RequestState();
 
 	VariantHash vrid = r["rid"].toHash();
 
-	if(!vrid.contains("sender") || typeId(vrid["sender"]) != QMetaType::QByteArray)
+	if(!vrid.contains("sender") || typeId(vrid["sender"]) != VariantType::ByteArray)
 		return RequestState();
 
-	if(!vrid.contains("id") || typeId(vrid["id"]) != QMetaType::QByteArray)
+	if(!vrid.contains("id") || typeId(vrid["id"]) != VariantType::ByteArray)
 		return RequestState();
 
 	rs.rid = ZhttpRequest::Rid(vrid["sender"].toByteArray(), vrid["id"].toByteArray());
 
-	if(!r.contains("in-seq") || !canConvert(r["in-seq"], QMetaType::Int))
+	if(!r.contains("in-seq") || !canConvert(r["in-seq"], VariantType::Int))
 		return RequestState();
 
 	rs.inSeq = r["in-seq"].toInt();
 
-	if(!r.contains("out-seq") || !canConvert(r["out-seq"], QMetaType::Int))
+	if(!r.contains("out-seq") || !canConvert(r["out-seq"], VariantType::Int))
 		return RequestState();
 
 	rs.outSeq = r["out-seq"].toInt();
 
-	if(!r.contains("out-credits") || !canConvert(r["out-credits"], QMetaType::Int))
+	if(!r.contains("out-credits") || !canConvert(r["out-credits"], VariantType::Int))
 		return RequestState();
 
 	rs.outCredits = r["out-credits"].toInt();
 
 	if(r.contains("router-resp"))
 	{
-		if(typeId(r["router-resp"]) != QMetaType::Bool)
+		if(typeId(r["router-resp"]) != VariantType::Bool)
 			return RequestState();
 
 		rs.routerResp = r["router-resp"].toBool();
@@ -72,7 +72,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("response-code"))
 	{
-		if(!canConvert(r["response-code"], QMetaType::Int))
+		if(!canConvert(r["response-code"], VariantType::Int))
 			return RequestState();
 
 		rs.responseCode = r["response-code"].toInt();
@@ -80,7 +80,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("peer-address"))
 	{
-		if(typeId(r["peer-address"]) != QMetaType::QByteArray)
+		if(typeId(r["peer-address"]) != VariantType::ByteArray)
 			return RequestState();
 
 		if(!rs.peerAddress.setAddress(QString::fromUtf8(r["peer-address"].toByteArray())))
@@ -89,7 +89,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("logical-peer-address"))
 	{
-		if(typeId(r["logical-peer-address"]) != QMetaType::QByteArray)
+		if(typeId(r["logical-peer-address"]) != VariantType::ByteArray)
 			return RequestState();
 
 		if(!rs.logicalPeerAddress.setAddress(QString::fromUtf8(r["logical-peer-address"].toByteArray())))
@@ -98,7 +98,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("https"))
 	{
-		if(typeId(r["https"]) != QMetaType::Bool)
+		if(typeId(r["https"]) != VariantType::Bool)
 			return RequestState();
 
 		rs.isHttps = r["https"].toBool();
@@ -106,7 +106,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("debug"))
 	{
-		if(typeId(r["debug"]) != QMetaType::Bool)
+		if(typeId(r["debug"]) != VariantType::Bool)
 			return RequestState();
 
 		rs.debug = r["debug"].toBool();
@@ -114,7 +114,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("is-retry"))
 	{
-		if(typeId(r["is-retry"]) != QMetaType::Bool)
+		if(typeId(r["is-retry"]) != VariantType::Bool)
 			return RequestState();
 
 		rs.isRetry = r["is-retry"].toBool();
@@ -122,7 +122,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("auto-cross-origin"))
 	{
-		if(typeId(r["auto-cross-origin"]) != QMetaType::Bool)
+		if(typeId(r["auto-cross-origin"]) != VariantType::Bool)
 			return RequestState();
 
 		rs.autoCrossOrigin = r["auto-cross-origin"].toBool();
@@ -130,7 +130,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("jsonp-callback"))
 	{
-		if(typeId(r["jsonp-callback"]) != QMetaType::QByteArray)
+		if(typeId(r["jsonp-callback"]) != VariantType::ByteArray)
 			return RequestState();
 
 		rs.jsonpCallback = r["jsonp-callback"].toByteArray();
@@ -138,7 +138,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("jsonp-extended-response"))
 	{
-		if(typeId(r["jsonp-extended-response"]) != QMetaType::Bool)
+		if(typeId(r["jsonp-extended-response"]) != VariantType::Bool)
 			return RequestState();
 
 		rs.jsonpExtendedResponse = r["jsonp-extended-response"].toBool();
@@ -146,7 +146,7 @@ RequestState RequestState::fromVariant(const Variant &in)
 
 	if(r.contains("unreported-time"))
 	{
-		if(!canConvert(r["unreported-time"], QMetaType::Int))
+		if(!canConvert(r["unreported-time"], VariantType::Int))
 			return RequestState();
 
 		rs.unreportedTime = r["unreported-time"].toInt();

--- a/src/handler/sessionrequest.cpp
+++ b/src/handler/sessionrequest.cpp
@@ -97,7 +97,7 @@ private:
 		if(req->success())
 		{
 			Variant vresult = req->result();
-			if(typeId(vresult) != QMetaType::QVariantList)
+			if(typeId(vresult) != VariantType::List)
 			{
 				setFinished(false);
 				return;
@@ -108,7 +108,7 @@ private:
 			QList<DetectRule> rules;
 			foreach(const Variant &vr, result)
 			{
-				if(typeId(vr) != QMetaType::QVariantHash)
+				if(typeId(vr) != VariantType::Hash)
 				{
 					setFinished(false);
 					return;
@@ -118,7 +118,7 @@ private:
 
 				DetectRule rule;
 
-				if(!r.contains("domain") || typeId(r["domain"]) != QMetaType::QByteArray)
+				if(!r.contains("domain") || typeId(r["domain"]) != VariantType::ByteArray)
 				{
 					setFinished(false);
 					return;
@@ -126,7 +126,7 @@ private:
 
 				rule.domain = QString::fromUtf8(r["domain"].toByteArray());
 
-				if(!r.contains("path-prefix") || typeId(r["path-prefix"]) != QMetaType::QByteArray)
+				if(!r.contains("path-prefix") || typeId(r["path-prefix"]) != VariantType::ByteArray)
 				{
 					setFinished(false);
 					return;
@@ -134,7 +134,7 @@ private:
 
 				rule.pathPrefix = r["path-prefix"].toByteArray();
 
-				if(!r.contains("sid-ptr") || typeId(r["sid-ptr"]) != QMetaType::QByteArray)
+				if(!r.contains("sid-ptr") || typeId(r["sid-ptr"]) != VariantType::ByteArray)
 				{
 					setFinished(false);
 					return;
@@ -144,7 +144,7 @@ private:
 
 				if(r.contains("json-param"))
 				{
-					if(typeId(r["json-param"]) != QMetaType::QByteArray)
+					if(typeId(r["json-param"]) != VariantType::ByteArray)
 					{
 						setFinished(false);
 						return;
@@ -279,7 +279,7 @@ private:
 		if(req->success())
 		{
 			Variant vresult = req->result();
-			if(typeId(vresult) != QMetaType::QVariantHash)
+			if(typeId(vresult) != VariantType::Hash)
 			{
 				setFinished(false);
 				return;
@@ -293,7 +293,7 @@ private:
 			{
 				it.next();
 				const Variant &i = it.value();
-				if(typeId(i) != QMetaType::QByteArray)
+				if(typeId(i) != VariantType::ByteArray)
 				{
 					setFinished(false);
 					return;

--- a/src/handler/variantutil.cpp
+++ b/src/handler/variantutil.cpp
@@ -46,14 +46,14 @@ void setError(bool *ok, QString *errorMessage, const QString &msg)
 
 bool isKeyedObject(const Variant &in)
 {
-	return (typeId(in) == QMetaType::QVariantHash || typeId(in) == QMetaType::QVariantMap);
+	return (typeId(in) == VariantType::Hash || typeId(in) == VariantType::Map);
 }
 
 Variant createSameKeyedObject(const Variant &in)
 {
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 		return VariantHash();
-	else if(typeId(in) == QMetaType::QVariantMap)
+	else if(typeId(in) == VariantType::Map)
 		return VariantMap();
 	else
 		return Variant();
@@ -61,9 +61,9 @@ Variant createSameKeyedObject(const Variant &in)
 
 bool keyedObjectIsEmpty(const Variant &in)
 {
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 		return in.toHash().isEmpty();
-	else if(typeId(in) == QMetaType::QVariantMap)
+	else if(typeId(in) == VariantType::Map)
 		return in.toMap().isEmpty();
 	else
 		return true;
@@ -71,9 +71,9 @@ bool keyedObjectIsEmpty(const Variant &in)
 
 bool keyedObjectContains(const Variant &in, const QString &name)
 {
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 		return in.toHash().contains(name);
-	else if(typeId(in) == QMetaType::QVariantMap)
+	else if(typeId(in) == VariantType::Map)
 		return in.toMap().contains(name);
 	else
 		return false;
@@ -81,9 +81,9 @@ bool keyedObjectContains(const Variant &in, const QString &name)
 
 Variant keyedObjectGetValue(const Variant &in, const QString &name)
 {
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 		return in.toHash().value(name);
-	else if(typeId(in) == QMetaType::QVariantMap)
+	else if(typeId(in) == VariantType::Map)
 		return in.toMap().value(name);
 	else
 		return Variant();
@@ -91,13 +91,13 @@ Variant keyedObjectGetValue(const Variant &in, const QString &name)
 
 void keyedObjectInsert(Variant *in, const QString &name, const Variant &value)
 {
-	if(typeId(*in) == QMetaType::QVariantHash)
+	if(typeId(*in) == VariantType::Hash)
 	{
 		VariantHash h = in->toHash();
 		h.insert(name, value);
 		*in = h;
 	}
-	else if(typeId(*in) == QMetaType::QVariantMap)
+	else if(typeId(*in) == VariantType::Map)
 	{
 		VariantMap h = in->toMap();
 		h.insert(name, value);
@@ -117,7 +117,7 @@ Variant getChild(const Variant &in, const QString &parentName, const QString &ch
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
 	Variant v;
-	if(typeId(in) == QMetaType::QVariantHash)
+	if(typeId(in) == VariantType::Hash)
 	{
 		VariantHash h = in.toHash();
 
@@ -202,7 +202,7 @@ VariantList getList(const Variant &in, const QString &parentName, const QString 
 
 	QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	if(typeId(v) != QMetaType::QVariantList)
+	if(typeId(v) != VariantType::List)
 	{
 		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
 		return VariantList();
@@ -214,13 +214,13 @@ VariantList getList(const Variant &in, const QString &parentName, const QString 
 
 QString getString(const Variant &in, bool *ok)
 {
-	if(typeId(in) == QMetaType::QString)
+	if(typeId(in) == VariantType::String)
 	{
 		if(ok)
 			*ok = true;
 		return in.toString();
 	}
-	else if(typeId(in) == QMetaType::QByteArray)
+	else if(typeId(in) == VariantType::ByteArray)
 	{
 		QByteArray buf = in.toByteArray();
 		if(ok)
@@ -275,8 +275,8 @@ bool convertToJsonStyleInPlace(Variant *in)
 
 	bool changed = false;
 
-	QMetaType::Type type = typeId(*in);
-	if(type == QMetaType::QVariantHash)
+	VariantType::Type type = typeId(*in);
+	if(type == VariantType::Hash)
 	{
 		VariantMap vmap;
 		VariantHash vhash = in->toHash();
@@ -292,7 +292,7 @@ bool convertToJsonStyleInPlace(Variant *in)
 		*in = vmap;
 		changed = true;
 	}
-	else if(type == QMetaType::QVariantList)
+	else if(type == VariantType::List)
 	{
 		VariantList vlist = in->toList();
 		for(int n = 0; n < vlist.count(); ++n)
@@ -305,7 +305,7 @@ bool convertToJsonStyleInPlace(Variant *in)
 		*in = vlist;
 		changed = true;
 	}
-	else if(type == QMetaType::QByteArray)
+	else if(type == VariantType::ByteArray)
 	{
 		QByteArray buf = in->toByteArray();
 		if(!buf.isNull())

--- a/src/handler/wscontrolmessage.cpp
+++ b/src/handler/wscontrolmessage.cpp
@@ -183,9 +183,9 @@ WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QStr
 		{
 			Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
 
-			if(typeId(in) == QMetaType::QVariantMap) // JSON input
+			if(typeId(in) == VariantType::Map) // JSON input
 			{
-				if(typeId(vcontentBin) != QMetaType::QString)
+				if(typeId(vcontentBin) != VariantType::String)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
 					return WsControlMessage();
@@ -195,7 +195,7 @@ WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QStr
 			}
 			else
 			{
-				if(typeId(vcontentBin) != QMetaType::QByteArray)
+				if(typeId(vcontentBin) != VariantType::ByteArray)
 				{
 					setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
 					return WsControlMessage();
@@ -210,9 +210,9 @@ WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QStr
 		else if(keyedObjectContains(in, "content"))
 		{
 			Variant vcontent = keyedObjectGetValue(in, "content");
-			if(typeId(vcontent) == QMetaType::QByteArray)
+			if(typeId(vcontent) == VariantType::ByteArray)
 				out.content = vcontent.toByteArray();
-			else if(typeId(vcontent) == QMetaType::QString)
+			else if(typeId(vcontent) == VariantType::String)
 				out.content = vcontent.toString().toUtf8();
 			else
 			{
@@ -229,7 +229,7 @@ WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QStr
 			if(keyedObjectContains(in, "timeout"))
 			{
 				Variant vtimeout = keyedObjectGetValue(in, "timeout");
-				if(!canConvert(vtimeout, QMetaType::Int))
+				if(!canConvert(vtimeout, VariantType::Int))
 				{
 					setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(pn));
 					return WsControlMessage();

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -1276,7 +1276,7 @@ public:
 			log_debug("m2: IN control %s %s", m2_send_idents[index].data(), qPrintable(TnetString::variantToString(data)));
 #endif
 
-		if(typeId(data) != QMetaType::QVariantHash)
+		if(typeId(data) != VariantType::Hash)
 			return;
 
 		VariantHash vhash = data.toHash();
@@ -1296,7 +1296,7 @@ public:
 		QSet<QByteArray> ids;
 		foreach(const Variant &row, rows.toList())
 		{
-			if(typeId(row) != QMetaType::QVariantList)
+			if(typeId(row) != VariantType::List)
 				break;
 
 			VariantList vlist = row.toList();

--- a/src/m2adapter/m2requestpacket.cpp
+++ b/src/m2adapter/m2requestpacket.cpp
@@ -122,7 +122,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 			QString key = vit.key();
 			Variant val = vit.value();
 
-			if(typeId(val) == QMetaType::QByteArray)
+			if(typeId(val) == VariantType::ByteArray)
 			{
 				QByteArray ba = val.toByteArray();
 
@@ -131,13 +131,13 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 				if(!isAllCaps(key) && !skipHeaders.contains(key))
 					headers += HttpHeader(makeMixedCaseHeader(key).toLatin1(), ba);
 			}
-			else if(typeId(val) == QMetaType::QVariantList)
+			else if(typeId(val) == VariantType::List)
 			{
 				VariantList vl = val.toList();
 				if(vl.isEmpty())
 					return false;
 
-				if(typeId(vl[0]) != QMetaType::QByteArray)
+				if(typeId(vl[0]) != VariantType::ByteArray)
 					return false;
 
 				m2headers[key] = vl[0].toByteArray();
@@ -148,7 +148,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 
 					foreach(const Variant &v, vl)
 					{
-						if(typeId(v) != QMetaType::QByteArray)
+						if(typeId(v) != VariantType::ByteArray)
 							return false;
 
 						headers += HttpHeader(name, v.toByteArray());
@@ -175,7 +175,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 			QString key = vit.key();
 			Variant val = vit.value();
 
-			if(typeId(val) == QMetaType::QString)
+			if(typeId(val) == VariantType::String)
 			{
 				QByteArray ba = val.toString().toUtf8();
 
@@ -184,13 +184,13 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 				if(!isAllCaps(key) && !skipHeaders.contains(key))
 					headers += HttpHeader(makeMixedCaseHeader(key).toLatin1(), ba);
 			}
-			else if(typeId(val) == QMetaType::QVariantList)
+			else if(typeId(val) == VariantType::List)
 			{
 				VariantList vl = val.toList();
 				if(vl.isEmpty())
 					return false;
 
-				if(typeId(vl[0]) != QMetaType::QString)
+				if(typeId(vl[0]) != VariantType::String)
 					return false;
 
 				m2headers[key] = vl[0].toString().toUtf8();
@@ -201,7 +201,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 
 					foreach(const Variant &v, vl)
 					{
-						if(typeId(v) != QMetaType::QString)
+						if(typeId(v) != VariantType::String)
 							return false;
 
 						headers += HttpHeader(name, v.toString().toUtf8());
@@ -241,7 +241,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 			return false;
 
 		VariantMap data = doc.object().toVariantMap();
-		if(!data.contains("type") || typeId(data["type"]) != QMetaType::QString)
+		if(!data.contains("type") || typeId(data["type"]) != VariantType::String)
 			return false;
 
 		QString jtype = data["type"].toString();

--- a/src/proxy/acceptrequest.cpp
+++ b/src/proxy/acceptrequest.cpp
@@ -229,7 +229,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 {
 	AcceptRequest::ResponseData out;
 
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 	{
 		*ok = false;
 		return AcceptRequest::ResponseData();
@@ -239,7 +239,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 
 	if(obj.contains("accepted"))
 	{
-		if(typeId(obj["accepted"]) != QMetaType::Bool)
+		if(typeId(obj["accepted"]) != VariantType::Bool)
 		{
 			*ok = false;
 			return AcceptRequest::ResponseData();
@@ -250,7 +250,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 
 	if(obj.contains("response"))
 	{
-		if(typeId(obj["response"]) != QMetaType::QVariantHash)
+		if(typeId(obj["response"]) != VariantType::Hash)
 		{
 			*ok = false;
 			return AcceptRequest::ResponseData();
@@ -260,7 +260,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 
 		if(vresponse.contains("code"))
 		{
-			if(!canConvert(vresponse["code"], QMetaType::Int))
+			if(!canConvert(vresponse["code"], VariantType::Int))
 			{
 				*ok = false;
 				return AcceptRequest::ResponseData();
@@ -271,7 +271,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 
 		if(vresponse.contains("reason"))
 		{
-			if(typeId(vresponse["reason"]) != QMetaType::QByteArray)
+			if(typeId(vresponse["reason"]) != VariantType::ByteArray)
 			{
 				*ok = false;
 				return AcceptRequest::ResponseData();
@@ -282,7 +282,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 
 		if(vresponse.contains("headers"))
 		{
-			if(typeId(vresponse["headers"]) != QMetaType::QVariantList)
+			if(typeId(vresponse["headers"]) != VariantType::List)
 			{
 				*ok = false;
 				return AcceptRequest::ResponseData();
@@ -297,7 +297,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 					return AcceptRequest::ResponseData();
 				}
 
-				if(typeId(list[0]) != QMetaType::QByteArray || typeId(list[1]) != QMetaType::QByteArray)
+				if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
 				{
 					*ok = false;
 					return AcceptRequest::ResponseData();
@@ -309,7 +309,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 
 		if(vresponse.contains("body"))
 		{
-			if(typeId(vresponse["body"]) != QMetaType::QByteArray)
+			if(typeId(vresponse["body"]) != VariantType::ByteArray)
 			{
 				*ok = false;
 				return AcceptRequest::ResponseData();

--- a/src/proxy/inspectrequest.cpp
+++ b/src/proxy/inspectrequest.cpp
@@ -32,7 +32,7 @@ static InspectData resultToData(const Variant &in, bool *ok)
 {
 	InspectData out;
 
-	if(typeId(in) != QMetaType::QVariantHash)
+	if(typeId(in) != VariantType::Hash)
 	{
 		*ok = false;
 		return InspectData();
@@ -40,7 +40,7 @@ static InspectData resultToData(const Variant &in, bool *ok)
 
 	VariantHash obj = in.toHash();
 
-	if(!obj.contains("no-proxy") || typeId(obj["no-proxy"]) != QMetaType::Bool)
+	if(!obj.contains("no-proxy") || typeId(obj["no-proxy"]) != VariantType::Bool)
 	{
 		*ok = false;
 		return InspectData();
@@ -50,7 +50,7 @@ static InspectData resultToData(const Variant &in, bool *ok)
 	out.sharingKey.clear();
 	if(obj.contains("sharing-key"))
 	{
-		if(typeId(obj["sharing-key"]) != QMetaType::QByteArray)
+		if(typeId(obj["sharing-key"]) != VariantType::ByteArray)
 		{
 			*ok = false;
 			return InspectData();
@@ -62,7 +62,7 @@ static InspectData resultToData(const Variant &in, bool *ok)
 	out.sid.clear();
 	if(obj.contains("sid"))
 	{
-		if(typeId(obj["sid"]) != QMetaType::QByteArray)
+		if(typeId(obj["sid"]) != VariantType::ByteArray)
 		{
 			*ok = false;
 			return InspectData();
@@ -74,7 +74,7 @@ static InspectData resultToData(const Variant &in, bool *ok)
 	out.lastIds.clear();
 	if(obj.contains("last-ids"))
 	{
-		if(typeId(obj["last-ids"]) != QMetaType::QVariantHash)
+		if(typeId(obj["last-ids"]) != VariantType::Hash)
 		{
 			*ok = false;
 			return InspectData();
@@ -86,7 +86,7 @@ static InspectData resultToData(const Variant &in, bool *ok)
 		{
 			it.next();
 
-			if(typeId(it.value()) != QMetaType::QByteArray)
+			if(typeId(it.value()) != VariantType::ByteArray)
 			{
 				*ok = false;
 				return InspectData();

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -934,7 +934,7 @@ private:
 			}
 
 			VariantHash args = req->args();
-			if(!args.contains("ids") || typeId(args["ids"]) != QMetaType::QVariantList)
+			if(!args.contains("ids") || typeId(args["ids"]) != VariantType::List)
 			{
 				req->respondError("bad-format");
 				delete req;
@@ -947,7 +947,7 @@ private:
 			QList<QByteArray> ids;
 			foreach(const Variant &vid, vids)
 			{
-				if(typeId(vid) != QMetaType::QByteArray)
+				if(typeId(vid) != VariantType::ByteArray)
 				{
 					ok = false;
 					break;
@@ -974,7 +974,7 @@ private:
 		else if(req->method() == "refresh")
 		{
 			VariantHash args = req->args();
-			if(!args.contains("cid") || typeId(args["cid"]) != QMetaType::QByteArray)
+			if(!args.contains("cid") || typeId(args["cid"]) != VariantType::ByteArray)
 			{
 				req->respondError("bad-format");
 				delete req;

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -1463,7 +1463,7 @@ public:
 		{
 			// Wake up receivers and reject
 
-			if(acceptRequest->errorCondition() == ZrpcRequest::ErrorFormat && typeId(((ZrpcRequest *)acceptRequest.get())->result()) == QMetaType::QByteArray)
+			if(acceptRequest->errorCondition() == ZrpcRequest::ErrorFormat && typeId(((ZrpcRequest *)acceptRequest.get())->result()) == VariantType::ByteArray)
 			{
 				QString errorString = QString::fromUtf8(((ZrpcRequest *)acceptRequest.get())->result().toByteArray());
 				QString msg = "Error while proxying to origin.";

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -43,7 +43,7 @@ static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key)
 static bool validate_token(const QByteArray &token, const Jwt::DecodingKey &key)
 {
 	Variant claimObj = Jwt::decode(token, key);
-	if(!claimObj.isValid() || typeId(claimObj) != QMetaType::QVariantMap)
+	if(!claimObj.isValid() || typeId(claimObj) != VariantType::Map)
 		return false;
 
 	VariantMap claim = claimObj.toMap();

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -694,7 +694,7 @@ public:
 			{
 				vit.next();
 
-				if(typeId(vit.value()) != QMetaType::QString)
+				if(typeId(vit.value()) != VariantType::String)
 				{
 					log_debug("requestsession: id=%s invalid _headers parameter, rejecting", rid.second.data());
 					*ok = false;

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -330,7 +330,7 @@ public:
 		if(data.isValid())
 		{
 			QJsonDocument doc;
-			if(typeId(data) == QMetaType::QVariantMap)
+			if(typeId(data) == VariantType::Map)
 				doc = QJsonDocument(QJsonObject::fromVariantMap(data.toMap()));
 			else // List
 				doc = QJsonDocument(QJsonArray::fromVariantList(data.toList()));

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -409,7 +409,7 @@ public:
 			int bytes = 0;
 			foreach(const Variant &vmessage, messages)
 			{
-				if(typeId(vmessage) != QMetaType::QString)
+				if(typeId(vmessage) != VariantType::String)
 				{
 					requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
 					respondError(_req, 400, "Bad Request", "Payload expected");
@@ -795,7 +795,7 @@ public:
 				int bytes = 0;
 				foreach(const Variant &vmessage, messages)
 				{
-					if(typeId(vmessage) != QMetaType::QString)
+					if(typeId(vmessage) != VariantType::String)
 					{
 						error = true;
 						break;

--- a/src/runner/template.cpp
+++ b/src/runner/template.cpp
@@ -250,7 +250,7 @@ static Variant getVar(const QString &s, const VariantMap &context)
 			return Variant();
 
 		Variant subContext = context[parent];
-		if(typeId(subContext) != QMetaType::QVariantMap)
+		if(typeId(subContext) != VariantType::Map)
 			return Variant();
 
 		return getVar(member, subContext.toMap());
@@ -286,11 +286,11 @@ static bool evalCondition(const QString &s, const VariantMap &context)
 	else
 	{
 		Variant val = getVar(s, context);
-		if(typeId(val) == QMetaType::QString)
+		if(typeId(val) == VariantType::String)
 			return !val.toString().isEmpty();
-		else if(typeId(val) == QMetaType::Bool)
+		else if(typeId(val) == VariantType::Bool)
 			return val.toBool();
-		else if(canConvert(val, QMetaType::Int))
+		else if(canConvert(val, VariantType::Int))
 			return (val.toInt() != 0);
 		else
 			return false;
@@ -312,7 +312,7 @@ static VariantList parseFor(const QString &s, QString *iterVarName, const Varian
 	QString containerName = s.mid(at + 4);
 
 	Variant container = getVar(containerName, context);
-	if(typeId(container) != QMetaType::QVariantList)
+	if(typeId(container) != VariantType::List)
 	{
 		*error = "\"for\" container must be a list";
 		return VariantList();


### PR DESCRIPTION
#48320 mentions that working with variant types still involves `QMetaType`. This PR introduces our own substitute enum, with values that are identical to those of `QMetaType`, and updates the whole codebase to use it everywhere. This way, variant call sites don't have to reference `QMetaType` directly.

The enum looks like this:

```c++
#include <QMetaType>

namespace VariantType {
	enum Type {
		Invalid = QMetaType::UnknownType,
		Bool = QMetaType::Bool,
		Int = QMetaType::Int,
		Double = QMetaType::Double,
		LongLong = QMetaType::LongLong,
		String = QMetaType::QString,
		ByteArray = QMetaType::QByteArray,
		Hash = QMetaType::QVariantHash,
		Map = QMetaType::QVariantMap,
		List = QMetaType::QVariantList
	};
}
```

Since the values are the same, there should be no change in behavior.

Note that there is still some remaining direct usage of Qt's meta type system via the `Q_DECLARE_METATYPE` macro, which enables storing user-defined types in `QVariant`. We'll address that separately.