### PR TITLE
connmgr: make new buffers for every client request

### DIFF
--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -4734,9 +4734,9 @@ async fn client_req_connect(
     log_id: &str,
     id: Option<&[u8]>,
     zreq: memorypool::Rc<zhttppacket::OwnedRequest>,
-    buf1: &mut VecRingBuffer,
-    buf2: &mut VecRingBuffer,
-    body_buf: &mut ContiguousBuffer,
+    buffer_size: usize,
+    body_buffer_size: usize,
+    rb_tmp: &Rc<TmpBuffer>,
     packet_buf: &RefCell<Vec<u8>>,
     deny: &[IpNet],
     resolver: &resolver::Resolver,
@@ -4808,6 +4808,10 @@ async fn client_req_connect(
         )
         .await?;
 
+        let mut buf1 = VecRingBuffer::new(buffer_size, rb_tmp);
+        let mut buf2 = VecRingBuffer::new(buffer_size, rb_tmp);
+        let mut body_buf = ContiguousBuffer::new(body_buffer_size);
+
         let done = match &mut stream {
             AsyncStream::Plain(stream) => {
                 client_req_handler(
@@ -4819,9 +4823,9 @@ async fn client_req_connect(
                     url,
                     include_body,
                     rdata.follow_redirects,
-                    buf1,
-                    buf2,
-                    body_buf,
+                    &mut buf1,
+                    &mut buf2,
+                    &mut body_buf,
                     packet_buf,
                 )
                 .await?
@@ -4836,9 +4840,9 @@ async fn client_req_connect(
                     url,
                     include_body,
                     rdata.follow_redirects,
-                    buf1,
-                    buf2,
-                    body_buf,
+                    &mut buf1,
+                    &mut buf2,
+                    &mut body_buf,
                     packet_buf,
                 )
                 .await?
@@ -4912,17 +4916,13 @@ async fn client_req_connection_inner(
 
     let (zheader, zreq) = zreq;
 
-    let mut buf1 = VecRingBuffer::new(buffer_size, rb_tmp);
-    let mut buf2 = VecRingBuffer::new(buffer_size, rb_tmp);
-    let mut body_buf = ContiguousBuffer::new(body_buffer_size);
-
     let handler = client_req_connect(
         log_id,
         id,
         zreq,
-        &mut buf1,
-        &mut buf2,
-        &mut body_buf,
+        buffer_size,
+        body_buffer_size,
+        rb_tmp,
         &packet_buf,
         deny,
         resolver,
@@ -5543,12 +5543,11 @@ async fn client_stream_connect<E, R1, R2>(
     log_id: &str,
     id: &[u8],
     zreq: memorypool::Rc<zhttppacket::OwnedRequest>,
-    buf1: &mut VecRingBuffer,
-    buf2: &mut VecRingBuffer,
     buffer_size: usize,
     blocks_max: usize,
     blocks_avail: &Counter,
     messages_max: usize,
+    rb_tmp: &Rc<TmpBuffer>,
     allow_compression: bool,
     packet_buf: &RefCell<Vec<u8>>,
     tmp_buf: &RefCell<Vec<u8>>,
@@ -5692,6 +5691,9 @@ where
             }
         };
 
+        let mut buf1 = VecRingBuffer::new(buffer_size, rb_tmp);
+        let mut buf2 = VecRingBuffer::new(buffer_size, rb_tmp);
+
         let mut blocks_avail = CounterDec::new(blocks_avail);
 
         let done = match &mut stream {
@@ -5704,8 +5706,8 @@ where
                     url,
                     include_body,
                     rdata.follow_redirects,
-                    buf1,
-                    buf2,
+                    &mut buf1,
+                    &mut buf2,
                     blocks_max,
                     &mut blocks_avail,
                     messages_max,
@@ -5727,8 +5729,8 @@ where
                     url,
                     include_body,
                     rdata.follow_redirects,
-                    buf1,
-                    buf2,
+                    &mut buf1,
+                    &mut buf2,
                     blocks_max,
                     &mut blocks_avail,
                     messages_max,
@@ -5744,8 +5746,6 @@ where
         };
 
         let stream = if done.is_persistent() {
-            buf2.resize(buffer_size);
-
             match pool.push(
                 peer_addr,
                 using_tls,
@@ -5836,9 +5836,6 @@ where
 {
     let reactor = Reactor::current().unwrap();
 
-    let mut buf1 = VecRingBuffer::new(buffer_size, rb_tmp);
-    let mut buf2 = VecRingBuffer::new(buffer_size, rb_tmp);
-
     let stream_timeout = Timeout::new(reactor.now() + stream_timeout_duration);
     let session_timeout = Timeout::new(reactor.now() + ZHTTP_SESSION_TIMEOUT);
 
@@ -5857,12 +5854,11 @@ where
             log_id,
             id,
             zreq,
-            &mut buf1,
-            &mut buf2,
             buffer_size,
             blocks_max,
             blocks_avail,
             messages_max,
+            rb_tmp,
             allow_compression,
             &packet_buf,
             &tmp_buf,


### PR DESCRIPTION
Currently, when a client (outbound) request completes as part of a series of requests when following redirects, the connection buffers are not cleared between requests nor are they always resized down (the resize only happens if the connection is persistent). We should always be clearing+resizing between requests. This PR fixes the issue by simply reconstructing the connection buffers for every request. This is done by moving their construction into the inner loop.

(The odd resize-only-when-persistent behavior is likely due to the client handler code originally being adapted from the server handler code. In the server handling, if a connection isn't persistent then the buffers are simply destroyed and the task ends, so there is no chance of using an expanded write buffer in a subsequent request, but the client handling works differently with the loop to follow redirects.)