### PR TITLE
add Url type alias and use it everywhere, as preparation to migrate away from QUrl

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,6 +1,7 @@
 HEADERS += \
 	$$PWD/cowbytearray.h \
 	$$PWD/cowstring.h \
+	$$PWD/url.h \
 	$$PWD/variant.h
 
 HEADERS += \

--- a/src/core/httprequest.h
+++ b/src/core/httprequest.h
@@ -24,7 +24,7 @@
 #ifndef HTTPREQUEST_H
 #define HTTPREQUEST_H
 
-#include <QUrl>
+#include "url.h"
 #include <QHostAddress>
 #include "httpheaders.h"
 #include <boost/signals2.hpp>
@@ -61,7 +61,7 @@ public:
 	virtual void setTimeout(int msecs) = 0;
 	virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
-	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers) = 0;
+	virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers) = 0;
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) = 0;
 
 	// May call this multiple times
@@ -78,7 +78,7 @@ public:
 	virtual ErrorCondition errorCondition() const = 0;
 
 	virtual QString requestMethod() const = 0;
-	virtual QUrl requestUri() const = 0;
+	virtual Url requestUri() const = 0;
 	virtual HttpHeaders requestHeaders() const = 0;
 
 	virtual int responseCode() const = 0;

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -145,7 +145,7 @@ void logVariantWithContent(int level, const Variant &data, const QString &conten
 
 void logRequest(int level, const RequestData &data, const Config &config)
 {
-	QString msg = QString("%1 %2").arg(data.requestData.method, data.requestData.uri.toString(QUrl::FullyEncoded));
+	QString msg = QString("%1 %2").arg(data.requestData.method, data.requestData.uri.toString(Url::FullyEncoded));
 
 	if(!data.targetStr.isEmpty())
 		msg += QString(" -> %1").arg(data.targetStr);
@@ -156,9 +156,9 @@ void logRequest(int level, const RequestData &data, const Config &config)
 	if(config.fromAddress && !data.fromAddress.isNull())
 		msg += QString(" from=%1").arg(data.fromAddress.toString());
 
-	QUrl ref = QUrl(QString::fromUtf8(data.requestData.headers.get("Referer").asQByteArray()));
+	Url ref = Url(QString::fromUtf8(data.requestData.headers.get("Referer").asQByteArray()));
 	if(!ref.isEmpty())
-		msg += QString(" ref=%1").arg(ref.toString(QUrl::FullyEncoded));
+		msg += QString(" ref=%1").arg(ref.toString(Url::FullyEncoded));
 
 	if(!data.routeId.isEmpty())
 		msg += QString(" route=%1").arg(data.routeId);

--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -275,7 +275,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in)
 
 	if(!vrequestData.contains("uri") || typeId(vrequestData["uri"]) != VariantType::ByteArray)
 		return false;
-	requestData.uri = QUrl::fromEncoded(vrequestData["uri"].toByteArray(), QUrl::StrictMode);
+	requestData.uri = Url::fromEncoded(vrequestData["uri"].toByteArray(), Url::StrictMode);
 
 	requestData.headers.clear();
 	if(vrequestData.contains("headers"))

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -110,7 +110,7 @@ public:
 				return WsControlPacket();
 			}
 
-			msg.uri = QUrl::fromEncoded(getString(vitem, pn, "uri", false, &ok_, errorMessage).toUtf8(), QUrl::StrictMode);
+			msg.uri = Url::fromEncoded(getString(vitem, pn, "uri", false, &ok_, errorMessage).toUtf8(), Url::StrictMode);
 			if(!ok_)
 			{
 				if(ok)
@@ -321,7 +321,7 @@ bool WsControlPacket::fromVariant(const Variant &in)
 			if(typeId(vitem["uri"]) != VariantType::ByteArray)
 				return false;
 
-			item.uri = QUrl::fromEncoded(vitem["uri"].toByteArray(), QUrl::StrictMode);
+			item.uri = Url::fromEncoded(vitem["uri"].toByteArray(), Url::StrictMode);
 		}
 
 		if(vitem.contains("content-type"))

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -27,7 +27,7 @@
 #include <QByteArray>
 #include <QList>
 #include "variant.h"
-#include <QUrl>
+#include "url.h"
 
 class WsControlPacket
 {
@@ -55,7 +55,7 @@ public:
 		QByteArray cid;
 		Type type;
 		QByteArray requestId;
-		QUrl uri;
+		Url uri;
 		QByteArray contentType;
 		QByteArray message;
 		bool queue;

--- a/src/core/url.h
+++ b/src/core/url.h
@@ -1,9 +1,5 @@
 /*
- * Copyright (C) 2012-2013 Fanout, Inc.
- *
- * This file is part of Pushpin.
- *
- * $FANOUT_BEGIN_LICENSE:APACHE2$
+ * Copyright (C) 2026 Fastly, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * $FANOUT_END_LICENSE$
  */
 
-#ifndef HTTPREQUESTDATA_H
-#define HTTPREQUESTDATA_H
+#ifndef URL_H
+#define URL_H
 
-#include "../httpheaders.h"
-#include "url.h"
+#include <QUrl>
 
-class HttpRequestData
-{
-public:
-	QString method;
-	Url uri;
-	HttpHeaders headers;
-	QByteArray body;
-};
+// Type alias for URL handling - this will be replaced with a custom implementation later
+using Url = QUrl;
 
-#endif
+#endif // URL_H

--- a/src/core/websocket.h
+++ b/src/core/websocket.h
@@ -24,7 +24,7 @@
 #ifndef WEBSOCKET_H
 #define WEBSOCKET_H
 
-#include <QUrl>
+#include "url.h"
 #include <QHostAddress>
 #include "httpheaders.h"
 #include <boost/signals2.hpp>
@@ -89,13 +89,13 @@ public:
 	virtual void setIgnoreTlsErrors(bool on) = 0;
 	virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
-	virtual void start(const QUrl &uri, const HttpHeaders &headers) = 0;
+	virtual void start(const Url &uri, const HttpHeaders &headers) = 0;
 
 	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers) = 0;
 	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body) = 0;
 
 	virtual State state() const = 0;
-	virtual QUrl requestUri() const = 0;
+	virtual Url requestUri() const = 0;
 	virtual HttpHeaders requestHeaders() const = 0;
 	virtual int responseCode() const = 0;
 	virtual QByteArray responseReason() const = 0;

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -1285,14 +1285,14 @@ void ZhttpManager::unregisterKeepAlive(ZWebSocket *sock)
 	d->unregisterKeepAlive(sock);
 }
 
-int ZhttpManager::estimateRequestHeaderBytes(const QString &method, const QUrl &uri, const HttpHeaders &headers)
+int ZhttpManager::estimateRequestHeaderBytes(const QString &method, const Url &uri, const HttpHeaders &headers)
 {
 	int total = method.toUtf8().length();
 
-	total += uri.path(QUrl::FullyEncoded).length();
+	total += uri.path(Url::FullyEncoded).length();
 
 	if(uri.hasQuery())
-		total += uri.query(QUrl::FullyEncoded).length() + 1; // +1 for question mark
+		total += uri.query(Url::FullyEncoded).length() + 1; // +1 for question mark
 
 	foreach(const HttpHeader &h, headers)
 	{

--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -27,6 +27,7 @@
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include <boost/signals2.hpp>
+#include "url.h"
 
 using Signal = boost::signals2::signal<void()>;
 
@@ -69,7 +70,7 @@ public:
 	// For server mode, jump directly to responding state
 	ZhttpRequest *createRequestFromState(const ZhttpRequest::ServerState &state);
 
-	static int estimateRequestHeaderBytes(const QString &method, const QUrl &uri, const HttpHeaders &headers);
+	static int estimateRequestHeaderBytes(const QString &method, const Url &uri, const HttpHeaders &headers);
 	static int estimateResponseHeaderBytes(int code, const QByteArray &reason, const HttpHeaders &headers);
 
 	Signal requestReady;

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -78,7 +78,7 @@ public:
 	bool sendBodyAfterAck;
 	Variant passthrough;
 	QString requestMethod;
-	QUrl requestUri;
+	Url requestUri;
 	HttpHeaders requestHeaders;
 	BufferList requestBodyBuf;
 	int inSeq;
@@ -1266,7 +1266,7 @@ void ZhttpRequest::setQuiet(bool on)
 	d->quiet = on;
 }
 
-void ZhttpRequest::start(const QString &method, const QUrl &uri, const HttpHeaders &headers)
+void ZhttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers)
 {
 	assert(!d->server);
 
@@ -1380,7 +1380,7 @@ QString ZhttpRequest::requestMethod() const
 	return d->requestMethod;
 }
 
-QUrl ZhttpRequest::requestUri() const
+Url ZhttpRequest::requestUri() const
 {
 	return d->requestUri;
 }

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -27,6 +27,7 @@
 #include "variant.h"
 #include "httprequest.h"
 #include <boost/signals2.hpp>
+#include "url.h"
 
 #define TIMERS_PER_ZHTTPREQUEST 3
 
@@ -48,7 +49,7 @@ public:
 		Rid rid;
 		QHostAddress peerAddress;
 		QString requestMethod;
-		QUrl requestUri;
+		Url requestUri;
 		HttpHeaders requestHeaders;
 		QByteArray requestBody;
 		int responseCode;
@@ -94,7 +95,7 @@ public:
 	virtual void setTimeout(int msecs);
 	virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers);
+	virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
 
 	virtual void writeBody(const QByteArray &body);
@@ -110,7 +111,7 @@ public:
 	virtual ErrorCondition errorCondition() const;
 
 	virtual QString requestMethod() const;
-	virtual QUrl requestUri() const;
+	virtual Url requestUri() const;
 	virtual HttpHeaders requestHeaders() const;
 
 	virtual int responseCode() const;

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -361,7 +361,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in)
 		if(typeId(obj["uri"]) != VariantType::ByteArray)
 			return false;
 
-		uri = QUrl::fromEncoded(obj["uri"].toByteArray(), QUrl::StrictMode);
+		uri = Url::fromEncoded(obj["uri"].toByteArray(), Url::StrictMode);
 	}
 
 	headers.clear();

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -22,7 +22,7 @@
 #ifndef ZHTTPREQUESTPACKET_H
 #define ZHTTPREQUESTPACKET_H
 
-#include <QUrl>
+#include "url.h"
 #include <QHostAddress>
 #include "cowstring.h"
 #include "cowbytearray.h"
@@ -78,7 +78,7 @@ public:
 	int timeout;
 
 	CowString method;
-	QUrl uri;
+	Url uri;
 	HttpHeaders headers;
 	CowByteArray body;
 

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -64,7 +64,7 @@ public:
 	bool ignoreTlsErrors;
 	QString clientCert;
 	QString clientKey;
-	QUrl requestUri;
+	Url requestUri;
 	HttpHeaders requestHeaders;
 	int inSeq;
 	int outSeq;
@@ -1134,7 +1134,7 @@ void ZWebSocket::setClientCert(const QString &cert, const QString &key)
 	d->clientKey = key;
 }
 
-void ZWebSocket::start(const QUrl &uri, const HttpHeaders &headers)
+void ZWebSocket::start(const Url &uri, const HttpHeaders &headers)
 {
 	assert(!d->server);
 
@@ -1189,7 +1189,7 @@ WebSocket::State ZWebSocket::state() const
 	}
 }
 
-QUrl ZWebSocket::requestUri() const
+Url ZWebSocket::requestUri() const
 {
 	return d->requestUri;
 }

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -26,6 +26,7 @@
 
 #include "websocket.h"
 #include <boost/signals2.hpp>
+#include "url.h"
 
 using Connection = boost::signals2::scoped_connection;
 
@@ -55,13 +56,13 @@ public:
 	virtual void setIgnoreTlsErrors(bool on);
 	virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QUrl &uri, const HttpHeaders &headers);
+	virtual void start(const Url &uri, const HttpHeaders &headers);
 
 	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
 	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
 
 	virtual State state() const;
-	virtual QUrl requestUri() const;
+	virtual Url requestUri() const;
 	virtual HttpHeaders requestHeaders() const;
 	virtual int responseCode() const;
 	virtual QByteArray responseReason() const;

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -350,7 +350,7 @@ class HttpFilterInner
 public:
 	HttpFilter::Mode mode;
 	std::unique_ptr<ZhttpRequest> req;
-	QUrl uri;
+	Url uri;
 	HttpHeaders headers;
 	QByteArray origContent;
 	bool haveResponseHeader;
@@ -366,7 +366,7 @@ public:
 	{
 	}
 
-	void setup(ZhttpManager *zhttpOut, const QUrl &_uri, const HttpHeaders &_headers, const Variant &passthroughData, const QByteArray &content, int _responseSizeMax)
+	void setup(ZhttpManager *zhttpOut, const Url &_uri, const HttpHeaders &_headers, const Variant &passthroughData, const QByteArray &content, int _responseSizeMax)
 	{
 		uri = _uri;
 		headers = _headers;
@@ -528,7 +528,7 @@ HttpFilter::HttpFilter(Mode mode)
 
 void HttpFilter::start(const Filter::Context &context, const QByteArray &content)
 {
-	QUrl url = QUrl(context.subscriptionMeta.value("url"), QUrl::StrictMode);
+	Url url = Url(context.subscriptionMeta.value("url"), Url::StrictMode);
 	if(!url.isValid())
 	{
 		Result r;
@@ -537,13 +537,13 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 		return;
 	}
 
-	QUrl currentUri = context.currentUri;
+	Url currentUri = context.currentUri;
 	if(currentUri.scheme() == "wss")
 		currentUri.setScheme("https");
 	else if(currentUri.scheme() == "ws")
 		currentUri.setScheme("http");
 
-	QUrl destUri = currentUri.resolved(url);
+	Url destUri = currentUri.resolved(url);
 
 	int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
 	int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -27,7 +27,7 @@
 #include <QString>
 #include <QStringList>
 #include <QHash>
-#include <QUrl>
+#include "url.h"
 #include <boost/signals2.hpp>
 #include "zhttprequest.h"
 #include "ratelimiter.h"
@@ -65,7 +65,7 @@ public:
 
 		// For network access
 		ZhttpManager *zhttpOut;
-		QUrl currentUri;
+		Url currentUri;
 		QString route;
 		bool trusted;
 		std::shared_ptr<RateLimiter> limiter;

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -111,7 +111,7 @@ public:
 			return;
 		}
 
-		QUrl uri = req->requestUri();
+		Url uri = req->requestUri();
 		QByteArray body = req->readBody();
 
 		if(uri.path() == "/filter/accept")

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -150,7 +150,7 @@ public:
 				return;
 			}
 
-			requestData.uri = QUrl(args["uri"].toString(), QUrl::StrictMode);
+			requestData.uri = Url(args["uri"].toString(), Url::StrictMode);
 			if(!requestData.uri.isValid())
 			{
 				respondError("bad-request");
@@ -229,7 +229,7 @@ public:
 			{
 				// Determine session info
 
-				auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(QUrl::FullyEncoded).toUtf8()));
+				auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(Url::FullyEncoded).toUtf8()));
 
 				// Safe to not track, since d can't outlive this
 				d->finished.connect(boost::bind(&InspectWorker::sessionDetectRulesGet_finished, this, d.get(), boost::placeholders::_1));
@@ -265,7 +265,7 @@ private:
 			// considered is because it may vary per client and Grip-Last
 			// supersedes whatever is in the query
 
-			QUrl uri = requestData.uri;
+			Url uri = requestData.uri;
 			uri.setQuery(QString()); // Remove the query part
 
 			QList<QByteArray> gripLastHeaders = requestData.headers.getAll("Grip-Last").asQByteArrayList();
@@ -319,7 +319,7 @@ private:
 				if(!rule.jsonParam.isEmpty())
 				{
 					QUrlQuery tmp(QString::fromUtf8(requestData.body));
-					jsonData = tmp.queryItemValue(rule.jsonParam, QUrl::FullyDecoded).toUtf8();
+					jsonData = tmp.queryItemValue(rule.jsonParam, Url::FullyDecoded).toUtf8();
 				}
 				else
 				{
@@ -856,7 +856,7 @@ private:
 		if(!rd.contains("uri") || typeId(rd["uri"]) != VariantType::ByteArray)
 			return HttpRequestData();
 
-		out.uri = QUrl(rd["uri"].toString(), QUrl::StrictMode);
+		out.uri = Url(rd["uri"].toString(), Url::StrictMode);
 		if(!out.uri.isValid())
 			return HttpRequestData();
 
@@ -2668,7 +2668,7 @@ private:
 						stats->addSubscription("ws", channel, cs.wsSessionsByChannel.value(channel).count());
 						addSub(channel);
 
-						log_info("subscribe %s channel=%s", qPrintable(s->requestData.uri.toString(QUrl::FullyEncoded)), qPrintable(channel));
+						log_info("subscribe %s channel=%s", qPrintable(s->requestData.uri.toString(Url::FullyEncoded)), qPrintable(channel));
 					}
 					else
 					{
@@ -2805,7 +2805,7 @@ private:
 				stats->addSubscription("ws", channel, cs.wsSessionsByChannel.value(channel).count());
 				addSub(channel);
 
-				log_info("subscribe %s channel=%s", qPrintable(s->requestData.uri.toString(QUrl::FullyEncoded)), qPrintable(channel));
+				log_info("subscribe %s channel=%s", qPrintable(s->requestData.uri.toString(Url::FullyEncoded)), qPrintable(channel));
 			}
 			else if(item.type == WsControlPacket::Item::Ack)
 			{
@@ -3098,7 +3098,7 @@ private:
 		stats->addSubscription(modeStr, channel, sessionsByChannel->value(channel).count());
 		addSub(channel);
 
-		QString msg = QString("subscribe %1 channel=%2").arg(hs->requestUri().toString(QUrl::FullyEncoded), channel);
+		QString msg = QString("subscribe %1 channel=%2").arg(hs->requestUri().toString(Url::FullyEncoded), channel);
 		if(hs->isRetry())
 			msg += " retry";
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -258,7 +258,7 @@ public:
 		zresp.code = 200;
 		zresp.reason = "OK";
 
-		QByteArray encPath = zreq.uri.path(QUrl::FullyEncoded).toUtf8();
+		QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
 
 		zresp.headers += HttpHeader("Content-Type", "text/plain");
 		zresp.body = "this is what's next\n";

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -177,9 +177,9 @@ public:
 	int sentOutReqData;
 	int retries;
 	QString errorMessage;
-	QUrl currentUri;
-	QUrl nextUri;
-	QUrl goneUri;
+	Url currentUri;
+	Url nextUri;
+	Url goneUri;
 	bool needUpdate;
 	Priority needUpdatePriority;
 	UpdateAction *pendingAction;
@@ -1134,7 +1134,7 @@ private:
 		finishedCallback.call({q});
 	}
 
-	void prepareOutReq(const QUrl &destUri, bool autoShare = false)
+	void prepareOutReq(const Url &destUri, bool autoShare = false)
 	{
 		haveOutReqHeaders = false;
 		sentOutReqData = 0;
@@ -1344,7 +1344,7 @@ private:
 		}
 	}
 
-	void logRequest(const QString &method, const QUrl &uri, const HttpHeaders &headers, int code, int bodySize)
+	void logRequest(const QString &method, const Url &uri, const HttpHeaders &headers, int code, int bodySize)
 	{
 		LogUtil::RequestData rd;
 
@@ -1364,7 +1364,7 @@ private:
 		LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
 	}
 
-	void logRequestError(const QString &method, const QUrl &uri, const HttpHeaders &headers)
+	void logRequestError(const QString &method, const Url &uri, const HttpHeaders &headers)
 	{
 		LogUtil::RequestData rd;
 
@@ -1697,7 +1697,7 @@ ZhttpRequest::Rid HttpSession::rid() const
 	return d->req->rid();
 }
 
-QUrl HttpSession::requestUri() const
+Url HttpSession::requestUri() const
 {
 	return d->req->requestUri();
 }

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -33,6 +33,7 @@
 #include "instruct.h"
 #include "filter.h"
 #include "clientsession.h"
+#include "url.h"
 
 // Each session can have a bunch of timers:
 // incoming request
@@ -97,7 +98,7 @@ public:
 
 	Instruct::HoldMode holdMode() const;
 	ZhttpRequest::Rid rid() const;
-	QUrl requestUri() const;
+	Url requestUri() const;
 	bool isRetry() const;
 	QString statsRoute() const;
 	QString sid() const;

--- a/src/handler/httpsessionupdatemanager.cpp
+++ b/src/handler/httpsessionupdatemanager.cpp
@@ -23,7 +23,7 @@
 
 #include "httpsessionupdatemanager.h"
 
-#include <QUrl>
+#include "url.h"
 #include "timer.h"
 #include "defercall.h"
 #include "httpsession.h"
@@ -34,14 +34,14 @@ public:
 	class Bucket
 	{
 	public:
-		QPair<int, QUrl> key;
+		QPair<int, Url> key;
 		QSet<HttpSession*> sessions;
 		QSet<HttpSession*> deferredSessions;
 		std::unique_ptr<Timer> timer;
 	};
 
 	HttpSessionUpdateManager *q;
-	QHash<QPair<int, QUrl>, Bucket*> buckets;
+	QHash<QPair<int, Url>, Bucket*> buckets;
 	QHash<Timer*, Bucket*> bucketsByTimer;
 	QHash<HttpSession*, Bucket*> bucketsBySession;
 
@@ -65,11 +65,11 @@ public:
 		delete bucket;
 	}
 
-	void registerSession(HttpSession *hs, int timeout, const QUrl &uri, bool resetTimeout)
+	void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout)
 	{
-		QUrl tmp = uri;
+		Url tmp = uri;
 		tmp.setQuery(QString()); // Remove the query part
-		QPair<int, QUrl> key(timeout, tmp);
+		QPair<int, Url> key(timeout, tmp);
 
 		Bucket *bucket = buckets.value(key);
 		if(bucket)
@@ -169,7 +169,7 @@ HttpSessionUpdateManager::~HttpSessionUpdateManager()
 	delete d;
 }
 
-void HttpSessionUpdateManager::registerSession(HttpSession *hs, int timeout, const QUrl &uri, bool resetTimeout)
+void HttpSessionUpdateManager::registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout)
 {
 	d->registerSession(hs, timeout, uri, resetTimeout);
 }

--- a/src/handler/httpsessionupdatemanager.h
+++ b/src/handler/httpsessionupdatemanager.h
@@ -24,9 +24,9 @@
 #ifndef HTTPSESSIONUPDATEMANAGER_H
 #define HTTPSESSIONUPDATEMANAGER_H
 
-#define TIMERS_PER_UNIQUE_UPDATE_REGISTRATION 1
+#include "url.h"
 
-class QUrl;
+#define TIMERS_PER_UNIQUE_UPDATE_REGISTRATION 1
 class HttpSession;
 
 class HttpSessionUpdateManager
@@ -36,7 +36,7 @@ public:
 	~HttpSessionUpdateManager();
 
 	// No-op if session already registered and resetTimeout=false
-	void registerSession(HttpSession *hs, int timeout, const QUrl &uri, bool resetTimeout = false);
+	void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout = false);
 
 	void unregisterSession(HttpSession *hs);
 

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -292,9 +292,9 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 		newResponse.reason = reason;
 	}
 
-	QUrl nextLink;
+	Url nextLink;
 	int nextLinkTimeout = -1;
-	QUrl goneLink;
+	Url goneLink;
 	foreach(const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link"))
 	{
 		if(params.count() < 2)
@@ -307,7 +307,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
 			return Instruct();
 		}
 
-		QUrl link = QUrl::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
+		Url link = Url::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
 		if(!link.isValid())
 		{
 			setError(ok, errorMessage, "Grip-Link contains invalid link");

--- a/src/handler/instruct.h
+++ b/src/handler/instruct.h
@@ -28,8 +28,8 @@
 #include <QByteArray>
 #include <QList>
 #include <QHash>
-#include <QUrl>
 #include "packet/httpresponsedata.h"
+#include "url.h"
 
 class Instruct
 {
@@ -65,9 +65,9 @@ public:
 	int keepAliveTimeout;
 	QHash<QString, QString> meta;
 	HttpResponseData response;
-	QUrl nextLink;
+	Url nextLink;
 	int nextLinkTimeout;
-	QUrl goneLink;
+	Url goneLink;
 
 	Instruct() :
 		holdMode(NoHold),

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -2519,7 +2519,7 @@ public:
 			}
 
 			QByteArray uriRaw = scheme + "://" + host + mreq.uri;
-			QUrl uri = QUrl::fromEncoded(uriRaw, QUrl::TolerantMode);
+			Url uri = Url::fromEncoded(uriRaw, Url::TolerantMode);
 			if(!uri.isValid())
 			{
 				log_warning("m2: invalid constructed uri: [%s]", uriRaw.data());

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -561,7 +561,7 @@ public:
 			}
 
 			DomainMap::Target target;
-			QUrl uri = req->requestUri();
+			Url uri = req->requestUri();
 			bool isHttps = (uri.scheme() == "https");
 			target.connectHost = uri.host();
 			target.connectPort = uri.port(isHttps ? 443 : 80);
@@ -619,14 +619,14 @@ public:
 		if(config.acceptXForwardedProto && isXForwardedProtocolTls(sock->requestHeaders()))
 			sock->setIsTls(true);
 
-		QUrl requestUri = sock->requestUri();
+		Url requestUri = sock->requestUri();
 
 		log_debug("worker %d: IN ws id=%s, %s", config.id, sock->rid().second.data(), requestUri.toEncoded().data());
 
 		bool isSecure = (requestUri.scheme() == "wss");
 		QString host = requestUri.host();
 
-		QByteArray encPath = requestUri.path(QUrl::FullyEncoded).toUtf8();
+		QByteArray encPath = requestUri.path(Url::FullyEncoded).toUtf8();
 
 		QString routeId;
 

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -366,7 +366,7 @@ private:
 		zresp.code = 200;
 		zresp.reason = "OK";
 
-		QByteArray encPath = zreq.uri.path(QUrl::FullyEncoded).toUtf8();
+		QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
 
 		QUrlQuery query(zreq.uri.query());
 		QString hold = query.queryItemValue("hold");

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -25,7 +25,7 @@
 
 #include <assert.h>
 #include <QSet>
-#include <QUrl>
+#include "url.h"
 #include <QHostAddress>
 #include "packet/statspacket.h"
 #include "packet/httprequestdata.h"
@@ -279,7 +279,7 @@ public:
 			if(!route.asHost.isEmpty())
 				ProxyUtil::applyHost(&requestData.uri, route.asHost);
 
-			QByteArray path = requestData.uri.path(QUrl::FullyEncoded).toUtf8();
+			QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
 
 			if(route.pathRemove > 0)
 				path = path.mid(route.pathRemove);
@@ -287,7 +287,7 @@ public:
 			if(!route.pathPrepend.isEmpty())
 				path = route.pathPrepend + path;
 
-			requestData.uri.setPath(QString::fromUtf8(path), QUrl::StrictMode);
+			requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
 
 			QByteArray sigIss = defaultSigIss;
 			Jwt::EncodingKey sigKey = defaultSigKey;
@@ -406,7 +406,7 @@ public:
 			}
 		}
 
-		QUrl uri = requestData.uri;
+		Url uri = requestData.uri;
 		if(target.ssl)
 			uri.setScheme("https");
 		else
@@ -431,7 +431,7 @@ public:
 					--pathRemove;
 
 				if(pathRemove > 0)
-					uri.setPath(uri.path(QUrl::FullyEncoded).mid(pathRemove));
+					uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
 			}
 
 			zhttpRequest = std::make_unique<TestHttpRequest>();

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -236,7 +236,7 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
 		requestData->headers += HttpHeader("X-Forwarded-For", HttpHeaders::join(xffValues));
 }
 
-void applyHost(QUrl *url, const QString &host)
+void applyHost(Url *url, const QString &host)
 {
 	int at = host.indexOf(':');
 	if(at != -1)
@@ -251,7 +251,7 @@ void applyHost(QUrl *url, const QString &host)
 	}
 }
 
-void applyHostHeader(HttpHeaders *headers, const QUrl &uri)
+void applyHostHeader(HttpHeaders *headers, const Url &uri)
 {
 	QByteArray hostHeader = uri.host().toUtf8();
 	if(uri.port() != -1)

--- a/src/proxy/proxyutil.h
+++ b/src/proxy/proxyutil.h
@@ -29,6 +29,7 @@
 #include "packet/httprequestdata.h"
 #include "domainmap.h"
 #include "xffrule.h"
+#include "url.h"
 
 namespace Jwt {
     class EncodingKey;
@@ -43,9 +44,9 @@ bool checkTrustedClient(const char *logprefix, void *object, const HttpRequestDa
 
 void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestData *requestData, bool trustedClient, const DomainMap::Entry &entry, const QByteArray &sigIss, const Jwt::EncodingKey &sigKey, bool acceptXForwardedProtocol, bool useXForwardedProto, bool useXForwardedProtocol, const XffRule &xffTrustedRule, const XffRule &xffRule, const QList<QByteArray> &origHeadersNeedMark, bool acceptPushpinRoute, const QByteArray &cdnLoop, const QHostAddress &peerAddress, const InspectData &idata, bool gripEnabled, bool intReq);
 
-void applyHost(QUrl *url, const QString &host);
+void applyHost(Url *url, const QString &host);
 
-void applyHostHeader(HttpHeaders *headers, const QUrl &uri);
+void applyHostHeader(HttpHeaders *headers, const Url &uri);
 void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers, const QByteArray &sigIss, const Jwt::EncodingKey &sigKey);
 
 QString targetToString(const DomainMap::Target &target);

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -24,7 +24,7 @@
 #include "requestsession.h"
 
 #include <assert.h>
-#include <QUrl>
+#include "url.h"
 #include <QHostAddress>
 #include <QUrlQuery>
 #include <QJsonDocument>
@@ -291,7 +291,7 @@ public:
 
 		if(route.isNull() && domainMap)
 		{
-			QByteArray encPath = requestData.uri.path(QUrl::FullyEncoded).toUtf8();
+			QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
 
 			// Look up the route
 			if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
@@ -403,7 +403,7 @@ public:
 		bool isHttps = (requestData.uri.scheme() == "https");
 		QString host = requestData.uri.host();
 
-		QByteArray encPath = requestData.uri.path(QUrl::FullyEncoded).toUtf8();
+		QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
 
 		// Look up the route
 		if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
@@ -630,7 +630,7 @@ public:
 		if(!config.bodyParam.isEmpty())
 			bodyParam = QString::fromUtf8(config.bodyParam);
 
-		QUrl uri = requestData.uri;
+		Url uri = requestData.uri;
 		QUrlQuery query(uri);
 
 		// Two ways to activate JSON-P:
@@ -645,7 +645,7 @@ public:
 		QByteArray callback;
 		if(query.hasQueryItem(callbackParam))
 		{
-			callback = parsePercentEncoding(query.queryItemValue(callbackParam, QUrl::FullyEncoded).toUtf8());
+			callback = parsePercentEncoding(query.queryItemValue(callbackParam, Url::FullyEncoded).toUtf8());
 			if(callback.isEmpty())
 			{
 				log_debug("requestsession: id=%s invalid callback parameter, rejecting", rid.second.data());
@@ -662,7 +662,7 @@ public:
 		QString method;
 		if(query.hasQueryItem("_method"))
 		{
-			method = QString::fromLatin1(parsePercentEncoding(query.queryItemValue("_method", QUrl::FullyEncoded).toUtf8()));
+			method = QString::fromLatin1(parsePercentEncoding(query.queryItemValue("_method", Url::FullyEncoded).toUtf8()));
 			if(!validMethod(method))
 			{
 				log_debug("requestsession: id=%s invalid _method parameter, rejecting", rid.second.data());
@@ -678,7 +678,7 @@ public:
 		if(query.hasQueryItem("_headers"))
 		{
 			QJsonParseError e;
-			QJsonDocument doc = QJsonDocument::fromJson(parsePercentEncoding(query.queryItemValue("_headers", QUrl::FullyEncoded).toUtf8()), &e);
+			QJsonDocument doc = QJsonDocument::fromJson(parsePercentEncoding(query.queryItemValue("_headers", Url::FullyEncoded).toUtf8()), &e);
 			if(e.error != QJsonParseError::NoError || !doc.isObject())
 			{
 				log_debug("requestsession: id=%s invalid _headers parameter, rejecting", rid.second.data());
@@ -718,7 +718,7 @@ public:
 		{
 			if(query.hasQueryItem(bodyParam))
 			{
-				body = parsePercentEncoding(query.queryItemValue(bodyParam, QUrl::FullyEncoded).toUtf8());
+				body = parsePercentEncoding(query.queryItemValue(bodyParam, Url::FullyEncoded).toUtf8());
 				if(body.isNull())
 				{
 					log_debug("requestsession: id=%s invalid body parameter, rejecting", rid.second.data());
@@ -759,7 +759,7 @@ public:
 			if(tmp.length() > 0 && tmp[tmp.length() - 1] == '?')
 			{
 				tmp.truncate(tmp.length() - 1);
-				uri = QUrl::fromEncoded(tmp, QUrl::StrictMode);
+				uri = Url::fromEncoded(tmp, Url::StrictMode);
 			}
 		}
 

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -92,7 +92,7 @@ public:
 		BufferList reqBody;
 		QByteArray path;
 		QByteArray jsonpCallback;
-		QUrl asUri;
+		Url asUri;
 		DomainMap::Entry route;
 		QByteArray sid;
 		QByteArray lastPart;
@@ -220,9 +220,9 @@ public:
 		Session *s = new Session(this);
 		s->req = req;
 
-		QUrl uri = req->requestUri();
+		Url uri = req->requestUri();
 
-		QByteArray encPath = uri.path(QUrl::FullyEncoded).toUtf8();
+		QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
 		s->path = encPath.mid(basePathStart);
 
 		QUrlQuery query(uri);
@@ -245,9 +245,9 @@ public:
 		s->asUri = uri;
 		s->asUri.setScheme((s->asUri.scheme() == "https") ? "wss" : "ws");
 		if(!asPath.isEmpty())
-			s->asUri.setPath(QString::fromUtf8(asPath), QUrl::StrictMode);
+			s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
 		else
-			s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart)), QUrl::StrictMode);
+			s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart)), Url::StrictMode);
 
 		s->route = route;
 
@@ -268,13 +268,13 @@ public:
 		Session *s = new Session(this);
 		s->sock = sock;
 
-		QByteArray encPath = sock->requestUri().path(QUrl::FullyEncoded).toUtf8();
+		QByteArray encPath = sock->requestUri().path(Url::FullyEncoded).toUtf8();
 		s->path = encPath.mid(basePathStart);
 		s->asUri = sock->requestUri();
 		if(!asPath.isEmpty())
-			s->asUri.setPath(QString::fromUtf8(asPath), QUrl::StrictMode);
+			s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
 		else
-			s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart) + "/websocket"), QUrl::StrictMode);
+			s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart) + "/websocket"), Url::StrictMode);
 		s->route = route;
 
 		wsConnectionMap[sock] = {

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -380,9 +380,9 @@ public:
 						if(at == -1)
 							continue;
 
-						if(QUrl::fromPercentEncoding(kv.mid(0, at)) == "d")
+						if(Url::fromPercentEncoding(kv.mid(0, at)) == "d")
 						{
-							param = QUrl::fromPercentEncoding(kv.mid(at + 1)).toUtf8();
+							param = Url::fromPercentEncoding(kv.mid(at + 1)).toUtf8();
 							break;
 						}
 					}
@@ -1181,7 +1181,7 @@ void SockJsSession::setClientCert(const QString &cert, const QString &key)
 	assert(0);
 }
 
-void SockJsSession::start(const QUrl &uri, const HttpHeaders &headers)
+void SockJsSession::start(const Url &uri, const HttpHeaders &headers)
 {
 	Q_UNUSED(uri);
 	Q_UNUSED(headers);
@@ -1205,7 +1205,7 @@ WebSocket::State SockJsSession::state() const
 	return d->state;
 }
 
-QUrl SockJsSession::requestUri() const
+Url SockJsSession::requestUri() const
 {
 	return d->requestData.uri;
 }
@@ -1304,7 +1304,7 @@ void SockJsSession::close(int code, const QString &reason)
 	d->close(code, reason);
 }
 
-void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const QUrl &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route)
+void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route)
 {
 	d->manager = manager;
 	d->mode = Private::Http;
@@ -1325,7 +1325,7 @@ void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req, const
 	d->setup();
 }
 
-void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const QUrl &asUri, const DomainMap::Entry &route)
+void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const DomainMap::Entry &route)
 {
 	d->manager = manager;
 	d->mode = Private::WebSocketPassthrough;
@@ -1338,7 +1338,7 @@ void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const 
 	d->setup();
 }
 
-void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const QUrl &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route)
+void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route)
 {
 	Q_UNUSED(lastPart);
 

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -24,7 +24,7 @@
 #ifndef SOCKJSSESSION_H
 #define SOCKJSSESSION_H
 
-#include <QUrl>
+#include "url.h"
 #include <QHostAddress>
 #include "httpheaders.h"
 #include "websocket.h"
@@ -58,13 +58,13 @@ public:
 	virtual void setIgnoreTlsErrors(bool on);
 	virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QUrl &uri, const HttpHeaders &headers);
+	virtual void start(const Url &uri, const HttpHeaders &headers);
 
 	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
 	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
 
 	virtual State state() const;
-	virtual QUrl requestUri() const;
+	virtual Url requestUri() const;
 	virtual HttpHeaders requestHeaders() const;
 	virtual int responseCode() const;
 	virtual QByteArray responseReason() const;
@@ -87,9 +87,9 @@ private:
 
 	friend class SockJsManager;
 	SockJsSession();
-	void setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const QUrl &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route);
-	void setupServer(SockJsManager *manager, ZWebSocket *sock, const QUrl &asUri, const DomainMap::Entry &route);
-	void setupServer(SockJsManager *manager, ZWebSocket *sock, const QUrl &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route);
+	void setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route);
+	void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const DomainMap::Entry &route);
+	void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route);
 
 	void startServer();
 	void handleRequest(ZhttpRequest *req, const QByteArray &jsonpCallback, const QByteArray &lastPart, const QByteArray &body);

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -191,7 +191,7 @@ void TestHttpRequest::setClientCert(const QString &cert, const QString &key)
 	Q_UNUSED(key);
 }
 
-void TestHttpRequest::start(const QString &method, const QUrl &uri, const HttpHeaders &headers)
+void TestHttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers)
 {
 	assert(d->state == Private::Idle);
 
@@ -287,7 +287,7 @@ QString TestHttpRequest::requestMethod() const
 	return d->request.method;
 }
 
-QUrl TestHttpRequest::requestUri() const
+Url TestHttpRequest::requestUri() const
 {
 	return d->request.uri;
 }

--- a/src/proxy/testhttprequest.h
+++ b/src/proxy/testhttprequest.h
@@ -24,6 +24,7 @@
 #define TESTHTTPREQUEST_H
 
 #include "httprequest.h"
+#include "url.h"
 
 /// HTTP request instance for testing that simulates HTTP behavior
 class TestHttpRequest : public HttpRequest
@@ -47,7 +48,7 @@ public:
 	virtual void setTimeout(int msecs);
 	virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QString &method, const QUrl &uri, const HttpHeaders &headers);
+	virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
 	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
 
 	virtual void writeBody(const QByteArray &body);
@@ -63,7 +64,7 @@ public:
 	virtual ErrorCondition errorCondition() const;
 
 	virtual QString requestMethod() const;
-	virtual QUrl requestUri() const;
+	virtual Url requestUri() const;
 	virtual HttpHeaders requestHeaders() const;
 
 	virtual int responseCode() const;

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -199,7 +199,7 @@ void TestWebSocket::setClientCert(const QString &cert, const QString &key)
 	Q_UNUSED(key);
 }
 
-void TestWebSocket::start(const QUrl &uri, const HttpHeaders &headers)
+void TestWebSocket::start(const Url &uri, const HttpHeaders &headers)
 {
 	d->request.uri = uri;
 	d->request.headers = headers;
@@ -241,7 +241,7 @@ WebSocket::State TestWebSocket::state() const
 		return Closing;
 }
 
-QUrl TestWebSocket::requestUri() const
+Url TestWebSocket::requestUri() const
 {
 	return d->request.uri;
 }

--- a/src/proxy/testwebsocket.h
+++ b/src/proxy/testwebsocket.h
@@ -25,6 +25,7 @@
 #define TESTWEBSOCKET_H
 
 #include "websocket.h"
+#include "url.h"
 
 class ZhttpManager;
 
@@ -46,13 +47,13 @@ public:
 	virtual void setIgnoreTlsErrors(bool on);
 	virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QUrl &uri, const HttpHeaders &headers);
+	virtual void start(const Url &uri, const HttpHeaders &headers);
 
 	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
 	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
 
 	virtual State state() const;
-	virtual QUrl requestUri() const;
+	virtual Url requestUri() const;
 	virtual HttpHeaders requestHeaders() const;
 	virtual int responseCode() const;
 	virtual QByteArray responseReason() const;

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -1124,7 +1124,7 @@ void WebSocketOverHttp::setClientCert(const QString &cert, const QString &key)
 	d->clientKey = key;
 }
 
-void WebSocketOverHttp::start(const QUrl &uri, const HttpHeaders &headers)
+void WebSocketOverHttp::start(const Url &uri, const HttpHeaders &headers)
 {
 	assert(d->state == Idle);
 
@@ -1161,7 +1161,7 @@ WebSocket::State WebSocketOverHttp::state() const
 	return d->state;
 }
 
-QUrl WebSocketOverHttp::requestUri() const
+Url WebSocketOverHttp::requestUri() const
 {
 	return d->requestData.uri;
 }

--- a/src/proxy/websocketoverhttp.h
+++ b/src/proxy/websocketoverhttp.h
@@ -25,6 +25,7 @@
 #define WEBSOCKETOVERHTTP_H
 
 #include "websocket.h"
+#include "url.h"
 #include <boost/signals2.hpp>
 #include <map>
 
@@ -75,13 +76,13 @@ public:
 	virtual void setIgnoreTlsErrors(bool on);
 	virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QUrl &uri, const HttpHeaders &headers);
+	virtual void start(const Url &uri, const HttpHeaders &headers);
 
 	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
 	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
 
 	virtual State state() const;
-	virtual QUrl requestUri() const;
+	virtual Url requestUri() const;
 	virtual HttpHeaders requestHeaders() const;
 	virtual int responseCode() const;
 	virtual QByteArray responseReason() const;

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -109,7 +109,7 @@ public:
 			return;
 		}
 
-		QUrl uri = req->requestUri();
+		Url uri = req->requestUri();
 		HttpHeaders headers = req->requestHeaders();
 		QByteArray body = req->readBody();
 
@@ -282,7 +282,7 @@ static void io(std::function<void (int)> loop_wait)
 		clientError = true;
 	});
 
-	client.start(QUrl("ws://localhost/ws"), HttpHeaders());
+	client.start(Url("ws://localhost/ws"), HttpHeaders());
 
 	while(!clientConnected && !clientError)
 		loop_wait(10);
@@ -352,7 +352,7 @@ static void replay(std::function<void (int)> loop_wait)
 		clientError = true;
 	});
 
-	client.start(QUrl("ws://localhost/ws"), HttpHeaders());
+	client.start(Url("ws://localhost/ws"), HttpHeaders());
 
 	while(!clientConnected && !clientError)
 		loop_wait(10);

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -25,7 +25,7 @@
 
 #include <assert.h>
 #include <QDateTime>
-#include <QUrl>
+#include "url.h"
 #include <boost/signals2.hpp>
 #include "timer.h"
 #include "wscontrolmanager.h"
@@ -52,7 +52,7 @@ public:
 	bool separateStats;
 	QByteArray channelPrefix;
 	int logLevel;
-	QUrl uri;
+	Url uri;
 	bool targetTrusted;
 	Connection requestTimerConnection;
 
@@ -328,7 +328,7 @@ QByteArray WsControlSession::cid() const
 	return d->cid;
 }
 
-void WsControlSession::start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted)
+void WsControlSession::start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const Url &uri, bool targetTrusted)
 {
 	d->debug = debug;
 	d->route = routeId;

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -29,6 +29,7 @@
 #include "websocket.h"
 #include "wscontrol.h"
 #include "packet/wscontrolpacket.h"
+#include "url.h"
 
 using Signal = boost::signals2::signal<void()>;
 
@@ -44,7 +45,7 @@ public:
 	QByteArray peer() const;
 	QByteArray cid() const;
 
-	void start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const QUrl &uri, bool targetTrusted);
+	void start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const Url &uri, bool targetTrusted);
 	void sendGripMessage(const QByteArray &message);
 	void sendNeedKeepAlive();
 	void sendSubscribe(const QByteArray &channel);

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -25,7 +25,7 @@
 
 #include <assert.h>
 #include <QDateTime>
-#include <QUrl>
+#include "url.h"
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QHostAddress>
@@ -434,7 +434,7 @@ public:
 		if(!route.asHost.isEmpty())
 			ProxyUtil::applyHost(&requestData.uri, route.asHost);
 
-		QByteArray path = requestData.uri.path(QUrl::FullyEncoded).toUtf8();
+		QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
 
 		if(route.pathRemove > 0)
 			path = path.mid(route.pathRemove);
@@ -442,7 +442,7 @@ public:
 		if(!route.pathPrepend.isEmpty())
 			path = route.pathPrepend + path;
 
-		requestData.uri.setPath(QString::fromUtf8(path), QUrl::StrictMode);
+		requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
 
 		sigIss = defaultSigIss;
 		sigKey = defaultSigKey;
@@ -511,7 +511,7 @@ public:
 
 		target = targets.takeFirst();
 
-		QUrl uri = requestData.uri;
+		Url uri = requestData.uri;
 		if(target.ssl)
 			uri.setScheme("wss");
 		else
@@ -536,7 +536,7 @@ public:
 					--pathRemove;
 
 				if(pathRemove > 0)
-					uri.setPath(uri.path(QUrl::FullyEncoded).mid(pathRemove));
+					uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
 			}
 
 			outSock = std::make_unique<TestWebSocket>();

--- a/src/runner/connmgrservice.cpp
+++ b/src/runner/connmgrservice.cpp
@@ -24,7 +24,7 @@
 
 #include <QDir>
 #include <QProcess>
-#include <QUrl>
+#include "url.h"
 #include "log.h"
 #include "template.h"
 
@@ -85,7 +85,7 @@ ConnmgrService::ConnmgrService(
 			}
 			else
 			{
-				QUrl url;
+				Url url;
 				url.setHost(!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
 				url.setPort(p.port);
 

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -28,7 +28,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
-#include <QUrl>
+#include "url.h"
 #include <QUrlQuery>
 #include "rust/bindings.h"
 #include "processquit.h"
@@ -80,8 +80,8 @@ static QPair<QHostAddress, int> parsePort(const QString &s)
 
 	// Otherwise, assume it's an address:port combination
 
-	// Parse with QUrl in order to support bracketed IPv6 notation
-	QUrl url{QUrl::fromUserInput(s)};
+	// Parse with Url in order to support bracketed IPv6 notation
+	Url url{Url::fromUserInput(s)};
 
 	return QPair<QHostAddress, int>(QHostAddress(url.host()), url.port());
 }
@@ -539,7 +539,7 @@ public:
 
 			foreach(const QString &localPortStr, localPortStrs)
 			{
-				QUrl path = QUrl::fromEncoded(localPortStr.toUtf8());
+				Url path = Url::fromEncoded(localPortStr.toUtf8());
 				if(!path.isValid())
 				{
 					log_error("invalid local port: %s", qPrintable(localPortStr));


### PR DESCRIPTION
As part of our ongoing process of migrating away from Qt types, this PR is the first in a series for addressing `QUrl`. It adds a type alias and changes all call sites to use it. Since it's technically still the same type, the code should compile to the same thing with no change in behavior. Later, we can replace the alias with an alternative implementation, likely based on the Rust `url` crate via FFI.