### PR TITLE
use stl-style and ranged-for iteration for variant containers

### DIFF
--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -155,7 +155,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 		return false;
 
 	requests.clear();
-	foreach(const Variant &i, obj["requests"].toList())
+	for(const Variant &i : obj["requests"].toList())
 	{
 		if(typeId(i) != VariantType::Hash)
 			return false;
@@ -283,7 +283,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 		if(typeId(vrequestData["headers"]) != VariantType::List)
 			return false;
 
-		foreach(const Variant &i, vrequestData["headers"].toList())
+		for(const Variant &i : vrequestData["headers"].toList())
 		{
 			VariantList list = i.toList();
 			if(list.count() != 2)
@@ -333,11 +333,8 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 				return false;
 
 			VariantHash vlastIds = vinspect["last-ids"].toHash();
-			QHashIterator<QString, Variant> it(vlastIds);
-			while(it.hasNext())
+			for(auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it)
 			{
-				it.next();
-
 				if(typeId(it.value()) != VariantType::ByteArray)
 					return false;
 

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -74,7 +74,7 @@ public:
 
 		WsControlPacket out;
 
-		foreach(const Variant &vitem, vitems)
+		for(const Variant &vitem : vitems)
 		{
 			Message msg;
 
@@ -262,7 +262,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 	VariantList vitems = obj["items"].toList();
 
 	items.clear();
-	foreach(const Variant &v, vitems)
+	for(const Variant &v : vitems)
 	{
 		if(typeId(v) != VariantType::Hash)
 			return false;

--- a/src/core/tnetstring.cpp
+++ b/src/core/tnetstring.cpp
@@ -85,10 +85,8 @@ QByteArray fromVariant(const Variant &in)
 QByteArray fromHash(const VariantHash &in)
 {
 	QByteArray val;
-	QHashIterator<QString, Variant> it(in);
-	while(it.hasNext())
+	for(auto it = in.constBegin(); it != in.constEnd(); ++it)
 	{
-		it.next();
 		val += fromByteArray(it.key().toUtf8());
 		val += fromVariant(it.value());
 	}
@@ -98,7 +96,7 @@ QByteArray fromHash(const VariantHash &in)
 QByteArray fromList(const VariantList &in)
 {
 	QByteArray val;
-	foreach(const Variant &v, in)
+	for(const Variant &v : in)
 		val += fromVariant(v);
 	return QByteArray::number(val.size()) + ':' + val + ']';
 }
@@ -393,16 +391,15 @@ QString variantToString(const Variant &in, int indent)
 		else
 			out += ' ';
 
-		QHashIterator<QString, Variant> it(hash);
-		while(it.hasNext())
+		for(auto it = hash.constBegin(); it != hash.constEnd(); ++it)
 		{
-			it.next();
-
 			if(indent >= 0)
 				out += QString(indent + 2, ' ');
 
 			out += '\"' + byteArrayToEscapedString(it.key().toUtf8()) + "\": " + variantToString(it.value(), indent >= 0 ? indent + 2 : -1);
-			if(it.hasNext())
+			auto next_it = it;
+			++next_it;
+			if(next_it != hash.constEnd())
 				out += ',';
 
 			if(indent >= 0)

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -207,7 +207,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 		else if(typeId(obj["id"]) == VariantType::List)
 		{
 			VariantList vl = obj["id"].toList();
-			foreach(const Variant &v, vl)
+			for(const Variant &v : vl)
 			{
 				if(typeId(v) != VariantType::Hash)
 					return false;
@@ -370,7 +370,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 		if(typeId(obj["headers"]) != VariantType::List)
 			return false;
 
-		foreach(const Variant &i, obj["headers"].toList())
+		for(const Variant &i : obj["headers"].toList())
 		{
 			VariantList list = i.toList();
 			if(list.count() != 2)

--- a/src/core/zhttpresponsepacket.cpp
+++ b/src/core/zhttpresponsepacket.cpp
@@ -150,7 +150,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 		else if(typeId(obj["id"]) == VariantType::List)
 		{
 			VariantList vl = obj["id"].toList();
-			foreach(const Variant &v, vl)
+			for(const Variant &v : vl)
 			{
 				if(typeId(v) != VariantType::Hash)
 					return false;
@@ -277,7 +277,7 @@ bool ZhttpResponsePacket::fromVariant(const Variant &in)
 		if(typeId(obj["headers"]) != VariantType::List)
 			return false;
 
-		foreach(const Variant &i, obj["headers"].toList())
+		for(const Variant &i : obj["headers"].toList())
 		{
 			VariantList list = i.toList();
 			if(list.count() != 2)

--- a/src/handler/conncheckworker.cpp
+++ b/src/handler/conncheckworker.cpp
@@ -42,7 +42,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 
 	VariantList vids = args["ids"].toList();
 
-	foreach(const Variant &vid, vids)
+	for(const Variant &vid : vids)
 	{
 		if(typeId(vid) != VariantType::ByteArray)
 		{
@@ -53,7 +53,7 @@ ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClie
 		cids_ += QString::fromUtf8(vid.toByteArray());
 	}
 
-	foreach(const QString &cid, cids_)
+	for(const QString &cid : cids_)
 	{
 		if(!stats->checkConnection(cid.toUtf8()))
 			missing_ += cid;
@@ -82,7 +82,7 @@ void ConnCheckWorker::doFinish()
 		cids_.remove(cid);
 
 	VariantList result;
-	foreach(const QString &cid, cids_)
+	for(const QString &cid : cids_)
 		result += cid.toUtf8();
 
 	req_->respond(result);

--- a/src/handler/controlrequest.cpp
+++ b/src/handler/controlrequest.cpp
@@ -40,7 +40,7 @@ public:
 		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this));
 
 		VariantList vcids;
-		foreach(const QString &cid, cids)
+		for(const QString &cid : cids)
 			vcids += cid.toUtf8();
 
 		VariantHash args;
@@ -66,7 +66,7 @@ private:
 			VariantList result = vresult.toList();
 
 			CidSet out;
-			foreach(const Variant &vcid, result)
+			for(const Variant &vcid : result)
 			{
 				if(typeId(vcid) != VariantType::ByteArray)
 				{

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -94,7 +94,7 @@ static QList<PublishItem> parseItems(const VariantList &vitems, bool *ok = 0, QS
 {
 	QList<PublishItem> out;
 
-	foreach(const Variant &vitem, vitems)
+	for(const Variant &vitem : vitems)
 	{
 		bool ok_;
 		PublishItem item = PublishItem::fromVariant(vitem, QString(), &ok_, errorMessage);
@@ -163,7 +163,7 @@ public:
 				return;
 			}
 
-			foreach(const Variant &vheader, args["headers"].toList())
+			for(const Variant &vheader : args["headers"].toList())
 			{
 				if(typeId(vheader) != VariantType::List)
 				{
@@ -488,7 +488,7 @@ public:
 
 			VariantList packets = args["conn-max"].toList();
 
-			foreach(const Variant &data, packets)
+			for(const Variant &data : packets)
 			{
 				StatsPacket p;
 				if(!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax)
@@ -557,7 +557,7 @@ public:
 			}
 
 			VariantList vchannels = args["channels"].toList();
-			foreach(const Variant &v, vchannels)
+			for(const Variant &v : vchannels)
 			{
 				if(typeId(v) != VariantType::ByteArray)
 				{
@@ -588,7 +588,7 @@ public:
 			return;
 		}
 
-		foreach(const Variant &vr, args["requests"].toList())
+		for(const Variant &vr : args["requests"].toList())
 		{
 			RequestState rs = RequestState::fromVariant(vr);
 			if(rs.rid.first.isEmpty())
@@ -650,7 +650,7 @@ public:
 			return;
 		}
 
-		foreach(const Variant &vheader, rd["headers"].toList())
+		for(const Variant &vheader : rd["headers"].toList())
 		{
 			if(typeId(vheader) != VariantType::List)
 			{
@@ -726,11 +726,8 @@ public:
 				}
 
 				VariantHash vlastIds = vinspect["last-ids"].toHash();
-				QHashIterator<QString, Variant> it(vlastIds);
-				while(it.hasNext())
+				for(auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it)
 				{
-					it.next();
-
 					if(typeId(it.value()) != VariantType::ByteArray)
 					{
 						respondError("bad-request");
@@ -866,7 +863,7 @@ private:
 		if(!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List)
 			return HttpRequestData();
 
-		foreach(const Variant &vheader, rd["headers"].toList())
+		for(const Variant &vheader : rd["headers"].toList())
 		{
 			if(typeId(vheader) != VariantType::List)
 				return HttpRequestData();
@@ -1939,7 +1936,7 @@ private:
 				{
 					VariantList packets = args["conn-max"].toList();
 
-					foreach(const Variant &data, packets)
+					for(const Variant &data : packets)
 					{
 						StatsPacket p;
 						if(!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax)

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -919,10 +919,8 @@ private:
 					{
 						// Don't add the same header name twice. We'll collect all values for a single header
 						bool found = false;
-						QMapIterator<QString, Variant> it(vheaders);
-						while(it.hasNext())
+						for(auto it = vheaders.constBegin(); it != vheaders.constEnd(); ++it)
 						{
-							it.next();
 							const QString &name = it.key();
 
 							QByteArray uname = name.toUtf8();

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -448,7 +448,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				return Instruct();
 			}
 
-			foreach(const Variant &vchannel, vchannels)
+			for(const Variant &vchannel : vchannels)
 			{
 				QString cpn = "channel";
 				Channel c;
@@ -477,7 +477,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 					return Instruct();
 				}
 
-				foreach(const Variant &vfilter, vfilters)
+				for(const Variant &vfilter : vfilters)
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -585,10 +585,8 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				{
 					VariantHash hmeta = vmeta.toHash();
 
-					QHashIterator<QString, Variant> it(hmeta);
-					while(it.hasNext())
+					for(auto it = hmeta.constBegin(); it != hmeta.constEnd(); ++it)
 					{
-						it.next();
 						const QString &key = it.key();
 						const Variant &vval = it.value();
 
@@ -606,10 +604,8 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				{
 					VariantMap mmeta = vmeta.toMap();
 
-					QMapIterator<QString, Variant> it(mmeta);
-					while(it.hasNext())
+					for(auto it = mmeta.constBegin(); it != mmeta.constEnd(); ++it)
 					{
-						it.next();
 						const QString &key = it.key();
 						const Variant &vval = it.value();
 
@@ -680,7 +676,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 				Variant vheaders = keyedObjectGetValue(in, "headers");
 				if(typeId(vheaders) == VariantType::List)
 				{
-					foreach(const Variant &vheader, vheaders.toList())
+					for(const Variant &vheader : vheaders.toList())
 					{
 						if(typeId(vheader) != VariantType::List)
 						{
@@ -718,10 +714,8 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 					{
 						VariantHash hheaders = vheaders.toHash();
 
-						QHashIterator<QString, Variant> it(hheaders);
-						while(it.hasNext())
+						for(auto it = hheaders.constBegin(); it != hheaders.constEnd(); ++it)
 						{
-							it.next();
 							const QString &key = it.key();
 							const Variant &vval = it.value();
 
@@ -739,10 +733,8 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 					{
 						VariantMap mheaders = vheaders.toMap();
 
-						QMapIterator<QString, Variant> it(mheaders);
-						while(it.hasNext())
+						for(auto it = mheaders.constBegin(); it != mheaders.constEnd(); ++it)
 						{
-							it.next();
 							const QString &key = it.key();
 							const Variant &vval = it.value();
 

--- a/src/handler/jsonpatch.cpp
+++ b/src/handler/jsonpatch.cpp
@@ -185,10 +185,8 @@ static bool convertToJsonStyleInPlace(Variant *in)
 	{
 		VariantMap vmap;
 		VariantHash vhash = in->toHash();
-		QHashIterator<QString, Variant> it(vhash);
-		while(it.hasNext())
+		for(auto it = vhash.constBegin(); it != vhash.constEnd(); ++it)
 		{
-			it.next();
 			Variant i = it.value();
 			convertToJsonStyleInPlace(&i);
 			vmap[it.key()] = i;
@@ -236,10 +234,8 @@ static bool _compareJsonValues(const Variant &a, const Variant &b)
 		if(am.count() != bm.count())
 			return false;
 
-		QMapIterator<QString, Variant> it(am);
-		while(it.hasNext())
+		for(auto it = am.constBegin(); it != am.constEnd(); ++it)
 		{
-			it.next();
 			const QString &key = it.key();
 			const Variant &val = it.value();
 
@@ -299,7 +295,7 @@ Variant patch(const Variant &data, const VariantList &ops, QString *errorMessage
 {
 	Variant out = data;
 
-	foreach(const Variant &vop, ops)
+	for(const Variant &vop : ops)
 	{
 		if(!isKeyedObject(vop))
 		{

--- a/src/handler/publishformat.cpp
+++ b/src/handler/publishformat.cpp
@@ -122,7 +122,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				Variant vheaders = keyedObjectGetValue(in, "headers");
 				if(typeId(vheaders) == VariantType::List)
 				{
-					foreach(const Variant &vheader, vheaders.toList())
+					for(const Variant &vheader : vheaders.toList())
 					{
 						if(typeId(vheader) != VariantType::List)
 						{
@@ -160,10 +160,8 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 					{
 						VariantHash hheaders = vheaders.toHash();
 
-						QHashIterator<QString, Variant> it(hheaders);
-						while(it.hasNext())
+						for(auto it = hheaders.constBegin(); it != hheaders.constEnd(); ++it)
 						{
-							it.next();
 							const QString &key = it.key();
 							const Variant &vval = it.value();
 
@@ -181,10 +179,8 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 					{
 						VariantMap mheaders = vheaders.toMap();
 
-						QMapIterator<QString, Variant> it(mheaders);
-						while(it.hasNext())
+						for(auto it = mheaders.constBegin(); it != mheaders.constEnd(); ++it)
 						{
-							it.next();
 							const QString &key = it.key();
 							const Variant &vval = it.value();
 
@@ -216,7 +212,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				}
 
 				QStringList filters;
-				foreach(const Variant &vfilter, vfilters.toList())
+				for(const Variant &vfilter : vfilters.toList())
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -293,7 +289,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				}
 
 				QStringList filters;
-				foreach(const Variant &vfilter, vfilters.toList())
+				for(const Variant &vfilter : vfilters.toList())
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)
@@ -383,7 +379,7 @@ PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
 				}
 
 				QStringList filters;
-				foreach(const Variant &vfilter, vfilters.toList())
+				for(const Variant &vfilter : vfilters.toList())
 				{
 					QString filter = getString(vfilter, &ok_);
 					if(!ok_)

--- a/src/handler/publishitem.cpp
+++ b/src/handler/publishitem.cpp
@@ -157,10 +157,8 @@ PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channe
 		{
 			VariantHash hmeta = vmeta.toHash();
 
-			QHashIterator<QString, Variant> it(hmeta);
-			while(it.hasNext())
+			for(auto it = hmeta.constBegin(); it != hmeta.constEnd(); ++it)
 			{
-				it.next();
 				const QString &key = it.key();
 				const Variant &vval = it.value();
 
@@ -178,10 +176,8 @@ PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channe
 		{
 			VariantMap mmeta = vmeta.toMap();
 
-			QMapIterator<QString, Variant> it(mmeta);
-			while(it.hasNext())
+			for(auto it = mmeta.constBegin(); it != mmeta.constEnd(); ++it)
 			{
-				it.next();
 				const QString &key = it.key();
 				const Variant &vval = it.value();
 

--- a/src/handler/sessionrequest.cpp
+++ b/src/handler/sessionrequest.cpp
@@ -106,7 +106,7 @@ private:
 			VariantList result = vresult.toList();
 
 			QList<DetectRule> rules;
-			foreach(const Variant &vr, result)
+			for(const Variant &vr : result)
 			{
 				if(typeId(vr) != VariantType::Hash)
 				{
@@ -288,10 +288,8 @@ private:
 			VariantHash result = vresult.toHash();
 
 			QHash<QString, QString> out;
-			QHashIterator<QString, Variant> it(result);
-			while(it.hasNext())
+			for(auto it = result.constBegin(); it != result.constEnd(); ++it)
 			{
-				it.next();
 				const Variant &i = it.value();
 				if(typeId(i) != VariantType::ByteArray)
 				{

--- a/src/handler/variantutil.cpp
+++ b/src/handler/variantutil.cpp
@@ -280,10 +280,8 @@ bool convertToJsonStyleInPlace(Variant *in)
 	{
 		VariantMap vmap;
 		VariantHash vhash = in->toHash();
-		QHashIterator<QString, Variant> it(vhash);
-		while(it.hasNext())
+		for(auto it = vhash.constBegin(); it != vhash.constEnd(); ++it)
 		{
-			it.next();
 			Variant i = it.value();
 			convertToJsonStyleInPlace(&i);
 			vmap[it.key()] = i;

--- a/src/handler/wscontrolmessage.cpp
+++ b/src/handler/wscontrolmessage.cpp
@@ -100,7 +100,7 @@ WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QStr
 				return WsControlMessage();
 			}
 
-			foreach(const Variant &vfilter, vfilters)
+			for(const Variant &vfilter : vfilters)
 			{
 				QString filter = getString(vfilter, &ok_);
 				if(!ok_)

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -1294,7 +1294,7 @@ public:
 		}
 
 		QSet<QByteArray> ids;
-		foreach(const Variant &row, rows.toList())
+		for(const Variant &row : rows.toList())
 		{
 			if(typeId(row) != VariantType::List)
 				break;

--- a/src/m2adapter/m2requestpacket.cpp
+++ b/src/m2adapter/m2requestpacket.cpp
@@ -114,13 +114,10 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 	if(htype == TnetString::Hash)
 	{
 		VariantMap headersMap = vheaders.toMap();
-		QMapIterator<QString, Variant> vit(headersMap);
-		while(vit.hasNext())
+		for(auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit)
 		{
-			vit.next();
-
-			QString key = vit.key();
-			Variant val = vit.value();
+			const QString &key = vit.key();
+			const Variant &val = vit.value();
 
 			if(typeId(val) == VariantType::ByteArray)
 			{
@@ -146,7 +143,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 				{
 					QByteArray name = makeMixedCaseHeader(key).toLatin1();
 
-					foreach(const Variant &v, vl)
+					for(const Variant &v : vl)
 					{
 						if(typeId(v) != VariantType::ByteArray)
 							return false;
@@ -167,13 +164,10 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 			return false;
 
 		VariantMap headersMap = doc.object().toVariantMap();
-		QMapIterator<QString, Variant> vit(headersMap);
-		while(vit.hasNext())
+		for(auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit)
 		{
-			vit.next();
-
-			QString key = vit.key();
-			Variant val = vit.value();
+			const QString &key = vit.key();
+			const Variant &val = vit.value();
 
 			if(typeId(val) == VariantType::String)
 			{
@@ -199,7 +193,7 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in)
 				{
 					QByteArray name = makeMixedCaseHeader(key).toLatin1();
 
-					foreach(const Variant &v, vl)
+					for(const Variant &v : vl)
 					{
 						if(typeId(v) != VariantType::String)
 							return false;

--- a/src/proxy/acceptrequest.cpp
+++ b/src/proxy/acceptrequest.cpp
@@ -288,7 +288,7 @@ static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
 				return AcceptRequest::ResponseData();
 			}
 
-			foreach(const Variant &i, vresponse["headers"].toList())
+			for(const Variant &i : vresponse["headers"].toList())
 			{
 				VariantList list = i.toList();
 				if(list.count() != 2)

--- a/src/proxy/inspectrequest.cpp
+++ b/src/proxy/inspectrequest.cpp
@@ -81,11 +81,8 @@ static InspectData resultToData(const Variant &in, bool *ok)
 		}
 
 		VariantHash vlastIds = obj["last-ids"].toHash();
-		QHashIterator<QString, Variant> it(vlastIds);
-		while(it.hasNext())
+		for(auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it)
 		{
-			it.next();
-
 			if(typeId(it.value()) != VariantType::ByteArray)
 			{
 				*ok = false;

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -945,7 +945,7 @@ private:
 
 			bool ok = true;
 			QList<QByteArray> ids;
-			foreach(const Variant &vid, vids)
+			for(const Variant &vid : vids)
 			{
 				if(typeId(vid) != VariantType::ByteArray)
 				{

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -509,7 +509,7 @@ private:
 		VariantHash vresponse = vaccept["response"].toHash();
 
 		acceptHeaders.clear();
-		foreach(const Variant &vheader, vresponse["headers"].toList())
+		for(const Variant &vheader : vresponse["headers"].toList())
 		{
 			VariantList h = vheader.toList();
 			acceptHeaders += HttpHeader(h[0].toByteArray(), h[1].toByteArray());

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -689,11 +689,8 @@ public:
 
 			VariantMap headersMap = doc.object().toVariantMap();
 
-			QMapIterator<QString, Variant> vit(headersMap);
-			while(vit.hasNext())
+			for(auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit)
 			{
-				vit.next();
-
 				if(typeId(vit.value()) != VariantType::String)
 				{
 					log_debug("requestsession: id=%s invalid _headers parameter, rejecting", rid.second.data());

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -407,7 +407,7 @@ public:
 
 			QList<Frame> frames;
 			int bytes = 0;
-			foreach(const Variant &vmessage, messages)
+			for(const Variant &vmessage : messages)
 			{
 				if(typeId(vmessage) != VariantType::String)
 				{
@@ -793,7 +793,7 @@ public:
 
 				QList<Frame> frames;
 				int bytes = 0;
-				foreach(const Variant &vmessage, messages)
+				for(const Variant &vmessage : messages)
 				{
 					if(typeId(vmessage) != VariantType::String)
 					{


### PR DESCRIPTION
#48320 mentions that iterating variant containers still involves working with types like `QHashIterator`. Qt's `foreach` macro is also used when looping over variant lists. This PR changes all variant iterator usage to STL-style (`begin()`/`end()`), and replaces all variant-related `foreach` loops with standard ranged `for` loops (i.e. `for(element : collection)`).

After this, all variant usage will be free of direct references to Qt, except for when working with APIs that specifically require `QVariant`, such as `QSettings` and `QJson`. And of course, custom variant types still require `Q_DECLARE_METATYPE`.