### PR TITLE
reformat all c++ files with clang-format

### DIFF
--- a/src/core/bufferlist.cpp
+++ b/src/core/bufferlist.cpp
@@ -22,164 +22,144 @@
 
 #include <assert.h>
 
-BufferList::BufferList() :
-	size_(0),
-	offset_(0)
-{
+BufferList::BufferList() : size_(0), offset_(0) {}
+
+void BufferList::findPos(int pos, int *bufferIndex, int *offset) const {
+    assert(pos < size_);
+
+    int at = 0;
+    int curOffset = offset_;
+
+    while (true) {
+        const QByteArray &buf = bufs_[at];
+        if (curOffset + pos < buf.size())
+            break;
+
+        ++at;
+        pos -= (buf.size() - curOffset);
+        curOffset = 0;
+    }
+
+    *bufferIndex = at;
+    *offset = curOffset + pos;
 }
 
-void BufferList::findPos(int pos, int *bufferIndex, int *offset) const
-{
-	assert(pos < size_);
+QByteArray BufferList::mid(int pos, int size) const {
+    assert(pos >= 0);
 
-	int at = 0;
-	int curOffset = offset_;
+    if (size_ == 0 || size == 0 || pos >= size_)
+        return QByteArray();
 
-	while(true)
-	{
-		const QByteArray &buf = bufs_[at];
-		if(curOffset + pos < buf.size())
-			break;
+    int toRead;
+    if (size > 0)
+        toRead = qMin(size, size_ - pos);
+    else
+        toRead = size_ - pos;
 
-		++at;
-		pos -= (buf.size() - curOffset);
-		curOffset = 0;
-	}
+    assert(!bufs_.isEmpty());
 
-	*bufferIndex = at;
-	*offset = curOffset + pos;
+    int at;
+    int offset;
+    findPos(pos, &at, &offset);
+
+    // If we're reading the exact size of the current buffer, cheaply
+    // return it
+    if (offset == 0 && bufs_[at].size() == toRead)
+        return bufs_[at];
+
+    QByteArray out;
+    out.resize(toRead);
+    char *outp = out.data();
+
+    while (toRead > 0) {
+        const QByteArray &buf = bufs_[at];
+        int bsize = qMin(buf.size() - offset, toRead);
+        memcpy(outp, buf.data() + offset, bsize);
+
+        if (offset + bsize >= buf.size()) {
+            ++at;
+            offset = 0;
+        }
+
+        toRead -= bsize;
+        outp += bsize;
+    }
+
+    return out;
 }
 
-QByteArray BufferList::mid(int pos, int size) const
-{
-	assert(pos >= 0);
-
-	if(size_ == 0 || size == 0 || pos >= size_)
-		return QByteArray();
-
-	int toRead;
-	if(size > 0)
-		toRead = qMin(size, size_ - pos);
-	else
-		toRead = size_ - pos;
-
-	assert(!bufs_.isEmpty());
-
-	int at;
-	int offset;
-	findPos(pos, &at, &offset);
-
-	// If we're reading the exact size of the current buffer, cheaply
-	// return it
-	if(offset == 0 && bufs_[at].size() == toRead)
-		return bufs_[at];
-
-	QByteArray out;
-	out.resize(toRead);
-	char *outp = out.data();
-
-	while(toRead > 0)
-	{
-		const QByteArray &buf = bufs_[at];
-		int bsize = qMin(buf.size() - offset, toRead);
-		memcpy(outp, buf.data() + offset, bsize);
-
-		if(offset + bsize >= buf.size())
-		{
-			++at;
-			offset = 0;
-		}
-
-		toRead -= bsize;
-		outp += bsize;
-	}
-
-	return out;
+void BufferList::clear() {
+    bufs_.clear();
+    size_ = 0;
+    offset_ = 0;
 }
 
-void BufferList::clear()
-{
-	bufs_.clear();
-	size_ = 0;
-	offset_ = 0;
+void BufferList::append(const QByteArray &buf) {
+    if (buf.size() < 1)
+        return;
+
+    bufs_ += buf;
+    size_ += buf.size();
 }
 
-void BufferList::append(const QByteArray &buf)
-{
-	if(buf.size() < 1)
-		return;
+QByteArray BufferList::take(int size) {
+    if (size_ == 0 || size == 0)
+        return QByteArray();
 
-	bufs_ += buf;
-	size_ += buf.size();
+    int toRead;
+    if (size > 0)
+        toRead = qMin(size, size_);
+    else
+        toRead = size_;
+
+    assert(!bufs_.isEmpty());
+
+    // If we're reading the exact size of the first buffer, cheaply
+    // return it
+    if (offset_ == 0 && bufs_.first().size() == toRead) {
+        size_ -= toRead;
+        return bufs_.takeFirst();
+    }
+
+    QByteArray out;
+    out.resize(toRead);
+    char *outp = out.data();
+
+    while (toRead > 0) {
+        const QByteArray &buf = bufs_.first();
+        int bsize = qMin(buf.size() - offset_, toRead);
+        memcpy(outp, buf.data() + offset_, bsize);
+
+        if (offset_ + bsize >= buf.size()) {
+            bufs_.removeFirst();
+            offset_ = 0;
+        } else
+            offset_ += bsize;
+
+        toRead -= bsize;
+        size_ -= bsize;
+        outp += bsize;
+    }
+
+    return out;
 }
 
-QByteArray BufferList::take(int size)
-{
-	if(size_ == 0 || size == 0)
-		return QByteArray();
+QByteArray BufferList::toByteArray() {
+    if (size_ == 0)
+        return QByteArray();
 
-	int toRead;
-	if(size > 0)
-		toRead = qMin(size, size_);
-	else
-		toRead = size_;
+    QByteArray out;
+    while (!bufs_.isEmpty()) {
+        if (offset_ > 0) {
+            out += bufs_.first().mid(offset_);
+            offset_ = 0;
+            bufs_.removeFirst();
+        } else
+            out += bufs_.takeFirst();
+    }
 
-	assert(!bufs_.isEmpty());
+    // Keep the rewritten buffer as the only buffer
+    bufs_ += out;
 
-	// If we're reading the exact size of the first buffer, cheaply
-	// return it
-	if(offset_ == 0 && bufs_.first().size() == toRead)
-	{
-		size_ -= toRead;
-		return bufs_.takeFirst();
-	}
-
-	QByteArray out;
-	out.resize(toRead);
-	char *outp = out.data();
-
-	while(toRead > 0)
-	{
-		const QByteArray &buf = bufs_.first();
-		int bsize = qMin(buf.size() - offset_, toRead);
-		memcpy(outp, buf.data() + offset_, bsize);
-
-		if(offset_ + bsize >= buf.size())
-		{
-			bufs_.removeFirst();
-			offset_ = 0;
-		}
-		else
-			offset_ += bsize;
-
-		toRead -= bsize;
-		size_ -= bsize;
-		outp += bsize;
-	}
-
-	return out;
-}
-
-QByteArray BufferList::toByteArray()
-{
-	if(size_ == 0)
-		return QByteArray();
-
-	QByteArray out;
-	while(!bufs_.isEmpty())
-	{
-		if(offset_ > 0)
-		{
-			out += bufs_.first().mid(offset_);
-			offset_ = 0;
-			bufs_.removeFirst();
-		}
-		else
-			out += bufs_.takeFirst();
-	}
-
-	// Keep the rewritten buffer as the only buffer
-	bufs_ += out;
-
-	return out;
+    return out;
 }

--- a/src/core/bufferlist.h
+++ b/src/core/bufferlist.h
@@ -21,37 +21,35 @@
 #ifndef BUFFERLIST_H
 #define BUFFERLIST_H
 
-#include <QList>
 #include <QByteArray>
+#include <QList>
 
-class BufferList
-{
+class BufferList {
 public:
-	BufferList();
+    BufferList();
 
-	int size() const { return size_; }
-	bool isEmpty() const { return size_ == 0; }
+    int size() const { return size_; }
+    bool isEmpty() const { return size_ == 0; }
 
-	QByteArray mid(int pos, int size = -1) const;
+    QByteArray mid(int pos, int size = -1) const;
 
-	void clear();
-	void append(const QByteArray &buf);
-	QByteArray take(int size = -1);
+    void clear();
+    void append(const QByteArray &buf);
+    QByteArray take(int size = -1);
 
-	QByteArray toByteArray(); // Non-const because we rewrite the list
+    QByteArray toByteArray(); // Non-const because we rewrite the list
 
-	BufferList & operator+=(const QByteArray &buf)
-	{
-		append(buf);
-		return *this;
-	}
+    BufferList &operator+=(const QByteArray &buf) {
+        append(buf);
+        return *this;
+    }
 
 private:
-	QList<QByteArray> bufs_;
-	int size_;
-	int offset_;
+    QList<QByteArray> bufs_;
+    int size_;
+    int offset_;
 
-	void findPos(int pos, int *bufferIndex, int *offset) const;
+    void findPos(int pos, int *bufferIndex, int *offset) const;
 };
 
 #endif

--- a/src/core/callback.h
+++ b/src/core/callback.h
@@ -23,62 +23,46 @@
 #ifndef CALLBACK_H
 #define CALLBACK_H
 
-#include <assert.h>
 #include <QList>
+#include <assert.h>
 
-template <typename T> class Callback
-{
+template <typename T> class Callback {
 public:
     typedef void (*CallbackFunc)(void *data, T);
 
-    Callback() :
-        activeCalls_(0),
-        destroyed_(0)
-    {
-    }
+    Callback() : activeCalls_(0), destroyed_(0) {}
 
-    ~Callback()
-    {
-        if(destroyed_)
+    ~Callback() {
+        if (destroyed_)
             *destroyed_ = true;
     }
 
-    void add(CallbackFunc cb, void *data)
-    {
-        targets_ += Target(cb, data);
-    }
+    void add(CallbackFunc cb, void *data) { targets_ += Target(cb, data); }
 
-    void remove(void *data)
-    {
+    void remove(void *data) {
         // Mark for removal, but don't actually remove
-        for(int n = 0; n < targets_.count(); ++n)
-        {
+        for (int n = 0; n < targets_.count(); ++n) {
             Target &t = targets_[n];
 
-            if(t.second == data)
-            {
+            if (t.second == data) {
                 t.second = 0;
             }
         }
 
         // Only actually remove if not in the middle of a call
-        if(activeCalls_ == 0)
-        {
+        if (activeCalls_ == 0) {
             removeMarked();
         }
     }
 
-    void call(T value)
-    {
+    void call(T value) {
         activeCalls_ += 1;
 
-        for(int n = 0; n < targets_.count(); ++n)
-        {
+        for (int n = 0; n < targets_.count(); ++n) {
             const Target &t = targets_[n];
 
             // Skip if marked for removal
-            if(!t.second)
-            {
+            if (!t.second) {
                 continue;
             }
 
@@ -92,10 +76,8 @@ public:
 
             f(data, value);
 
-            if(destroyed)
-            {
-                if(prevDestroyed)
-                {
+            if (destroyed) {
+                if (prevDestroyed) {
                     *prevDestroyed = true;
                 }
 
@@ -108,8 +90,7 @@ public:
         assert(activeCalls_ >= 1);
         activeCalls_ -= 1;
 
-        if(activeCalls_ == 0)
-        {
+        if (activeCalls_ == 0) {
             removeMarked();
         }
     }
@@ -120,14 +101,11 @@ private:
     bool activeCalls_;
     bool *destroyed_;
 
-    void removeMarked()
-    {
+    void removeMarked() {
         assert(activeCalls_ == 0);
 
-        for(int n = 0; n < targets_.count(); ++n)
-        {
-            if(!targets_[n].second)
-            {
+        for (int n = 0; n < targets_.count(); ++n) {
+            if (!targets_[n].second) {
                 targets_.removeAt(n);
                 --n; // Adjust position
             }

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -28,22 +28,20 @@ namespace Config {
 
 static thread_local Config *g_config = 0;
 
-Config & get()
-{
-	if(!g_config)
-	{
-		Config *c = new Config;
+Config &get() {
+    if (!g_config) {
+        Config *c = new Config;
 
-		ffi::BuildConfig *bc = ffi::build_config_new();
-		c->version = QString(bc->version);
-		c->configDir = QString(bc->config_dir);
-		c->libDir = QString(bc->lib_dir);
-		ffi::build_config_destroy(bc);
+        ffi::BuildConfig *bc = ffi::build_config_new();
+        c->version = QString(bc->version);
+        c->configDir = QString(bc->config_dir);
+        c->libDir = QString(bc->lib_dir);
+        ffi::build_config_destroy(bc);
 
-		g_config = c;
-	}
+        g_config = c;
+    }
 
-	return *g_config;
+    return *g_config;
 }
 
-}
+} // namespace Config

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -27,17 +27,16 @@
 
 namespace Config {
 
-class Config
-{
+class Config {
 public:
-	QString version;
-	QString configDir;
-	QString libDir;
+    QString version;
+    QString configDir;
+    QString libDir;
 };
 
 // Value is thread local
-Config & get();
+Config &get();
 
-}
+} // namespace Config
 
 #endif

--- a/src/core/cors.cpp
+++ b/src/core/cors.cpp
@@ -27,88 +27,81 @@
 
 namespace Cors {
 
-static bool isSimpleHeader(const QByteArray &in)
-{
-	return (qstricmp(in.data(), "Cache-Control") == 0 ||
-		qstricmp(in.data(), "Content-Language") == 0 ||
-		qstricmp(in.data(), "Content-Length") == 0 ||
-		qstricmp(in.data(), "Content-Type") == 0 ||
-		qstricmp(in.data(), "Expires") == 0 ||
-		qstricmp(in.data(), "Last-Modified") == 0 ||
-		qstricmp(in.data(), "Pragma") == 0);
+static bool isSimpleHeader(const QByteArray &in) {
+    return (qstricmp(in.data(), "Cache-Control") == 0 ||
+            qstricmp(in.data(), "Content-Language") == 0 ||
+            qstricmp(in.data(), "Content-Length") == 0 ||
+            qstricmp(in.data(), "Content-Type") == 0 || qstricmp(in.data(), "Expires") == 0 ||
+            qstricmp(in.data(), "Last-Modified") == 0 || qstricmp(in.data(), "Pragma") == 0);
 }
 
-static bool headerNamesContains(const QList<QByteArray> &names, const QByteArray &name)
-{
-	foreach(const QByteArray &i, names)
-	{
-		if(qstricmp(name.data(), i.data()) == 0)
-			return true;
-	}
+static bool headerNamesContains(const QList<QByteArray> &names, const QByteArray &name) {
+    foreach (const QByteArray &i, names) {
+        if (qstricmp(name.data(), i.data()) == 0)
+            return true;
+    }
 
-	return false;
+    return false;
 }
 
-static bool headerNameStartsWith(const QByteArray &name, const char *value)
-{
-	return (qstrnicmp(name.data(), value, qstrlen(value)) == 0);
+static bool headerNameStartsWith(const QByteArray &name, const char *value) {
+    return (qstrnicmp(name.data(), value, qstrlen(value)) == 0);
 }
 
-void applyCorsHeaders(const HttpHeaders &requestHeaders, HttpHeaders *responseHeaders)
-{
-	if(!responseHeaders->contains("Access-Control-Allow-Methods"))
-	{
-		QByteArray method = requestHeaders.get("Access-Control-Request-Method").asQByteArray();
+void applyCorsHeaders(const HttpHeaders &requestHeaders, HttpHeaders *responseHeaders) {
+    if (!responseHeaders->contains("Access-Control-Allow-Methods")) {
+        QByteArray method = requestHeaders.get("Access-Control-Request-Method").asQByteArray();
 
-		if(!method.isEmpty())
-			*responseHeaders += HttpHeader("Access-Control-Allow-Methods", method);
-		else
-			*responseHeaders += HttpHeader("Access-Control-Allow-Methods", "OPTIONS, HEAD, GET, POST, PUT, DELETE");
-	}
+        if (!method.isEmpty())
+            *responseHeaders += HttpHeader("Access-Control-Allow-Methods", method);
+        else
+            *responseHeaders +=
+                HttpHeader("Access-Control-Allow-Methods", "OPTIONS, HEAD, GET, POST, PUT, DELETE");
+    }
 
-	if(!responseHeaders->contains("Access-Control-Allow-Headers"))
-	{
-		CowByteArrayList allowHeaders;
+    if (!responseHeaders->contains("Access-Control-Allow-Headers")) {
+        CowByteArrayList allowHeaders;
 
-		CowByteArrayList l = requestHeaders.getAll("Access-Control-Request-Headers", true);
-		for(CowByteArrayConstRef h : std::as_const(l))
-		{
-			if(!h.isEmpty())
-				allowHeaders += h;
-		}
+        CowByteArrayList l = requestHeaders.getAll("Access-Control-Request-Headers", true);
+        for (CowByteArrayConstRef h : std::as_const(l)) {
+            if (!h.isEmpty())
+                allowHeaders += h;
+        }
 
-		if(!allowHeaders.isEmpty())
-			*responseHeaders += HttpHeader("Access-Control-Allow-Headers", HttpHeaders::join(allowHeaders));
-	}
+        if (!allowHeaders.isEmpty())
+            *responseHeaders +=
+                HttpHeader("Access-Control-Allow-Headers", HttpHeaders::join(allowHeaders));
+    }
 
-	if(!responseHeaders->contains("Access-Control-Expose-Headers"))
-	{
-		QList<QByteArray> exposeHeaders;
-		foreach(const HttpHeader &h, *responseHeaders)
-		{
-			if(!isSimpleHeader(h.first.asQByteArray()) && !headerNameStartsWith(h.first.asQByteArray(), "Access-Control-") && !headerNameStartsWith(h.first.asQByteArray(), "Grip-") && !headerNamesContains(exposeHeaders, h.first.asQByteArray()))
-				exposeHeaders += h.first.asQByteArray();
-		}
+    if (!responseHeaders->contains("Access-Control-Expose-Headers")) {
+        QList<QByteArray> exposeHeaders;
+        foreach (const HttpHeader &h, *responseHeaders) {
+            if (!isSimpleHeader(h.first.asQByteArray()) &&
+                !headerNameStartsWith(h.first.asQByteArray(), "Access-Control-") &&
+                !headerNameStartsWith(h.first.asQByteArray(), "Grip-") &&
+                !headerNamesContains(exposeHeaders, h.first.asQByteArray()))
+                exposeHeaders += h.first.asQByteArray();
+        }
 
-		if(!exposeHeaders.isEmpty())
-			*responseHeaders += HttpHeader("Access-Control-Expose-Headers", HttpHeaders::join(exposeHeaders));
-	}
+        if (!exposeHeaders.isEmpty())
+            *responseHeaders +=
+                HttpHeader("Access-Control-Expose-Headers", HttpHeaders::join(exposeHeaders));
+    }
 
-	if(!responseHeaders->contains("Access-Control-Allow-Credentials"))
-		*responseHeaders += HttpHeader("Access-Control-Allow-Credentials", "true");
+    if (!responseHeaders->contains("Access-Control-Allow-Credentials"))
+        *responseHeaders += HttpHeader("Access-Control-Allow-Credentials", "true");
 
-	if(!responseHeaders->contains("Access-Control-Allow-Origin"))
-	{
-		CowByteArray origin = requestHeaders.get("Origin");
+    if (!responseHeaders->contains("Access-Control-Allow-Origin")) {
+        CowByteArray origin = requestHeaders.get("Origin");
 
-		if(origin.isEmpty())
-			origin = "*";
+        if (origin.isEmpty())
+            origin = "*";
 
-		*responseHeaders += HttpHeader("Access-Control-Allow-Origin", origin);
-	}
+        *responseHeaders += HttpHeader("Access-Control-Allow-Origin", origin);
+    }
 
-	if(!responseHeaders->contains("Access-Control-Max-Age"))
-		*responseHeaders += HttpHeader("Access-Control-Max-Age", "3600");
+    if (!responseHeaders->contains("Access-Control-Max-Age"))
+        *responseHeaders += HttpHeader("Access-Control-Max-Age", "3600");
 }
 
-}
+} // namespace Cors

--- a/src/core/cowbytearray.h
+++ b/src/core/cowbytearray.h
@@ -22,201 +22,250 @@
 
 class CowByteArray;
 
-class CowByteArrayConstRef
-{
+class CowByteArrayConstRef {
 public:
-	CowByteArrayConstRef(const QByteArray &a) : inner_(a) {}
+    CowByteArrayConstRef(const QByteArray &a) : inner_(a) {}
 
-	bool isEmpty() const { return inner_.isEmpty(); }
-	ssize_t size() const { return inner_.size(); }
-	ssize_t length() const { return size(); }
-	const char *data() const { return inner_.data(); }
+    bool isEmpty() const { return inner_.isEmpty(); }
+    ssize_t size() const { return inner_.size(); }
+    ssize_t length() const { return size(); }
+    const char *data() const { return inner_.data(); }
 
-	ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
-	CowByteArray mid(ssize_t pos, ssize_t len = -1) const;
+    ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
+    CowByteArray mid(ssize_t pos, ssize_t len = -1) const;
 
-	char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }
+    char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }
 
-	const QByteArray & asQByteArray() const { return inner_; }
+    const QByteArray &asQByteArray() const { return inner_; }
 
 private:
-	friend class CowByteArray;
+    friend class CowByteArray;
 
-	const QByteArray &inner_;
+    const QByteArray &inner_;
 };
 
-class CowByteArrayRef
-{
+class CowByteArrayRef {
 public:
-	CowByteArrayRef(QByteArray &a) : inner_(a) {}
-	CowByteArrayRef & operator=(const CowByteArray &other);
+    CowByteArrayRef(QByteArray &a) : inner_(a) {}
+    CowByteArrayRef &operator=(const CowByteArray &other);
 
-	bool isEmpty() const { return inner_.isEmpty(); }
-	ssize_t size() const { return inner_.size(); }
-	ssize_t length() const { return size(); }
-	const char *data() const { return inner_.data(); }
-	char *data() { return inner_.data(); }
+    bool isEmpty() const { return inner_.isEmpty(); }
+    ssize_t size() const { return inner_.size(); }
+    ssize_t length() const { return size(); }
+    const char *data() const { return inner_.data(); }
+    char *data() { return inner_.data(); }
 
-	ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
-	CowByteArray mid(ssize_t pos, ssize_t len = -1) const;
+    ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
+    CowByteArray mid(ssize_t pos, ssize_t len = -1) const;
 
-	void resize(ssize_t size) { inner_.resize(size); }
+    void resize(ssize_t size) { inner_.resize(size); }
 
-	char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }
-	char & operator[](ssize_t i) { return inner_[(qsizetype)i]; }
+    char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }
+    char &operator[](ssize_t i) { return inner_[(qsizetype)i]; }
 
-	const QByteArray & asQByteArray() const { return inner_; }
+    const QByteArray &asQByteArray() const { return inner_; }
 
 private:
-	friend class CowByteArray;
+    friend class CowByteArray;
 
-	QByteArray &inner_;
+    QByteArray &inner_;
 };
 
 // QByteArray-like class that currently forwards to an inner QByteArray, to
 // assist with reducing direct dependency on Qt. The API is designed to allow
 // cheap conversion to/from QByteArray.
-class CowByteArray
-{
+class CowByteArray {
 public:
-	CowByteArray() = default;
-	CowByteArray(const CowByteArray &other): inner_(other.inner_) {}
-	CowByteArray(CowByteArrayConstRef ref): inner_(ref.inner_) {}
-	CowByteArray(CowByteArrayRef ref): inner_(ref.inner_) {}
-	CowByteArray(const char *data, ssize_t size = -1) : inner_(data, size) {}
-	CowByteArray(ssize_t size, char ch) : inner_(size, ch) {}
-	CowByteArray(const QByteArray &other) : inner_(other) {}
-	CowByteArray & operator=(const CowByteArray &other) { inner_ = other.inner_; return *this; }
+    CowByteArray() = default;
+    CowByteArray(const CowByteArray &other) : inner_(other.inner_) {}
+    CowByteArray(CowByteArrayConstRef ref) : inner_(ref.inner_) {}
+    CowByteArray(CowByteArrayRef ref) : inner_(ref.inner_) {}
+    CowByteArray(const char *data, ssize_t size = -1) : inner_(data, size) {}
+    CowByteArray(ssize_t size, char ch) : inner_(size, ch) {}
+    CowByteArray(const QByteArray &other) : inner_(other) {}
+    CowByteArray &operator=(const CowByteArray &other) {
+        inner_ = other.inner_;
+        return *this;
+    }
 
-	bool isNull() const { return inner_.isNull(); }
-	bool isEmpty() const { return inner_.isEmpty(); }
-	ssize_t size() const { return inner_.size(); }
-	ssize_t length() const { return size(); }
-	const char *data() const { return inner_.data(); }
-	char *data() { return inner_.data(); }
+    bool isNull() const { return inner_.isNull(); }
+    bool isEmpty() const { return inner_.isEmpty(); }
+    ssize_t size() const { return inner_.size(); }
+    ssize_t length() const { return size(); }
+    const char *data() const { return inner_.data(); }
+    char *data() { return inner_.data(); }
 
-	ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
-	CowByteArray mid(ssize_t pos, ssize_t len = -1) const { return inner_.mid(pos, len); }
-	CowByteArray trimmed() const { return inner_.trimmed(); }
+    ssize_t indexOf(char ch, ssize_t from = 0) const { return inner_.indexOf(ch, from); }
+    CowByteArray mid(ssize_t pos, ssize_t len = -1) const { return inner_.mid(pos, len); }
+    CowByteArray trimmed() const { return inner_.trimmed(); }
 
-	void clear() { inner_.clear(); }
-	void resize(ssize_t size) { inner_.resize(size); }
+    void clear() { inner_.clear(); }
+    void resize(ssize_t size) { inner_.resize(size); }
 
-	char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }
-	char & operator[](ssize_t i) { return inner_[(qsizetype)i]; }
-	CowByteArray & operator+=(const CowByteArray &other) { inner_ += other.inner_; return *this; }
-	CowByteArray & operator+=(char ch) { inner_ += ch; return *this; }
-	CowByteArray & operator+=(const char *str) { inner_ += str; return *this; }
+    char operator[](ssize_t i) const { return inner_[(qsizetype)i]; }
+    char &operator[](ssize_t i) { return inner_[(qsizetype)i]; }
+    CowByteArray &operator+=(const CowByteArray &other) {
+        inner_ += other.inner_;
+        return *this;
+    }
+    CowByteArray &operator+=(char ch) {
+        inner_ += ch;
+        return *this;
+    }
+    CowByteArray &operator+=(const char *str) {
+        inner_ += str;
+        return *this;
+    }
 
-	const QByteArray & asQByteArray() const { return inner_; }
+    const QByteArray &asQByteArray() const { return inner_; }
 
-	friend CowByteArray operator+(const CowByteArray &lhs, const CowByteArray &rhs);
-	friend CowByteArray operator+(const CowByteArray &lhs, const char *rhs);
-	friend CowByteArray operator+(const char *lhs, const CowByteArray &rhs);
+    friend CowByteArray operator+(const CowByteArray &lhs, const CowByteArray &rhs);
+    friend CowByteArray operator+(const CowByteArray &lhs, const char *rhs);
+    friend CowByteArray operator+(const char *lhs, const CowByteArray &rhs);
 
-	friend bool operator==(const CowByteArray &lhs, const CowByteArray &rhs);
-	friend bool operator==(const CowByteArray &lhs, const char *const &rhs);
-	friend bool operator==(const char *const &lhs, const CowByteArray &rhs);
+    friend bool operator==(const CowByteArray &lhs, const CowByteArray &rhs);
+    friend bool operator==(const CowByteArray &lhs, const char *const &rhs);
+    friend bool operator==(const char *const &lhs, const CowByteArray &rhs);
 
 private:
-	friend class CowByteArrayRef;
+    friend class CowByteArrayRef;
 
-	QByteArray inner_;
+    QByteArray inner_;
 };
 
-inline CowByteArray operator+(const CowByteArray &lhs, const CowByteArray &rhs) { return lhs.inner_ + rhs.inner_; }
+inline CowByteArray operator+(const CowByteArray &lhs, const CowByteArray &rhs) {
+    return lhs.inner_ + rhs.inner_;
+}
 inline CowByteArray operator+(const CowByteArray &lhs, const char *rhs) { return lhs.inner_ + rhs; }
 inline CowByteArray operator+(const char *lhs, const CowByteArray &rhs) { return lhs + rhs.inner_; }
 
-inline bool operator==(const CowByteArray &lhs, const CowByteArray &rhs) { return lhs.inner_ == rhs.inner_; }
-inline bool operator==(const CowByteArray &lhs, const char *const &rhs) { return lhs.inner_ == rhs; }
-inline bool operator==(const char *const &lhs, const CowByteArray &rhs) { return lhs == rhs.inner_; }
+inline bool operator==(const CowByteArray &lhs, const CowByteArray &rhs) {
+    return lhs.inner_ == rhs.inner_;
+}
+inline bool operator==(const CowByteArray &lhs, const char *const &rhs) {
+    return lhs.inner_ == rhs;
+}
+inline bool operator==(const char *const &lhs, const CowByteArray &rhs) {
+    return lhs == rhs.inner_;
+}
 inline bool operator!=(const CowByteArray &lhs, const CowByteArray &rhs) { return !(lhs == rhs); }
 inline bool operator!=(const CowByteArray &lhs, const char *const &rhs) { return !(lhs == rhs); }
 inline bool operator!=(const char *const &lhs, const CowByteArray &rhs) { return !(lhs == rhs); }
 
-inline CowByteArray CowByteArrayConstRef::mid(ssize_t pos, ssize_t len) const { return inner_.mid(pos, len); }
+inline CowByteArray CowByteArrayConstRef::mid(ssize_t pos, ssize_t len) const {
+    return inner_.mid(pos, len);
+}
 
-inline CowByteArrayRef & CowByteArrayRef::operator=(const CowByteArray &other) { inner_ = other.inner_; return *this; }
-inline CowByteArray CowByteArrayRef::mid(ssize_t pos, ssize_t len) const { return inner_.mid(pos, len); }
+inline CowByteArrayRef &CowByteArrayRef::operator=(const CowByteArray &other) {
+    inner_ = other.inner_;
+    return *this;
+}
+inline CowByteArray CowByteArrayRef::mid(ssize_t pos, ssize_t len) const {
+    return inner_.mid(pos, len);
+}
 
 // QList-like class for working with CowByteArray that currently forwards to
 // an inner QList<QByteArray>, to assist with reducing direct dependency on
 // Qt. The API is designed to allow cheap conversion to/from
 // QList<QByteArray> and to allow cheap conversions of inserts/lookups
 // to/from QByteArray.
-class CowByteArrayList
-{
+class CowByteArrayList {
 public:
-	class iterator
-	{
-	public:
-		typedef std::random_access_iterator_tag iterator_category;
-		typedef qptrdiff difference_type;
-		typedef CowByteArray value_type;
-		typedef CowByteArray *pointer;
-		typedef CowByteArrayRef reference;
+    class iterator {
+    public:
+        typedef std::random_access_iterator_tag iterator_category;
+        typedef qptrdiff difference_type;
+        typedef CowByteArray value_type;
+        typedef CowByteArray *pointer;
+        typedef CowByteArrayRef reference;
 
-		iterator(QList<QByteArray>::iterator it) : inner_(it) {}
+        iterator(QList<QByteArray>::iterator it) : inner_(it) {}
 
-		inline CowByteArrayRef operator*() const { return CowByteArrayRef(*inner_); }
+        inline CowByteArrayRef operator*() const { return CowByteArrayRef(*inner_); }
 
-		inline bool operator==(const iterator &other) const noexcept { return inner_ == other.inner_; }
-		inline bool operator!=(const iterator &other) const noexcept { return !(inner_ == other.inner_); }
+        inline bool operator==(const iterator &other) const noexcept {
+            return inner_ == other.inner_;
+        }
+        inline bool operator!=(const iterator &other) const noexcept {
+            return !(inner_ == other.inner_);
+        }
 
-		inline iterator &operator++() { inner_++; return *this; }
+        inline iterator &operator++() {
+            inner_++;
+            return *this;
+        }
 
-	private:
-		QList<QByteArray>::iterator inner_;
-	};
+    private:
+        QList<QByteArray>::iterator inner_;
+    };
 
-	class const_iterator
-	{
-	public:
-		typedef std::random_access_iterator_tag iterator_category;
-		typedef qptrdiff difference_type;
-		typedef CowByteArray value_type;
-		typedef const CowByteArray *pointer;
-		typedef CowByteArrayConstRef reference;
+    class const_iterator {
+    public:
+        typedef std::random_access_iterator_tag iterator_category;
+        typedef qptrdiff difference_type;
+        typedef CowByteArray value_type;
+        typedef const CowByteArray *pointer;
+        typedef CowByteArrayConstRef reference;
 
-		const_iterator(QList<QByteArray>::const_iterator it) : inner_(it) {}
+        const_iterator(QList<QByteArray>::const_iterator it) : inner_(it) {}
 
-		inline CowByteArrayConstRef operator*() const { return CowByteArrayConstRef(*inner_); }
+        inline CowByteArrayConstRef operator*() const { return CowByteArrayConstRef(*inner_); }
 
-		inline bool operator==(const const_iterator &other) const noexcept { return inner_ == other.inner_; }
-		inline bool operator!=(const const_iterator &other) const noexcept { return !(inner_ == other.inner_); }
+        inline bool operator==(const const_iterator &other) const noexcept {
+            return inner_ == other.inner_;
+        }
+        inline bool operator!=(const const_iterator &other) const noexcept {
+            return !(inner_ == other.inner_);
+        }
 
-		inline const_iterator &operator++() { inner_++; return *this; }
+        inline const_iterator &operator++() {
+            inner_++;
+            return *this;
+        }
 
-	private:
-		QList<QByteArray>::const_iterator inner_;
-	};
+    private:
+        QList<QByteArray>::const_iterator inner_;
+    };
 
-	CowByteArrayList() = default;
-	CowByteArrayList(const QList<QByteArray> &other) : inner_(other) {}
+    CowByteArrayList() = default;
+    CowByteArrayList(const QList<QByteArray> &other) : inner_(other) {}
 
-	bool isEmpty() const { return inner_.isEmpty(); }
-	ssize_t count() const { return inner_.count(); }
-	bool contains(const CowByteArray &a) const { return inner_.contains(a.asQByteArray()); }
+    bool isEmpty() const { return inner_.isEmpty(); }
+    ssize_t count() const { return inner_.count(); }
+    bool contains(const CowByteArray &a) const { return inner_.contains(a.asQByteArray()); }
 
-	iterator begin() { return inner_.begin(); }
-	const_iterator begin() const { return inner_.begin(); }
-	iterator end() { return inner_.end(); }
-	const_iterator end() const { return inner_.end(); }
+    iterator begin() { return inner_.begin(); }
+    const_iterator begin() const { return inner_.begin(); }
+    iterator end() { return inner_.end(); }
+    const_iterator end() const { return inner_.end(); }
 
-	CowByteArrayList & operator+=(const CowByteArrayList &other) { inner_ += other.asQByteArrayList(); return *this; }
-	CowByteArrayList & operator+=(const CowByteArray &a) { inner_ += a.asQByteArray(); return *this; }
-	CowByteArrayList & operator+=(const QByteArray &a) { inner_ += a; return *this; }
-	CowByteArrayList & operator+=(const char *str) { inner_ += str; return *this; }
+    CowByteArrayList &operator+=(const CowByteArrayList &other) {
+        inner_ += other.asQByteArrayList();
+        return *this;
+    }
+    CowByteArrayList &operator+=(const CowByteArray &a) {
+        inner_ += a.asQByteArray();
+        return *this;
+    }
+    CowByteArrayList &operator+=(const QByteArray &a) {
+        inner_ += a;
+        return *this;
+    }
+    CowByteArrayList &operator+=(const char *str) {
+        inner_ += str;
+        return *this;
+    }
 
-	CowByteArrayConstRef operator[](ssize_t index) const { return CowByteArrayConstRef(inner_[index]); }
-	CowByteArrayRef operator[](ssize_t index) { return CowByteArrayRef(inner_[index]); }
+    CowByteArrayConstRef operator[](ssize_t index) const {
+        return CowByteArrayConstRef(inner_[index]);
+    }
+    CowByteArrayRef operator[](ssize_t index) { return CowByteArrayRef(inner_[index]); }
 
-	const QList<QByteArray> & asQByteArrayList() const { return inner_; }
-	QList<QByteArray> & asQByteArrayList() { return inner_; }
+    const QList<QByteArray> &asQByteArrayList() const { return inner_; }
+    QList<QByteArray> &asQByteArrayList() { return inner_; }
 
 private:
-	QList<QByteArray> inner_;
+    QList<QByteArray> inner_;
 };
 
 #endif

--- a/src/core/cowbytearraytest.cpp
+++ b/src/core/cowbytearraytest.cpp
@@ -20,245 +20,236 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <string.h>
-#include "test.h"
 #include "cowbytearray.h"
+#include "test.h"
+#include <string.h>
 
-static void constructors()
-{
-	// Default
-	CowByteArray a;
-	TEST_ASSERT(a.isEmpty());
+static void constructors() {
+    // Default
+    CowByteArray a;
+    TEST_ASSERT(a.isEmpty());
 
-	// Char*
-	CowByteArray b("hello");
-	TEST_ASSERT_EQ(b, "hello");
+    // Char*
+    CowByteArray b("hello");
+    TEST_ASSERT_EQ(b, "hello");
 
-	// Copy
-	CowByteArray c(b);
-	TEST_ASSERT_EQ(c, "hello");
+    // Copy
+    CowByteArray c(b);
+    TEST_ASSERT_EQ(c, "hello");
 
-	// Const ref
-	QByteArray qa("hello");
-	CowByteArrayConstRef constRef(qa);
-	CowByteArray d(constRef);
-	TEST_ASSERT_EQ(d, "hello");
+    // Const ref
+    QByteArray qa("hello");
+    CowByteArrayConstRef constRef(qa);
+    CowByteArray d(constRef);
+    TEST_ASSERT_EQ(d, "hello");
 
-	// Ref
-	CowByteArrayRef ref(qa);
-	CowByteArray e(ref);
-	TEST_ASSERT_EQ(e, "hello");
+    // Ref
+    CowByteArrayRef ref(qa);
+    CowByteArray e(ref);
+    TEST_ASSERT_EQ(e, "hello");
 
-	// QByteArray
-	CowByteArray f(qa);
-	TEST_ASSERT_EQ(f, "hello");
+    // QByteArray
+    CowByteArray f(qa);
+    TEST_ASSERT_EQ(f, "hello");
 
-	// Char* with limit
-	CowByteArray g("hello", 3);
-	TEST_ASSERT_EQ(g, "hel");
+    // Char* with limit
+    CowByteArray g("hello", 3);
+    TEST_ASSERT_EQ(g, "hel");
 
-	// Sized
-	CowByteArray h(10, 'a');
-	TEST_ASSERT_EQ(h, "aaaaaaaaaa");
+    // Sized
+    CowByteArray h(10, 'a');
+    TEST_ASSERT_EQ(h, "aaaaaaaaaa");
 }
 
-static void methods()
-{
-	// IsNull
-	CowByteArray n;
-	TEST_ASSERT(n.isNull());
-	TEST_ASSERT(n.isEmpty());
+static void methods() {
+    // IsNull
+    CowByteArray n;
+    TEST_ASSERT(n.isNull());
+    TEST_ASSERT(n.isEmpty());
 
-	// IsEmpty
-	CowByteArray empty("");
-	TEST_ASSERT(!empty.isNull());
-	TEST_ASSERT(empty.isEmpty());
+    // IsEmpty
+    CowByteArray empty("");
+    TEST_ASSERT(!empty.isNull());
+    TEST_ASSERT(empty.isEmpty());
 
-	// Size and length
-	CowByteArray a("hello");
-	TEST_ASSERT_EQ(a.size(), 5);
-	TEST_ASSERT_EQ(a.length(), 5);
+    // Size and length
+    CowByteArray a("hello");
+    TEST_ASSERT_EQ(a.size(), 5);
+    TEST_ASSERT_EQ(a.length(), 5);
 
-	// Data (const and non)
-	// data is null-terminated but the null is not counted in the size
-	TEST_ASSERT_EQ(strcmp(std::as_const(a).data(), "hello"), 0);
-	TEST_ASSERT_EQ(strcmp(a.data(), "hello"), 0);
+    // Data (const and non)
+    // data is null-terminated but the null is not counted in the size
+    TEST_ASSERT_EQ(strcmp(std::as_const(a).data(), "hello"), 0);
+    TEST_ASSERT_EQ(strcmp(a.data(), "hello"), 0);
 
-	// IndexOf
-	TEST_ASSERT_EQ(a.indexOf('l'), 2);
-	TEST_ASSERT_EQ(a.indexOf('z'), -1);
+    // IndexOf
+    TEST_ASSERT_EQ(a.indexOf('l'), 2);
+    TEST_ASSERT_EQ(a.indexOf('z'), -1);
 
-	// Mid
-	CowByteArray b = a.mid(0, 3);
-	CowByteArray c = a.mid(3);
-	TEST_ASSERT_EQ(b, "hel");
-	TEST_ASSERT_EQ(c, "lo");
+    // Mid
+    CowByteArray b = a.mid(0, 3);
+    CowByteArray c = a.mid(3);
+    TEST_ASSERT_EQ(b, "hel");
+    TEST_ASSERT_EQ(c, "lo");
 
-	// Trimmed
-	TEST_ASSERT_EQ(CowByteArray(" hel lo ").trimmed(), "hel lo");
+    // Trimmed
+    TEST_ASSERT_EQ(CowByteArray(" hel lo ").trimmed(), "hel lo");
 
-	// Clear
-	CowByteArray d("hello");
-	TEST_ASSERT(!d.isEmpty());
-	d.clear();
-	TEST_ASSERT(d.isEmpty());
+    // Clear
+    CowByteArray d("hello");
+    TEST_ASSERT(!d.isEmpty());
+    d.clear();
+    TEST_ASSERT(d.isEmpty());
 
-	// Resize down
-	a.resize(3);
-	TEST_ASSERT_EQ(a, "hel");
+    // Resize down
+    a.resize(3);
+    TEST_ASSERT_EQ(a, "hel");
 
-	// Resize up
-	a.resize(10); // Extended data is uninitialized!
-	TEST_ASSERT_EQ(a.size(), 10);
+    // Resize up
+    a.resize(10); // Extended data is uninitialized!
+    TEST_ASSERT_EQ(a.size(), 10);
 }
 
-static void operators()
-{
-	// Operator=
-	CowByteArray a;
-	a = CowByteArray("hello");
-	TEST_ASSERT_EQ(a, "hello");
+static void operators() {
+    // Operator=
+    CowByteArray a;
+    a = CowByteArray("hello");
+    TEST_ASSERT_EQ(a, "hello");
 
-	// Operator[] (const)
-	TEST_ASSERT_EQ(std::as_const(a)[1], 'e');
-	TEST_ASSERT_EQ(a[1], 'e');
+    // Operator[] (const)
+    TEST_ASSERT_EQ(std::as_const(a)[1], 'e');
+    TEST_ASSERT_EQ(a[1], 'e');
 
-	// Operator[] (non-const)
-	a[1] = 'a';
-	TEST_ASSERT_EQ(a, "hallo");
+    // Operator[] (non-const)
+    a[1] = 'a';
+    TEST_ASSERT_EQ(a, "hallo");
 
-	// Operator+
-	TEST_ASSERT_EQ(CowByteArray("hello") + CowByteArray(" world"), "hello world");
-	TEST_ASSERT_EQ(CowByteArray("hello") + " world", "hello world");
-	TEST_ASSERT_EQ("hello" + CowByteArray(" world"), "hello world");
+    // Operator+
+    TEST_ASSERT_EQ(CowByteArray("hello") + CowByteArray(" world"), "hello world");
+    TEST_ASSERT_EQ(CowByteArray("hello") + " world", "hello world");
+    TEST_ASSERT_EQ("hello" + CowByteArray(" world"), "hello world");
 
-	// Operator+=
-	a += CowByteArray(" world");
-	TEST_ASSERT_EQ(a, "hallo world");
-	a += '!';
-	TEST_ASSERT_EQ(a, "hallo world!");
-	a += "11";
-	TEST_ASSERT_EQ(a, "hallo world!11");
+    // Operator+=
+    a += CowByteArray(" world");
+    TEST_ASSERT_EQ(a, "hallo world");
+    a += '!';
+    TEST_ASSERT_EQ(a, "hallo world!");
+    a += "11";
+    TEST_ASSERT_EQ(a, "hallo world!11");
 
-	// Operator==
-	a = "hello";
-	TEST_ASSERT(CowByteArray("hello") == CowByteArray("hello"));
-	TEST_ASSERT(CowByteArray("hello") == "hello");
-	TEST_ASSERT("hello" == CowByteArray("hello"));
+    // Operator==
+    a = "hello";
+    TEST_ASSERT(CowByteArray("hello") == CowByteArray("hello"));
+    TEST_ASSERT(CowByteArray("hello") == "hello");
+    TEST_ASSERT("hello" == CowByteArray("hello"));
 
-	// Operator!=
-	TEST_ASSERT(CowByteArray("hello") != CowByteArray("world"));
-	TEST_ASSERT(CowByteArray("hello") != "world");
-	TEST_ASSERT("hello" != CowByteArray("world"));
+    // Operator!=
+    TEST_ASSERT(CowByteArray("hello") != CowByteArray("world"));
+    TEST_ASSERT(CowByteArray("hello") != "world");
+    TEST_ASSERT("hello" != CowByteArray("world"));
 }
 
-static void conversions()
-{
-	CowByteArray a("hello");
-	TEST_ASSERT_EQ(a.asQByteArray(), "hello");
+static void conversions() {
+    CowByteArray a("hello");
+    TEST_ASSERT_EQ(a.asQByteArray(), "hello");
 }
 
-static void listConstructors()
-{
-	// Default
-	CowByteArrayList a;
-	TEST_ASSERT(a.isEmpty());
+static void listConstructors() {
+    // Default
+    CowByteArrayList a;
+    TEST_ASSERT(a.isEmpty());
 
-	// QList<QByteArray>
-	QList<QByteArray> ql;
-	ql += "hello";
-	ql += "world";
-	CowByteArrayList b(ql);
-	TEST_ASSERT_EQ(b.count(), 2);
-	TEST_ASSERT_EQ(b[0], "hello");
-	TEST_ASSERT_EQ(b[1], "world");
+    // QList<QByteArray>
+    QList<QByteArray> ql;
+    ql += "hello";
+    ql += "world";
+    CowByteArrayList b(ql);
+    TEST_ASSERT_EQ(b.count(), 2);
+    TEST_ASSERT_EQ(b[0], "hello");
+    TEST_ASSERT_EQ(b[1], "world");
 }
 
-static void listMethods()
-{
-	// IsEmpty
-	CowByteArrayList a;
-	TEST_ASSERT(a.isEmpty());
+static void listMethods() {
+    // IsEmpty
+    CowByteArrayList a;
+    TEST_ASSERT(a.isEmpty());
 
-	// Count
-	a += CowByteArray("hello");
-	a += CowByteArray("world");
-	TEST_ASSERT_EQ(a.count(), 2);
+    // Count
+    a += CowByteArray("hello");
+    a += CowByteArray("world");
+    TEST_ASSERT_EQ(a.count(), 2);
 
-	// Contains
-	TEST_ASSERT(a.contains("world"));
-	TEST_ASSERT(!a.contains("foo"));
+    // Contains
+    TEST_ASSERT(a.contains("world"));
+    TEST_ASSERT(!a.contains("foo"));
 
-	// Begin/end (const)
-	CowByteArrayList::const_iterator cit = std::as_const(a).begin();
-	TEST_ASSERT_EQ(*cit, "hello");
+    // Begin/end (const)
+    CowByteArrayList::const_iterator cit = std::as_const(a).begin();
+    TEST_ASSERT_EQ(*cit, "hello");
 
-	++cit;
-	TEST_ASSERT_EQ(*cit, "world");
+    ++cit;
+    TEST_ASSERT_EQ(*cit, "world");
 
-	++cit;
-	TEST_ASSERT_EQ(cit, std::as_const(a).end());
+    ++cit;
+    TEST_ASSERT_EQ(cit, std::as_const(a).end());
 
-	// Begin/end (non-const)
-	CowByteArrayList::iterator it = a.begin();
-	TEST_ASSERT_EQ(*it, "hello");
+    // Begin/end (non-const)
+    CowByteArrayList::iterator it = a.begin();
+    TEST_ASSERT_EQ(*it, "hello");
 
-	(*it)[1] = 'a';
-	TEST_ASSERT_EQ(a[0], "hallo");
+    (*it)[1] = 'a';
+    TEST_ASSERT_EQ(a[0], "hallo");
 }
 
-static void listOperators()
-{
-	CowByteArrayList a;
+static void listOperators() {
+    CowByteArrayList a;
 
-	CowByteArrayList b;
-	b += "apple";
-	b += "banana";
+    CowByteArrayList b;
+    b += "apple";
+    b += "banana";
 
-	a += b;
-	a += CowByteArray("cherry");
-	a += QByteArray("date");
-	a += "elderberry";
+    a += b;
+    a += CowByteArray("cherry");
+    a += QByteArray("date");
+    a += "elderberry";
 
-	const CowByteArrayList &ac = a;
-	TEST_ASSERT_EQ(ac.count(), 5);
-	TEST_ASSERT_EQ(ac[0], "apple");
-	TEST_ASSERT_EQ(ac[1], "banana");
-	TEST_ASSERT_EQ(ac[2], "cherry");
-	TEST_ASSERT_EQ(ac[3], "date");
-	TEST_ASSERT_EQ(ac[4], "elderberry");
+    const CowByteArrayList &ac = a;
+    TEST_ASSERT_EQ(ac.count(), 5);
+    TEST_ASSERT_EQ(ac[0], "apple");
+    TEST_ASSERT_EQ(ac[1], "banana");
+    TEST_ASSERT_EQ(ac[2], "cherry");
+    TEST_ASSERT_EQ(ac[3], "date");
+    TEST_ASSERT_EQ(ac[4], "elderberry");
 
-	a[2] = "cantaloupe";
-	TEST_ASSERT_EQ(a[2], "cantaloupe");
+    a[2] = "cantaloupe";
+    TEST_ASSERT_EQ(a[2], "cantaloupe");
 }
 
-static void listConversions()
-{
-	CowByteArrayList a;
-	a += "hello";
-	a += "world";
+static void listConversions() {
+    CowByteArrayList a;
+    a += "hello";
+    a += "world";
 
-	const QList<QByteArray> &qlc = std::as_const(a.asQByteArrayList());
-	TEST_ASSERT_EQ(qlc.count(), 2);
-	TEST_ASSERT_EQ(qlc[0], "hello");
-	TEST_ASSERT_EQ(qlc[1], "world");
+    const QList<QByteArray> &qlc = std::as_const(a.asQByteArrayList());
+    TEST_ASSERT_EQ(qlc.count(), 2);
+    TEST_ASSERT_EQ(qlc[0], "hello");
+    TEST_ASSERT_EQ(qlc[1], "world");
 
-	QList<QByteArray> &ql = a.asQByteArrayList();
-	ql += "foo";
-	TEST_ASSERT_EQ(a.count(), 3);
-	TEST_ASSERT_EQ(a[2], "foo");
+    QList<QByteArray> &ql = a.asQByteArrayList();
+    ql += "foo";
+    TEST_ASSERT_EQ(a.count(), 3);
+    TEST_ASSERT_EQ(a[2], "foo");
 }
 
-extern "C" int cowbytearray_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(constructors());
-	TEST_CATCH(methods());
-	TEST_CATCH(operators());
-	TEST_CATCH(conversions());
-	TEST_CATCH(listConstructors());
-	TEST_CATCH(listMethods());
-	TEST_CATCH(listOperators());
-	TEST_CATCH(listConversions());
+extern "C" int cowbytearray_test(ffi::TestException *out_ex) {
+    TEST_CATCH(constructors());
+    TEST_CATCH(methods());
+    TEST_CATCH(operators());
+    TEST_CATCH(conversions());
+    TEST_CATCH(listConstructors());
+    TEST_CATCH(listMethods());
+    TEST_CATCH(listOperators());
+    TEST_CATCH(listConversions());
 
-	return 0;
+    return 0;
 }

--- a/src/core/cowstring.h
+++ b/src/core/cowstring.h
@@ -17,39 +17,43 @@
 #ifndef COWSTRING_H
 #define COWSTRING_H
 
-#include <QString>
 #include "cowbytearray.h"
+#include <QString>
 
 // QString-like class that currently forwards to an inner QString, to
 // assist with reducing direct dependency on Qt. The API is designed to allow
 // cheap conversion to/from QString.
-class CowString
-{
+class CowString {
 public:
-	CowString() = default;
-	CowString(const CowString &other): inner_(other.inner_) {}
-	CowString(const char *str) : inner_(str) {}
-	CowString(const QString &other) : inner_(other) {}
-	CowString & operator=(const CowString &other) { inner_ = other.inner_; return *this; }
+    CowString() = default;
+    CowString(const CowString &other) : inner_(other.inner_) {}
+    CowString(const char *str) : inner_(str) {}
+    CowString(const QString &other) : inner_(other) {}
+    CowString &operator=(const CowString &other) {
+        inner_ = other.inner_;
+        return *this;
+    }
 
-	bool isEmpty() const { return inner_.isEmpty(); }
+    bool isEmpty() const { return inner_.isEmpty(); }
 
-	void clear() { inner_.clear(); }
+    void clear() { inner_.clear(); }
 
-	CowByteArray toUtf8() const { return inner_.toUtf8(); }
+    CowByteArray toUtf8() const { return inner_.toUtf8(); }
 
-	const QString & asQString() const { return inner_; }
-	QString & asQString() { return inner_; }
+    const QString &asQString() const { return inner_; }
+    QString &asQString() { return inner_; }
 
-	friend bool operator==(const CowString &lhs, const CowString &rhs);
-	friend bool operator==(const CowString &lhs, const char *const &rhs);
-	friend bool operator==(const char *const &lhs, const CowString &rhs);
+    friend bool operator==(const CowString &lhs, const CowString &rhs);
+    friend bool operator==(const CowString &lhs, const char *const &rhs);
+    friend bool operator==(const char *const &lhs, const CowString &rhs);
 
 private:
-	QString inner_;
+    QString inner_;
 };
 
-inline bool operator==(const CowString &lhs, const CowString &rhs) { return lhs.inner_ == rhs.inner_; }
+inline bool operator==(const CowString &lhs, const CowString &rhs) {
+    return lhs.inner_ == rhs.inner_;
+}
 inline bool operator==(const CowString &lhs, const char *const &rhs) { return lhs.inner_ == rhs; }
 inline bool operator==(const char *const &lhs, const CowString &rhs) { return lhs == rhs.inner_; }
 inline bool operator!=(const CowString &lhs, const CowString &rhs) { return !(lhs == rhs); }

--- a/src/core/cowstringtest.cpp
+++ b/src/core/cowstringtest.cpp
@@ -20,77 +20,72 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
 #include "cowstring.h"
+#include "test.h"
 
-static void constructors()
-{
-	// Default
-	CowString a;
-	TEST_ASSERT(a.isEmpty());
+static void constructors() {
+    // Default
+    CowString a;
+    TEST_ASSERT(a.isEmpty());
 
-	// Char*
-	CowString b("hello");
-	TEST_ASSERT_EQ(b, "hello");
+    // Char*
+    CowString b("hello");
+    TEST_ASSERT_EQ(b, "hello");
 
-	// Copy
-	CowString c(b);
-	TEST_ASSERT_EQ(c, "hello");
+    // Copy
+    CowString c(b);
+    TEST_ASSERT_EQ(c, "hello");
 
-	// QString
-	QString qs("hello");
-	CowString d(qs);
-	TEST_ASSERT_EQ(d, "hello");
+    // QString
+    QString qs("hello");
+    CowString d(qs);
+    TEST_ASSERT_EQ(d, "hello");
 }
 
-static void methods()
-{
-	// IsEmpty
-	CowString empty;
-	TEST_ASSERT(empty.isEmpty());
+static void methods() {
+    // IsEmpty
+    CowString empty;
+    TEST_ASSERT(empty.isEmpty());
 
-	// Clear
-	CowString a("hello");
-	TEST_ASSERT(!a.isEmpty());
-	a.clear();
-	TEST_ASSERT(a.isEmpty());
+    // Clear
+    CowString a("hello");
+    TEST_ASSERT(!a.isEmpty());
+    a.clear();
+    TEST_ASSERT(a.isEmpty());
 
-	// ToUtf8
-	CowString b("hello");
-	CowByteArray ba = b.toUtf8();
-	TEST_ASSERT_EQ(ba, "hello");
+    // ToUtf8
+    CowString b("hello");
+    CowByteArray ba = b.toUtf8();
+    TEST_ASSERT_EQ(ba, "hello");
 }
 
-static void operators()
-{
-	// Operator=
-	CowString a;
-	a = CowString("hello");
-	TEST_ASSERT_EQ(a, "hello");
+static void operators() {
+    // Operator=
+    CowString a;
+    a = CowString("hello");
+    TEST_ASSERT_EQ(a, "hello");
 
-	// Operator==
-	TEST_ASSERT(CowString("hello") == CowString("hello"));
-	TEST_ASSERT(CowString("hello") == "hello");
-	TEST_ASSERT("hello" == CowString("hello"));
+    // Operator==
+    TEST_ASSERT(CowString("hello") == CowString("hello"));
+    TEST_ASSERT(CowString("hello") == "hello");
+    TEST_ASSERT("hello" == CowString("hello"));
 
-	// Operator!=
-	TEST_ASSERT(CowString("hello") != CowString("world"));
-	TEST_ASSERT(CowString("hello") != "world");
-	TEST_ASSERT("hello" != CowString("world"));
+    // Operator!=
+    TEST_ASSERT(CowString("hello") != CowString("world"));
+    TEST_ASSERT(CowString("hello") != "world");
+    TEST_ASSERT("hello" != CowString("world"));
 }
 
-static void conversions()
-{
-	CowString a("hello");
-	TEST_ASSERT_EQ(a, "hello");
+static void conversions() {
+    CowString a("hello");
+    TEST_ASSERT_EQ(a, "hello");
 }
 
-extern "C" int cowstring_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(constructors());
-	TEST_CATCH(methods());
-	TEST_CATCH(operators());
-	TEST_CATCH(conversions());
+extern "C" int cowstring_test(ffi::TestException *out_ex) {
+    TEST_CATCH(constructors());
+    TEST_CATCH(methods());
+    TEST_CATCH(operators());
+    TEST_CATCH(conversions());
 
-	return 0;
+    return 0;
 }

--- a/src/core/defercall.cpp
+++ b/src/core/defercall.cpp
@@ -22,304 +22,265 @@
 
 #include "defercall.h"
 
-#include <QObject>
-#include <QMetaObject>
-#include <boost/signals2.hpp>
-#include "timer.h"
 #include "event.h"
 #include "eventloop.h"
+#include "timer.h"
+#include <QMetaObject>
+#include <QObject>
+#include <boost/signals2.hpp>
 
 namespace {
 
-class ThreadWake : public QObject
-{
-	Q_OBJECT
+class ThreadWake : public QObject {
+    Q_OBJECT
 
 public:
-	ThreadWake() :
-		customRegId_(-1),
-		wakeQueued_(false)
-	{
-		EventLoop *loop = EventLoop::instance();
+    ThreadWake() : customRegId_(-1), wakeQueued_(false) {
+        EventLoop *loop = EventLoop::instance();
 
-		if(loop)
-		{
-			auto [regId, sr] = loop->registerCustom(ThreadWake::cb_ready, this);
-			assert(regId >= 0);
+        if (loop) {
+            auto [regId, sr] = loop->registerCustom(ThreadWake::cb_ready, this);
+            assert(regId >= 0);
 
-			customRegId_ = regId;
-			sr_ = std::move(sr);
-		}
-	}
+            customRegId_ = regId;
+            sr_ = std::move(sr);
+        }
+    }
 
-	~ThreadWake()
-	{
-		if(customRegId_ >= 0)
-			EventLoop::instance()->deregister(customRegId_);
-	}
+    ~ThreadWake() {
+        if (customRegId_ >= 0)
+            EventLoop::instance()->deregister(customRegId_);
+    }
 
-	// Requests the awake signal to be emitted from the object's event loop
-	// at the next opportunity. This is safe to call from another thread. If
-	// this is called multiple times before the signal is emitted, the signal
-	// will only be emitted once.
-	void wake()
-	{
-		std::lock_guard<std::mutex> guard(mutex_);
+    // Requests the awake signal to be emitted from the object's event loop
+    // at the next opportunity. This is safe to call from another thread. If
+    // this is called multiple times before the signal is emitted, the signal
+    // will only be emitted once.
+    void wake() {
+        std::lock_guard<std::mutex> guard(mutex_);
 
-		if(wakeQueued_)
-			return;
+        if (wakeQueued_)
+            return;
 
-		wakeQueued_ = true;
+        wakeQueued_ = true;
 
-		if(sr_)
-			sr_->setReadiness(Event::Readable);
-		else
-			QMetaObject::invokeMethod(this, "slotReady", Qt::QueuedConnection);
-	}
+        if (sr_)
+            sr_->setReadiness(Event::Readable);
+        else
+            QMetaObject::invokeMethod(this, "slotReady", Qt::QueuedConnection);
+    }
 
-	boost::signals2::signal<void()> awake;
+    boost::signals2::signal<void()> awake;
 
 private slots:
-	void slotReady()
-	{
-		ready();
-	}
+    void slotReady() { ready(); }
 
 private:
-	int customRegId_;
-	std::unique_ptr<Event::SetReadiness> sr_;
-	std::mutex mutex_;
-	bool wakeQueued_;
+    int customRegId_;
+    std::unique_ptr<Event::SetReadiness> sr_;
+    std::mutex mutex_;
+    bool wakeQueued_;
 
-	static void cb_ready(void *ctx, uint8_t readiness)
-	{
-		Q_UNUSED(readiness);
+    static void cb_ready(void *ctx, uint8_t readiness) {
+        Q_UNUSED(readiness);
 
-		ThreadWake *self = (ThreadWake *)ctx;
+        ThreadWake *self = (ThreadWake *)ctx;
 
-		self->ready();
-	}
+        self->ready();
+    }
 
-	void ready()
-	{
-		{
-			std::lock_guard<std::mutex> guard(mutex_);
+    void ready() {
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
 
-			wakeQueued_ = false;
-		}
+            wakeQueued_ = false;
+        }
 
-		awake();
-	}
+        awake();
+    }
 };
 
-}
+} // namespace
 
-class DeferCall::Manager
-{
+class DeferCall::Manager {
 public:
-	Manager() :
-		thread_(std::this_thread::get_id())
-	{
-		timer_.setSingleShot(true);
-		timer_.timeout.connect(boost::bind(&Manager::timer_timeout, this));
+    Manager() : thread_(std::this_thread::get_id()) {
+        timer_.setSingleShot(true);
+        timer_.timeout.connect(boost::bind(&Manager::timer_timeout, this));
 
-		threadWake_.awake.connect(boost::bind(&Manager::threadWake_awake, this));
-	}
+        threadWake_.awake.connect(boost::bind(&Manager::threadWake_awake, this));
+    }
 
-	void add(const std::weak_ptr<Call> &c)
-	{
-		std::lock_guard<std::mutex> guard(callsMutex_);
+    void add(const std::weak_ptr<Call> &c) {
+        std::lock_guard<std::mutex> guard(callsMutex_);
 
-		calls_.push_back(c);
+        calls_.push_back(c);
 
-		if(std::this_thread::get_id() == thread_)
-		{
-			if(!timer_.isActive())
-				timer_.start(0);
-		}
-		else
-		{
-			threadWake_.wake();
-		}
-	}
+        if (std::this_thread::get_id() == thread_) {
+            if (!timer_.isActive())
+                timer_.start(0);
+        } else {
+            threadWake_.wake();
+        }
+    }
 
-	void flush()
-	{
-		while(!isCallsEmpty())
-			process();
-	}
+    void flush() {
+        while (!isCallsEmpty())
+            process();
+    }
 
 private:
-	std::thread::id thread_;
-	Timer timer_;
-	ThreadWake threadWake_;
-	std::mutex callsMutex_;
-	std::list<std::weak_ptr<Call>> calls_;
+    std::thread::id thread_;
+    Timer timer_;
+    ThreadWake threadWake_;
+    std::mutex callsMutex_;
+    std::list<std::weak_ptr<Call>> calls_;
 
-	// Thread-safe
-	bool isCallsEmpty()
-	{
-		std::lock_guard<std::mutex> guard(callsMutex_);
+    // Thread-safe
+    bool isCallsEmpty() {
+        std::lock_guard<std::mutex> guard(callsMutex_);
 
-		return calls_.empty();
-	}
+        return calls_.empty();
+    }
 
-	// Thread-safe
-	void process()
-	{
-		std::list<std::weak_ptr<Call>> ready;
+    // Thread-safe
+    void process() {
+        std::list<std::weak_ptr<Call>> ready;
 
-		// Lock to take list
-		{
-			std::lock_guard<std::mutex> guard(callsMutex_);
+        // Lock to take list
+        {
+            std::lock_guard<std::mutex> guard(callsMutex_);
 
-			// Process all calls queued so far, but not any that may get queued
-			// during processing
-			ready.swap(calls_);
-		}
+            // Process all calls queued so far, but not any that may get queued
+            // during processing
+            ready.swap(calls_);
+        }
 
-		// Process list while not locked
-		for(auto c : ready)
-		{
-			if(auto p = c.lock())
-			{
-				auto source = p->source.lock();
+        // Process list while not locked
+        for (auto c : ready) {
+            if (auto p = c.lock()) {
+                auto source = p->source.lock();
 
-				// If call is valid then its source will be too
-				assert(source);
+                // If call is valid then its source will be too
+                assert(source);
 
-				source->erase(p->sourceElement);
+                source->erase(p->sourceElement);
 
-				p->handler();
-			}
-		}
-	}
+                p->handler();
+            }
+        }
+    }
 
-	void timer_timeout()
-	{
-		process();
+    void timer_timeout() {
+        process();
 
-		// No need to re-arm the timer. If new calls were queued during
-		// processing, add() will have taken care of that
-	}
+        // No need to re-arm the timer. If new calls were queued during
+        // processing, add() will have taken care of that
+    }
 
-	void threadWake_awake()
-	{
-		process();
-	}
+    void threadWake_awake() { process(); }
 };
 
-std::list<std::shared_ptr<DeferCall::Call>>::size_type DeferCall::CallsList::size() const
-{
-	std::lock_guard<std::mutex> guard(mutex);
+std::list<std::shared_ptr<DeferCall::Call>>::size_type DeferCall::CallsList::size() const {
+    std::lock_guard<std::mutex> guard(mutex);
 
-	return l.size();
+    return l.size();
 }
 
-std::list<std::shared_ptr<DeferCall::Call>>::iterator DeferCall::CallsList::append(const std::shared_ptr<DeferCall::Call> &c)
-{
-	std::lock_guard<std::mutex> guard(mutex);
+std::list<std::shared_ptr<DeferCall::Call>>::iterator
+DeferCall::CallsList::append(const std::shared_ptr<DeferCall::Call> &c) {
+    std::lock_guard<std::mutex> guard(mutex);
 
-	l.push_back(c);
+    l.push_back(c);
 
-	// Get an iterator to the element that was pushed
-	auto it = l.end();
-	--it;
+    // Get an iterator to the element that was pushed
+    auto it = l.end();
+    --it;
 
-	return it;
+    return it;
 }
 
-void DeferCall::CallsList::erase(std::list<std::shared_ptr<DeferCall::Call>>::iterator position)
-{
-	std::lock_guard<std::mutex> guard(mutex);
+void DeferCall::CallsList::erase(std::list<std::shared_ptr<DeferCall::Call>>::iterator position) {
+    std::lock_guard<std::mutex> guard(mutex);
 
-	l.erase(position);
+    l.erase(position);
 }
 
-DeferCall::DeferCall() :
-	thread_(std::this_thread::get_id()),
-	deferredCalls_(std::make_shared<CallsList>())
-{
-	if(!localManager)
-	{
-		localManager = std::make_shared<Manager>();
+DeferCall::DeferCall()
+    : thread_(std::this_thread::get_id()), deferredCalls_(std::make_shared<CallsList>()) {
+    if (!localManager) {
+        localManager = std::make_shared<Manager>();
 
-		std::lock_guard<std::mutex> guard(managerByThreadMutex);
-		managerByThread[thread_] = localManager;
+        std::lock_guard<std::mutex> guard(managerByThreadMutex);
+        managerByThread[thread_] = localManager;
 
-		EventLoop *loop = EventLoop::instance();
-		if(loop)
-		{
-			// We use the manager pointer to uniquely identify the handler
-			// registration even though the handler function doesn't do
-			// anything with it
-			loop->addCleanupHandler(eventloop_cleanup_handler, localManager.get());
-		}
-	}
+        EventLoop *loop = EventLoop::instance();
+        if (loop) {
+            // We use the manager pointer to uniquely identify the handler
+            // registration even though the handler function doesn't do
+            // anything with it
+            loop->addCleanupHandler(eventloop_cleanup_handler, localManager.get());
+        }
+    }
 }
 
 DeferCall::~DeferCall() = default;
 
-void DeferCall::defer(std::function<void ()> handler)
-{
-	std::shared_ptr<Call> c = std::make_shared<Call>();
-	c->handler = handler;
-	c->source = deferredCalls_;
-	c->sourceElement = deferredCalls_->append(c);
+void DeferCall::defer(std::function<void()> handler) {
+    std::shared_ptr<Call> c = std::make_shared<Call>();
+    c->handler = handler;
+    c->source = deferredCalls_;
+    c->sourceElement = deferredCalls_->append(c);
 
-	Manager *manager = localManager.get();
+    Manager *manager = localManager.get();
 
-	if(std::this_thread::get_id() != thread_)
-	{
-		std::lock_guard<std::mutex> guard(managerByThreadMutex);
-		auto it = managerByThread.find(thread_);
-		assert(it != managerByThread.end());
+    if (std::this_thread::get_id() != thread_) {
+        std::lock_guard<std::mutex> guard(managerByThreadMutex);
+        auto it = managerByThread.find(thread_);
+        assert(it != managerByThread.end());
 
-		manager = it->second.get();
-	}
+        manager = it->second.get();
+    }
 
-	// Manager keeps a weak pointer, so we can invalidate pending calls by
-	// simply deleting them
-	manager->add(c);
+    // Manager keeps a weak pointer, so we can invalidate pending calls by
+    // simply deleting them
+    manager->add(c);
 }
 
-DeferCall *DeferCall::global()
-{
-	if(!localInstance)
-		localInstance = std::make_unique<DeferCall>();
+DeferCall *DeferCall::global() {
+    if (!localInstance)
+        localInstance = std::make_unique<DeferCall>();
 
-	return localInstance.get();
+    return localInstance.get();
 }
 
-void DeferCall::cleanup()
-{
-	if(localManager)
-		localManager->flush();
+void DeferCall::cleanup() {
+    if (localManager)
+        localManager->flush();
 
-	localInstance.reset();
+    localInstance.reset();
 
-	if(localManager)
-	{
-		EventLoop *loop = EventLoop::instance();
-		if(loop)
-			loop->removeCleanupHandler(eventloop_cleanup_handler, localManager.get());
+    if (localManager) {
+        EventLoop *loop = EventLoop::instance();
+        if (loop)
+            loop->removeCleanupHandler(eventloop_cleanup_handler, localManager.get());
 
-		std::lock_guard<std::mutex> guard(managerByThreadMutex);
-		managerByThread.erase(std::this_thread::get_id());
+        std::lock_guard<std::mutex> guard(managerByThreadMutex);
+        managerByThread.erase(std::this_thread::get_id());
 
-		localManager.reset();
-	}
+        localManager.reset();
+    }
 }
 
-void DeferCall::eventloop_cleanup_handler(void *)
-{
-	cleanup();
-}
+void DeferCall::eventloop_cleanup_handler(void *) { cleanup(); }
 
-thread_local std::shared_ptr<DeferCall::Manager> DeferCall::localManager = std::shared_ptr<DeferCall::Manager>();
+thread_local std::shared_ptr<DeferCall::Manager> DeferCall::localManager =
+    std::shared_ptr<DeferCall::Manager>();
 thread_local std::unique_ptr<DeferCall> DeferCall::localInstance = std::unique_ptr<DeferCall>();
 
-std::unordered_map<std::thread::id, std::shared_ptr<DeferCall::Manager>> DeferCall::managerByThread = std::unordered_map<std::thread::id, std::shared_ptr<DeferCall::Manager>>();
+std::unordered_map<std::thread::id, std::shared_ptr<DeferCall::Manager>>
+    DeferCall::managerByThread =
+        std::unordered_map<std::thread::id, std::shared_ptr<DeferCall::Manager>>();
 std::mutex DeferCall::managerByThreadMutex = std::mutex();
 
 #include "defercall.moc"

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -1,98 +1,93 @@
 /*
-* Copyright (C) 2025 Fastly, Inc.
-*
-* This file is part of Pushpin.
-*
-* $FANOUT_BEGIN_LICENSE:APACHE2$
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* $FANOUT_END_LICENSE$
-*/
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
 
 #ifndef DEFERCALL_H
 #define DEFERCALL_H
 
 #include <functional>
-#include <memory>
 #include <list>
-#include <unordered_map>
-#include <thread>
+#include <memory>
 #include <mutex>
+#include <thread>
+#include <unordered_map>
 
 // Queues calls to be run after returning to the event loop
-class DeferCall
-{
+class DeferCall {
 public:
-	DeferCall();
-	~DeferCall();
+    DeferCall();
+    ~DeferCall();
 
-	// Queue handler to be called after returning to the event loop. If
-	// handler contains references, they must outlive DeferCall. The
-	// recommended usage is for each object needing to perform deferred calls
-	// to keep a DeferCall as a member variable, and only refer to the
-	// object's own data in the handler. That way, any references are
-	// guaranteed to live long enough.
-	void defer(std::function<void ()> handler);
+    // Queue handler to be called after returning to the event loop. If
+    // handler contains references, they must outlive DeferCall. The
+    // recommended usage is for each object needing to perform deferred calls
+    // to keep a DeferCall as a member variable, and only refer to the
+    // object's own data in the handler. That way, any references are
+    // guaranteed to live long enough.
+    void defer(std::function<void()> handler);
 
-	int pendingCount() const { return deferredCalls_->size(); }
+    int pendingCount() const { return deferredCalls_->size(); }
 
-	static DeferCall *global();
-	static void cleanup();
+    static DeferCall *global();
+    static void cleanup();
 
-	template <typename T>
-	static void deleteLater(T *p)
-	{
-		global()->defer([=] { delete p; });
-	}
+    template <typename T> static void deleteLater(T *p) {
+        global()->defer([=] { delete p; });
+    }
 
 private:
-	class Call;
+    class Call;
 
-	class CallsList
-	{
-	public:
-		// All methods thread-safe
-		std::list<std::shared_ptr<Call>>::size_type size() const;
-		std::list<std::shared_ptr<Call>>::iterator append(const std::shared_ptr<Call> &c);
-		void erase(std::list<std::shared_ptr<Call>>::iterator position);
+    class CallsList {
+    public:
+        // All methods thread-safe
+        std::list<std::shared_ptr<Call>>::size_type size() const;
+        std::list<std::shared_ptr<Call>>::iterator append(const std::shared_ptr<Call> &c);
+        void erase(std::list<std::shared_ptr<Call>>::iterator position);
 
-	private:
-		mutable std::mutex mutex;
-		std::list<std::shared_ptr<Call>> l;
-	};
+    private:
+        mutable std::mutex mutex;
+        std::list<std::shared_ptr<Call>> l;
+    };
 
-	class Call
-	{
-	public:
-		std::function<void ()> handler;
-		std::weak_ptr<CallsList> source;
-		std::list<std::shared_ptr<Call>>::iterator sourceElement;
-	};
+    class Call {
+    public:
+        std::function<void()> handler;
+        std::weak_ptr<CallsList> source;
+        std::list<std::shared_ptr<Call>>::iterator sourceElement;
+    };
 
-	class Manager;
-	friend class Manager;
+    class Manager;
+    friend class Manager;
 
-	std::thread::id thread_;
-	std::shared_ptr<CallsList> deferredCalls_;
+    std::thread::id thread_;
+    std::shared_ptr<CallsList> deferredCalls_;
 
-	static thread_local std::shared_ptr<Manager> localManager;
-	static thread_local std::unique_ptr<DeferCall> localInstance;
+    static thread_local std::shared_ptr<Manager> localManager;
+    static thread_local std::unique_ptr<DeferCall> localInstance;
 
-	static std::unordered_map<std::thread::id, std::shared_ptr<Manager>> managerByThread;
-	static std::mutex managerByThreadMutex;
+    static std::unordered_map<std::thread::id, std::shared_ptr<Manager>> managerByThread;
+    static std::mutex managerByThreadMutex;
 
-	static void eventloop_cleanup_handler(void *ctx);
+    static void eventloop_cleanup_handler(void *ctx);
 };
 
 #endif

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -20,130 +20,112 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <thread>
-#include "test.h"
 #include "defercall.h"
 #include "eventloop.h"
+#include "test.h"
+#include <thread>
 
 // loop_advance should process enough events to cause the calls to run,
 // Without sleeping, in order to prove the calls are run immediately
-static std::tuple<int, int> runDeferCall(std::function<void ()> loop_advance)
-{
-	DeferCall deferCall;
-	int count = 0;
+static std::tuple<int, int> runDeferCall(std::function<void()> loop_advance) {
+    DeferCall deferCall;
+    int count = 0;
 
-	deferCall.defer([&] {
-		++count;
+    deferCall.defer([&] {
+        ++count;
 
-		deferCall.defer([&] {
-			++count;
-		});
-	});
+        deferCall.defer([&] { ++count; });
+    });
 
-	loop_advance();
+    loop_advance();
 
-	return {deferCall.pendingCount(), count};
+    return {deferCall.pendingCount(), count};
 }
 
 // Spawns a thread, triggers the deferCall from it, then waits for thread to
 // finish
-static void callNonLocal(DeferCall *deferCall, std::function<void ()> handler)
-{
-	std::thread thread([=] {
-		deferCall->defer(handler);
-	});
-	thread.join();
+static void callNonLocal(DeferCall *deferCall, std::function<void()> handler) {
+    std::thread thread([=] { deferCall->defer(handler); });
+    thread.join();
 }
 
 // loop_advance should process enough events to cause the calls to run,
 // Without sleeping, in order to prove the calls are run immediately
-static std::tuple<int, int> runNonLocal(std::function<void ()> loop_advance)
-{
-	DeferCall deferCall;
-	int count = 0;
+static std::tuple<int, int> runNonLocal(std::function<void()> loop_advance) {
+    DeferCall deferCall;
+    int count = 0;
 
-	callNonLocal(&deferCall, [&] {
-		++count;
-	});
+    callNonLocal(&deferCall, [&] { ++count; });
 
-	loop_advance();
+    loop_advance();
 
-	return {deferCall.pendingCount(), count};
+    return {deferCall.pendingCount(), count};
 }
 
-static void deferCall()
-{
-	EventLoop loop(2);
+static void deferCall() {
+    EventLoop loop(2);
 
-	auto [pendingCount, count] = runDeferCall([&] {
-		// Run the first call and queue the second
-		loop.step();
+    auto [pendingCount, count] = runDeferCall([&] {
+        // Run the first call and queue the second
+        loop.step();
 
-		// Run the second
-		loop.step();
-	});
+        // Run the second
+        loop.step();
+    });
 
-	TEST_ASSERT_EQ(pendingCount, 0);
-	TEST_ASSERT_EQ(count, 2);
+    TEST_ASSERT_EQ(pendingCount, 0);
+    TEST_ASSERT_EQ(count, 2);
 }
 
-static void nonLocal()
-{
-	EventLoop loop(2);
+static void nonLocal() {
+    EventLoop loop(2);
 
-	auto [pendingCount, count] = runNonLocal([&] {
-		// Run the first call
-		loop.step();
-	});
+    auto [pendingCount, count] = runNonLocal([&] {
+        // Run the first call
+        loop.step();
+    });
 
-	TEST_ASSERT_EQ(pendingCount, 0);
-	TEST_ASSERT_EQ(count, 1);
+    TEST_ASSERT_EQ(pendingCount, 0);
+    TEST_ASSERT_EQ(count, 1);
 }
 
-static void retract()
-{
-	EventLoop loop(2);
+static void retract() {
+    EventLoop loop(2);
 
-	bool called = false;
+    bool called = false;
 
-	{
-		DeferCall deferCall;
+    {
+        DeferCall deferCall;
 
-		deferCall.defer([&] {
-			called = true;
-		});
-	}
+        deferCall.defer([&] { called = true; });
+    }
 
-	DeferCall::cleanup();
-	TEST_ASSERT(!called);
+    DeferCall::cleanup();
+    TEST_ASSERT(!called);
 }
 
-static void managerCleanup()
-{
-	EventLoop loop(2);
+static void managerCleanup() {
+    EventLoop loop(2);
 
-	int count = 0;
+    int count = 0;
 
-	DeferCall::global()->defer([&] {
-		++count;
+    DeferCall::global()->defer([&] {
+        ++count;
 
-		DeferCall::global()->defer([&] {
-			++count;
-		});
-	});
+        DeferCall::global()->defer([&] { ++count; });
+    });
 
-	// Cleanup should process deferred calls queued so far as well as
-	// those queued during processing
-	DeferCall::cleanup();
-	TEST_ASSERT_EQ(count, 2);
+    // Cleanup should process deferred calls queued so far as well as
+    // those queued during processing
+    DeferCall::cleanup();
+    TEST_ASSERT_EQ(count, 2);
 }
 
-extern "C" int defercall_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(deferCall());
-	TEST_CATCH(nonLocal());
-	TEST_CATCH(retract());
-	TEST_CATCH(managerCleanup());
+extern "C" int defercall_test(ffi::TestException *out_ex) {
+    TEST_CATCH(deferCall());
+    TEST_CATCH(nonLocal());
+    TEST_CATCH(retract());
+    TEST_CATCH(managerCleanup());
 
-	return 0;
+    return 0;
 }

--- a/src/core/event.cpp
+++ b/src/core/event.cpp
@@ -18,19 +18,12 @@
 
 namespace Event {
 
-SetReadiness::SetReadiness(ffi::SetReadiness *inner) :
-	inner_(inner)
-{
+SetReadiness::SetReadiness(ffi::SetReadiness *inner) : inner_(inner) {}
+
+SetReadiness::~SetReadiness() { ffi::set_readiness_destroy(inner_); }
+
+int SetReadiness::setReadiness(uint8_t readiness) {
+    return ffi::set_readiness_set_readiness(inner_, readiness);
 }
 
-SetReadiness::~SetReadiness()
-{
-	ffi::set_readiness_destroy(inner_);
-}
-
-int SetReadiness::setReadiness(uint8_t readiness)
-{
-	return ffi::set_readiness_set_readiness(inner_, readiness);
-}
-
-}
+} // namespace Event

--- a/src/core/event.h
+++ b/src/core/event.h
@@ -23,32 +23,30 @@ class EventLoop;
 
 namespace Event {
 
-enum Interest
-{
-	Readable = ffi::READABLE,
-	Writable = ffi::WRITABLE,
+enum Interest {
+    Readable = ffi::READABLE,
+    Writable = ffi::WRITABLE,
 };
 
-class SetReadiness
-{
+class SetReadiness {
 public:
-	~SetReadiness();
+    ~SetReadiness();
 
-	// Disable copying
-	SetReadiness(const SetReadiness &) = delete;
-	SetReadiness & operator=(const SetReadiness &) = delete;
+    // Disable copying
+    SetReadiness(const SetReadiness &) = delete;
+    SetReadiness &operator=(const SetReadiness &) = delete;
 
-	// Pass a non-zero set of Interest flags
-	int setReadiness(uint8_t readiness);
+    // Pass a non-zero set of Interest flags
+    int setReadiness(uint8_t readiness);
 
 private:
-	friend class ::EventLoop;
+    friend class ::EventLoop;
 
-	SetReadiness(ffi::SetReadiness *inner);
+    SetReadiness(ffi::SetReadiness *inner);
 
-	ffi::SetReadiness *inner_;
+    ffi::SetReadiness *inner_;
 };
 
-}
+} // namespace Event
 
 #endif

--- a/src/core/eventloop.cpp
+++ b/src/core/eventloop.cpp
@@ -20,154 +20,127 @@
 
 static thread_local EventLoop *g_instance = nullptr;
 
-EventLoop::EventLoop(int capacity) :
-	taskManaged_(false)
-{
-	// Only one per thread allowed
-	assert(!g_instance);
+EventLoop::EventLoop(int capacity) : taskManaged_(false) {
+    // Only one per thread allowed
+    assert(!g_instance);
 
-	inner_ = ffi::event_loop_create(capacity);
+    inner_ = ffi::event_loop_create(capacity);
 
-	g_instance = this;
+    g_instance = this;
 }
 
-EventLoop::EventLoop(ffi::EventLoopRaw *inner) :
-	inner_(inner),
-	taskManaged_(true)
-{
-	// Instance is task-managed, meaning the task owns the inner handle and
-	// will manage where g_instance points. The instance should not destroy
-	// the inner handle nor modify g_instance.
+EventLoop::EventLoop(ffi::EventLoopRaw *inner) : inner_(inner), taskManaged_(true) {
+    // Instance is task-managed, meaning the task owns the inner handle and
+    // will manage where g_instance points. The instance should not destroy
+    // the inner handle nor modify g_instance.
 }
 
-EventLoop::~EventLoop()
-{
-	while(!cleanupHandlers_.empty())
-	{
-		CleanupHandler h = cleanupHandlers_.front();
-		cleanupHandlers_.pop_front();
+EventLoop::~EventLoop() {
+    while (!cleanupHandlers_.empty()) {
+        CleanupHandler h = cleanupHandlers_.front();
+        cleanupHandlers_.pop_front();
 
-		h.handler(h.ctx);
-	}
+        h.handler(h.ctx);
+    }
 
-	if(!taskManaged_)
-	{
-		ffi::event_loop_destroy(inner_);
+    if (!taskManaged_) {
+        ffi::event_loop_destroy(inner_);
 
-		g_instance = nullptr;
-	}
+        g_instance = nullptr;
+    }
 }
 
-std::optional<int> EventLoop::step()
-{
-	std::optional<int> code;
+std::optional<int> EventLoop::step() {
+    std::optional<int> code;
 
-	int x;
-	if(ffi::event_loop_step(inner_, &x) == 0)
-		code = x;
+    int x;
+    if (ffi::event_loop_step(inner_, &x) == 0)
+        code = x;
 
-	return code;
+    return code;
 }
 
-int EventLoop::exec()
-{
-	return ffi::event_loop_exec(inner_);
+int EventLoop::exec() { return ffi::event_loop_exec(inner_); }
+
+void EventLoop::exit(int code) { ffi::event_loop_exit(inner_, code); }
+
+int EventLoop::registerFd(int fd, uint8_t interest, void (*cb)(void *, uint8_t), void *ctx) {
+    size_t id;
+
+    if (ffi::event_loop_register_fd(inner_, fd, interest, cb, ctx, &id) != 0)
+        return -1;
+
+    return (int)id;
 }
 
-void EventLoop::exit(int code)
-{
-	ffi::event_loop_exit(inner_, code);
+int EventLoop::registerTimer(int timeout, void (*cb)(void *, uint8_t), void *ctx) {
+    size_t id;
+
+    if (ffi::event_loop_register_timer(inner_, timeout, cb, ctx, &id) != 0)
+        return -1;
+
+    return (int)id;
 }
 
-int EventLoop::registerFd(int fd, uint8_t interest, void (*cb)(void *, uint8_t), void *ctx)
-{
-	size_t id;
+std::tuple<int, std::unique_ptr<Event::SetReadiness>>
+EventLoop::registerCustom(void (*cb)(void *, uint8_t), void *ctx) {
+    size_t id;
+    ffi::SetReadiness *srRaw = nullptr;
 
-	if(ffi::event_loop_register_fd(inner_, fd, interest, cb, ctx, &id) != 0)
-		return -1;
+    if (ffi::event_loop_register_custom(inner_, cb, ctx, &id, &srRaw) != 0)
+        return std::tuple<int, std::unique_ptr<Event::SetReadiness>>();
 
-	return (int)id;
+    std::unique_ptr<Event::SetReadiness> sr(new Event::SetReadiness(srRaw));
+
+    return std::tuple<int, std::unique_ptr<Event::SetReadiness>>({(int)id, std::move(sr)});
 }
 
-int EventLoop::registerTimer(int timeout, void (*cb)(void *, uint8_t), void *ctx)
-{
-	size_t id;
+void EventLoop::deregister(int id) { assert(ffi::event_loop_deregister(inner_, id) == 0); }
 
-	if(ffi::event_loop_register_timer(inner_, timeout, cb, ctx, &id) != 0)
-		return -1;
+void EventLoop::addCleanupHandler(void (*handler)(void *), void *ctx) {
+    CleanupHandler h;
+    h.handler = handler;
+    h.ctx = ctx;
 
-	return (int)id;
+    cleanupHandlers_.push_front(h);
 }
 
-std::tuple<int, std::unique_ptr<Event::SetReadiness>> EventLoop::registerCustom(void (*cb)(void *, uint8_t), void *ctx)
-{
-	size_t id;
-	ffi::SetReadiness *srRaw = nullptr;
+void EventLoop::removeCleanupHandler(void (*handler)(void *), void *ctx) {
+    CleanupHandler h;
+    h.handler = handler;
+    h.ctx = ctx;
 
-	if(ffi::event_loop_register_custom(inner_, cb, ctx, &id, &srRaw) != 0)
-		return std::tuple<int, std::unique_ptr<Event::SetReadiness>>();
-
-	std::unique_ptr<Event::SetReadiness> sr(new Event::SetReadiness(srRaw));
-
-	return std::tuple<int, std::unique_ptr<Event::SetReadiness>>({(int)id, std::move(sr)});
+    cleanupHandlers_.remove(h);
 }
 
-void EventLoop::deregister(int id)
-{
-	assert(ffi::event_loop_deregister(inner_, id) == 0);
+EventLoop *EventLoop::instance() { return g_instance; }
+
+void EventLoop::setup_cb(void *ctx, const ffi::EventLoopRaw *l) {
+    std::function<void()> *setup = (std::function<void()> *)ctx;
+
+    // Only one per thread allowed
+    assert(!g_instance);
+
+    // The task provides a const pointer but the EventLoop class needs a
+    // non-const pointer. However, we promise not to call any non-const
+    // methods with it.
+    ffi::EventLoopRaw *inner = (ffi::EventLoopRaw *)l;
+
+    g_instance = new EventLoop(inner);
+
+    (*setup)();
 }
 
-void EventLoop::addCleanupHandler(void (*handler)(void *), void *ctx)
-{
-	CleanupHandler h;
-	h.handler = handler;
-	h.ctx = ctx;
+void EventLoop::done_cb(void *ctx, int code) {
+    std::function<void(int)> *done = (std::function<void(int)> *)ctx;
 
-	cleanupHandlers_.push_front(h);
+    (*done)(code);
+
+    delete g_instance;
+    g_instance = nullptr;
 }
 
-void EventLoop::removeCleanupHandler(void (*handler)(void *), void *ctx)
-{
-	CleanupHandler h;
-	h.handler = handler;
-	h.ctx = ctx;
-
-	cleanupHandlers_.remove(h);
-}
-
-EventLoop *EventLoop::instance()
-{
-	return g_instance;
-}
-
-void EventLoop::setup_cb(void *ctx, const ffi::EventLoopRaw *l)
-{
-	std::function<void ()> *setup = (std::function<void ()> *)ctx;
-
-	// Only one per thread allowed
-	assert(!g_instance);
-
-	// The task provides a const pointer but the EventLoop class needs a
-	// non-const pointer. However, we promise not to call any non-const
-	// methods with it.
-	ffi::EventLoopRaw *inner = (ffi::EventLoopRaw *)l;
-
-	g_instance = new EventLoop(inner);
-
-	(*setup)();
-}
-
-void EventLoop::done_cb(void *ctx, int code)
-{
-	std::function<void (int)> *done = (std::function<void (int)> *)ctx;
-
-	(*done)(code);
-
-	delete g_instance;
-	g_instance = nullptr;
-}
-
-ffi::UnitFuture *EventLoop::task(int capacity, std::function<void ()> *setup, std::function<void (int)> *done)
-{
-	return ffi::event_loop_task(capacity, setup_cb, setup, done_cb, done);
+ffi::UnitFuture *EventLoop::task(int capacity, std::function<void()> *setup,
+                                 std::function<void(int)> *done) {
+    return ffi::event_loop_task(capacity, setup_cb, setup, done_cb, done);
 }

--- a/src/core/eventloop.h
+++ b/src/core/eventloop.h
@@ -17,63 +17,62 @@
 #ifndef EVENTLOOP_H
 #define EVENTLOOP_H
 
-#include <memory>
-#include <optional>
+#include "event.h"
+#include "rust/bindings.h"
 #include <functional>
 #include <list>
-#include "rust/bindings.h"
-#include "event.h"
+#include <memory>
+#include <optional>
 
-class EventLoop
-{
+class EventLoop {
 public:
-	EventLoop(int capacity);
-	~EventLoop();
+    EventLoop(int capacity);
+    ~EventLoop();
 
-	// Disable copying
-	EventLoop(const EventLoop &) = delete;
-	EventLoop & operator=(const EventLoop &) = delete;
+    // Disable copying
+    EventLoop(const EventLoop &) = delete;
+    EventLoop &operator=(const EventLoop &) = delete;
 
-	std::optional<int> step();
-	int exec();
-	void exit(int code);
+    std::optional<int> step();
+    int exec();
+    void exit(int code);
 
-	int registerFd(int fd, uint8_t interest, void (*cb)(void *, uint8_t), void *ctx);
-	int registerTimer(int timeout, void (*cb)(void *, uint8_t), void *ctx);
-	std::tuple<int, std::unique_ptr<Event::SetReadiness>> registerCustom(void (*cb)(void *, uint8_t), void *ctx);
-	void deregister(int id);
+    int registerFd(int fd, uint8_t interest, void (*cb)(void *, uint8_t), void *ctx);
+    int registerTimer(int timeout, void (*cb)(void *, uint8_t), void *ctx);
+    std::tuple<int, std::unique_ptr<Event::SetReadiness>>
+    registerCustom(void (*cb)(void *, uint8_t), void *ctx);
+    void deregister(int id);
 
-	void addCleanupHandler(void (*handler)(void *), void *ctx);
-	void removeCleanupHandler(void (*handler)(void *), void *ctx);
+    void addCleanupHandler(void (*handler)(void *), void *ctx);
+    void removeCleanupHandler(void (*handler)(void *), void *ctx);
 
-	static EventLoop *instance();
+    static EventLoop *instance();
 
-	/// Returns a future that constructs an event loop and executes it
-	/// asynchronously. `setup` is called just prior to executing, and `done`
-	/// is called when the event loop exits. `setup` and `done` must point
-	/// to functions that live as long as the returned future.
-	static ffi::UnitFuture *task(int capacity, std::function<void ()> *setup, std::function<void (int)> *done);
+    /// Returns a future that constructs an event loop and executes it
+    /// asynchronously. `setup` is called just prior to executing, and `done`
+    /// is called when the event loop exits. `setup` and `done` must point
+    /// to functions that live as long as the returned future.
+    static ffi::UnitFuture *task(int capacity, std::function<void()> *setup,
+                                 std::function<void(int)> *done);
 
 private:
-	class CleanupHandler
-	{
-	public:
-		void (*handler)(void *);
-		void *ctx;
+    class CleanupHandler {
+    public:
+        void (*handler)(void *);
+        void *ctx;
 
-		bool operator==(const CleanupHandler &other) const
-		{
-			return (other.handler == handler && other.ctx == ctx);
-		}
-	};
+        bool operator==(const CleanupHandler &other) const {
+            return (other.handler == handler && other.ctx == ctx);
+        }
+    };
 
-	ffi::EventLoopRaw *inner_;
-	bool taskManaged_;
-	std::list<CleanupHandler> cleanupHandlers_;
+    ffi::EventLoopRaw *inner_;
+    bool taskManaged_;
+    std::list<CleanupHandler> cleanupHandlers_;
 
-	EventLoop(ffi::EventLoopRaw *inner);
-	static void setup_cb(void *ctx, const ffi::EventLoopRaw *l);
-	static void done_cb(void *ctx, int code);
+    EventLoop(ffi::EventLoopRaw *inner);
+    static void setup_cb(void *ctx, const ffi::EventLoopRaw *l);
+    static void done_cb(void *ctx, int code);
 };
 
 #endif

--- a/src/core/eventlooptest.cpp
+++ b/src/core/eventlooptest.cpp
@@ -1,130 +1,121 @@
 /*
-* Copyright (C) 2025 Fastly, Inc.
-*
-* This file is part of Pushpin.
-*
-* $FANOUT_BEGIN_LICENSE:APACHE2$
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* $FANOUT_END_LICENSE$
-*/
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * $FANOUT_BEGIN_LICENSE:APACHE2$
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $FANOUT_END_LICENSE$
+ */
 
-#include <unistd.h>
-#include <boost/signals2.hpp>
-#include "test.h"
-#include "defercall.h"
 #include "eventloop.h"
+#include "defercall.h"
 #include "socketnotifier.h"
+#include "test.h"
 #include "timer.h"
+#include <boost/signals2.hpp>
+#include <unistd.h>
 
-static void socketNotifier()
-{
-	EventLoop loop(1);
+static void socketNotifier() {
+    EventLoop loop(1);
 
-	int fds[2];
-	TEST_ASSERT_EQ(pipe(fds), 0);
+    int fds[2];
+    TEST_ASSERT_EQ(pipe(fds), 0);
 
-	SocketNotifier *sn = new SocketNotifier(fds[0], SocketNotifier::Read);
-	sn->clearReadiness(SocketNotifier::Read);
+    SocketNotifier *sn = new SocketNotifier(fds[0], SocketNotifier::Read);
+    sn->clearReadiness(SocketNotifier::Read);
 
-	int activatedFd = -1;
-	uint8_t activatedReadiness = -1;
-	sn->activated.connect([&](int fd, uint8_t readiness) {
-		activatedFd = fd;
-		activatedReadiness = readiness;
-		loop.exit(123);
-	});
+    int activatedFd = -1;
+    uint8_t activatedReadiness = -1;
+    sn->activated.connect([&](int fd, uint8_t readiness) {
+        activatedFd = fd;
+        activatedReadiness = readiness;
+        loop.exit(123);
+    });
 
-	unsigned char c = 1;
-	TEST_ASSERT_EQ(write(fds[1], &c, 1), 1);
+    unsigned char c = 1;
+    TEST_ASSERT_EQ(write(fds[1], &c, 1), 1);
 
-	TEST_ASSERT_EQ(loop.exec(), 123);
-	TEST_ASSERT_EQ(activatedFd, fds[0]);
-	TEST_ASSERT_EQ(activatedReadiness, SocketNotifier::Read);
+    TEST_ASSERT_EQ(loop.exec(), 123);
+    TEST_ASSERT_EQ(activatedFd, fds[0]);
+    TEST_ASSERT_EQ(activatedReadiness, SocketNotifier::Read);
 
-	delete sn;
-	close(fds[1]);
-	close(fds[0]);
+    delete sn;
+    close(fds[1]);
+    close(fds[0]);
 }
 
-static void timer()
-{
-	EventLoop loop(2);
+static void timer() {
+    EventLoop loop(2);
 
-	Timer *t1 = new Timer;
-	Timer *t2 = new Timer;
+    Timer *t1 = new Timer;
+    Timer *t2 = new Timer;
 
-	int timeoutCount = 0;
+    int timeoutCount = 0;
 
-	t1->timeout.connect([&] {
-		++timeoutCount;
-	});
+    t1->timeout.connect([&] { ++timeoutCount; });
 
-	t2->timeout.connect([&] {
-		++timeoutCount;
-		loop.exit(123);
-	});
+    t2->timeout.connect([&] {
+        ++timeoutCount;
+        loop.exit(123);
+    });
 
-	t1->setSingleShot(true);
-	t1->start(0);
+    t1->setSingleShot(true);
+    t1->start(0);
 
-	t2->setSingleShot(true);
-	t2->start(0);
+    t2->setSingleShot(true);
+    t2->start(0);
 
-	TEST_ASSERT_EQ(loop.exec(), 123);
-	TEST_ASSERT_EQ(timeoutCount, 2);
+    TEST_ASSERT_EQ(loop.exec(), 123);
+    TEST_ASSERT_EQ(timeoutCount, 2);
 
-	delete t2;
-	delete t1;
+    delete t2;
+    delete t1;
 }
 
-static void custom()
-{
-	class State
-	{
-	public:
-		EventLoop loop;
-		uint8_t activatedReadiness;
+static void custom() {
+    class State {
+    public:
+        EventLoop loop;
+        uint8_t activatedReadiness;
 
-		State() :
-			loop(EventLoop(1)),
-			activatedReadiness(-1)
-		{
-		}
-	};
+        State() : loop(EventLoop(1)), activatedReadiness(-1) {}
+    };
 
-	State state;
+    State state;
 
-	auto [id, sr] = state.loop.registerCustom([](void *ctx, uint8_t readiness) {
-		State *state = (State *)ctx;
-		state->activatedReadiness = readiness;
-		state->loop.exit(123);
-	}, (void *)&state);
+    auto [id, sr] = state.loop.registerCustom(
+        [](void *ctx, uint8_t readiness) {
+            State *state = (State *)ctx;
+            state->activatedReadiness = readiness;
+            state->loop.exit(123);
+        },
+        (void *)&state);
 
-	TEST_ASSERT(id >= 0);
-	TEST_ASSERT_EQ(sr->setReadiness(Event::Readable), 0);
-	TEST_ASSERT_EQ(state.loop.exec(), 123);
-	TEST_ASSERT_EQ(state.activatedReadiness, Event::Readable);
+    TEST_ASSERT(id >= 0);
+    TEST_ASSERT_EQ(sr->setReadiness(Event::Readable), 0);
+    TEST_ASSERT_EQ(state.loop.exec(), 123);
+    TEST_ASSERT_EQ(state.activatedReadiness, Event::Readable);
 
-	state.loop.deregister(id);
+    state.loop.deregister(id);
 }
 
-extern "C" int eventloop_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(socketNotifier());
-	TEST_CATCH(timer());
-	TEST_CATCH(custom());
+extern "C" int eventloop_test(ffi::TestException *out_ex) {
+    TEST_CATCH(socketNotifier());
+    TEST_CATCH(timer());
+    TEST_CATCH(custom());
 
-	return 0;
+    return 0;
 }

--- a/src/core/executor.cpp
+++ b/src/core/executor.cpp
@@ -16,42 +16,33 @@
 
 #include "executor.h"
 
-Executor::Executor(int tasksMax) :
-	inner_(ffi::executor_create(tasksMax))
-{
+Executor::Executor(int tasksMax) : inner_(ffi::executor_create(tasksMax)) {}
+
+Executor::~Executor() { ffi::executor_destroy(inner_); }
+
+int Executor::park_cb(void *ctx, int ms) {
+    std::function<bool(std::optional<int>)> *park = (std::function<bool(std::optional<int>)> *)ctx;
+
+    std::optional<int> x;
+    if (ms >= 0)
+        x = ms;
+
+    if (!(*park)(x))
+        return -1;
+
+    return 0;
 }
 
-Executor::~Executor()
-{
-	ffi::executor_destroy(inner_);
+bool Executor::run(std::function<bool(std::optional<int>)> park) {
+    if (ffi::executor_run(inner_, park_cb, &park) != 0)
+        return false;
+
+    return true;
 }
 
-int Executor::park_cb(void *ctx, int ms)
-{
-	std::function<bool (std::optional<int>)> *park = (std::function<bool (std::optional<int>)> *)ctx;
+bool Executor::currentSpawn(ffi::UnitFuture *fut) {
+    if (ffi::executor_current_spawn(fut) != 0)
+        return false;
 
-	std::optional<int> x;
-	if(ms >= 0)
-		x = ms;
-
-	if(!(*park)(x))
-		return -1;
-
-	return 0;
-}
-
-bool Executor::run(std::function<bool (std::optional<int>)> park)
-{
-	if(ffi::executor_run(inner_, park_cb, &park) != 0)
-		return false;
-
-	return true;
-}
-
-bool Executor::currentSpawn(ffi::UnitFuture *fut)
-{
-	if(ffi::executor_current_spawn(fut) != 0)
-		return false;
-
-	return true;
+    return true;
 }

--- a/src/core/executor.h
+++ b/src/core/executor.h
@@ -17,28 +17,27 @@
 #ifndef EXECUTOR_H
 #define EXECUTOR_H
 
-#include <optional>
-#include <functional>
 #include "rust/bindings.h"
+#include <functional>
+#include <optional>
 
-class Executor
-{
+class Executor {
 public:
-	Executor(int tasksMax);
-	~Executor();
+    Executor(int tasksMax);
+    ~Executor();
 
-	bool run(std::function<bool (std::optional<int>)> park);
+    bool run(std::function<bool(std::optional<int>)> park);
 
-	/// Spawns `fut` on the executor in the current thread. Returns true on
-	/// success or false on error. An error can occur if there is no executor in
-	/// the current thread or if the executor is at capacity. This function takes
-	/// ownership of `fut` regardless of whether spawning is successful.
-	static bool currentSpawn(ffi::UnitFuture *fut);
+    /// Spawns `fut` on the executor in the current thread. Returns true on
+    /// success or false on error. An error can occur if there is no executor in
+    /// the current thread or if the executor is at capacity. This function takes
+    /// ownership of `fut` regardless of whether spawning is successful.
+    static bool currentSpawn(ffi::UnitFuture *fut);
 
 private:
-	ffi::Executor *inner_;
+    ffi::Executor *inner_;
 
-	static int park_cb(void *ctx, int ms);
+    static int park_cb(void *ctx, int ms);
 };
 
 #endif

--- a/src/core/filewatcher.cpp
+++ b/src/core/filewatcher.cpp
@@ -16,51 +16,46 @@
 
 #include "filewatcher.h"
 
-#include <assert.h>
 #include <QString>
+#include <assert.h>
 
-FileWatcher::FileWatcher() :
-	inner_(nullptr)
-{
+FileWatcher::FileWatcher() : inner_(nullptr) {}
+
+FileWatcher::~FileWatcher() {
+    sn_.reset();
+
+    if (inner_)
+        ffi::file_watcher_destroy(inner_);
 }
 
-FileWatcher::~FileWatcher()
-{
-	sn_.reset();
+bool FileWatcher::start(const QString &filePath) {
+    assert(!inner_);
 
-	if(inner_)
-		ffi::file_watcher_destroy(inner_);
+    inner_ = ffi::file_watcher_create(filePath.toUtf8().data());
+    if (!inner_)
+        return false;
+
+    int fd = ffi::file_watcher_as_raw_fd(inner_);
+
+    sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
+    sn_->activated.connect(boost::bind(&FileWatcher::sn_activated, this, boost::placeholders::_1,
+                                       boost::placeholders::_2));
+    sn_->clearReadiness(SocketNotifier::Read);
+    sn_->setReadEnabled(true);
+
+    // In case the socket was activated before registering the notifier
+    if (ffi::file_watcher_file_changed(inner_))
+        deferCall_.defer([=] { fileChanged(); });
+
+    return true;
 }
 
-bool FileWatcher::start(const QString &filePath)
-{
-	assert(!inner_);
+void FileWatcher::sn_activated(int socket, uint8_t readiness) {
+    Q_UNUSED(socket);
+    Q_UNUSED(readiness);
 
-	inner_ = ffi::file_watcher_create(filePath.toUtf8().data());
-	if(!inner_)
-		return false;
+    sn_->clearReadiness(SocketNotifier::Read);
 
-	int fd = ffi::file_watcher_as_raw_fd(inner_);
-
-	sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
-	sn_->activated.connect(boost::bind(&FileWatcher::sn_activated, this, boost::placeholders::_1, boost::placeholders::_2));
-	sn_->clearReadiness(SocketNotifier::Read);
-	sn_->setReadEnabled(true);
-
-	// In case the socket was activated before registering the notifier
-	if(ffi::file_watcher_file_changed(inner_))
-		deferCall_.defer([=] { fileChanged(); });
-
-	return true;
-}
-
-void FileWatcher::sn_activated(int socket, uint8_t readiness)
-{
-	Q_UNUSED(socket);
-	Q_UNUSED(readiness);
-
-	sn_->clearReadiness(SocketNotifier::Read);
-
-	if(ffi::file_watcher_file_changed(inner_))
-		fileChanged();
+    if (ffi::file_watcher_file_changed(inner_))
+        fileChanged();
 }

--- a/src/core/filewatcher.h
+++ b/src/core/filewatcher.h
@@ -17,29 +17,28 @@
 #ifndef FILEWATCHER_H
 #define FILEWATCHER_H
 
-#include <boost/signals2.hpp>
-#include "socketnotifier.h"
 #include "defercall.h"
 #include "rust/bindings.h"
+#include "socketnotifier.h"
+#include <boost/signals2.hpp>
 
 class QString;
 
-class FileWatcher
-{
+class FileWatcher {
 public:
-	FileWatcher();
-	~FileWatcher();
+    FileWatcher();
+    ~FileWatcher();
 
-	bool start(const QString &filePath);
+    bool start(const QString &filePath);
 
-	boost::signals2::signal<void()> fileChanged;
+    boost::signals2::signal<void()> fileChanged;
 
 private:
-	ffi::FileWatcher *inner_;
-	std::unique_ptr<SocketNotifier> sn_;
-	DeferCall deferCall_;
+    ffi::FileWatcher *inner_;
+    std::unique_ptr<SocketNotifier> sn_;
+    DeferCall deferCall_;
 
-	void sn_activated(int socket, uint8_t readiness);
+    void sn_activated(int socket, uint8_t readiness);
 };
 
 #endif

--- a/src/core/httpheaders.cpp
+++ b/src/core/httpheaders.cpp
@@ -22,349 +22,284 @@
 #include "httpheaders.h"
 
 // Return position, end of string if not found, -1 on error
-static int findNonQuoted(const CowByteArray &in, char c, int offset = 0)
-{
-	bool inQuote = false;
+static int findNonQuoted(const CowByteArray &in, char c, int offset = 0) {
+    bool inQuote = false;
 
-	for(int n = offset; n < in.size(); ++n)
-	{
-		char i = in[n];
+    for (int n = offset; n < in.size(); ++n) {
+        char i = in[n];
 
-		if(inQuote)
-		{
-			if(i == '\\')
-			{
-				++n;
+        if (inQuote) {
+            if (i == '\\') {
+                ++n;
 
-				// No character after the escape
-				if(n >= in.size())
-				{
-					return -1;
-				}
-			}
-			else if(i == '\"')
-				inQuote = false;
-		}
-		else
-		{
-			if(i == '\"')
-			{
-				inQuote = true;
-			}
-			else if(i == c)
-			{
-				return n;
-			}
-		}
-	}
+                // No character after the escape
+                if (n >= in.size()) {
+                    return -1;
+                }
+            } else if (i == '\"')
+                inQuote = false;
+        } else {
+            if (i == '\"') {
+                inQuote = true;
+            } else if (i == c) {
+                return n;
+            }
+        }
+    }
 
-	// Unterminated quote
-	if(inQuote)
-	{
-		return -1;
-	}
+    // Unterminated quote
+    if (inQuote) {
+        return -1;
+    }
 
-	return in.size();
+    return in.size();
 }
 
 // Search for one of many chars
-static int findNext(const CowByteArray &in, const char *charList, int offset = 0)
-{
-	int len = qstrlen(charList);
-	for(int n = offset; n < in.size(); ++n)
-	{
-		char c = in[n];
-		for(int i = 0; i < len; ++i)
-		{
-			if(c == charList[i])
-				return n;
-		}
-	}
+static int findNext(const CowByteArray &in, const char *charList, int offset = 0) {
+    int len = qstrlen(charList);
+    for (int n = offset; n < in.size(); ++n) {
+        char c = in[n];
+        for (int i = 0; i < len; ++i) {
+            if (c == charList[i])
+                return n;
+        }
+    }
 
-	return -1;
+    return -1;
 }
 
-static CowByteArrayList headerSplit(const CowByteArray &in)
-{
-	CowByteArrayList parts;
-	int pos = 0;
-	while(pos < in.size())
-	{
-		int end = findNonQuoted(in, ',', pos);
-		if(end != -1)
-		{
-			parts += in.mid(pos, end - pos).trimmed();
+static CowByteArrayList headerSplit(const CowByteArray &in) {
+    CowByteArrayList parts;
+    int pos = 0;
+    while (pos < in.size()) {
+        int end = findNonQuoted(in, ',', pos);
+        if (end != -1) {
+            parts += in.mid(pos, end - pos).trimmed();
 
-			if(end < in.size())
-				pos = end + 1;
-			else
-				pos = in.size();
-		}
-		else
-		{
-			parts += in.mid(pos).trimmed();
+            if (end < in.size())
+                pos = end + 1;
+            else
+                pos = in.size();
+        } else {
+            parts += in.mid(pos).trimmed();
 
-			pos = in.size();
-		}
-	}
-	return parts;
+            pos = in.size();
+        }
+    }
+    return parts;
 }
 
-bool HttpHeaderParameters::contains(const CowByteArray &key) const
-{
-	for(int n = 0; n < count(); ++n)
-	{
-		if(qstricmp(at(n).first.data(), key.data()) == 0)
-			return true;
-	}
+bool HttpHeaderParameters::contains(const CowByteArray &key) const {
+    for (int n = 0; n < count(); ++n) {
+        if (qstricmp(at(n).first.data(), key.data()) == 0)
+            return true;
+    }
 
-	return false;
+    return false;
 }
 
-CowByteArray HttpHeaderParameters::get(const CowByteArray &key) const
-{
-	for(int n = 0; n < count(); ++n)
-	{
-		const HttpHeaderParameter &h = at(n);
-		if(qstricmp(h.first.data(), key.data()) == 0)
-			return h.second;
-	}
+CowByteArray HttpHeaderParameters::get(const CowByteArray &key) const {
+    for (int n = 0; n < count(); ++n) {
+        const HttpHeaderParameter &h = at(n);
+        if (qstricmp(h.first.data(), key.data()) == 0)
+            return h.second;
+    }
 
-	return CowByteArray();
+    return CowByteArray();
 }
 
-bool HttpHeaders::contains(const CowByteArray &key) const
-{
-	for(int n = 0; n < count(); ++n)
-	{
-		if(qstricmp(at(n).first.data(), key.data()) == 0)
-			return true;
-	}
+bool HttpHeaders::contains(const CowByteArray &key) const {
+    for (int n = 0; n < count(); ++n) {
+        if (qstricmp(at(n).first.data(), key.data()) == 0)
+            return true;
+    }
 
-	return false;
+    return false;
 }
 
-CowByteArray HttpHeaders::get(const CowByteArray &key) const
-{
-	for(int n = 0; n < count(); ++n)
-	{
-		const HttpHeader &h = at(n);
-		if(qstricmp(h.first.data(), key.data()) == 0)
-			return h.second;
-	}
+CowByteArray HttpHeaders::get(const CowByteArray &key) const {
+    for (int n = 0; n < count(); ++n) {
+        const HttpHeader &h = at(n);
+        if (qstricmp(h.first.data(), key.data()) == 0)
+            return h.second;
+    }
 
-	return CowByteArray();
+    return CowByteArray();
 }
 
-HttpHeaderParameters HttpHeaders::getAsParameters(const CowByteArray &key, ParseMode mode) const
-{
-	CowByteArray h = get(key);
-	if(h.isEmpty())
-		return HttpHeaderParameters();
+HttpHeaderParameters HttpHeaders::getAsParameters(const CowByteArray &key, ParseMode mode) const {
+    CowByteArray h = get(key);
+    if (h.isEmpty())
+        return HttpHeaderParameters();
 
-	return parseParameters(h, mode);
+    return parseParameters(h, mode);
 }
 
-CowByteArray HttpHeaders::getAsFirstParameter(const CowByteArray &key) const
-{
-	HttpHeaderParameters p = getAsParameters(key);
-	if(p.isEmpty())
-		return CowByteArray();
+CowByteArray HttpHeaders::getAsFirstParameter(const CowByteArray &key) const {
+    HttpHeaderParameters p = getAsParameters(key);
+    if (p.isEmpty())
+        return CowByteArray();
 
-	return p[0].first;
+    return p[0].first;
 }
 
-CowByteArrayList HttpHeaders::getAll(const CowByteArray &key, bool split) const
-{
-	CowByteArrayList out;
+CowByteArrayList HttpHeaders::getAll(const CowByteArray &key, bool split) const {
+    CowByteArrayList out;
 
-	for(int n = 0; n < count(); ++n)
-	{
-		const HttpHeader &h = at(n);
-		if(qstricmp(h.first.data(), key.data()) == 0)
-		{
-			if(split)
-				out += headerSplit(h.second);
-			else
-				out += h.second;
-		}
-	}
+    for (int n = 0; n < count(); ++n) {
+        const HttpHeader &h = at(n);
+        if (qstricmp(h.first.data(), key.data()) == 0) {
+            if (split)
+                out += headerSplit(h.second);
+            else
+                out += h.second;
+        }
+    }
 
-	return out;
+    return out;
 }
 
-QList<HttpHeaderParameters> HttpHeaders::getAllAsParameters(const CowByteArray &key, ParseMode mode, bool split) const
-{
-	QList<HttpHeaderParameters> out;
+QList<HttpHeaderParameters> HttpHeaders::getAllAsParameters(const CowByteArray &key, ParseMode mode,
+                                                            bool split) const {
+    QList<HttpHeaderParameters> out;
 
-	CowByteArrayList l = getAll(key, split);
-	for(CowByteArrayConstRef h : std::as_const(l))
-	{
-		bool ok;
-		HttpHeaderParameters params = parseParameters(h, mode, &ok);
-		if(ok)
-			out += params;
-	}
+    CowByteArrayList l = getAll(key, split);
+    for (CowByteArrayConstRef h : std::as_const(l)) {
+        bool ok;
+        HttpHeaderParameters params = parseParameters(h, mode, &ok);
+        if (ok)
+            out += params;
+    }
 
-	return out;
+    return out;
 }
 
-CowByteArrayList HttpHeaders::takeAll(const CowByteArray &key, bool split)
-{
-	CowByteArrayList out;
+CowByteArrayList HttpHeaders::takeAll(const CowByteArray &key, bool split) {
+    CowByteArrayList out;
 
-	for(int n = 0; n < count(); ++n)
-	{
-		const HttpHeader &h = at(n);
-		if(qstricmp(h.first.data(), key.data()) == 0)
-		{
-			if(split)
-				out += headerSplit(h.second);
-			else
-				out += h.second;
+    for (int n = 0; n < count(); ++n) {
+        const HttpHeader &h = at(n);
+        if (qstricmp(h.first.data(), key.data()) == 0) {
+            if (split)
+                out += headerSplit(h.second);
+            else
+                out += h.second;
 
-			removeAt(n);
-			--n; // Adjust position
-		}
-	}
+            removeAt(n);
+            --n; // Adjust position
+        }
+    }
 
-	return out;
+    return out;
 }
 
-void HttpHeaders::removeAll(const CowByteArray &key)
-{
-	for(int n = 0; n < count(); ++n)
-	{
-		if(qstricmp(at(n).first.data(), key.data()) == 0)
-		{
-			removeAt(n);
-			--n; // Adjust position
-		}
-	}
+void HttpHeaders::removeAll(const CowByteArray &key) {
+    for (int n = 0; n < count(); ++n) {
+        if (qstricmp(at(n).first.data(), key.data()) == 0) {
+            removeAt(n);
+            --n; // Adjust position
+        }
+    }
 }
 
-CowByteArray HttpHeaders::join(const CowByteArrayList &values)
-{
-	CowByteArray out;
+CowByteArray HttpHeaders::join(const CowByteArrayList &values) {
+    CowByteArray out;
 
-	bool first = true;
-	for(CowByteArrayConstRef val : std::as_const(values))
-	{
-		if(!first)
-			out += ", ";
+    bool first = true;
+    for (CowByteArrayConstRef val : std::as_const(values)) {
+        if (!first)
+            out += ", ";
 
-		out += val;
-		first = false;
-	}
+        out += val;
+        first = false;
+    }
 
-	return out;
+    return out;
 }
 
-HttpHeaderParameters HttpHeaders::parseParameters(const CowByteArray &in, ParseMode mode, bool *ok)
-{
-	HttpHeaderParameters out;
+HttpHeaderParameters HttpHeaders::parseParameters(const CowByteArray &in, ParseMode mode,
+                                                  bool *ok) {
+    HttpHeaderParameters out;
 
-	int start = 0;
-	if(mode == NoParseFirstParameter)
-	{
-		int at = in.indexOf(';');
-		if(at != -1)
-		{
-			out += HttpHeaderParameter(in.mid(0, at).trimmed(), CowByteArray());
-			start = at + 1;
-		}
-		else
-		{
-			out += HttpHeaderParameter(in.trimmed(), CowByteArray());
-			start = in.size();
-		}
-	}
+    int start = 0;
+    if (mode == NoParseFirstParameter) {
+        int at = in.indexOf(';');
+        if (at != -1) {
+            out += HttpHeaderParameter(in.mid(0, at).trimmed(), CowByteArray());
+            start = at + 1;
+        } else {
+            out += HttpHeaderParameter(in.trimmed(), CowByteArray());
+            start = in.size();
+        }
+    }
 
-	while(start < in.size())
-	{
-		CowByteArray var;
-		CowByteArray val;
+    while (start < in.size()) {
+        CowByteArray var;
+        CowByteArray val;
 
-		int at = findNext(in, "=;", start);
-		if(at != -1)
-		{
-			var = in.mid(start, at - start).trimmed();
-			if(in[at] == '=')
-			{
-				++at;
+        int at = findNext(in, "=;", start);
+        if (at != -1) {
+            var = in.mid(start, at - start).trimmed();
+            if (in[at] == '=') {
+                ++at;
 
-				if(at < in.size() && in[at] == '\"')
-				{
-					++at;
+                if (at < in.size() && in[at] == '\"') {
+                    ++at;
 
-					bool complete = false;
-					for(int n = at; n < in.size(); ++n)
-					{
-						if(in[n] == '\\')
-						{
-							if(n + 1 >= in.size())
-							{
-								if(ok)
-									*ok = false;
-								return HttpHeaderParameters();
-							}
+                    bool complete = false;
+                    for (int n = at; n < in.size(); ++n) {
+                        if (in[n] == '\\') {
+                            if (n + 1 >= in.size()) {
+                                if (ok)
+                                    *ok = false;
+                                return HttpHeaderParameters();
+                            }
 
-							++n;
-							val += in[n];
-						}
-						else if(in[n] == '\"')
-						{
-							complete = true;
-							at = n + 1;
-							break;
-						}
-						else
-							val += in[n];
-					}
+                            ++n;
+                            val += in[n];
+                        } else if (in[n] == '\"') {
+                            complete = true;
+                            at = n + 1;
+                            break;
+                        } else
+                            val += in[n];
+                    }
 
-					if(!complete)
-					{
-						if(ok)
-							*ok = false;
-						return HttpHeaderParameters();
-					}
+                    if (!complete) {
+                        if (ok)
+                            *ok = false;
+                        return HttpHeaderParameters();
+                    }
 
-					at = in.indexOf(';', at);
-					if(at != -1)
-						start = at + 1;
-					else
-						start = in.size();
-				}
-				else
-				{
-					int vstart = at;
-					at = in.indexOf(';', vstart);
-					if(at != -1)
-					{
-						val = in.mid(vstart, at - vstart).trimmed();
-						start = at + 1;
-					}
-					else
-					{
-						val = in.mid(vstart).trimmed();
-						start = in.size();
-					}
-				}
-			}
-			else
-				start = at + 1;
-		}
-		else
-		{
-			var = in.mid(start).trimmed();
-			start = in.size();
-		}
+                    at = in.indexOf(';', at);
+                    if (at != -1)
+                        start = at + 1;
+                    else
+                        start = in.size();
+                } else {
+                    int vstart = at;
+                    at = in.indexOf(';', vstart);
+                    if (at != -1) {
+                        val = in.mid(vstart, at - vstart).trimmed();
+                        start = at + 1;
+                    } else {
+                        val = in.mid(vstart).trimmed();
+                        start = in.size();
+                    }
+                }
+            } else
+                start = at + 1;
+        } else {
+            var = in.mid(start).trimmed();
+            start = in.size();
+        }
 
-		out.append(HttpHeaderParameter(var, val));
-	}
+        out.append(HttpHeaderParameter(var, val));
+    }
 
-	if(ok)
-		*ok = true;
+    if (ok)
+        *ok = true;
 
-	return out;
+    return out;
 }

--- a/src/core/httpheaders.h
+++ b/src/core/httpheaders.h
@@ -22,41 +22,39 @@
 #ifndef HTTPHEADERS_H
 #define HTTPHEADERS_H
 
-#include <QPair>
-#include <QList>
 #include "cowbytearray.h"
+#include <QList>
+#include <QPair>
 
 typedef QPair<CowByteArray, CowByteArray> HttpHeaderParameter;
 
-class HttpHeaderParameters : public QList<HttpHeaderParameter>
-{
+class HttpHeaderParameters : public QList<HttpHeaderParameter> {
 public:
-	bool contains(const CowByteArray &key) const;
-	CowByteArray get(const CowByteArray &key) const;
+    bool contains(const CowByteArray &key) const;
+    CowByteArray get(const CowByteArray &key) const;
 };
 
 typedef QPair<CowByteArray, CowByteArray> HttpHeader;
 
-class HttpHeaders : public QList<HttpHeader>
-{
+class HttpHeaders : public QList<HttpHeader> {
 public:
-	enum ParseMode
-	{
-		NoParseFirstParameter,
-		ParseAllParameters
-	};
+    enum ParseMode { NoParseFirstParameter, ParseAllParameters };
 
-	bool contains(const CowByteArray &key) const;
-	CowByteArray get(const CowByteArray &key) const;
-	HttpHeaderParameters getAsParameters(const CowByteArray &key, ParseMode mode = NoParseFirstParameter) const;
-	CowByteArray getAsFirstParameter(const CowByteArray &key) const;
-	CowByteArrayList getAll(const CowByteArray &key, bool split = true) const;
-	QList<HttpHeaderParameters> getAllAsParameters(const CowByteArray &key, ParseMode mode = NoParseFirstParameter, bool split = true) const;
-	CowByteArrayList takeAll(const CowByteArray &key, bool split = true);
-	void removeAll(const CowByteArray &key);
+    bool contains(const CowByteArray &key) const;
+    CowByteArray get(const CowByteArray &key) const;
+    HttpHeaderParameters getAsParameters(const CowByteArray &key,
+                                         ParseMode mode = NoParseFirstParameter) const;
+    CowByteArray getAsFirstParameter(const CowByteArray &key) const;
+    CowByteArrayList getAll(const CowByteArray &key, bool split = true) const;
+    QList<HttpHeaderParameters> getAllAsParameters(const CowByteArray &key,
+                                                   ParseMode mode = NoParseFirstParameter,
+                                                   bool split = true) const;
+    CowByteArrayList takeAll(const CowByteArray &key, bool split = true);
+    void removeAll(const CowByteArray &key);
 
-	static CowByteArray join(const CowByteArrayList &values);
-	static HttpHeaderParameters parseParameters(const CowByteArray &in, ParseMode mode = NoParseFirstParameter, bool *ok = 0);
+    static CowByteArray join(const CowByteArrayList &values);
+    static HttpHeaderParameters
+    parseParameters(const CowByteArray &in, ParseMode mode = NoParseFirstParameter, bool *ok = 0);
 };
 
 #endif

--- a/src/core/httpheaderstest.cpp
+++ b/src/core/httpheaderstest.cpp
@@ -20,70 +20,68 @@
  *
  */
 
-#include "test.h"
 #include "httpheaders.h"
+#include "test.h"
 
-static void parseParameters()
-{
-	HttpHeaders h;
-	h += HttpHeader("Fruit", "apple");
-	h += HttpHeader("Fruit", "banana");
-	h += HttpHeader("Fruit", "cherry");
+static void parseParameters() {
+    HttpHeaders h;
+    h += HttpHeader("Fruit", "apple");
+    h += HttpHeader("Fruit", "banana");
+    h += HttpHeader("Fruit", "cherry");
 
-	QList<HttpHeaderParameters> params = h.getAllAsParameters("Fruit");
-	TEST_ASSERT_EQ(params.count(), 3);
-	TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
-	TEST_ASSERT_EQ(params[1][0].first, CowByteArray("banana"));
-	TEST_ASSERT_EQ(params[2][0].first, CowByteArray("cherry"));
+    QList<HttpHeaderParameters> params = h.getAllAsParameters("Fruit");
+    TEST_ASSERT_EQ(params.count(), 3);
+    TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
+    TEST_ASSERT_EQ(params[1][0].first, CowByteArray("banana"));
+    TEST_ASSERT_EQ(params[2][0].first, CowByteArray("cherry"));
 
-	h.clear();
-	h += HttpHeader("Fruit", "apple, banana, cherry");
+    h.clear();
+    h += HttpHeader("Fruit", "apple, banana, cherry");
 
-	params = h.getAllAsParameters("Fruit");
-	TEST_ASSERT_EQ(params.count(), 3);
-	TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
-	TEST_ASSERT_EQ(params[1][0].first, CowByteArray("banana"));
-	TEST_ASSERT_EQ(params[2][0].first, CowByteArray("cherry"));
+    params = h.getAllAsParameters("Fruit");
+    TEST_ASSERT_EQ(params.count(), 3);
+    TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
+    TEST_ASSERT_EQ(params[1][0].first, CowByteArray("banana"));
+    TEST_ASSERT_EQ(params[2][0].first, CowByteArray("cherry"));
 
-	h.clear();
-	h += HttpHeader("Fruit", "apple; type=\"granny, smith\", banana; type=\"\\\"yellow\\\"\"");
+    h.clear();
+    h += HttpHeader("Fruit", "apple; type=\"granny, smith\", banana; type=\"\\\"yellow\\\"\"");
 
-	params = h.getAllAsParameters("Fruit");
-	TEST_ASSERT_EQ(params.count(), 2);
-	TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
-	TEST_ASSERT_EQ(params[0][1].first, CowByteArray("type"));
-	TEST_ASSERT_EQ(params[0][1].second, CowByteArray("granny, smith"));
-	TEST_ASSERT_EQ(params[1][0].first, CowByteArray("banana"));
-	TEST_ASSERT_EQ(params[1][1].first, CowByteArray("type"));
-	TEST_ASSERT_EQ(params[1][1].second, CowByteArray("\"yellow\""));
+    params = h.getAllAsParameters("Fruit");
+    TEST_ASSERT_EQ(params.count(), 2);
+    TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
+    TEST_ASSERT_EQ(params[0][1].first, CowByteArray("type"));
+    TEST_ASSERT_EQ(params[0][1].second, CowByteArray("granny, smith"));
+    TEST_ASSERT_EQ(params[1][0].first, CowByteArray("banana"));
+    TEST_ASSERT_EQ(params[1][1].first, CowByteArray("type"));
+    TEST_ASSERT_EQ(params[1][1].second, CowByteArray("\"yellow\""));
 
-	h.clear();
-	h += HttpHeader("Fruit", "\"apple");
+    h.clear();
+    h += HttpHeader("Fruit", "\"apple");
 
-	CowByteArrayList l = h.getAll("Fruit");
-	TEST_ASSERT_EQ(l.count(), 1);
-	TEST_ASSERT_EQ(l[0], CowByteArray("\"apple"));
+    CowByteArrayList l = h.getAll("Fruit");
+    TEST_ASSERT_EQ(l.count(), 1);
+    TEST_ASSERT_EQ(l[0], CowByteArray("\"apple"));
 
-	h.clear();
-	h += HttpHeader("Fruit", "\"apple\\");
+    h.clear();
+    h += HttpHeader("Fruit", "\"apple\\");
 
-	l = h.getAll("Fruit");
-	TEST_ASSERT_EQ(l.count(), 1);
-	TEST_ASSERT_EQ(l[0], CowByteArray("\"apple\\"));
+    l = h.getAll("Fruit");
+    TEST_ASSERT_EQ(l.count(), 1);
+    TEST_ASSERT_EQ(l[0], CowByteArray("\"apple\\"));
 
-	h.clear();
-	h += HttpHeader("Fruit", "apple; type=gala, banana; type=\"yellow, cherry");
+    h.clear();
+    h += HttpHeader("Fruit", "apple; type=gala, banana; type=\"yellow, cherry");
 
-	params = h.getAllAsParameters("Fruit");
-	TEST_ASSERT_EQ(params.count(), 1);
-	TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
-	TEST_ASSERT_EQ(params[0][1].first, CowByteArray("type"));
-	TEST_ASSERT_EQ(params[0][1].second, CowByteArray("gala"));
+    params = h.getAllAsParameters("Fruit");
+    TEST_ASSERT_EQ(params.count(), 1);
+    TEST_ASSERT_EQ(params[0][0].first, CowByteArray("apple"));
+    TEST_ASSERT_EQ(params[0][1].first, CowByteArray("type"));
+    TEST_ASSERT_EQ(params[0][1].second, CowByteArray("gala"));
 }
 
-extern "C" int httpheaders_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(parseParameters());
+extern "C" int httpheaders_test(ffi::TestException *out_ex) {
+    TEST_CATCH(parseParameters());
 
-	return 0;
+    return 0;
 }

--- a/src/core/httprequest.h
+++ b/src/core/httprequest.h
@@ -24,76 +24,74 @@
 #ifndef HTTPREQUEST_H
 #define HTTPREQUEST_H
 
+#include "httpheaders.h"
 #include "url.h"
 #include <QHostAddress>
-#include "httpheaders.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
 
-class HttpRequest
-{
+class HttpRequest {
 public:
-	enum ErrorCondition
-	{
-		ErrorGeneric,
-		ErrorPolicy,
-		ErrorConnect,
-		ErrorConnectTimeout,
-		ErrorTls,
-		ErrorLengthRequired,
-		ErrorDisconnected,
-		ErrorTimeout,
-		ErrorUnavailable,
-		ErrorRequestTooLarge
-	};
+    enum ErrorCondition {
+        ErrorGeneric,
+        ErrorPolicy,
+        ErrorConnect,
+        ErrorConnectTimeout,
+        ErrorTls,
+        ErrorLengthRequired,
+        ErrorDisconnected,
+        ErrorTimeout,
+        ErrorUnavailable,
+        ErrorRequestTooLarge
+    };
 
-	virtual ~HttpRequest() = default;
+    virtual ~HttpRequest() = default;
 
-	virtual QHostAddress peerAddress() const = 0;
+    virtual QHostAddress peerAddress() const = 0;
 
-	virtual void setConnectHost(const QString &host) = 0;
-	virtual void setConnectPort(int port) = 0;
-	virtual void setIgnorePolicies(bool on) = 0;
-	virtual void setTrustConnectHost(bool on) = 0;
-	virtual void setIgnoreTlsErrors(bool on) = 0;
-	virtual void setTimeout(int msecs) = 0;
-	virtual void setClientCert(const QString &cert, const QString &key) = 0;
+    virtual void setConnectHost(const QString &host) = 0;
+    virtual void setConnectPort(int port) = 0;
+    virtual void setIgnorePolicies(bool on) = 0;
+    virtual void setTrustConnectHost(bool on) = 0;
+    virtual void setIgnoreTlsErrors(bool on) = 0;
+    virtual void setTimeout(int msecs) = 0;
+    virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
-	virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers) = 0;
-	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) = 0;
+    virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers) = 0;
+    virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) = 0;
 
-	// May call this multiple times
-	virtual void writeBody(const QByteArray &body) = 0;
+    // May call this multiple times
+    virtual void writeBody(const QByteArray &body) = 0;
 
-	virtual void endBody() = 0;
+    virtual void endBody() = 0;
 
-	virtual int bytesAvailable() const = 0;
-	virtual int writeBytesAvailable() const = 0;
-	virtual bool isFinished() const = 0;
-	virtual bool isInputFinished() const = 0;
-	virtual bool isOutputFinished() const = 0;
-	virtual bool isErrored() const = 0;
-	virtual ErrorCondition errorCondition() const = 0;
+    virtual int bytesAvailable() const = 0;
+    virtual int writeBytesAvailable() const = 0;
+    virtual bool isFinished() const = 0;
+    virtual bool isInputFinished() const = 0;
+    virtual bool isOutputFinished() const = 0;
+    virtual bool isErrored() const = 0;
+    virtual ErrorCondition errorCondition() const = 0;
 
-	virtual QString requestMethod() const = 0;
-	virtual Url requestUri() const = 0;
-	virtual HttpHeaders requestHeaders() const = 0;
+    virtual QString requestMethod() const = 0;
+    virtual Url requestUri() const = 0;
+    virtual HttpHeaders requestHeaders() const = 0;
 
-	virtual int responseCode() const = 0;
-	virtual QByteArray responseReason() const = 0;
-	virtual HttpHeaders responseHeaders() const = 0;
+    virtual int responseCode() const = 0;
+    virtual QByteArray responseReason() const = 0;
+    virtual HttpHeaders responseHeaders() const = 0;
 
-	virtual QByteArray readBody(int size = -1) = 0; // Takes from the buffer
+    virtual QByteArray readBody(int size = -1) = 0; // Takes from the buffer
 
-	// Indicates input data and/or input finished
-	Signal readyRead;
-	// Indicates output data written and/or output finished
-	SignalInt bytesWritten;
-	Signal writeBytesChanged;
-	Signal paused;
-	Signal error;
+    // Indicates input data and/or input finished
+    Signal readyRead;
+    // Indicates output data written and/or output finished
+    SignalInt bytesWritten;
+    Signal writeBytesChanged;
+    Signal paused;
+    Signal error;
 };
 
 #endif

--- a/src/core/inspectdata.h
+++ b/src/core/inspectdata.h
@@ -23,22 +23,18 @@
 #ifndef INSPECTDATA_H
 #define INSPECTDATA_H
 
-#include <QByteArray>
 #include "variant.h"
+#include <QByteArray>
 
-class InspectData
-{
+class InspectData {
 public:
-	bool doProxy;
-	QByteArray sharingKey;
-	QByteArray sid;
-	QHash<QByteArray, QByteArray> lastIds;
-	Variant userData;
+    bool doProxy;
+    QByteArray sharingKey;
+    QByteArray sid;
+    QHash<QByteArray, QByteArray> lastIds;
+    Variant userData;
 
-	InspectData() :
-		doProxy(false)
-	{
-	}
+    InspectData() : doProxy(false) {}
 };
 
 #endif

--- a/src/core/jwt.cpp
+++ b/src/core/jwt.cpp
@@ -23,228 +23,197 @@
 
 #include "jwt.h"
 
-#include <QString>
+#include "variant.h"
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include "variant.h"
+#include <QString>
 
 namespace Jwt {
 
-EncodingKey::Private::Private() :
-	type((KeyType)-1),
-	raw(0)
-{
+EncodingKey::Private::Private() : type((KeyType)-1), raw(0) {}
+
+EncodingKey::Private::Private(ffi::JwtEncodingKey key) : type((KeyType)key.type), raw(key.key) {}
+
+EncodingKey::Private::~Private() { ffi::jwt_encoding_key_destroy(raw); }
+
+EncodingKey EncodingKey::fromSecret(const QByteArray &key) {
+    EncodingKey k;
+    k.d = new Private(ffi::jwt_encoding_key_from_secret((const uint8_t *)key.data(), key.size()));
+    return k;
 }
 
-EncodingKey::Private::Private(ffi::JwtEncodingKey key) :
-	type((KeyType)key.type),
-	raw(key.key)
-{
+EncodingKey EncodingKey::fromPem(const QByteArray &key) {
+    EncodingKey k;
+    k.d = new Private(ffi::jwt_encoding_key_from_pem((const uint8_t *)key.data(), key.size()));
+    return k;
 }
 
-EncodingKey::Private::~Private()
-{
-	ffi::jwt_encoding_key_destroy(raw);
+EncodingKey EncodingKey::fromFile(const QString &fileName) {
+    QFile f(fileName);
+    if (!f.open(QFile::ReadOnly)) {
+        return EncodingKey();
+    }
+
+    QByteArray data = f.readAll();
+
+    if (data.startsWith("-----BEGIN"))
+        return fromPem(data);
+    else
+        return fromSecret(QByteArray::fromHex(data.trimmed()));
 }
 
-EncodingKey EncodingKey::fromSecret(const QByteArray &key)
-{
-	EncodingKey k;
-	k.d = new Private(ffi::jwt_encoding_key_from_secret((const uint8_t *)key.data(), key.size()));
-	return k;
+EncodingKey EncodingKey::fromConfigString(const QString &s, const QDir &baseDir) {
+    if (s.startsWith("file:")) {
+        QString keyFile = s.mid(5);
+        QFileInfo fi(keyFile);
+        if (fi.isRelative())
+            keyFile = QFileInfo(baseDir, keyFile).filePath();
+
+        return fromFile(keyFile);
+    } else {
+        QByteArray secret;
+
+        if (s.startsWith("base64:"))
+            secret = QByteArray::fromBase64(s.mid(7).toUtf8());
+        else
+            secret = s.toUtf8();
+
+        return fromSecret(secret);
+    }
 }
 
-EncodingKey EncodingKey::fromPem(const QByteArray &key)
-{
-	EncodingKey k;
-	k.d = new Private(ffi::jwt_encoding_key_from_pem((const uint8_t *)key.data(), key.size()));
-	return k;
+DecodingKey::Private::Private() : type((KeyType)-1), raw(0) {}
+
+DecodingKey::Private::Private(ffi::JwtDecodingKey key) : type((KeyType)key.type), raw(key.key) {}
+
+DecodingKey::Private::~Private() { ffi::jwt_decoding_key_destroy(raw); }
+
+DecodingKey DecodingKey::fromSecret(const QByteArray &key) {
+    DecodingKey k;
+    k.d = new Private(ffi::jwt_decoding_key_from_secret((const uint8_t *)key.data(), key.size()));
+    return k;
 }
 
-EncodingKey EncodingKey::fromFile(const QString &fileName)
-{
-	QFile f(fileName);
-	if(!f.open(QFile::ReadOnly))
-	{
-		return EncodingKey();
-	}
-
-	QByteArray data = f.readAll();
-
-	if(data.startsWith("-----BEGIN"))
-		return fromPem(data);
-	else
-		return fromSecret(QByteArray::fromHex(data.trimmed()));
+DecodingKey DecodingKey::fromPem(const QByteArray &key) {
+    DecodingKey k;
+    k.d = new Private(ffi::jwt_decoding_key_from_pem((const uint8_t *)key.data(), key.size()));
+    return k;
 }
 
-EncodingKey EncodingKey::fromConfigString(const QString &s, const QDir &baseDir)
-{
-	if(s.startsWith("file:"))
-	{
-		QString keyFile = s.mid(5);
-		QFileInfo fi(keyFile);
-		if(fi.isRelative())
-			keyFile = QFileInfo(baseDir, keyFile).filePath();
+DecodingKey DecodingKey::fromFile(const QString &fileName) {
+    QFile f(fileName);
+    if (!f.open(QFile::ReadOnly)) {
+        return DecodingKey();
+    }
 
-		return fromFile(keyFile);
-	}
-	else
-	{
-		QByteArray secret;
+    QByteArray data = f.readAll();
 
-		if(s.startsWith("base64:"))
-			secret = QByteArray::fromBase64(s.mid(7).toUtf8());
-		else
-			secret = s.toUtf8();
-
-		return fromSecret(secret);
-	}
+    if (data.startsWith("-----BEGIN"))
+        return fromPem(data);
+    else
+        return fromSecret(QByteArray::fromHex(data.trimmed()));
 }
 
-DecodingKey::Private::Private() :
-	type((KeyType)-1),
-	raw(0)
-{
+DecodingKey DecodingKey::fromConfigString(const QString &s, const QDir &baseDir) {
+    if (s.startsWith("file:")) {
+        QString keyFile = s.mid(5);
+        QFileInfo fi(keyFile);
+        if (fi.isRelative())
+            keyFile = QFileInfo(baseDir, keyFile).filePath();
+
+        return fromFile(keyFile);
+    } else {
+        QByteArray secret;
+
+        if (s.startsWith("base64:"))
+            secret = QByteArray::fromBase64(s.mid(7).toUtf8());
+        else
+            secret = s.toUtf8();
+
+        return fromSecret(secret);
+    }
 }
 
-DecodingKey::Private::Private(ffi::JwtDecodingKey key) :
-	type((KeyType)key.type),
-	raw(key.key)
-{
+QByteArray encodeWithAlgorithm(Algorithm alg, const QByteArray &claim, const EncodingKey &key) {
+    char *token;
+
+    if (ffi::jwt_encode((int)alg, (const char *)claim.data(), key.raw(), &token) != 0) {
+        // Error
+        return QByteArray();
+    }
+
+    QByteArray out = QByteArray(token);
+    ffi::jwt_str_destroy(token);
+
+    return out;
 }
 
-DecodingKey::Private::~Private()
-{
-	ffi::jwt_decoding_key_destroy(raw);
+QByteArray decodeWithAlgorithm(Algorithm alg, const QByteArray &token, const DecodingKey &key) {
+    char *claim;
+
+    if (ffi::jwt_decode((int)alg, (const char *)token.data(), key.raw(), &claim) != 0) {
+        // Error
+        return QByteArray();
+    }
+
+    QByteArray out = QByteArray(claim);
+    ffi::jwt_str_destroy(claim);
+
+    return out;
 }
 
-DecodingKey DecodingKey::fromSecret(const QByteArray &key)
-{
-	DecodingKey k;
-	k.d = new Private(ffi::jwt_decoding_key_from_secret((const uint8_t *)key.data(), key.size()));
-	return k;
+QByteArray encode(const Variant &claim, const EncodingKey &key) {
+    Algorithm alg;
+    switch (key.type()) {
+    case Jwt::KeyType::Secret:
+        alg = Jwt::HS256;
+        break;
+    case Jwt::KeyType::Ec:
+        alg = Jwt::ES256;
+        break;
+    case Jwt::KeyType::Rsa:
+        alg = Jwt::RS256;
+        break;
+    default:
+        return QByteArray();
+    }
+
+    QByteArray claimJson =
+        QJsonDocument(QJsonObject::fromVariantMap(claim.toMap())).toJson(QJsonDocument::Compact);
+    if (claimJson.isNull())
+        return QByteArray();
+
+    return encodeWithAlgorithm(alg, claimJson, key);
 }
 
-DecodingKey DecodingKey::fromPem(const QByteArray &key)
-{
-	DecodingKey k;
-	k.d = new Private(ffi::jwt_decoding_key_from_pem((const uint8_t *)key.data(), key.size()));
-	return k;
+Variant decode(const QByteArray &token, const DecodingKey &key) {
+    Algorithm alg;
+    switch (key.type()) {
+    case Jwt::KeyType::Secret:
+        alg = Jwt::HS256;
+        break;
+    case Jwt::KeyType::Ec:
+        alg = Jwt::ES256;
+        break;
+    case Jwt::KeyType::Rsa:
+        alg = Jwt::RS256;
+        break;
+    default:
+        return Variant();
+    }
+
+    QByteArray claimJson = decodeWithAlgorithm(alg, token, key);
+    if (claimJson.isEmpty())
+        return Variant();
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(claimJson, &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject())
+        return Variant();
+
+    return doc.object().toVariantMap();
 }
 
-DecodingKey DecodingKey::fromFile(const QString &fileName)
-{
-	QFile f(fileName);
-	if(!f.open(QFile::ReadOnly))
-	{
-		return DecodingKey();
-	}
-
-	QByteArray data = f.readAll();
-
-	if(data.startsWith("-----BEGIN"))
-		return fromPem(data);
-	else
-		return fromSecret(QByteArray::fromHex(data.trimmed()));
-}
-
-DecodingKey DecodingKey::fromConfigString(const QString &s, const QDir &baseDir)
-{
-	if(s.startsWith("file:"))
-	{
-		QString keyFile = s.mid(5);
-		QFileInfo fi(keyFile);
-		if(fi.isRelative())
-			keyFile = QFileInfo(baseDir, keyFile).filePath();
-
-		return fromFile(keyFile);
-	}
-	else
-	{
-		QByteArray secret;
-
-		if(s.startsWith("base64:"))
-			secret = QByteArray::fromBase64(s.mid(7).toUtf8());
-		else
-			secret = s.toUtf8();
-
-		return fromSecret(secret);
-	}
-}
-
-QByteArray encodeWithAlgorithm(Algorithm alg, const QByteArray &claim, const EncodingKey &key)
-{
-	char *token;
-
-	if(ffi::jwt_encode((int)alg, (const char *)claim.data(), key.raw(), &token) != 0)
-	{
-		// Error
-		return QByteArray();
-	}
-
-	QByteArray out = QByteArray(token);
-	ffi::jwt_str_destroy(token);
-
-	return out;
-}
-
-QByteArray decodeWithAlgorithm(Algorithm alg, const QByteArray &token, const DecodingKey &key)
-{
-	char *claim;
-
-	if(ffi::jwt_decode((int)alg, (const char *)token.data(), key.raw(), &claim) != 0)
-	{
-		// Error
-		return QByteArray();
-	}
-
-	QByteArray out = QByteArray(claim);
-	ffi::jwt_str_destroy(claim);
-
-	return out;
-}
-
-QByteArray encode(const Variant &claim, const EncodingKey &key)
-{
-	Algorithm alg;
-	switch(key.type())
-	{
-		case Jwt::KeyType::Secret: alg = Jwt::HS256; break;
-		case Jwt::KeyType::Ec: alg = Jwt::ES256; break;
-		case Jwt::KeyType::Rsa: alg = Jwt::RS256; break;
-		default: return QByteArray();
-	}
-
-	QByteArray claimJson = QJsonDocument(QJsonObject::fromVariantMap(claim.toMap())).toJson(QJsonDocument::Compact);
-	if(claimJson.isNull())
-		return QByteArray();
-
-	return encodeWithAlgorithm(alg, claimJson, key);
-}
-
-Variant decode(const QByteArray &token, const DecodingKey &key)
-{
-	Algorithm alg;
-	switch(key.type())
-	{
-		case Jwt::KeyType::Secret: alg = Jwt::HS256; break;
-		case Jwt::KeyType::Ec: alg = Jwt::ES256; break;
-		case Jwt::KeyType::Rsa: alg = Jwt::RS256; break;
-		default: return Variant();
-	}
-
-	QByteArray claimJson = decodeWithAlgorithm(alg, token, key);
-	if(claimJson.isEmpty())
-		return Variant();
-
-	QJsonParseError error;
-	QJsonDocument doc = QJsonDocument::fromJson(claimJson, &error);
-	if(error.error != QJsonParseError::NoError || !doc.isObject())
-		return Variant();
-
-	return doc.object().toVariantMap();
-}
-
-}
+} // namespace Jwt

--- a/src/core/jwt.h
+++ b/src/core/jwt.h
@@ -24,83 +24,102 @@
 #ifndef JWT_H
 #define JWT_H
 
-#include <QByteArray>
-#include "variant.h"
-#include <QSharedData>
-#include <QDir>
 #include "rust/bindings.h"
+#include "variant.h"
+#include <QByteArray>
+#include <QDir>
+#include <QSharedData>
 
 class QString;
 
 namespace Jwt {
 
 enum KeyType {
-	Secret = ffi::JWT_KEYTYPE_SECRET,
-	Ec = ffi::JWT_KEYTYPE_EC,
-	Rsa = ffi::JWT_KEYTYPE_RSA,
+    Secret = ffi::JWT_KEYTYPE_SECRET,
+    Ec = ffi::JWT_KEYTYPE_EC,
+    Rsa = ffi::JWT_KEYTYPE_RSA,
 };
 
-enum Algorithm
-{
-	HS256 = ffi::JWT_ALGORITHM_HS256,
-	ES256 = ffi::JWT_ALGORITHM_ES256,
-	RS256 = ffi::JWT_ALGORITHM_RS256,
+enum Algorithm {
+    HS256 = ffi::JWT_ALGORITHM_HS256,
+    ES256 = ffi::JWT_ALGORITHM_ES256,
+    RS256 = ffi::JWT_ALGORITHM_RS256,
 };
 
-class EncodingKey
-{
+class EncodingKey {
 public:
-	bool isNull() const { return !d; }
-	KeyType type() const { if(d) { return d->type; } else { return (KeyType)-1; } }
+    bool isNull() const { return !d; }
+    KeyType type() const {
+        if (d) {
+            return d->type;
+        } else {
+            return (KeyType)-1;
+        }
+    }
 
-	const ffi::EncodingKey *raw() const { if(d) { return d->raw; } else { return 0; } }
+    const ffi::EncodingKey *raw() const {
+        if (d) {
+            return d->raw;
+        } else {
+            return 0;
+        }
+    }
 
-	static EncodingKey fromSecret(const QByteArray &key);
-	static EncodingKey fromPem(const QByteArray &key);
-	static EncodingKey fromFile(const QString &fileName);
-	static EncodingKey fromConfigString(const QString &s, const QDir &baseDir = QDir());
+    static EncodingKey fromSecret(const QByteArray &key);
+    static EncodingKey fromPem(const QByteArray &key);
+    static EncodingKey fromFile(const QString &fileName);
+    static EncodingKey fromConfigString(const QString &s, const QDir &baseDir = QDir());
 
 private:
-	class Private : public QSharedData
-	{
-	public:
-		KeyType type;
-		ffi::EncodingKey *raw;
+    class Private : public QSharedData {
+    public:
+        KeyType type;
+        ffi::EncodingKey *raw;
 
-		Private();
-		Private(ffi::JwtEncodingKey key);
-		~Private();
-	};
+        Private();
+        Private(ffi::JwtEncodingKey key);
+        ~Private();
+    };
 
-	QSharedDataPointer<Private> d;
+    QSharedDataPointer<Private> d;
 };
 
-class DecodingKey
-{
+class DecodingKey {
 public:
-	bool isNull() const { return !d; }
-	KeyType type() const { if(d) { return d->type; } else { return (KeyType)-1; } }
+    bool isNull() const { return !d; }
+    KeyType type() const {
+        if (d) {
+            return d->type;
+        } else {
+            return (KeyType)-1;
+        }
+    }
 
-	const ffi::DecodingKey *raw() const { if(d) { return d->raw; } else { return 0; } }
+    const ffi::DecodingKey *raw() const {
+        if (d) {
+            return d->raw;
+        } else {
+            return 0;
+        }
+    }
 
-	static DecodingKey fromSecret(const QByteArray &key);
-	static DecodingKey fromPem(const QByteArray &key);
-	static DecodingKey fromFile(const QString &fileName);
-	static DecodingKey fromConfigString(const QString &s, const QDir &baseDir = QDir());
+    static DecodingKey fromSecret(const QByteArray &key);
+    static DecodingKey fromPem(const QByteArray &key);
+    static DecodingKey fromFile(const QString &fileName);
+    static DecodingKey fromConfigString(const QString &s, const QDir &baseDir = QDir());
 
 private:
-	class Private : public QSharedData
-	{
-	public:
-		KeyType type;
-		ffi::DecodingKey *raw;
+    class Private : public QSharedData {
+    public:
+        KeyType type;
+        ffi::DecodingKey *raw;
 
-		Private();
-		Private(ffi::JwtDecodingKey key);
-		~Private();
-	};
+        Private();
+        Private(ffi::JwtDecodingKey key);
+        ~Private();
+    };
 
-	QSharedDataPointer<Private> d;
+    QSharedDataPointer<Private> d;
 };
 
 // Returns token, null on error
@@ -112,6 +131,6 @@ QByteArray decodeWithAlgorithm(Algorithm alg, const QByteArray &token, const Dec
 QByteArray encode(const Variant &claim, const EncodingKey &key);
 Variant decode(const QByteArray &token, const DecodingKey &key);
 
-}
+} // namespace Jwt
 
 #endif

--- a/src/core/jwttest.cpp
+++ b/src/core/jwttest.cpp
@@ -21,163 +21,165 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "jwt.h"
+#include "qtcompat.h"
 #include "test.h"
+#include "variant.h"
 #include <QJsonDocument>
 #include <QJsonObject>
-#include "qtcompat.h"
-#include "variant.h"
-#include "jwt.h"
 
 static const char *test_ec_private_key_pem =
-	"-----BEGIN PRIVATE KEY-----\n"
-	"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgFcZQVV16cpGC4QUQ\n"
-	"8O8H85totFiAB54WBTxKQQElI7KhRANCAAQA3D4/QkBACQuC99MFqZllTOaamPAJ\n"
-	"3+Z3JkPsrd/z651PYmlywcdEGVWRiD2PNhvdzM7Nckxx1ZofDLlkvoxH\n"
-	"-----END PRIVATE KEY-----\n";
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgFcZQVV16cpGC4QUQ\n"
+    "8O8H85totFiAB54WBTxKQQElI7KhRANCAAQA3D4/QkBACQuC99MFqZllTOaamPAJ\n"
+    "3+Z3JkPsrd/z651PYmlywcdEGVWRiD2PNhvdzM7Nckxx1ZofDLlkvoxH\n"
+    "-----END PRIVATE KEY-----\n";
 
 static const char *test_ec_public_key_pem =
-	"-----BEGIN PUBLIC KEY-----\n"
-	"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEANw+P0JAQAkLgvfTBamZZUzmmpjw\n"
-	"Cd/mdyZD7K3f8+udT2JpcsHHRBlVkYg9jzYb3czOzXJMcdWaHwy5ZL6MRw==\n"
-	"-----END PUBLIC KEY-----\n";
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEANw+P0JAQAkLgvfTBamZZUzmmpjw\n"
+    "Cd/mdyZD7K3f8+udT2JpcsHHRBlVkYg9jzYb3czOzXJMcdWaHwy5ZL6MRw==\n"
+    "-----END PUBLIC KEY-----\n";
 
 static const char *test_rsa_private_key_pem =
-	"-----BEGIN PRIVATE KEY-----\n"
-	"MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDOgE+exziD5kFF\n"
-	"4x3F76G64XAccp1KqWMgrTYM3c4C/7hxwuu7kMdGXlXL+xQOHe6vX6EM/H9tWaIf\n"
-	"CyQ+KfdyBBDO05MXZcxEl3496ShN/UN1TghJk12gg3yPm3+V2mfh+NQi7jEFt1uv\n"
-	"beco5T1ve5yhtu58PrCC87TuWINW+iFrUg41MEHcXWL/7COBR/azFOZqedZPCdnL\n"
-	"5SoY1H5WAazZUftD6W7PvCYmQN+uCSr1SjbGg5g+9OQ6i7viHXRg0U9mIZVII56V\n"
-	"g2sD0w6ClO4Tq+mQs94frKakD960drvg2QNCvW0cUiRBLkadOSqZkIp0It4r5ivi\n"
-	"S2gJQO8XAgMBAAECggEBAJs4W6DwAw0yULIlq8WTALCmsEzR4mWyuW5ghJZbS3V5\n"
-	"nrz0VZmhlAjS9A7l5gdOfJGagkZuraIWlARdrZqElRlA8Rlmc9RMkqSkcyI6Vi95\n"
-	"RfGw/A3CFciHzWNs8RRFHX0AOwUeof63+tT8+ZsF5Y4dDnmINe9yd9+XLNNT+TWw\n"
-	"aCFJ+RQ8j7xGtZb2N/AOI0prTCka/SNRYxNommdS1x9qCaTVKd1fXM/ZhRjIlsEo\n"
-	"OzmcoG0Kdfq6pu2OgJ8DzSigXyWbCEy/amSWgPX80kubG1Xjc8MSFlQcg493Gve1\n"
-	"JagUZEbKIQFNCxN42cAzuuf3hKV9vIT+L8yApuacwQECgYEA+Lgp8UtANVFOBSuE\n"
-	"5HHP+dB3Ot8HdbK2FIQEQ+xwVUHgLnnWpQHhw8COpZgAoMGMPl37KGrTuPW/C/4o\n"
-	"yGj/hK+df1ksLR8ViXFVpB5GbzfdsvMgPo1GCYVFVGJlVHO/oFxV6YQtydhiAMp+\n"
-	"dcgQO3paKrzEoFSJdomNtoqMdUECgYEA1IvGiaiwk5yPafs2mbsoMM7K6NpzlO3x\n"
-	"pPlTqgGgVgIM+Lg6FWEm3kWN6A/hELyfCIosHP5pdkPKxgkzs6OqVFxKa2anHSRT\n"
-	"1lLUhU0kOrkYyfq1oMXumPb5Kc4zzbOnxScF7lCIzMo9y82OJSjHDbjAgmzNyJbm\n"
-	"CEhOgf2RllcCgYAfyqKJ1j2R0x+u534oGSglXXEwFDwG3l4Jx0ooSHufWjlGl4pJ\n"
-	"MzFhbSaOohxKcBL2Eds9slH3zWmrJcSewVUP58aw9XwBFH0TQWpZ/QixxKlQ62TO\n"
-	"ug4ev2s6Ow2KuvTekY7lt2CG8WKtiTSa54SzpZMK7XAQsl2TykdT8ue7QQKBgGrG\n"
-	"KR/gkYwmG1m3bK9/+OnECOU/UM8hVcJ1ylTeakiq0Q9lpTA2VQtWT7qjt4Hr78yf\n"
-	"dRe/qwVRex1PZBy7fIbSskQQFqWqKT/C7qZkoW2qrMxS2UmCBaHseDFLOHT+6qo9\n"
-	"N1qINKEEfFTU17LNMGoxROyAckRxoe/JOz9MPgYTAoGBAJKreX73d6s1s9oVB3u/\n"
-	"DS1YXRmek+OkXQhFxekKXB3KxG8obx2uveeg18PtNf0RoYq9LF0hKcTqSCusfF9m\n"
-	"lM+s5xc1mQfXI55AEOjT+8AssmhebHbFkpjr1/DSUUsCssO+1znkeZwAOApm/4kR\n"
-	"pGokHI67k9CxNFZW3Z0U9EeW\n"
-	"-----END PRIVATE KEY-----\n";
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDOgE+exziD5kFF\n"
+    "4x3F76G64XAccp1KqWMgrTYM3c4C/7hxwuu7kMdGXlXL+xQOHe6vX6EM/H9tWaIf\n"
+    "CyQ+KfdyBBDO05MXZcxEl3496ShN/UN1TghJk12gg3yPm3+V2mfh+NQi7jEFt1uv\n"
+    "beco5T1ve5yhtu58PrCC87TuWINW+iFrUg41MEHcXWL/7COBR/azFOZqedZPCdnL\n"
+    "5SoY1H5WAazZUftD6W7PvCYmQN+uCSr1SjbGg5g+9OQ6i7viHXRg0U9mIZVII56V\n"
+    "g2sD0w6ClO4Tq+mQs94frKakD960drvg2QNCvW0cUiRBLkadOSqZkIp0It4r5ivi\n"
+    "S2gJQO8XAgMBAAECggEBAJs4W6DwAw0yULIlq8WTALCmsEzR4mWyuW5ghJZbS3V5\n"
+    "nrz0VZmhlAjS9A7l5gdOfJGagkZuraIWlARdrZqElRlA8Rlmc9RMkqSkcyI6Vi95\n"
+    "RfGw/A3CFciHzWNs8RRFHX0AOwUeof63+tT8+ZsF5Y4dDnmINe9yd9+XLNNT+TWw\n"
+    "aCFJ+RQ8j7xGtZb2N/AOI0prTCka/SNRYxNommdS1x9qCaTVKd1fXM/ZhRjIlsEo\n"
+    "OzmcoG0Kdfq6pu2OgJ8DzSigXyWbCEy/amSWgPX80kubG1Xjc8MSFlQcg493Gve1\n"
+    "JagUZEbKIQFNCxN42cAzuuf3hKV9vIT+L8yApuacwQECgYEA+Lgp8UtANVFOBSuE\n"
+    "5HHP+dB3Ot8HdbK2FIQEQ+xwVUHgLnnWpQHhw8COpZgAoMGMPl37KGrTuPW/C/4o\n"
+    "yGj/hK+df1ksLR8ViXFVpB5GbzfdsvMgPo1GCYVFVGJlVHO/oFxV6YQtydhiAMp+\n"
+    "dcgQO3paKrzEoFSJdomNtoqMdUECgYEA1IvGiaiwk5yPafs2mbsoMM7K6NpzlO3x\n"
+    "pPlTqgGgVgIM+Lg6FWEm3kWN6A/hELyfCIosHP5pdkPKxgkzs6OqVFxKa2anHSRT\n"
+    "1lLUhU0kOrkYyfq1oMXumPb5Kc4zzbOnxScF7lCIzMo9y82OJSjHDbjAgmzNyJbm\n"
+    "CEhOgf2RllcCgYAfyqKJ1j2R0x+u534oGSglXXEwFDwG3l4Jx0ooSHufWjlGl4pJ\n"
+    "MzFhbSaOohxKcBL2Eds9slH3zWmrJcSewVUP58aw9XwBFH0TQWpZ/QixxKlQ62TO\n"
+    "ug4ev2s6Ow2KuvTekY7lt2CG8WKtiTSa54SzpZMK7XAQsl2TykdT8ue7QQKBgGrG\n"
+    "KR/gkYwmG1m3bK9/+OnECOU/UM8hVcJ1ylTeakiq0Q9lpTA2VQtWT7qjt4Hr78yf\n"
+    "dRe/qwVRex1PZBy7fIbSskQQFqWqKT/C7qZkoW2qrMxS2UmCBaHseDFLOHT+6qo9\n"
+    "N1qINKEEfFTU17LNMGoxROyAckRxoe/JOz9MPgYTAoGBAJKreX73d6s1s9oVB3u/\n"
+    "DS1YXRmek+OkXQhFxekKXB3KxG8obx2uveeg18PtNf0RoYq9LF0hKcTqSCusfF9m\n"
+    "lM+s5xc1mQfXI55AEOjT+8AssmhebHbFkpjr1/DSUUsCssO+1znkeZwAOApm/4kR\n"
+    "pGokHI67k9CxNFZW3Z0U9EeW\n"
+    "-----END PRIVATE KEY-----\n";
 
 static const char *test_rsa_public_key_pem =
-	"-----BEGIN PUBLIC KEY-----\n"
-	"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzoBPnsc4g+ZBReMdxe+h\n"
-	"uuFwHHKdSqljIK02DN3OAv+4ccLru5DHRl5Vy/sUDh3ur1+hDPx/bVmiHwskPin3\n"
-	"cgQQztOTF2XMRJd+PekoTf1DdU4ISZNdoIN8j5t/ldpn4fjUIu4xBbdbr23nKOU9\n"
-	"b3ucobbufD6wgvO07liDVvoha1IONTBB3F1i/+wjgUf2sxTmannWTwnZy+UqGNR+\n"
-	"VgGs2VH7Q+luz7wmJkDfrgkq9Uo2xoOYPvTkOou74h10YNFPZiGVSCOelYNrA9MO\n"
-	"gpTuE6vpkLPeH6ympA/etHa74NkDQr1tHFIkQS5GnTkqmZCKdCLeK+Yr4ktoCUDv\n"
-	"FwIDAQAB\n"
-	"-----END PUBLIC KEY-----\n";
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzoBPnsc4g+ZBReMdxe+h\n"
+    "uuFwHHKdSqljIK02DN3OAv+4ccLru5DHRl5Vy/sUDh3ur1+hDPx/bVmiHwskPin3\n"
+    "cgQQztOTF2XMRJd+PekoTf1DdU4ISZNdoIN8j5t/ldpn4fjUIu4xBbdbr23nKOU9\n"
+    "b3ucobbufD6wgvO07liDVvoha1IONTBB3F1i/+wjgUf2sxTmannWTwnZy+UqGNR+\n"
+    "VgGs2VH7Q+luz7wmJkDfrgkq9Uo2xoOYPvTkOou74h10YNFPZiGVSCOelYNrA9MO\n"
+    "gpTuE6vpkLPeH6ympA/etHa74NkDQr1tHFIkQS5GnTkqmZCKdCLeK+Yr4ktoCUDv\n"
+    "FwIDAQAB\n"
+    "-----END PUBLIC KEY-----\n";
 
-static void validToken()
-{
-	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("secret"));
-	TEST_ASSERT(typeId(vclaim) == VariantType::Map);
-	VariantMap claim = vclaim.toMap();
-	TEST_ASSERT(claim.value("foo") == "bar");
+static void validToken() {
+    Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0."
+                                 "oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs",
+                                 Jwt::DecodingKey::fromSecret("secret"));
+    TEST_ASSERT(typeId(vclaim) == VariantType::Map);
+    VariantMap claim = vclaim.toMap();
+    TEST_ASSERT(claim.value("foo") == "bar");
 }
 
-static void validTokenBinaryKey()
-{
-	QByteArray key;
-	key += 0x01;
-	key += 0x61;
-	key += 0x80;
-	key += 0xfe;
-	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.-eLxyGEITnd6IP4WvGJx9CmIOt--Qcs3LB6wblJ7KXI", Jwt::DecodingKey::fromSecret(key));
-	TEST_ASSERT(typeId(vclaim) == VariantType::Map);
-	VariantMap claim = vclaim.toMap();
-	TEST_ASSERT(claim.value("foo") == "bar");
+static void validTokenBinaryKey() {
+    QByteArray key;
+    key += 0x01;
+    key += 0x61;
+    key += 0x80;
+    key += 0xfe;
+    Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.-"
+                                 "eLxyGEITnd6IP4WvGJx9CmIOt--Qcs3LB6wblJ7KXI",
+                                 Jwt::DecodingKey::fromSecret(key));
+    TEST_ASSERT(typeId(vclaim) == VariantType::Map);
+    VariantMap claim = vclaim.toMap();
+    TEST_ASSERT(claim.value("foo") == "bar");
 }
 
-static void invalidKey()
-{
-	Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0.oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs", Jwt::DecodingKey::fromSecret("wrong"));
-	TEST_ASSERT(vclaim.isNull());
+static void invalidKey() {
+    Variant vclaim = Jwt::decode("eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJmb28iOiAiYmFyIn0."
+                                 "oBia0Fph39FwQWv0TS7Disg4qa0aFa8qpMaYDrIXZqs",
+                                 Jwt::DecodingKey::fromSecret("wrong"));
+    TEST_ASSERT(vclaim.isNull());
 }
 
-static void es256EncodeDecode()
-{
-	Jwt::EncodingKey privateKey = Jwt::EncodingKey::fromPem(QByteArray(test_ec_private_key_pem));
-	TEST_ASSERT(!privateKey.isNull());
-	TEST_ASSERT_EQ(privateKey.type(), Jwt::KeyType::Ec);
+static void es256EncodeDecode() {
+    Jwt::EncodingKey privateKey = Jwt::EncodingKey::fromPem(QByteArray(test_ec_private_key_pem));
+    TEST_ASSERT(!privateKey.isNull());
+    TEST_ASSERT_EQ(privateKey.type(), Jwt::KeyType::Ec);
 
-	Jwt::DecodingKey publicKey = Jwt::DecodingKey::fromPem(QByteArray(test_ec_public_key_pem));
-	TEST_ASSERT(!publicKey.isNull());
-	TEST_ASSERT_EQ(publicKey.type(), Jwt::KeyType::Ec);
+    Jwt::DecodingKey publicKey = Jwt::DecodingKey::fromPem(QByteArray(test_ec_public_key_pem));
+    TEST_ASSERT(!publicKey.isNull());
+    TEST_ASSERT_EQ(publicKey.type(), Jwt::KeyType::Ec);
 
-	VariantMap claim;
-	claim["iss"] = "nobody";
+    VariantMap claim;
+    claim["iss"] = "nobody";
 
-	QByteArray claimJson = QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
-	TEST_ASSERT(!claimJson.isNull());
+    QByteArray claimJson =
+        QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
+    TEST_ASSERT(!claimJson.isNull());
 
-	QByteArray token = Jwt::encodeWithAlgorithm(Jwt::ES256, claimJson, privateKey);
-	TEST_ASSERT(!token.isNull());
+    QByteArray token = Jwt::encodeWithAlgorithm(Jwt::ES256, claimJson, privateKey);
+    TEST_ASSERT(!token.isNull());
 
-	QByteArray resultJson = Jwt::decodeWithAlgorithm(Jwt::ES256, token, publicKey);
-	TEST_ASSERT(!resultJson.isNull());
+    QByteArray resultJson = Jwt::decodeWithAlgorithm(Jwt::ES256, token, publicKey);
+    TEST_ASSERT(!resultJson.isNull());
 
-	QJsonParseError error;
-	QJsonDocument doc = QJsonDocument::fromJson(resultJson, &error);
-	TEST_ASSERT(error.error == QJsonParseError::NoError);
-	TEST_ASSERT(doc.isObject());
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(resultJson, &error);
+    TEST_ASSERT(error.error == QJsonParseError::NoError);
+    TEST_ASSERT(doc.isObject());
 
-	VariantMap result = doc.object().toVariantMap();
-	TEST_ASSERT_EQ(result["iss"], "nobody");
+    VariantMap result = doc.object().toVariantMap();
+    TEST_ASSERT_EQ(result["iss"], "nobody");
 }
 
-static void rs256EncodeDecode()
-{
-	Jwt::EncodingKey privateKey = Jwt::EncodingKey::fromPem(QByteArray(test_rsa_private_key_pem));
-	TEST_ASSERT(!privateKey.isNull());
-	TEST_ASSERT_EQ(privateKey.type(), Jwt::KeyType::Rsa);
+static void rs256EncodeDecode() {
+    Jwt::EncodingKey privateKey = Jwt::EncodingKey::fromPem(QByteArray(test_rsa_private_key_pem));
+    TEST_ASSERT(!privateKey.isNull());
+    TEST_ASSERT_EQ(privateKey.type(), Jwt::KeyType::Rsa);
 
-	Jwt::DecodingKey publicKey = Jwt::DecodingKey::fromPem(QByteArray(test_rsa_public_key_pem));
-	TEST_ASSERT(!publicKey.isNull());
-	TEST_ASSERT_EQ(publicKey.type(), Jwt::KeyType::Rsa);
+    Jwt::DecodingKey publicKey = Jwt::DecodingKey::fromPem(QByteArray(test_rsa_public_key_pem));
+    TEST_ASSERT(!publicKey.isNull());
+    TEST_ASSERT_EQ(publicKey.type(), Jwt::KeyType::Rsa);
 
-	VariantMap claim;
-	claim["iss"] = "nobody";
+    VariantMap claim;
+    claim["iss"] = "nobody";
 
-	QByteArray claimJson = QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
-	TEST_ASSERT(!claimJson.isNull());
+    QByteArray claimJson =
+        QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
+    TEST_ASSERT(!claimJson.isNull());
 
-	QByteArray token = Jwt::encodeWithAlgorithm(Jwt::RS256, claimJson, privateKey);
-	TEST_ASSERT(!token.isNull());
+    QByteArray token = Jwt::encodeWithAlgorithm(Jwt::RS256, claimJson, privateKey);
+    TEST_ASSERT(!token.isNull());
 
-	QByteArray resultJson = Jwt::decodeWithAlgorithm(Jwt::RS256, token, publicKey);
-	TEST_ASSERT(!resultJson.isNull());
+    QByteArray resultJson = Jwt::decodeWithAlgorithm(Jwt::RS256, token, publicKey);
+    TEST_ASSERT(!resultJson.isNull());
 
-	QJsonParseError error;
-	QJsonDocument doc = QJsonDocument::fromJson(resultJson, &error);
-	TEST_ASSERT(error.error == QJsonParseError::NoError);
-	TEST_ASSERT(doc.isObject());
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(resultJson, &error);
+    TEST_ASSERT(error.error == QJsonParseError::NoError);
+    TEST_ASSERT(doc.isObject());
 
-	VariantMap result = doc.object().toVariantMap();
-	TEST_ASSERT_EQ(result["iss"], "nobody");
+    VariantMap result = doc.object().toVariantMap();
+    TEST_ASSERT_EQ(result["iss"], "nobody");
 }
 
-extern "C" int jwt_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(validToken());
-	TEST_CATCH(validTokenBinaryKey());
-	TEST_CATCH(invalidKey());
-	TEST_CATCH(es256EncodeDecode());
-	TEST_CATCH(rs256EncodeDecode());
+extern "C" int jwt_test(ffi::TestException *out_ex) {
+    TEST_CATCH(validToken());
+    TEST_CATCH(validTokenBinaryKey());
+    TEST_CATCH(invalidKey());
+    TEST_CATCH(es256EncodeDecode());
+    TEST_CATCH(rs256EncodeDecode());
 
-	return 0;
+    return 0;
 }

--- a/src/core/layertracker.cpp
+++ b/src/core/layertracker.cpp
@@ -22,53 +22,42 @@
 
 #include <assert.h>
 
-LayerTracker::LayerTracker() :
-	plain_(0)
-{
+LayerTracker::LayerTracker() : plain_(0) {}
+
+void LayerTracker::reset() {
+    plain_ = 0;
+    items_.clear();
 }
 
-void LayerTracker::reset()
-{
-	plain_ = 0;
-	items_.clear();
+void LayerTracker::addPlain(int plain) { plain_ += plain; }
+
+void LayerTracker::specifyEncoded(int encoded, int plain) {
+    // Can't specify more bytes than we have
+    assert(plain <= plain_);
+
+    plain_ -= plain;
+    Item i;
+    i.plain = plain;
+    i.encoded = encoded;
+    items_ += i;
 }
 
-void LayerTracker::addPlain(int plain)
-{
-	plain_ += plain;
-}
+int LayerTracker::finished(int encoded) {
+    int plain = 0;
 
-void LayerTracker::specifyEncoded(int encoded, int plain)
-{
-	// Can't specify more bytes than we have
-	assert(plain <= plain_);
+    for (QList<Item>::Iterator it = items_.begin(); it != items_.end();) {
+        Item &i = *it;
 
-	plain_ -= plain;
-	Item i;
-	i.plain = plain;
-	i.encoded = encoded;
-	items_ += i;
-}
+        // Not enough?
+        if (encoded < i.encoded) {
+            i.encoded -= encoded;
+            break;
+        }
 
-int LayerTracker::finished(int encoded)
-{
-	int plain = 0;
+        encoded -= i.encoded;
+        plain += i.plain;
+        it = items_.erase(it);
+    }
 
-	for(QList<Item>::Iterator it = items_.begin(); it != items_.end();)
-	{
-		Item &i = *it;
-
-		// Not enough?
-		if(encoded < i.encoded)
-		{
-			i.encoded -= encoded;
-			break;
-		}
-
-		encoded -= i.encoded;
-		plain += i.plain;
-		it = items_.erase(it);
-	}
-
-	return plain;
+    return plain;
 }

--- a/src/core/layertracker.h
+++ b/src/core/layertracker.h
@@ -23,27 +23,25 @@
 
 #include <QList>
 
-class LayerTracker
-{
+class LayerTracker {
 public:
-	LayerTracker();
+    LayerTracker();
 
-	void reset();
+    void reset();
 
-	void addPlain(int plain);
-	void specifyEncoded(int encoded, int plain);
-	int finished(int encoded);
+    void addPlain(int plain);
+    void specifyEncoded(int encoded, int plain);
+    int finished(int encoded);
 
 private:
-	class Item
-	{
-	public:
-		int plain;
-		int encoded;
-	};
+    class Item {
+    public:
+        int plain;
+        int encoded;
+    };
 
-	int plain_;
-	QList<Item> items_;
+    int plain_;
+    QList<Item> items_;
 };
 
 #endif

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -20,12 +20,12 @@
 
 #include "log.h"
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <QString>
-#include <QElapsedTimer>
 #include <QDateTime>
+#include <QElapsedTimer>
 #include <QMutex>
+#include <QString>
+#include <stdarg.h>
+#include <stdio.h>
 
 Q_GLOBAL_STATIC(QMutex, g_mutex)
 static int g_level = LOG_LEVEL_DEBUG;
@@ -33,156 +33,142 @@ static QElapsedTimer g_time;
 static QString *g_filename;
 static FILE *g_file;
 
-static void log(const char *s)
-{
-	FILE *out;
-	if(g_file)
-		out = g_file;
-	else
-		out = stdout;
-	fprintf(out, "%s\n", s);
-	fflush(out);
+static void log(const char *s) {
+    FILE *out;
+    if (g_file)
+        out = g_file;
+    else
+        out = stdout;
+    fprintf(out, "%s\n", s);
+    fflush(out);
 }
 
-static void log(int level, const char *fmt, va_list ap)
-{
-	g_mutex()->lock();
-	int current_level = g_level;
-	int elapsed;
-	if(g_time.isValid())
-		elapsed = g_time.elapsed();
-	else
-		elapsed = -1;
-	g_mutex()->unlock();
+static void log(int level, const char *fmt, va_list ap) {
+    g_mutex()->lock();
+    int current_level = g_level;
+    int elapsed;
+    if (g_time.isValid())
+        elapsed = g_time.elapsed();
+    else
+        elapsed = -1;
+    g_mutex()->unlock();
 
-	if(level <= current_level)
-	{
-		QString str = QString::vasprintf(fmt, ap);
+    if (level <= current_level) {
+        QString str = QString::vasprintf(fmt, ap);
 
-		const char *lstr;
-		switch(level)
-		{
-			case LOG_LEVEL_ERROR:   lstr = "ERR"; break;
-			case LOG_LEVEL_WARNING: lstr = "WARN"; break;
-			case LOG_LEVEL_INFO:    lstr = "INFO"; break;
-			case LOG_LEVEL_DEBUG:
-			default:
-				lstr = "DEBUG"; break;
-		}
+        const char *lstr;
+        switch (level) {
+        case LOG_LEVEL_ERROR:
+            lstr = "ERR";
+            break;
+        case LOG_LEVEL_WARNING:
+            lstr = "WARN";
+            break;
+        case LOG_LEVEL_INFO:
+            lstr = "INFO";
+            break;
+        case LOG_LEVEL_DEBUG:
+        default:
+            lstr = "DEBUG";
+            break;
+        }
 
-		QString tstr;
-		if(elapsed != -1)
-		{
-			QTime t(0, 0);
-			t = t.addMSecs(elapsed);
-			tstr = t.toString("HH:mm:ss.zzz");
-		}
-		else
-		{
-			tstr = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
-		}
+        QString tstr;
+        if (elapsed != -1) {
+            QTime t(0, 0);
+            t = t.addMSecs(elapsed);
+            tstr = t.toString("HH:mm:ss.zzz");
+        } else {
+            tstr = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
+        }
 
-		FILE *out;
-		if(g_file)
-			out = g_file;
-		else
-			out = stdout;
-		fprintf(out, "[%s] %s %s\n", lstr, qPrintable(tstr), qPrintable(str));
-		fflush(out);
-	}
+        FILE *out;
+        if (g_file)
+            out = g_file;
+        else
+            out = stdout;
+        fprintf(out, "[%s] %s %s\n", lstr, qPrintable(tstr), qPrintable(str));
+        fflush(out);
+    }
 }
 
-void log_startClock()
-{
-	QMutexLocker locker(g_mutex());
-	g_time.start();
+void log_startClock() {
+    QMutexLocker locker(g_mutex());
+    g_time.start();
 }
 
-int log_outputLevel()
-{
-	QMutexLocker locker(g_mutex());
-	return g_level;
+int log_outputLevel() {
+    QMutexLocker locker(g_mutex());
+    return g_level;
 }
 
-void log_setOutputLevel(int level)
-{
-	QMutexLocker locker(g_mutex());
-	g_level = level;
+void log_setOutputLevel(int level) {
+    QMutexLocker locker(g_mutex());
+    g_level = level;
 }
 
-bool log_setFile(const QString &fname)
-{
-	QMutexLocker locker(g_mutex());
-	if(g_file)
-	{
-		fclose(g_file);
-		delete g_filename;
-		g_filename = 0;
-		g_file = 0;
-	}
-	if(fname.isEmpty())
-		return true;
-	FILE *f = fopen(fname.toLocal8Bit().data(), "a");
-	if(!f)
-		return false;
-	setbuf(f, NULL);
-	g_filename = new QString(fname);
-	g_file = f;
-	return true;
+bool log_setFile(const QString &fname) {
+    QMutexLocker locker(g_mutex());
+    if (g_file) {
+        fclose(g_file);
+        delete g_filename;
+        g_filename = 0;
+        g_file = 0;
+    }
+    if (fname.isEmpty())
+        return true;
+    FILE *f = fopen(fname.toLocal8Bit().data(), "a");
+    if (!f)
+        return false;
+    setbuf(f, NULL);
+    g_filename = new QString(fname);
+    g_file = f;
+    return true;
 }
 
-bool log_rotate()
-{
-	QMutexLocker locker(g_mutex());
-	if(!g_file)
-		return true;
-	if(!freopen(g_filename->toLocal8Bit().data(), "a", g_file))
-		return false;
-	setbuf(g_file, NULL);
-	return true;
+bool log_rotate() {
+    QMutexLocker locker(g_mutex());
+    if (!g_file)
+        return true;
+    if (!freopen(g_filename->toLocal8Bit().data(), "a", g_file))
+        return false;
+    setbuf(g_file, NULL);
+    return true;
 }
 
-void log(int level, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	log(level, fmt, ap);
-	va_end(ap);
+void log(int level, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    log(level, fmt, ap);
+    va_end(ap);
 }
 
-void log_error(const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	log(LOG_LEVEL_ERROR, fmt, ap);
-	va_end(ap);
+void log_error(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    log(LOG_LEVEL_ERROR, fmt, ap);
+    va_end(ap);
 }
 
-void log_warning(const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	log(LOG_LEVEL_WARNING, fmt, ap);
-	va_end(ap);
+void log_warning(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    log(LOG_LEVEL_WARNING, fmt, ap);
+    va_end(ap);
 }
 
-void log_info(const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	log(LOG_LEVEL_INFO, fmt, ap);
-	va_end(ap);
+void log_info(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    log(LOG_LEVEL_INFO, fmt, ap);
+    va_end(ap);
 }
 
-void log_debug(const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	log(LOG_LEVEL_DEBUG, fmt, ap);
-	va_end(ap);
+void log_debug(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    log(LOG_LEVEL_DEBUG, fmt, ap);
+    va_end(ap);
 }
 
-void log_raw(const char *s)
-{
-	log(s);
-}
+void log_raw(const char *s) { log(s); }

--- a/src/core/log.h
+++ b/src/core/log.h
@@ -25,10 +25,10 @@
 
 // Really simply logging stuff
 
-#define LOG_LEVEL_ERROR   0
+#define LOG_LEVEL_ERROR 0
 #define LOG_LEVEL_WARNING 1
-#define LOG_LEVEL_INFO    2
-#define LOG_LEVEL_DEBUG   3
+#define LOG_LEVEL_INFO 2
+#define LOG_LEVEL_DEBUG 3
 
 void log_startClock();
 int log_outputLevel();

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -23,188 +23,174 @@
 
 #include "logutil.h"
 
-#include <assert.h>
-#include <stdarg.h>
+#include "log.h"
 #include "qtcompat.h"
 #include "tnetstring.h"
 #include "variant.h"
-#include "log.h"
+#include <assert.h>
+#include <stdarg.h>
 
 #define MAX_DATA_LENGTH 1000
 #define MAX_CONTENT_LENGTH 1000
 
 namespace LogUtil {
 
-static QString trim(const QString &in, int max)
-{
-	if(in.length() > max && max >= 7)
-		return in.mid(0, max / 2) + "..." + in.mid(in.length() - (max / 2) + 3);
-	else
-		return in;
+static QString trim(const QString &in, int max) {
+    if (in.length() > max && max >= 7)
+        return in.mid(0, max / 2) + "..." + in.mid(in.length() - (max / 2) + 3);
+    else
+        return in;
 }
 
-static QByteArray trim(const QByteArray &in, int max)
-{
-	if(in.size() > max && max >= 7)
-		return in.mid(0, max / 2) + "..." + in.mid(in.size() - (max / 2) + 3);
-	else
-		return in;
+static QByteArray trim(const QByteArray &in, int max) {
+    if (in.size() > max && max >= 7)
+        return in.mid(0, max / 2) + "..." + in.mid(in.size() - (max / 2) + 3);
+    else
+        return in;
 }
 
-static QString makeLastIdsStr(const HttpHeaders &headers)
-{
-	QString out;
+static QString makeLastIdsStr(const HttpHeaders &headers) {
+    QString out;
 
-	bool first = true;
-	foreach(const HttpHeaderParameters &params, headers.getAllAsParameters("Grip-Last"))
-	{
-		if(!first)
-			out += ' ';
-		out += QString("#%1=%2").arg(QString::fromUtf8(params[0].first.asQByteArray()), QString::fromUtf8(params.get("last-id").asQByteArray()));
-		first = false;
-	}
+    bool first = true;
+    foreach (const HttpHeaderParameters &params, headers.getAllAsParameters("Grip-Last")) {
+        if (!first)
+            out += ' ';
+        out += QString("#%1=%2").arg(QString::fromUtf8(params[0].first.asQByteArray()),
+                                     QString::fromUtf8(params.get("last-id").asQByteArray()));
+        first = false;
+    }
 
-	return out;
+    return out;
 }
 
-static void logPacket(int level, const QString &message, const Variant &data = Variant(), int dataMax = -1, const QByteArray &content = QByteArray(), int contentMax = -1)
-{
-	QString out = message;
+static void logPacket(int level, const QString &message, const Variant &data = Variant(),
+                      int dataMax = -1, const QByteArray &content = QByteArray(),
+                      int contentMax = -1) {
+    QString out = message;
 
-	if(data.isValid())
-	{
-		out += ' ' + trim(TnetString::variantToString(data, -1), dataMax);
-	}
+    if (data.isValid()) {
+        out += ' ' + trim(TnetString::variantToString(data, -1), dataMax);
+    }
 
-	if(!content.isNull())
-	{
-		out += ' ' + QString::number(content.size()) + ' ';
-		QByteArray buf = trim(content, contentMax);
-		out += TnetString::variantToString(Variant(buf), -1);
-	}
+    if (!content.isNull()) {
+        out += ' ' + QString::number(content.size()) + ' ';
+        QByteArray buf = trim(content, contentMax);
+        out += TnetString::variantToString(Variant(buf), -1);
+    }
 
-	log(level, "%s", qPrintable(out));
+    log(level, "%s", qPrintable(out));
 }
 
-static void logPacket(int level, const Variant &data, const char *fmt, va_list ap)
-{
-	logPacket(level, QString::vasprintf(fmt, ap), data, MAX_DATA_LENGTH);
+static void logPacket(int level, const Variant &data, const char *fmt, va_list ap) {
+    logPacket(level, QString::vasprintf(fmt, ap), data, MAX_DATA_LENGTH);
 }
 
-static void logPacket(int level, const QByteArray &content, const char *fmt, va_list ap)
-{
-	logPacket(level, QString::vasprintf(fmt, ap), Variant(), -1, content, MAX_CONTENT_LENGTH);
+static void logPacket(int level, const QByteArray &content, const char *fmt, va_list ap) {
+    logPacket(level, QString::vasprintf(fmt, ap), Variant(), -1, content, MAX_CONTENT_LENGTH);
 }
 
-static void logPacket(int level, const Variant &data, const QString &contentField, const char *fmt, va_list ap)
-{
-	Variant meta;
-	QByteArray content;
+static void logPacket(int level, const Variant &data, const QString &contentField, const char *fmt,
+                      va_list ap) {
+    Variant meta;
+    QByteArray content;
 
-	if(typeId(data) == VariantType::Hash)
-	{
-		// Extract content. Meta is the remaining data
-		VariantHash hdata = data.toHash();
-		content = hdata.value(contentField).toByteArray();
-		hdata.remove(contentField);
-		meta = hdata;
-	}
-	else
-	{
-		// If data isn't a hash, then we can't extract content, so
-		// the meta part will be the entire data
-		meta = data;
-	}
+    if (typeId(data) == VariantType::Hash) {
+        // Extract content. Meta is the remaining data
+        VariantHash hdata = data.toHash();
+        content = hdata.value(contentField).toByteArray();
+        hdata.remove(contentField);
+        meta = hdata;
+    } else {
+        // If data isn't a hash, then we can't extract content, so
+        // the meta part will be the entire data
+        meta = data;
+    }
 
-	logPacket(level, QString::vasprintf(fmt, ap), meta, MAX_DATA_LENGTH, content, MAX_CONTENT_LENGTH);
+    logPacket(level, QString::vasprintf(fmt, ap), meta, MAX_DATA_LENGTH, content,
+              MAX_CONTENT_LENGTH);
 }
 
-void logVariant(int level, const Variant &data, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	logPacket(level, data, fmt, ap);
-	va_end(ap);
+void logVariant(int level, const Variant &data, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    logPacket(level, data, fmt, ap);
+    va_end(ap);
 }
 
-void logByteArray(int level, const QByteArray &content, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	logPacket(level, content, fmt, ap);
-	va_end(ap);
+void logByteArray(int level, const QByteArray &content, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    logPacket(level, content, fmt, ap);
+    va_end(ap);
 }
 
-void logVariantWithContent(int level, const Variant &data, const QString &contentField, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	logPacket(level, data, contentField, fmt, ap);
-	va_end(ap);
+void logVariantWithContent(int level, const Variant &data, const QString &contentField,
+                           const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    logPacket(level, data, contentField, fmt, ap);
+    va_end(ap);
 }
 
-void logRequest(int level, const RequestData &data, const Config &config)
-{
-	QString msg = QString("%1 %2").arg(data.requestData.method, data.requestData.uri.toString(Url::FullyEncoded));
+void logRequest(int level, const RequestData &data, const Config &config) {
+    QString msg = QString("%1 %2").arg(data.requestData.method,
+                                       data.requestData.uri.toString(Url::FullyEncoded));
 
-	if(!data.targetStr.isEmpty())
-		msg += QString(" -> %1").arg(data.targetStr);
+    if (!data.targetStr.isEmpty())
+        msg += QString(" -> %1").arg(data.targetStr);
 
-	if(data.requestData.uri.scheme() != "http" && data.requestData.uri.scheme() != "https" && data.targetOverHttp)
-		msg += "[http]";
+    if (data.requestData.uri.scheme() != "http" && data.requestData.uri.scheme() != "https" &&
+        data.targetOverHttp)
+        msg += "[http]";
 
-	if(config.fromAddress && !data.fromAddress.isNull())
-		msg += QString(" from=%1").arg(data.fromAddress.toString());
+    if (config.fromAddress && !data.fromAddress.isNull())
+        msg += QString(" from=%1").arg(data.fromAddress.toString());
 
-	Url ref = Url(QString::fromUtf8(data.requestData.headers.get("Referer").asQByteArray()));
-	if(!ref.isEmpty())
-		msg += QString(" ref=%1").arg(ref.toString(Url::FullyEncoded));
+    Url ref = Url(QString::fromUtf8(data.requestData.headers.get("Referer").asQByteArray()));
+    if (!ref.isEmpty())
+        msg += QString(" ref=%1").arg(ref.toString(Url::FullyEncoded));
 
-	if(!data.routeId.isEmpty())
-		msg += QString(" route=%1").arg(data.routeId);
+    if (!data.routeId.isEmpty())
+        msg += QString(" route=%1").arg(data.routeId);
 
-	if(data.status == LogUtil::Response)
-	{
-		msg += QString(" code=%1 %2").arg(QString::number(data.responseData.code), QString::number(data.responseBodySize));
-	}
-	else if(data.status == LogUtil::Accept)
-	{
-		msg += " accept";
-	}
-	else
-	{
-		msg += " error";
-	}
+    if (data.status == LogUtil::Response) {
+        msg += QString(" code=%1 %2")
+                   .arg(QString::number(data.responseData.code),
+                        QString::number(data.responseBodySize));
+    } else if (data.status == LogUtil::Accept) {
+        msg += " accept";
+    } else {
+        msg += " error";
+    }
 
-	if(data.retry)
-		msg += " retry";
+    if (data.retry)
+        msg += " retry";
 
-	if(data.sharedBy)
-		msg += QString::asprintf(" shared=%p", data.sharedBy);
+    if (data.sharedBy)
+        msg += QString::asprintf(" shared=%p", data.sharedBy);
 
-	if(config.userAgent)
-	{
-		QString userAgent = data.requestData.headers.get("User-Agent").asQByteArray();
-		if(!userAgent.isEmpty())
-			msg += QString(" ua=%1").arg(userAgent);
-	}
+    if (config.userAgent) {
+        QString userAgent = data.requestData.headers.get("User-Agent").asQByteArray();
+        if (!userAgent.isEmpty())
+            msg += QString(" ua=%1").arg(userAgent);
+    }
 
-	QString lastIdsStr = makeLastIdsStr(data.requestData.headers);
-	if(!lastIdsStr.isEmpty())
-		msg += ' ' + lastIdsStr;
+    QString lastIdsStr = makeLastIdsStr(data.requestData.headers);
+    if (!lastIdsStr.isEmpty())
+        msg += ' ' + lastIdsStr;
 
-	log(level, "%s", qPrintable(msg));
+    log(level, "%s", qPrintable(msg));
 }
 
-void logForRoute(const RouteInfo &routeInfo, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	QString msg = QString::vasprintf(fmt, ap);
-	if(!routeInfo.id.isEmpty())
-		msg += QString(" route=%1").arg(routeInfo.id);
-	logPacket(routeInfo.logLevel, msg);
-	va_end(ap);
+void logForRoute(const RouteInfo &routeInfo, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    QString msg = QString::vasprintf(fmt, ap);
+    if (!routeInfo.id.isEmpty())
+        msg += QString(" route=%1").arg(routeInfo.id);
+    logPacket(routeInfo.logLevel, msg);
+    va_end(ap);
 }
 
-}
+} // namespace LogUtil

--- a/src/core/logutil.h
+++ b/src/core/logutil.h
@@ -24,77 +24,61 @@
 #ifndef LOGUTIL_H
 #define LOGUTIL_H
 
-#include <QHostAddress>
 #include "log.h"
-#include "variant.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
+#include "variant.h"
+#include <QHostAddress>
 
 namespace LogUtil {
 
-enum RequestStatus
-{
-	Response,
-	Accept,
-	Error
+enum RequestStatus { Response, Accept, Error };
+
+class RequestData {
+public:
+    QString routeId;
+    RequestStatus status;
+    HttpRequestData requestData;
+    HttpResponseData responseData;
+    int responseBodySize;
+    QString targetStr;
+    bool targetOverHttp;
+    bool retry;
+    void *sharedBy;
+    QHostAddress fromAddress;
+
+    RequestData()
+        : status(Response),
+          responseBodySize(-1),
+          targetOverHttp(false),
+          retry(false),
+          sharedBy(0) {}
 };
 
-class RequestData
-{
+class Config {
 public:
-	QString routeId;
-	RequestStatus status;
-	HttpRequestData requestData;
-	HttpResponseData responseData;
-	int responseBodySize;
-	QString targetStr;
-	bool targetOverHttp;
-	bool retry;
-	void *sharedBy;
-	QHostAddress fromAddress;
+    bool fromAddress;
+    bool userAgent;
 
-	RequestData() :
-		status(Response),
-		responseBodySize(-1),
-		targetOverHttp(false),
-		retry(false),
-		sharedBy(0)
-	{
-	}
+    Config() : fromAddress(false), userAgent(false) {}
 };
 
-class Config
-{
+class RouteInfo {
 public:
-	bool fromAddress;
-	bool userAgent;
+    QString id;
+    int logLevel;
 
-	Config() :
-		fromAddress(false),
-		userAgent(false)
-	{
-	}
-};
-
-class RouteInfo
-{
-public:
-	QString id;
-	int logLevel;
-
-	RouteInfo(const QString &initId = QString(), int initLogLevel = LOG_LEVEL_DEBUG) :
-		id(initId),
-		logLevel(initLogLevel)
-	{
-	}
+    RouteInfo(const QString &initId = QString(), int initLogLevel = LOG_LEVEL_DEBUG)
+        : id(initId), logLevel(initLogLevel) {}
 };
 
 void logVariant(int level, const Variant &data, const char *fmt, ...);
 void logByteArray(int level, const QByteArray &content, const char *fmt, ...);
-void logVariantWithContent(int level, const Variant &data, const QString &contentField, const char *fmt, ...);
+void logVariantWithContent(int level, const Variant &data, const QString &contentField,
+                           const char *fmt, ...);
 void logRequest(int level, const RequestData &data, const Config &config = Config());
 void logForRoute(const RouteInfo &routeInfo, const char *fmt, ...);
 
-}
+} // namespace LogUtil
 
 #endif

--- a/src/core/packet/httprequestdata.h
+++ b/src/core/packet/httprequestdata.h
@@ -26,13 +26,12 @@
 #include "../httpheaders.h"
 #include "url.h"
 
-class HttpRequestData
-{
+class HttpRequestData {
 public:
-	QString method;
-	Url uri;
-	HttpHeaders headers;
-	QByteArray body;
+    QString method;
+    Url uri;
+    HttpHeaders headers;
+    QByteArray body;
 };
 
 #endif

--- a/src/core/packet/httpresponsedata.h
+++ b/src/core/packet/httpresponsedata.h
@@ -25,18 +25,14 @@
 
 #include "../httpheaders.h"
 
-class HttpResponseData
-{
+class HttpResponseData {
 public:
-	int code;
-	QByteArray reason;
-	HttpHeaders headers;
-	QByteArray body;
+    int code;
+    QByteArray reason;
+    HttpHeaders headers;
+    QByteArray body;
 
-	HttpResponseData() :
-		code(-1)
-	{
-	}
+    HttpResponseData() : code(-1) {}
 };
 
 #endif

--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -26,344 +26,319 @@
 #include "qtcompat.h"
 #include "variant.h"
 
-RetryRequestPacket::RetryRequestPacket() :
-	haveInspectInfo(false),
-	retrySeq(-1)
-{
+RetryRequestPacket::RetryRequestPacket() : haveInspectInfo(false), retrySeq(-1) {}
+
+Variant RetryRequestPacket::toVariant() const {
+    VariantHash obj;
+
+    VariantList vrequests;
+    foreach (const Request &r, requests) {
+        VariantHash vrequest;
+
+        VariantHash vrid;
+        vrid["sender"] = r.rid.first;
+        vrid["id"] = r.rid.second;
+
+        vrequest["rid"] = vrid;
+
+        if (r.https)
+            vrequest["https"] = true;
+
+        if (!r.peerAddress.isNull())
+            vrequest["peer-address"] = r.peerAddress.toString().toUtf8();
+
+        if (r.debug)
+            vrequest["debug"] = true;
+
+        if (r.autoCrossOrigin)
+            vrequest["auto-cross-origin"] = true;
+
+        if (!r.jsonpCallback.isEmpty())
+            vrequest["jsonp-callback"] = r.jsonpCallback;
+
+        if (r.jsonpExtendedResponse)
+            vrequest["jsonp-extended-response"] = true;
+
+        if (r.unreportedTime > 0)
+            vrequest["unreported-time"] = r.unreportedTime;
+
+        vrequest["in-seq"] = r.inSeq;
+        vrequest["out-seq"] = r.outSeq;
+        vrequest["out-credits"] = r.outCredits;
+
+        if (r.routerResp)
+            vrequest["router-resp"] = r.routerResp;
+
+        if (r.userData.isValid())
+            vrequest["user-data"] = r.userData;
+
+        vrequests += vrequest;
+    }
+
+    obj["requests"] = vrequests;
+
+    VariantHash vrequestData;
+
+    vrequestData["method"] = requestData.method.toLatin1();
+    vrequestData["uri"] = requestData.uri.toEncoded();
+
+    VariantList vheaders;
+    foreach (const HttpHeader &h, requestData.headers) {
+        VariantList vheader;
+        vheader += h.first.asQByteArray();
+        vheader += h.second.asQByteArray();
+        vheaders += Variant(vheader);
+    }
+    vrequestData["headers"] = vheaders;
+
+    vrequestData["body"] = requestData.body;
+
+    obj["request-data"] = vrequestData;
+
+    if (haveInspectInfo) {
+        VariantHash vinspect;
+
+        vinspect["no-proxy"] = !inspectInfo.doProxy;
+
+        if (!inspectInfo.sharingKey.isEmpty())
+            vinspect["sharing-key"] = inspectInfo.sharingKey;
+
+        if (!inspectInfo.sid.isEmpty())
+            vinspect["sid"] = inspectInfo.sid;
+
+        if (!inspectInfo.lastIds.isEmpty()) {
+            VariantHash vlastIds;
+
+            QHashIterator<QByteArray, QByteArray> it(inspectInfo.lastIds);
+            while (it.hasNext()) {
+                it.next();
+
+                vlastIds[QString::fromUtf8(it.key())] = it.value();
+            }
+
+            vinspect["last-ids"] = vlastIds;
+        }
+
+        if (inspectInfo.userData.isValid())
+            vinspect["user-data"] = inspectInfo.userData;
+
+        obj["inspect"] = vinspect;
+    }
+
+    if (!route.isEmpty())
+        obj["route"] = route;
+
+    if (retrySeq >= 0)
+        obj["retry-seq"] = retrySeq;
+
+    return obj;
 }
 
-Variant RetryRequestPacket::toVariant() const
-{
-	VariantHash obj;
+bool RetryRequestPacket::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
 
-	VariantList vrequests;
-	foreach(const Request &r, requests)
-	{
-		VariantHash vrequest;
+    VariantHash obj = in.toHash();
 
-		VariantHash vrid;
-		vrid["sender"] = r.rid.first;
-		vrid["id"] = r.rid.second;
+    if (!obj.contains("requests") || typeId(obj["requests"]) != VariantType::List)
+        return false;
 
-		vrequest["rid"] = vrid;
+    requests.clear();
+    for (const Variant &i : obj["requests"].toList()) {
+        if (typeId(i) != VariantType::Hash)
+            return false;
 
-		if(r.https)
-			vrequest["https"] = true;
+        VariantHash vrequest = i.toHash();
 
-		if(!r.peerAddress.isNull())
-			vrequest["peer-address"] = r.peerAddress.toString().toUtf8();
+        Request r;
 
-		if(r.debug)
-			vrequest["debug"] = true;
+        if (!vrequest.contains("rid") || typeId(vrequest["rid"]) != VariantType::Hash)
+            return false;
 
-		if(r.autoCrossOrigin)
-			vrequest["auto-cross-origin"] = true;
+        VariantHash vrid = vrequest["rid"].toHash();
 
-		if(!r.jsonpCallback.isEmpty())
-			vrequest["jsonp-callback"] = r.jsonpCallback;
+        QByteArray sender, id;
 
-		if(r.jsonpExtendedResponse)
-			vrequest["jsonp-extended-response"] = true;
+        if (!vrid.contains("sender") || typeId(vrid["sender"]) != VariantType::ByteArray)
+            return false;
 
-		if(r.unreportedTime > 0)
-			vrequest["unreported-time"] = r.unreportedTime;
+        sender = vrid["sender"].toByteArray();
 
-		vrequest["in-seq"] = r.inSeq;
-		vrequest["out-seq"] = r.outSeq;
-		vrequest["out-credits"] = r.outCredits;
+        if (!vrid.contains("id") || typeId(vrid["id"]) != VariantType::ByteArray)
+            return false;
 
-		if(r.routerResp)
-			vrequest["router-resp"] = r.routerResp;
+        id = vrid["id"].toByteArray();
 
-		if(r.userData.isValid())
-			vrequest["user-data"] = r.userData;
+        r.rid = Rid(sender, id);
 
-		vrequests += vrequest;
-	}
+        if (vrequest.contains("https")) {
+            if (typeId(vrequest["https"]) != VariantType::Bool)
+                return false;
 
-	obj["requests"] = vrequests;
+            r.https = vrequest["https"].toBool();
+        }
 
-	VariantHash vrequestData;
+        if (vrequest.contains("peer-address")) {
+            if (typeId(vrequest["peer-address"]) != VariantType::ByteArray)
+                return false;
 
-	vrequestData["method"] = requestData.method.toLatin1();
-	vrequestData["uri"] = requestData.uri.toEncoded();
+            r.peerAddress = QHostAddress(QString::fromUtf8(vrequest["peer-address"].toByteArray()));
+        }
 
-	VariantList vheaders;
-	foreach(const HttpHeader &h, requestData.headers)
-	{
-		VariantList vheader;
-		vheader += h.first.asQByteArray();
-		vheader += h.second.asQByteArray();
-		vheaders += Variant(vheader);
-	}
-	vrequestData["headers"] = vheaders;
+        if (vrequest.contains("debug")) {
+            if (typeId(vrequest["debug"]) != VariantType::Bool)
+                return false;
 
-	vrequestData["body"] = requestData.body;
+            r.debug = vrequest["debug"].toBool();
+        }
 
-	obj["request-data"] = vrequestData;
+        if (vrequest.contains("auto-cross-origin")) {
+            if (typeId(vrequest["auto-cross-origin"]) != VariantType::Bool)
+                return false;
 
-	if(haveInspectInfo)
-	{
-		VariantHash vinspect;
+            r.autoCrossOrigin = vrequest["auto-cross-origin"].toBool();
+        }
 
-		vinspect["no-proxy"] = !inspectInfo.doProxy;
+        if (vrequest.contains("jsonp-callback")) {
+            if (typeId(vrequest["jsonp-callback"]) != VariantType::ByteArray)
+                return false;
 
-		if(!inspectInfo.sharingKey.isEmpty())
-			vinspect["sharing-key"] = inspectInfo.sharingKey;
+            r.jsonpCallback = vrequest["jsonp-callback"].toByteArray();
 
-		if(!inspectInfo.sid.isEmpty())
-			vinspect["sid"] = inspectInfo.sid;
+            if (vrequest.contains("jsonp-extended-response")) {
+                if (typeId(vrequest["jsonp-extended-response"]) != VariantType::Bool)
+                    return false;
 
-		if(!inspectInfo.lastIds.isEmpty())
-		{
-			VariantHash vlastIds;
+                r.jsonpExtendedResponse = vrequest["jsonp-extended-response"].toBool();
+            }
+        }
 
-			QHashIterator<QByteArray, QByteArray> it(inspectInfo.lastIds);
-			while(it.hasNext())
-			{
-				it.next();
+        if (vrequest.contains("unreported-time")) {
+            if (!canConvert(vrequest["unreported-time"], VariantType::Int))
+                return false;
 
-				vlastIds[QString::fromUtf8(it.key())] = it.value();
-			}
+            r.unreportedTime = vrequest["unreported-time"].toInt();
+        }
 
-			vinspect["last-ids"] = vlastIds;
-		}
+        if (!vrequest.contains("in-seq") || !canConvert(vrequest["in-seq"], VariantType::Int))
+            return false;
+        r.inSeq = vrequest["in-seq"].toInt();
 
-		if(inspectInfo.userData.isValid())
-			vinspect["user-data"] = inspectInfo.userData;
+        if (!vrequest.contains("out-seq") || !canConvert(vrequest["out-seq"], VariantType::Int))
+            return false;
+        r.outSeq = vrequest["out-seq"].toInt();
 
-		obj["inspect"] = vinspect;
-	}
+        if (!vrequest.contains("out-credits") ||
+            !canConvert(vrequest["out-credits"], VariantType::Int))
+            return false;
+        r.outCredits = vrequest["out-credits"].toInt();
 
-	if(!route.isEmpty())
-		obj["route"] = route;
+        if (vrequest.contains("router-resp")) {
+            if (typeId(vrequest["router-resp"]) != VariantType::Bool)
+                return false;
+
+            r.routerResp = vrequest["router-resp"].toBool();
+        }
+
+        if (vrequest.contains("user-data"))
+            r.userData = vrequest["user-data"];
 
-	if(retrySeq >= 0)
-		obj["retry-seq"] = retrySeq;
+        requests += r;
+    }
 
-	return obj;
-}
+    if (!obj.contains("request-data") || typeId(obj["request-data"]) != VariantType::Hash)
+        return false;
+    VariantHash vrequestData = obj["request-data"].toHash();
 
-bool RetryRequestPacket::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
+    if (!vrequestData.contains("method") ||
+        typeId(vrequestData["method"]) != VariantType::ByteArray)
+        return false;
+    requestData.method = QString::fromLatin1(vrequestData["method"].toByteArray());
 
-	VariantHash obj = in.toHash();
+    if (!vrequestData.contains("uri") || typeId(vrequestData["uri"]) != VariantType::ByteArray)
+        return false;
+    requestData.uri = Url::fromEncoded(vrequestData["uri"].toByteArray(), Url::StrictMode);
 
-	if(!obj.contains("requests") || typeId(obj["requests"]) != VariantType::List)
-		return false;
+    requestData.headers.clear();
+    if (vrequestData.contains("headers")) {
+        if (typeId(vrequestData["headers"]) != VariantType::List)
+            return false;
 
-	requests.clear();
-	for(const Variant &i : obj["requests"].toList())
-	{
-		if(typeId(i) != VariantType::Hash)
-			return false;
+        for (const Variant &i : vrequestData["headers"].toList()) {
+            VariantList list = i.toList();
+            if (list.count() != 2)
+                return false;
 
-		VariantHash vrequest = i.toHash();
+            if (typeId(list[0]) != VariantType::ByteArray ||
+                typeId(list[1]) != VariantType::ByteArray)
+                return false;
 
-		Request r;
+            requestData.headers +=
+                QPair<QByteArray, QByteArray>(list[0].toByteArray(), list[1].toByteArray());
+        }
+    }
 
-		if(!vrequest.contains("rid") || typeId(vrequest["rid"]) != VariantType::Hash)
-			return false;
+    if (!vrequestData.contains("body") || typeId(vrequestData["body"]) != VariantType::ByteArray)
+        return false;
+    requestData.body = vrequestData["body"].toByteArray();
 
-		VariantHash vrid = vrequest["rid"].toHash();
+    if (obj.contains("inspect")) {
+        if (typeId(obj["inspect"]) != VariantType::Hash)
+            return false;
+        VariantHash vinspect = obj["inspect"].toHash();
 
-		QByteArray sender, id;
+        if (!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != VariantType::Bool)
+            return false;
+        inspectInfo.doProxy = !vinspect["no-proxy"].toBool();
 
-		if(!vrid.contains("sender") || typeId(vrid["sender"]) != VariantType::ByteArray)
-			return false;
+        inspectInfo.sharingKey.clear();
+        if (vinspect.contains("sharing-key")) {
+            if (typeId(vinspect["sharing-key"]) != VariantType::ByteArray)
+                return false;
 
-		sender = vrid["sender"].toByteArray();
+            inspectInfo.sharingKey = vinspect["sharing-key"].toByteArray();
+        }
 
-		if(!vrid.contains("id") || typeId(vrid["id"]) != VariantType::ByteArray)
-			return false;
+        if (vinspect.contains("sid")) {
+            if (typeId(vinspect["sid"]) != VariantType::ByteArray)
+                return false;
 
-		id = vrid["id"].toByteArray();
+            inspectInfo.sid = vinspect["sid"].toByteArray();
+        }
 
-		r.rid = Rid(sender, id);
+        if (vinspect.contains("last-ids")) {
+            if (typeId(vinspect["last-ids"]) != VariantType::Hash)
+                return false;
 
-		if(vrequest.contains("https"))
-		{
-			if(typeId(vrequest["https"]) != VariantType::Bool)
-				return false;
+            VariantHash vlastIds = vinspect["last-ids"].toHash();
+            for (auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it) {
+                if (typeId(it.value()) != VariantType::ByteArray)
+                    return false;
 
-			r.https = vrequest["https"].toBool();
-		}
+                QByteArray key = it.key().toUtf8();
+                QByteArray val = it.value().toByteArray();
+                inspectInfo.lastIds.insert(key, val);
+            }
+        }
 
-		if(vrequest.contains("peer-address"))
-		{
-			if(typeId(vrequest["peer-address"]) != VariantType::ByteArray)
-				return false;
+        inspectInfo.userData = vinspect["user-data"];
 
-			r.peerAddress = QHostAddress(QString::fromUtf8(vrequest["peer-address"].toByteArray()));
-		}
+        haveInspectInfo = true;
+    }
 
-		if(vrequest.contains("debug"))
-		{
-			if(typeId(vrequest["debug"]) != VariantType::Bool)
-				return false;
+    if (obj.contains("route")) {
+        if (typeId(obj["route"]) != VariantType::ByteArray)
+            return false;
 
-			r.debug = vrequest["debug"].toBool();
-		}
+        route = obj["route"].toByteArray();
+    }
 
-		if(vrequest.contains("auto-cross-origin"))
-		{
-			if(typeId(vrequest["auto-cross-origin"]) != VariantType::Bool)
-				return false;
+    if (obj.contains("retry-seq")) {
+        if (!canConvert(obj["retry-seq"], VariantType::Int))
+            return false;
 
-			r.autoCrossOrigin = vrequest["auto-cross-origin"].toBool();
-		}
+        retrySeq = obj["retry-seq"].toInt();
+    }
 
-		if(vrequest.contains("jsonp-callback"))
-		{
-			if(typeId(vrequest["jsonp-callback"]) != VariantType::ByteArray)
-				return false;
-
-			r.jsonpCallback = vrequest["jsonp-callback"].toByteArray();
-
-			if(vrequest.contains("jsonp-extended-response"))
-			{
-				if(typeId(vrequest["jsonp-extended-response"]) != VariantType::Bool)
-					return false;
-
-				r.jsonpExtendedResponse = vrequest["jsonp-extended-response"].toBool();
-			}
-		}
-
-		if(vrequest.contains("unreported-time"))
-		{
-			if(!canConvert(vrequest["unreported-time"], VariantType::Int))
-				return false;
-
-			r.unreportedTime = vrequest["unreported-time"].toInt();
-		}
-
-		if(!vrequest.contains("in-seq") || !canConvert(vrequest["in-seq"], VariantType::Int))
-			return false;
-		r.inSeq = vrequest["in-seq"].toInt();
-
-		if(!vrequest.contains("out-seq") || !canConvert(vrequest["out-seq"], VariantType::Int))
-			return false;
-		r.outSeq = vrequest["out-seq"].toInt();
-
-		if(!vrequest.contains("out-credits") || !canConvert(vrequest["out-credits"], VariantType::Int))
-			return false;
-		r.outCredits = vrequest["out-credits"].toInt();
-
-		if(vrequest.contains("router-resp"))
-		{
-			if(typeId(vrequest["router-resp"]) != VariantType::Bool)
-				return false;
-
-			r.routerResp = vrequest["router-resp"].toBool();
-		}
-
-		if(vrequest.contains("user-data"))
-			r.userData = vrequest["user-data"];
-
-		requests += r;
-	}
-
-	if(!obj.contains("request-data") || typeId(obj["request-data"]) != VariantType::Hash)
-		return false;
-	VariantHash vrequestData = obj["request-data"].toHash();
-
-	if(!vrequestData.contains("method") || typeId(vrequestData["method"]) != VariantType::ByteArray)
-		return false;
-	requestData.method = QString::fromLatin1(vrequestData["method"].toByteArray());
-
-	if(!vrequestData.contains("uri") || typeId(vrequestData["uri"]) != VariantType::ByteArray)
-		return false;
-	requestData.uri = Url::fromEncoded(vrequestData["uri"].toByteArray(), Url::StrictMode);
-
-	requestData.headers.clear();
-	if(vrequestData.contains("headers"))
-	{
-		if(typeId(vrequestData["headers"]) != VariantType::List)
-			return false;
-
-		for(const Variant &i : vrequestData["headers"].toList())
-		{
-			VariantList list = i.toList();
-			if(list.count() != 2)
-				return false;
-
-			if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
-				return false;
-
-			requestData.headers += QPair<QByteArray, QByteArray>(list[0].toByteArray(), list[1].toByteArray());
-		}
-	}
-
-	if(!vrequestData.contains("body") || typeId(vrequestData["body"]) != VariantType::ByteArray)
-		return false;
-	requestData.body = vrequestData["body"].toByteArray();
-
-	if(obj.contains("inspect"))
-	{
-		if(typeId(obj["inspect"]) != VariantType::Hash)
-			return false;
-		VariantHash vinspect = obj["inspect"].toHash();
-
-		if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != VariantType::Bool)
-			return false;
-		inspectInfo.doProxy = !vinspect["no-proxy"].toBool();
-
-		inspectInfo.sharingKey.clear();
-		if(vinspect.contains("sharing-key"))
-		{
-			if(typeId(vinspect["sharing-key"]) != VariantType::ByteArray)
-				return false;
-
-			inspectInfo.sharingKey = vinspect["sharing-key"].toByteArray();
-		}
-
-		if(vinspect.contains("sid"))
-		{
-			if(typeId(vinspect["sid"]) != VariantType::ByteArray)
-				return false;
-
-			inspectInfo.sid = vinspect["sid"].toByteArray();
-		}
-
-		if(vinspect.contains("last-ids"))
-		{
-			if(typeId(vinspect["last-ids"]) != VariantType::Hash)
-				return false;
-
-			VariantHash vlastIds = vinspect["last-ids"].toHash();
-			for(auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it)
-			{
-				if(typeId(it.value()) != VariantType::ByteArray)
-					return false;
-
-				QByteArray key = it.key().toUtf8();
-				QByteArray val = it.value().toByteArray();
-				inspectInfo.lastIds.insert(key, val);
-			}
-		}
-
-		inspectInfo.userData = vinspect["user-data"];
-
-		haveInspectInfo = true;
-	}
-
-	if(obj.contains("route"))
-	{
-		if(typeId(obj["route"]) != VariantType::ByteArray)
-			return false;
-
-		route = obj["route"].toByteArray();
-	}
-
-	if(obj.contains("retry-seq"))
-	{
-		if(!canConvert(obj["retry-seq"], VariantType::Int))
-			return false;
-
-		retrySeq = obj["retry-seq"].toInt();
-	}
-
-	return true;
+    return true;
 }

--- a/src/core/packet/retryrequestpacket.h
+++ b/src/core/packet/retryrequestpacket.h
@@ -24,76 +24,68 @@
 #ifndef RETRYREQUESTPACKET_H
 #define RETRYREQUESTPACKET_H
 
+#include "httprequestdata.h"
 #include "variant.h"
 #include <QHostAddress>
-#include "httprequestdata.h"
 
-class RetryRequestPacket
-{
+class RetryRequestPacket {
 public:
-	typedef QPair<QByteArray, QByteArray> Rid;
+    typedef QPair<QByteArray, QByteArray> Rid;
 
-	class Request
-	{
-	public:
-		Rid rid;
-		bool https;
-		QHostAddress peerAddress;
-		bool debug;
-		bool autoCrossOrigin;
-		QByteArray jsonpCallback;
-		bool jsonpExtendedResponse;
-		int unreportedTime;
+    class Request {
+    public:
+        Rid rid;
+        bool https;
+        QHostAddress peerAddress;
+        bool debug;
+        bool autoCrossOrigin;
+        QByteArray jsonpCallback;
+        bool jsonpExtendedResponse;
+        int unreportedTime;
 
-		// Zhttp
-		int inSeq;
-		int outSeq;
-		int outCredits;
-		bool routerResp;
-		Variant userData;
+        // Zhttp
+        int inSeq;
+        int outSeq;
+        int outCredits;
+        bool routerResp;
+        Variant userData;
 
-		Request() :
-			https(false),
-			debug(false),
-			autoCrossOrigin(false),
-			jsonpExtendedResponse(false),
-			unreportedTime(-1),
-			inSeq(-1),
-			outSeq(-1),
-			outCredits(-1),
-			routerResp(false)
-		{
-		}
-	};
+        Request()
+            : https(false),
+              debug(false),
+              autoCrossOrigin(false),
+              jsonpExtendedResponse(false),
+              unreportedTime(-1),
+              inSeq(-1),
+              outSeq(-1),
+              outCredits(-1),
+              routerResp(false) {}
+    };
 
-	class InspectInfo
-	{
-	public:
-		bool doProxy;
-		QByteArray sharingKey;
-		QByteArray sid;
-		QHash<QByteArray, QByteArray> lastIds;
-		Variant userData;
+    class InspectInfo {
+    public:
+        bool doProxy;
+        QByteArray sharingKey;
+        QByteArray sid;
+        QHash<QByteArray, QByteArray> lastIds;
+        Variant userData;
 
-		InspectInfo() :
-			doProxy(false)
-		{
-		}
-	};
+        InspectInfo() : doProxy(false) {}
+    };
 
-	QList<Request> requests;
-	HttpRequestData requestData;
+    QList<Request> requests;
+    HttpRequestData requestData;
 
-	bool haveInspectInfo;
-	InspectInfo inspectInfo;
+    bool haveInspectInfo;
+    InspectInfo inspectInfo;
 
-	QByteArray route;
-	int retrySeq;
+    QByteArray route;
+    int retrySeq;
 
-	RetryRequestPacket();
+    RetryRequestPacket();
 
-	Variant toVariant() const;
-	bool fromVariant(const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/packet/statspacket.cpp
+++ b/src/core/packet/statspacket.cpp
@@ -26,469 +26,414 @@
 #include "qtcompat.h"
 #include "variant.h"
 
-static bool tryGetInt(const VariantHash &obj, const QString &name, int *result)
-{
-	if(obj.contains(name))
-	{
-		if(!canConvert(obj[name], VariantType::Int))
-			return false;
+static bool tryGetInt(const VariantHash &obj, const QString &name, int *result) {
+    if (obj.contains(name)) {
+        if (!canConvert(obj[name], VariantType::Int))
+            return false;
 
-		*result = obj[name].toInt();
-	}
+        *result = obj[name].toInt();
+    }
 
-	return true;
+    return true;
 }
 
-Variant StatsPacket::toVariant() const
-{
-	VariantHash obj;
+Variant StatsPacket::toVariant() const {
+    VariantHash obj;
 
-	if(!from.isEmpty())
-		obj["from"] = from;
+    if (!from.isEmpty())
+        obj["from"] = from;
 
-	if(!route.isEmpty())
-		obj["route"] = route;
+    if (!route.isEmpty())
+        obj["route"] = route;
 
-	if(type == Activity)
-	{
-		int x = count;
-		if(x < 0)
-			x = 0;
-		obj["count"] = x;
-	}
-	else if(type == Message)
-	{
-		obj["channel"] = channel;
+    if (type == Activity) {
+        int x = count;
+        if (x < 0)
+            x = 0;
+        obj["count"] = x;
+    } else if (type == Message) {
+        obj["channel"] = channel;
 
-		if(!itemId.isNull())
-			obj["item-id"] = itemId;
+        if (!itemId.isNull())
+            obj["item-id"] = itemId;
 
-		int x = count;
-		if(x < 0)
-			x = 0;
-		obj["count"] = x;
+        int x = count;
+        if (x < 0)
+            x = 0;
+        obj["count"] = x;
 
-		if(blocks >= 0)
-			obj["blocks"] = blocks;
+        if (blocks >= 0)
+            obj["blocks"] = blocks;
 
-		obj["transport"] = transport;
-	}
-	else if(type == Connected || type == Disconnected)
-	{
-		obj["id"] = connectionId;
+        obj["transport"] = transport;
+    } else if (type == Connected || type == Disconnected) {
+        obj["id"] = connectionId;
 
-		if(type == Connected)
-		{
-			if(connectionType == WebSocket)
-				obj["type"] = QByteArray("ws");
-			else // Http
-				obj["type"] = QByteArray("http");
+        if (type == Connected) {
+            if (connectionType == WebSocket)
+                obj["type"] = QByteArray("ws");
+            else // Http
+                obj["type"] = QByteArray("http");
 
-			if(!peerAddress.isNull())
-				obj["peer-address"] = peerAddress.toString().toUtf8();
+            if (!peerAddress.isNull())
+                obj["peer-address"] = peerAddress.toString().toUtf8();
 
-			if(ssl)
-				obj["ssl"] = true;
+            if (ssl)
+                obj["ssl"] = true;
 
-			obj["ttl"] = ttl;
-		}
-		else // Disconnected
-		{
-			obj["unavailable"] = true;
-		}
-	}
-	else if(type == Subscribed || type == Unsubscribed)
-	{
-		obj["mode"] = mode;
-		obj["channel"] = channel;
+            obj["ttl"] = ttl;
+        } else // Disconnected
+        {
+            obj["unavailable"] = true;
+        }
+    } else if (type == Subscribed || type == Unsubscribed) {
+        obj["mode"] = mode;
+        obj["channel"] = channel;
 
-		if(type == Subscribed)
-		{
-			obj["ttl"] = ttl;
+        if (type == Subscribed) {
+            obj["ttl"] = ttl;
 
-			if(subscribers >= 0)
-				obj["subscribers"] = subscribers;
-		}
-		else // Unsubscribed
-		{
-			obj["unavailable"] = true;
-		}
-	}
-	else if(type == Report)
-	{
-		if(connectionsMax != -1)
-			obj["connections"] = connectionsMax;
-		if(connectionsMinutes != -1)
-			obj["minutes"] = connectionsMinutes;
-		if(messagesReceived != -1)
-			obj["received"] = messagesReceived;
-		if(messagesSent != -1)
-			obj["sent"] = messagesSent;
-		if(httpResponseMessagesSent != -1)
-			obj["http-response-sent"] = httpResponseMessagesSent;
-		if(blocksReceived >= 0)
-			obj["blocks-received"] = blocksReceived;
-		if(blocksSent >= 0)
-			obj["blocks-sent"] = blocksSent;
-		if(duration >= 0)
-			obj["duration"] = duration;
+            if (subscribers >= 0)
+                obj["subscribers"] = subscribers;
+        } else // Unsubscribed
+        {
+            obj["unavailable"] = true;
+        }
+    } else if (type == Report) {
+        if (connectionsMax != -1)
+            obj["connections"] = connectionsMax;
+        if (connectionsMinutes != -1)
+            obj["minutes"] = connectionsMinutes;
+        if (messagesReceived != -1)
+            obj["received"] = messagesReceived;
+        if (messagesSent != -1)
+            obj["sent"] = messagesSent;
+        if (httpResponseMessagesSent != -1)
+            obj["http-response-sent"] = httpResponseMessagesSent;
+        if (blocksReceived >= 0)
+            obj["blocks-received"] = blocksReceived;
+        if (blocksSent >= 0)
+            obj["blocks-sent"] = blocksSent;
+        if (duration >= 0)
+            obj["duration"] = duration;
 
-		if(clientHeaderBytesReceived >= 0)
-			obj["client-header-bytes-received"] = clientHeaderBytesReceived;
-		if(clientHeaderBytesSent >= 0)
-			obj["client-header-bytes-sent"] = clientHeaderBytesSent;
-		if(clientContentBytesReceived >= 0)
-			obj["client-content-bytes-received"] = clientContentBytesReceived;
-		if(clientContentBytesSent >= 0)
-			obj["client-content-bytes-sent"] = clientContentBytesSent;
-		if(clientMessagesReceived >= 0)
-			obj["client-messages-received"] = clientMessagesReceived;
-		if(clientMessagesSent >= 0)
-			obj["client-messages-sent"] = clientMessagesSent;
-		if(serverHeaderBytesReceived >= 0)
-			obj["server-header-bytes-received"] = serverHeaderBytesReceived;
-		if(serverHeaderBytesSent >= 0)
-			obj["server-header-bytes-sent"] = serverHeaderBytesSent;
-		if(serverContentBytesReceived >= 0)
-			obj["server-content-bytes-received"] = serverContentBytesReceived;
-		if(serverContentBytesSent >= 0)
-			obj["server-content-bytes-sent"] = serverContentBytesSent;
-		if(serverMessagesReceived >= 0)
-			obj["server-messages-received"] = serverMessagesReceived;
-		if(serverMessagesSent >= 0)
-			obj["server-messages-sent"] = serverMessagesSent;
-	}
-	else if(type == Counts)
-	{
-		if(requestsReceived > 0)
-			obj["requests-received"] = requestsReceived;
-	}
-	else // ConnectionsMax
-	{
-		obj["max"] = qMax(connectionsMax, 0);
-		obj["ttl"] = qMax(ttl, 0);
+        if (clientHeaderBytesReceived >= 0)
+            obj["client-header-bytes-received"] = clientHeaderBytesReceived;
+        if (clientHeaderBytesSent >= 0)
+            obj["client-header-bytes-sent"] = clientHeaderBytesSent;
+        if (clientContentBytesReceived >= 0)
+            obj["client-content-bytes-received"] = clientContentBytesReceived;
+        if (clientContentBytesSent >= 0)
+            obj["client-content-bytes-sent"] = clientContentBytesSent;
+        if (clientMessagesReceived >= 0)
+            obj["client-messages-received"] = clientMessagesReceived;
+        if (clientMessagesSent >= 0)
+            obj["client-messages-sent"] = clientMessagesSent;
+        if (serverHeaderBytesReceived >= 0)
+            obj["server-header-bytes-received"] = serverHeaderBytesReceived;
+        if (serverHeaderBytesSent >= 0)
+            obj["server-header-bytes-sent"] = serverHeaderBytesSent;
+        if (serverContentBytesReceived >= 0)
+            obj["server-content-bytes-received"] = serverContentBytesReceived;
+        if (serverContentBytesSent >= 0)
+            obj["server-content-bytes-sent"] = serverContentBytesSent;
+        if (serverMessagesReceived >= 0)
+            obj["server-messages-received"] = serverMessagesReceived;
+        if (serverMessagesSent >= 0)
+            obj["server-messages-sent"] = serverMessagesSent;
+    } else if (type == Counts) {
+        if (requestsReceived > 0)
+            obj["requests-received"] = requestsReceived;
+    } else // ConnectionsMax
+    {
+        obj["max"] = qMax(connectionsMax, 0);
+        obj["ttl"] = qMax(ttl, 0);
 
-		if(retrySeq >= 0)
-			obj["retry-seq"] = (qint64)retrySeq;
-	}
+        if (retrySeq >= 0)
+            obj["retry-seq"] = (qint64)retrySeq;
+    }
 
-	return obj;
+    return obj;
 }
 
-bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
-
-	VariantHash obj = in.toHash();
-
-	if(obj.contains("from"))
-	{
-		if(typeId(obj["from"]) != VariantType::ByteArray)
-			return false;
-
-		from = obj["from"].toByteArray();
-	}
-
-	if(obj.contains("route"))
-	{
-		if(typeId(obj["route"]) != VariantType::ByteArray)
-			return false;
-
-		route = obj["route"].toByteArray();
-	}
-
-	if(_type == "activity")
-	{
-		type = Activity;
-
-		if(!obj.contains("count") || !canConvert(obj["count"], VariantType::Int))
-			return false;
-
-		count = obj["count"].toInt();
-		if(count < 0)
-			return false;
-	}
-	else if(_type == "message")
-	{
-		type = Message;
-
-		if(!obj.contains("channel") || typeId(obj["channel"]) != VariantType::ByteArray)
-			return false;
-
-		channel = obj["channel"].toByteArray();
-
-		if(obj.contains("item-id"))
-		{
-			if(typeId(obj["item-id"]) != VariantType::ByteArray)
-				return false;
-
-			itemId = obj["item-id"].toByteArray();
-		}
-
-		if(!obj.contains("count") || !canConvert(obj["count"], VariantType::Int))
-			return false;
-
-		count = obj["count"].toInt();
-		if(count < 0)
-			return false;
-
-		if(obj.contains("blocks"))
-		{
-			if(!canConvert(obj["blocks"], VariantType::Int))
-				return false;
-
-			blocks = obj["blocks"].toInt();
-		}
-
-		if(!obj.contains("transport") || typeId(obj["transport"]) != VariantType::ByteArray)
-			return false;
-
-		transport = obj["transport"].toByteArray();
-	}
-	else if(_type == "conn")
-	{
-		if(!obj.contains("id") || typeId(obj["id"]) != VariantType::ByteArray)
-			return false;
-
-		connectionId = obj["id"].toByteArray();
-
-		type = Connected;
-		if(obj.contains("unavailable"))
-		{
-			if(typeId(obj["unavailable"]) != VariantType::Bool)
-				return false;
-
-			if(obj["unavailable"].toBool())
-				type = Disconnected;
-		}
-
-		if(type == Connected)
-		{
-			if(!obj.contains("type") || typeId(obj["type"]) != VariantType::ByteArray)
-				return false;
-
-			QByteArray typeStr = obj["type"].toByteArray();
-			if(typeStr == "ws")
-				connectionType = WebSocket;
-			else if(typeStr == "http")
-				connectionType = Http;
-			else
-				return false;
-
-			if(obj.contains("peer-address"))
-			{
-				if(typeId(obj["peer-address"]) != VariantType::ByteArray)
-					return false;
-
-				QByteArray peerAddressStr = obj["peer-address"].toByteArray();
-				if(!peerAddress.setAddress(QString::fromUtf8(peerAddressStr)))
-					return false;
-			}
-
-			if(obj.contains("ssl"))
-			{
-				if(typeId(obj["ssl"]) != VariantType::Bool)
-					return false;
-
-				ssl = obj["ssl"].toBool();
-			}
-
-			if(!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
-				return false;
-
-			ttl = obj["ttl"].toInt();
-			if(ttl < 0)
-				return false;
-		}
-	}
-	else if(_type == "sub")
-	{
-		if(!obj.contains("mode") || typeId(obj["mode"]) != VariantType::ByteArray)
-			return false;
-
-		mode = obj["mode"].toByteArray();
-
-		if(!obj.contains("channel") || typeId(obj["channel"]) != VariantType::ByteArray)
-			return false;
-
-		channel = obj["channel"].toByteArray();
-
-		type = Subscribed;
-		if(obj.contains("unavailable"))
-		{
-			if(typeId(obj["unavailable"]) != VariantType::Bool)
-				return false;
-
-			if(obj["unavailable"].toBool())
-				type = Unsubscribed;
-		}
-
-		if(type == Subscribed)
-		{
-			if(!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
-				return false;
-
-			ttl = obj["ttl"].toInt();
-			if(ttl < 0)
-				return false;
-
-			if(obj.contains("subscribers"))
-			{
-				if(!canConvert(obj["subscribers"], VariantType::Int))
-					return false;
-
-				subscribers = obj["subscribers"].toInt();
-				if(subscribers < 0)
-					return false;
-			}
-		}
-	}
-	else if(_type == "report")
-	{
-		type = Report;
-
-		if(obj.contains("connections"))
-		{
-			if(!canConvert(obj["connections"], VariantType::Int))
-				return false;
-
-			connectionsMax = obj["connections"].toInt();
-		}
-
-		if(obj.contains("minutes"))
-		{
-			if(!canConvert(obj["minutes"], VariantType::Int))
-				return false;
-
-			connectionsMinutes = obj["minutes"].toInt();
-		}
-
-		if(obj.contains("received"))
-		{
-			if(!canConvert(obj["received"], VariantType::Int))
-				return false;
-
-			messagesReceived = obj["received"].toInt();
-		}
-
-		if(obj.contains("sent"))
-		{
-			if(!canConvert(obj["sent"], VariantType::Int))
-				return false;
-
-			messagesSent = obj["sent"].toInt();
-		}
-
-		if(obj.contains("http-response-sent"))
-		{
-			if(!canConvert(obj["http-response-sent"], VariantType::Int))
-				return false;
-
-			httpResponseMessagesSent = obj["http-response-sent"].toInt();
-		}
-
-		if(obj.contains("blocks-received"))
-		{
-			if(!canConvert(obj["blocks-received"], VariantType::Int))
-				return false;
-
-			blocksReceived = obj["blocks-received"].toInt();
-		}
-
-		if(obj.contains("blocks-sent"))
-		{
-			if(!canConvert(obj["blocks-sent"], VariantType::Int))
-				return false;
-
-			blocksSent = obj["blocks-sent"].toInt();
-		}
-
-		if(obj.contains("duration"))
-		{
-			if(!canConvert(obj["duration"], VariantType::Int))
-				return false;
-
-			duration = obj["duration"].toInt();
-		}
-
-		if(!tryGetInt(obj, "client-header-bytes-received", &clientHeaderBytesReceived))
-			return false;
-		if(!tryGetInt(obj, "client-header-bytes-sent", &clientHeaderBytesSent))
-			return false;
-		if(!tryGetInt(obj, "client-content-bytes-received", &clientContentBytesReceived))
-			return false;
-		if(!tryGetInt(obj, "client-content-bytes-sent", &clientContentBytesSent))
-			return false;
-		if(!tryGetInt(obj, "client-messages-received", &clientMessagesReceived))
-			return false;
-		if(!tryGetInt(obj, "client-messages-sent", &clientMessagesSent))
-			return false;
-		if(!tryGetInt(obj, "server-header-bytes-received", &serverHeaderBytesReceived))
-			return false;
-		if(!tryGetInt(obj, "server-header-bytes-sent", &serverHeaderBytesSent))
-			return false;
-		if(!tryGetInt(obj, "server-content-bytes-received", &serverContentBytesReceived))
-			return false;
-		if(!tryGetInt(obj, "server-content-bytes-sent", &serverContentBytesSent))
-			return false;
-		if(!tryGetInt(obj, "server-messages-received", &serverMessagesReceived))
-			return false;
-		if(!tryGetInt(obj, "server-messages-sent", &serverMessagesSent))
-			return false;
-	}
-	else if(_type == "counts")
-	{
-		type = Counts;
-
-		if(obj.contains("requests-received"))
-		{
-			if(!canConvert(obj["requests-received"], VariantType::Int))
-				return false;
-
-			int x = obj["requests-received"].toInt();
-			if(x < 0)
-				return false;
-
-			requestsReceived = x;
-		}
-	}
-	else if(_type == "conn-max")
-	{
-		type = ConnectionsMax;
-
-		if(!obj.contains("max") || !canConvert(obj["max"], VariantType::Int))
-			return false;
-
-		int x = obj["max"].toInt();
-		if(x < 0)
-			return false;
-
-		connectionsMax = x;
-
-		if(!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
-			return false;
-
-		x = obj["ttl"].toInt();
-		if(x < 0)
-			return false;
-
-		ttl = x;
-
-		if(obj.contains("retry-seq"))
-		{
-			if(!canConvert(obj["retry-seq"], VariantType::LongLong))
-				return false;
-
-			int x = obj["retry-seq"].toLongLong();
-			if(x < 0)
-				return false;
-
-			retrySeq = x;
-		}
-	}
-	else
-		return false;
-
-	return true;
+bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
+
+    VariantHash obj = in.toHash();
+
+    if (obj.contains("from")) {
+        if (typeId(obj["from"]) != VariantType::ByteArray)
+            return false;
+
+        from = obj["from"].toByteArray();
+    }
+
+    if (obj.contains("route")) {
+        if (typeId(obj["route"]) != VariantType::ByteArray)
+            return false;
+
+        route = obj["route"].toByteArray();
+    }
+
+    if (_type == "activity") {
+        type = Activity;
+
+        if (!obj.contains("count") || !canConvert(obj["count"], VariantType::Int))
+            return false;
+
+        count = obj["count"].toInt();
+        if (count < 0)
+            return false;
+    } else if (_type == "message") {
+        type = Message;
+
+        if (!obj.contains("channel") || typeId(obj["channel"]) != VariantType::ByteArray)
+            return false;
+
+        channel = obj["channel"].toByteArray();
+
+        if (obj.contains("item-id")) {
+            if (typeId(obj["item-id"]) != VariantType::ByteArray)
+                return false;
+
+            itemId = obj["item-id"].toByteArray();
+        }
+
+        if (!obj.contains("count") || !canConvert(obj["count"], VariantType::Int))
+            return false;
+
+        count = obj["count"].toInt();
+        if (count < 0)
+            return false;
+
+        if (obj.contains("blocks")) {
+            if (!canConvert(obj["blocks"], VariantType::Int))
+                return false;
+
+            blocks = obj["blocks"].toInt();
+        }
+
+        if (!obj.contains("transport") || typeId(obj["transport"]) != VariantType::ByteArray)
+            return false;
+
+        transport = obj["transport"].toByteArray();
+    } else if (_type == "conn") {
+        if (!obj.contains("id") || typeId(obj["id"]) != VariantType::ByteArray)
+            return false;
+
+        connectionId = obj["id"].toByteArray();
+
+        type = Connected;
+        if (obj.contains("unavailable")) {
+            if (typeId(obj["unavailable"]) != VariantType::Bool)
+                return false;
+
+            if (obj["unavailable"].toBool())
+                type = Disconnected;
+        }
+
+        if (type == Connected) {
+            if (!obj.contains("type") || typeId(obj["type"]) != VariantType::ByteArray)
+                return false;
+
+            QByteArray typeStr = obj["type"].toByteArray();
+            if (typeStr == "ws")
+                connectionType = WebSocket;
+            else if (typeStr == "http")
+                connectionType = Http;
+            else
+                return false;
+
+            if (obj.contains("peer-address")) {
+                if (typeId(obj["peer-address"]) != VariantType::ByteArray)
+                    return false;
+
+                QByteArray peerAddressStr = obj["peer-address"].toByteArray();
+                if (!peerAddress.setAddress(QString::fromUtf8(peerAddressStr)))
+                    return false;
+            }
+
+            if (obj.contains("ssl")) {
+                if (typeId(obj["ssl"]) != VariantType::Bool)
+                    return false;
+
+                ssl = obj["ssl"].toBool();
+            }
+
+            if (!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
+                return false;
+
+            ttl = obj["ttl"].toInt();
+            if (ttl < 0)
+                return false;
+        }
+    } else if (_type == "sub") {
+        if (!obj.contains("mode") || typeId(obj["mode"]) != VariantType::ByteArray)
+            return false;
+
+        mode = obj["mode"].toByteArray();
+
+        if (!obj.contains("channel") || typeId(obj["channel"]) != VariantType::ByteArray)
+            return false;
+
+        channel = obj["channel"].toByteArray();
+
+        type = Subscribed;
+        if (obj.contains("unavailable")) {
+            if (typeId(obj["unavailable"]) != VariantType::Bool)
+                return false;
+
+            if (obj["unavailable"].toBool())
+                type = Unsubscribed;
+        }
+
+        if (type == Subscribed) {
+            if (!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
+                return false;
+
+            ttl = obj["ttl"].toInt();
+            if (ttl < 0)
+                return false;
+
+            if (obj.contains("subscribers")) {
+                if (!canConvert(obj["subscribers"], VariantType::Int))
+                    return false;
+
+                subscribers = obj["subscribers"].toInt();
+                if (subscribers < 0)
+                    return false;
+            }
+        }
+    } else if (_type == "report") {
+        type = Report;
+
+        if (obj.contains("connections")) {
+            if (!canConvert(obj["connections"], VariantType::Int))
+                return false;
+
+            connectionsMax = obj["connections"].toInt();
+        }
+
+        if (obj.contains("minutes")) {
+            if (!canConvert(obj["minutes"], VariantType::Int))
+                return false;
+
+            connectionsMinutes = obj["minutes"].toInt();
+        }
+
+        if (obj.contains("received")) {
+            if (!canConvert(obj["received"], VariantType::Int))
+                return false;
+
+            messagesReceived = obj["received"].toInt();
+        }
+
+        if (obj.contains("sent")) {
+            if (!canConvert(obj["sent"], VariantType::Int))
+                return false;
+
+            messagesSent = obj["sent"].toInt();
+        }
+
+        if (obj.contains("http-response-sent")) {
+            if (!canConvert(obj["http-response-sent"], VariantType::Int))
+                return false;
+
+            httpResponseMessagesSent = obj["http-response-sent"].toInt();
+        }
+
+        if (obj.contains("blocks-received")) {
+            if (!canConvert(obj["blocks-received"], VariantType::Int))
+                return false;
+
+            blocksReceived = obj["blocks-received"].toInt();
+        }
+
+        if (obj.contains("blocks-sent")) {
+            if (!canConvert(obj["blocks-sent"], VariantType::Int))
+                return false;
+
+            blocksSent = obj["blocks-sent"].toInt();
+        }
+
+        if (obj.contains("duration")) {
+            if (!canConvert(obj["duration"], VariantType::Int))
+                return false;
+
+            duration = obj["duration"].toInt();
+        }
+
+        if (!tryGetInt(obj, "client-header-bytes-received", &clientHeaderBytesReceived))
+            return false;
+        if (!tryGetInt(obj, "client-header-bytes-sent", &clientHeaderBytesSent))
+            return false;
+        if (!tryGetInt(obj, "client-content-bytes-received", &clientContentBytesReceived))
+            return false;
+        if (!tryGetInt(obj, "client-content-bytes-sent", &clientContentBytesSent))
+            return false;
+        if (!tryGetInt(obj, "client-messages-received", &clientMessagesReceived))
+            return false;
+        if (!tryGetInt(obj, "client-messages-sent", &clientMessagesSent))
+            return false;
+        if (!tryGetInt(obj, "server-header-bytes-received", &serverHeaderBytesReceived))
+            return false;
+        if (!tryGetInt(obj, "server-header-bytes-sent", &serverHeaderBytesSent))
+            return false;
+        if (!tryGetInt(obj, "server-content-bytes-received", &serverContentBytesReceived))
+            return false;
+        if (!tryGetInt(obj, "server-content-bytes-sent", &serverContentBytesSent))
+            return false;
+        if (!tryGetInt(obj, "server-messages-received", &serverMessagesReceived))
+            return false;
+        if (!tryGetInt(obj, "server-messages-sent", &serverMessagesSent))
+            return false;
+    } else if (_type == "counts") {
+        type = Counts;
+
+        if (obj.contains("requests-received")) {
+            if (!canConvert(obj["requests-received"], VariantType::Int))
+                return false;
+
+            int x = obj["requests-received"].toInt();
+            if (x < 0)
+                return false;
+
+            requestsReceived = x;
+        }
+    } else if (_type == "conn-max") {
+        type = ConnectionsMax;
+
+        if (!obj.contains("max") || !canConvert(obj["max"], VariantType::Int))
+            return false;
+
+        int x = obj["max"].toInt();
+        if (x < 0)
+            return false;
+
+        connectionsMax = x;
+
+        if (!obj.contains("ttl") || !canConvert(obj["ttl"], VariantType::Int))
+            return false;
+
+        x = obj["ttl"].toInt();
+        if (x < 0)
+            return false;
+
+        ttl = x;
+
+        if (obj.contains("retry-seq")) {
+            if (!canConvert(obj["retry-seq"], VariantType::LongLong))
+                return false;
+
+            int x = obj["retry-seq"].toLongLong();
+            if (x < 0)
+                return false;
+
+            retrySeq = x;
+        }
+    } else
+        return false;
+
+    return true;
 }

--- a/src/core/packet/statspacket.h
+++ b/src/core/packet/statspacket.h
@@ -24,105 +24,97 @@
 #ifndef STATSPACKET_H
 #define STATSPACKET_H
 
-#include <QByteArray>
 #include "variant.h"
+#include <QByteArray>
 #include <QHostAddress>
 
-class StatsPacket
-{
+class StatsPacket {
 public:
-	enum Type
-	{
-		Activity,
-		Message,
-		Connected,
-		Disconnected,
-		Subscribed,
-		Unsubscribed,
-		Report,
-		Counts,
-		ConnectionsMax,
-	};
+    enum Type {
+        Activity,
+        Message,
+        Connected,
+        Disconnected,
+        Subscribed,
+        Unsubscribed,
+        Report,
+        Counts,
+        ConnectionsMax,
+    };
 
-	enum ConnectionType
-	{
-		Http,
-		WebSocket
-	};
+    enum ConnectionType { Http, WebSocket };
 
-	Type type;
-	QByteArray from;
-	QByteArray route;
-	int64_t retrySeq; // Connections max
-	int count; // Activity, message
-	QByteArray connectionId; // Connected, disconnected
-	ConnectionType connectionType; // Connected
-	QHostAddress peerAddress; // Connected
-	bool ssl; // Connected
-	int ttl; // Connected, subscribed, connections max
-	QByteArray mode; // Subscribed, unsubscribed
-	QByteArray channel; // Message, subscribed, unsubscribed
-	QByteArray itemId; // Message
-	QByteArray transport; // Message
-	int blocks; // Message
-	int subscribers; // Subscribed
-	int connectionsMax; // Report, connections max
-	int connectionsMinutes; // Report
-	int messagesReceived; // Report
-	int messagesSent; // Report
-	int httpResponseMessagesSent; // Report
-	int blocksReceived; // Report
-	int blocksSent; // Report
-	int duration; // Report
-	int requestsReceived; // Counts
-	int clientHeaderBytesReceived; // Report
-	int clientHeaderBytesSent; // Report
-	int clientContentBytesReceived; // Report
-	int clientContentBytesSent; // Report
-	int clientMessagesReceived; // Report
-	int clientMessagesSent; // Report
-	int serverHeaderBytesReceived; // Report
-	int serverHeaderBytesSent; // Report
-	int serverContentBytesReceived; // Report
-	int serverContentBytesSent; // Report
-	int serverMessagesReceived; // Report
-	int serverMessagesSent; // Report
+    Type type;
+    QByteArray from;
+    QByteArray route;
+    int64_t retrySeq;               // Connections max
+    int count;                      // Activity, message
+    QByteArray connectionId;        // Connected, disconnected
+    ConnectionType connectionType;  // Connected
+    QHostAddress peerAddress;       // Connected
+    bool ssl;                       // Connected
+    int ttl;                        // Connected, subscribed, connections max
+    QByteArray mode;                // Subscribed, unsubscribed
+    QByteArray channel;             // Message, subscribed, unsubscribed
+    QByteArray itemId;              // Message
+    QByteArray transport;           // Message
+    int blocks;                     // Message
+    int subscribers;                // Subscribed
+    int connectionsMax;             // Report, connections max
+    int connectionsMinutes;         // Report
+    int messagesReceived;           // Report
+    int messagesSent;               // Report
+    int httpResponseMessagesSent;   // Report
+    int blocksReceived;             // Report
+    int blocksSent;                 // Report
+    int duration;                   // Report
+    int requestsReceived;           // Counts
+    int clientHeaderBytesReceived;  // Report
+    int clientHeaderBytesSent;      // Report
+    int clientContentBytesReceived; // Report
+    int clientContentBytesSent;     // Report
+    int clientMessagesReceived;     // Report
+    int clientMessagesSent;         // Report
+    int serverHeaderBytesReceived;  // Report
+    int serverHeaderBytesSent;      // Report
+    int serverContentBytesReceived; // Report
+    int serverContentBytesSent;     // Report
+    int serverMessagesReceived;     // Report
+    int serverMessagesSent;         // Report
 
-	StatsPacket() :
-		type((Type)-1),
-		retrySeq(-1),
-		count(-1),
-		connectionType((ConnectionType)-1),
-		ssl(false),
-		ttl(-1),
-		blocks(-1),
-		subscribers(-1),
-		connectionsMax(-1),
-		connectionsMinutes(-1),
-		messagesReceived(-1),
-		messagesSent(-1),
-		httpResponseMessagesSent(-1),
-		blocksReceived(-1),
-		blocksSent(-1),
-		duration(-1),
-		requestsReceived(-1),
-		clientHeaderBytesReceived(-1),
-		clientHeaderBytesSent(-1),
-		clientContentBytesReceived(-1),
-		clientContentBytesSent(-1),
-		clientMessagesReceived(-1),
-		clientMessagesSent(-1),
-		serverHeaderBytesReceived(-1),
-		serverHeaderBytesSent(-1),
-		serverContentBytesReceived(-1),
-		serverContentBytesSent(-1),
-		serverMessagesReceived(-1),
-		serverMessagesSent(-1)
-	{
-	}
+    StatsPacket()
+        : type((Type)-1),
+          retrySeq(-1),
+          count(-1),
+          connectionType((ConnectionType)-1),
+          ssl(false),
+          ttl(-1),
+          blocks(-1),
+          subscribers(-1),
+          connectionsMax(-1),
+          connectionsMinutes(-1),
+          messagesReceived(-1),
+          messagesSent(-1),
+          httpResponseMessagesSent(-1),
+          blocksReceived(-1),
+          blocksSent(-1),
+          duration(-1),
+          requestsReceived(-1),
+          clientHeaderBytesReceived(-1),
+          clientHeaderBytesSent(-1),
+          clientContentBytesReceived(-1),
+          clientContentBytesSent(-1),
+          clientMessagesReceived(-1),
+          clientMessagesSent(-1),
+          serverHeaderBytesReceived(-1),
+          serverHeaderBytesSent(-1),
+          serverContentBytesReceived(-1),
+          serverContentBytesSent(-1),
+          serverMessagesReceived(-1),
+          serverMessagesSent(-1) {}
 
-	Variant toVariant() const;
-	bool fromVariant(const QByteArray &type, const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const QByteArray &type, const Variant &in);
 };
 
 #endif

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -23,443 +23,448 @@
 
 #include "wscontrolpacket.h"
 
-#include <assert.h>
 #include "qtcompat.h"
 #include "variant.h"
+#include <assert.h>
 
 // FIXME: rewrite packet class using this code?
 /*class WsControlPacket
 {
 public:
-	class Message
-	{
-	public:
-		enum Type
-		{
-			Here,
-			Gone,
-			Cancel,
-			Grip
-		};
+        class Message
+        {
+        public:
+                enum Type
+                {
+                        Here,
+                        Gone,
+                        Cancel,
+                        Grip
+                };
 
-		Type type;
-		QString cid;
-		QString channelPrefix; // Here only
-		QByteArray message; // Grip only
-	};
+                Type type;
+                QString cid;
+                QString channelPrefix; // Here only
+                QByteArray message; // Grip only
+        };
 
-	QString channelPrefix;
-	QList<Message> messages;
+        QString channelPrefix;
+        QList<Message> messages;
 
-	static WsControlPacket fromVariant(const Variant &in, bool *ok = 0, QString *errorMessage = 0)
-	{
-		QString pn = "wscontrol packet";
+        static WsControlPacket fromVariant(const Variant &in, bool *ok = 0,
+QString *errorMessage = 0)
+        {
+                QString pn = "wscontrol packet";
 
-		if(!isKeyedObject(in))
-		{
-			setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-			return WsControlPacket();
-		}
+                if(!isKeyedObject(in))
+                {
+                        setError(ok, errorMessage, QString("%1 is not an
+object").arg(pn)); return WsControlPacket();
+                }
 
-		pn = "wscontrol object";
+                pn = "wscontrol object";
 
-		bool ok_;
-		VariantList vitems = getList(in, pn, "items", false, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return WsControlPacket();
-		}
+                bool ok_;
+                VariantList vitems = getList(in, pn, "items", false, &ok_,
+errorMessage); if(!ok_)
+                {
+                        if(ok)
+                                *ok = false;
+                        return WsControlPacket();
+                }
 
-		WsControlPacket out;
+                WsControlPacket out;
 
-		for(const Variant &vitem : vitems)
-		{
-			Message msg;
+                for(const Variant &vitem : vitems)
+                {
+                        Message msg;
 
-			pn = "wscontrol item";
+                        pn = "wscontrol item";
 
-			QString type = getString(vitem, pn, "type", true, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return WsControlPacket();
-			}
+                        QString type = getString(vitem, pn, "type", true, &ok_,
+errorMessage); if(!ok_)
+                        {
+                                if(ok)
+                                        *ok = false;
+                                return WsControlPacket();
+                        }
 
-			if(type == "here")
-				msg.type = Message::Here;
-			else if(type == "gone")
-				msg.type = Message::Gone;
-			else if(type == "cancel")
-				msg.type = Message::Cancel;
-			else if(type == "grip")
-				msg.type = Message::Grip;
-			else
-			{
-				setError(ok, errorMessage, QString("'type' contains unknown value: %1").arg(type));
-				return WsControlPacket();
-			}
+                        if(type == "here")
+                                msg.type = Message::Here;
+                        else if(type == "gone")
+                                msg.type = Message::Gone;
+                        else if(type == "cancel")
+                                msg.type = Message::Cancel;
+                        else if(type == "grip")
+                                msg.type = Message::Grip;
+                        else
+                        {
+                                setError(ok, errorMessage, QString("'type'
+contains unknown value: %1").arg(type)); return WsControlPacket();
+                        }
 
-			msg.cid = getString(vitem, pn, "cid", true, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return WsControlPacket();
-			}
+                        msg.cid = getString(vitem, pn, "cid", true, &ok_,
+errorMessage); if(!ok_)
+                        {
+                                if(ok)
+                                        *ok = false;
+                                return WsControlPacket();
+                        }
 
-			msg.uri = Url::fromEncoded(getString(vitem, pn, "uri", false, &ok_, errorMessage).toUtf8(), Url::StrictMode);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return WsControlPacket();
-			}
+                        msg.uri = Url::fromEncoded(getString(vitem, pn, "uri",
+false, &ok_, errorMessage).toUtf8(), Url::StrictMode); if(!ok_)
+                        {
+                                if(ok)
+                                        *ok = false;
+                                return WsControlPacket();
+                        }
 
-			msg.channelPrefix = getString(vitem, pn, "channel-prefix", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return WsControlPacket();
-			}
+                        msg.channelPrefix = getString(vitem, pn,
+"channel-prefix", false, &ok_, errorMessage); if(!ok_)
+                        {
+                                if(ok)
+                                        *ok = false;
+                                return WsControlPacket();
+                        }
 
-			if(msg.type == Message::Grip)
-			{
-				if(!keyedObjectContains(vitem, "message"))
-				{
-					setError(ok, errorMessage, QString("'%1' does not contain 'message'").arg(pn));
-					return WsControlPacket();
-				}
+                        if(msg.type == Message::Grip)
+                        {
+                                if(!keyedObjectContains(vitem, "message"))
+                                {
+                                        setError(ok, errorMessage, QString("'%1'
+does not contain 'message'").arg(pn)); return WsControlPacket();
+                                }
 
-				Variant vmessage = keyedObjectGetValue(vitem, "message");
-				if(vmessage.type() != VariantType::ByteArray)
-				{
-					setError(ok, errorMessage, QString("'%1' contains 'message' with wrong type").arg(pn));
-					return WsControlPacket();
-				}
+                                Variant vmessage = keyedObjectGetValue(vitem,
+"message"); if(vmessage.type() != VariantType::ByteArray)
+                                {
+                                        setError(ok, errorMessage, QString("'%1'
+contains 'message' with wrong type").arg(pn)); return WsControlPacket();
+                                }
 
-				msg.message = vmessage.toByteArray();
-			}
+                                msg.message = vmessage.toByteArray();
+                        }
 
-			out.messages += msg;
-		}
+                        out.messages += msg;
+                }
 
-		setSuccess(ok, errorMessage);
-		return out;
-	}
+                setSuccess(ok, errorMessage);
+                return out;
+        }
 };*/
 
-Variant WsControlPacket::toVariant() const
-{
-	VariantHash obj;
+Variant WsControlPacket::toVariant() const {
+    VariantHash obj;
 
-	obj["from"] = from;
+    obj["from"] = from;
 
-	VariantList vitems;
-	foreach(const Item &item, items)
-	{
-		VariantHash vitem;
+    VariantList vitems;
+    foreach (const Item &item, items) {
+        VariantHash vitem;
 
-		vitem["cid"] = item.cid;
+        vitem["cid"] = item.cid;
 
-		QByteArray typeStr;
-		switch(item.type)
-		{
-			case Item::Here:           typeStr = "here"; break;
-			case Item::KeepAlive:      typeStr = "keep-alive"; break;
-			case Item::Gone:           typeStr = "gone"; break;
-			case Item::Grip:           typeStr = "grip"; break;
-			case Item::KeepAliveSetup: typeStr = "keep-alive-setup"; break;
-			case Item::Cancel:         typeStr = "cancel"; break;
-			case Item::Send:           typeStr = "send"; break;
-			case Item::NeedKeepAlive:  typeStr = "need-keep-alive"; break;
-			case Item::Subscribe:      typeStr = "subscribe"; break;
-			case Item::Refresh:        typeStr = "refresh"; break;
-			case Item::Close:          typeStr = "close"; break;
-			case Item::Detach:         typeStr = "detach"; break;
-			case Item::Ack:            typeStr = "ack"; break;
-			default:
-				assert(0);
-		}
-		vitem["type"] = typeStr;
+        QByteArray typeStr;
+        switch (item.type) {
+        case Item::Here:
+            typeStr = "here";
+            break;
+        case Item::KeepAlive:
+            typeStr = "keep-alive";
+            break;
+        case Item::Gone:
+            typeStr = "gone";
+            break;
+        case Item::Grip:
+            typeStr = "grip";
+            break;
+        case Item::KeepAliveSetup:
+            typeStr = "keep-alive-setup";
+            break;
+        case Item::Cancel:
+            typeStr = "cancel";
+            break;
+        case Item::Send:
+            typeStr = "send";
+            break;
+        case Item::NeedKeepAlive:
+            typeStr = "need-keep-alive";
+            break;
+        case Item::Subscribe:
+            typeStr = "subscribe";
+            break;
+        case Item::Refresh:
+            typeStr = "refresh";
+            break;
+        case Item::Close:
+            typeStr = "close";
+            break;
+        case Item::Detach:
+            typeStr = "detach";
+            break;
+        case Item::Ack:
+            typeStr = "ack";
+            break;
+        default:
+            assert(0);
+        }
+        vitem["type"] = typeStr;
 
-		if(!item.requestId.isEmpty())
-			vitem["req-id"] = item.requestId;
+        if (!item.requestId.isEmpty())
+            vitem["req-id"] = item.requestId;
 
-		if(!item.uri.isEmpty())
-			vitem["uri"] = item.uri.toEncoded();
+        if (!item.uri.isEmpty())
+            vitem["uri"] = item.uri.toEncoded();
 
-		if(!item.contentType.isEmpty())
-			vitem["content-type"] = item.contentType;
+        if (!item.contentType.isEmpty())
+            vitem["content-type"] = item.contentType;
 
-		if(!item.message.isNull())
-			vitem["message"] = item.message;
+        if (!item.message.isNull())
+            vitem["message"] = item.message;
 
-		if(item.queue)
-			vitem["queue"] = true;
+        if (item.queue)
+            vitem["queue"] = true;
 
-		if(item.code >= 0)
-			vitem["code"] = item.code;
+        if (item.code >= 0)
+            vitem["code"] = item.code;
 
-		if(!item.reason.isEmpty())
-			vitem["reason"] = item.reason;
+        if (!item.reason.isEmpty())
+            vitem["reason"] = item.reason;
 
-		if(item.debug)
-			vitem["debug"] = true;
+        if (item.debug)
+            vitem["debug"] = true;
 
-		if(!item.route.isEmpty())
-			vitem["route"] = item.route;
+        if (!item.route.isEmpty())
+            vitem["route"] = item.route;
 
-		if(item.separateStats)
-			vitem["separate-stats"] = true;
+        if (item.separateStats)
+            vitem["separate-stats"] = true;
 
-		if(!item.channelPrefix.isEmpty())
-			vitem["channel-prefix"] = item.channelPrefix;
+        if (!item.channelPrefix.isEmpty())
+            vitem["channel-prefix"] = item.channelPrefix;
 
-		if(item.logLevel >= 0)
-			vitem["log-level"] = item.logLevel;
+        if (item.logLevel >= 0)
+            vitem["log-level"] = item.logLevel;
 
-		if(item.trusted)
-			vitem["trusted"] = true;
+        if (item.trusted)
+            vitem["trusted"] = true;
 
-		if(!item.channel.isEmpty())
-			vitem["channel"] = item.channel;
+        if (!item.channel.isEmpty())
+            vitem["channel"] = item.channel;
 
-		if(item.ttl >= 0)
-			vitem["ttl"] = item.ttl;
+        if (item.ttl >= 0)
+            vitem["ttl"] = item.ttl;
 
-		if(item.timeout >= 0)
-			vitem["timeout"] = item.timeout;
+        if (item.timeout >= 0)
+            vitem["timeout"] = item.timeout;
 
-		if(!item.keepAliveMode.isEmpty())
-			vitem["keep-alive-mode"] = item.keepAliveMode;
+        if (!item.keepAliveMode.isEmpty())
+            vitem["keep-alive-mode"] = item.keepAliveMode;
 
-		vitems += vitem;
-	}
+        vitems += vitem;
+    }
 
-	obj["items"] = vitems;
-	return obj;
+    obj["items"] = vitems;
+    return obj;
 }
 
-bool WsControlPacket::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
+bool WsControlPacket::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
 
-	VariantHash obj = in.toHash();
+    VariantHash obj = in.toHash();
 
-	if(!obj.contains("from") || typeId(obj["from"]) != VariantType::ByteArray)
-		return false;
+    if (!obj.contains("from") || typeId(obj["from"]) != VariantType::ByteArray)
+        return false;
 
-	from = obj["from"].toByteArray();
+    from = obj["from"].toByteArray();
 
-	if(!obj.contains("items") || typeId(obj["items"]) != VariantType::List)
-		return false;
+    if (!obj.contains("items") || typeId(obj["items"]) != VariantType::List)
+        return false;
 
-	VariantList vitems = obj["items"].toList();
+    VariantList vitems = obj["items"].toList();
 
-	items.clear();
-	for(const Variant &v : vitems)
-	{
-		if(typeId(v) != VariantType::Hash)
-			return false;
+    items.clear();
+    for (const Variant &v : vitems) {
+        if (typeId(v) != VariantType::Hash)
+            return false;
 
-		VariantHash vitem = v.toHash();
+        VariantHash vitem = v.toHash();
 
-		Item item;
+        Item item;
 
-		if(!vitem.contains("cid") || typeId(vitem["cid"]) != VariantType::ByteArray)
-			return false;
-		item.cid = vitem["cid"].toByteArray();
+        if (!vitem.contains("cid") || typeId(vitem["cid"]) != VariantType::ByteArray)
+            return false;
+        item.cid = vitem["cid"].toByteArray();
 
-		if(!vitem.contains("type") || typeId(vitem["type"]) != VariantType::ByteArray)
-			return false;
-		QByteArray typeStr = vitem["type"].toByteArray();
+        if (!vitem.contains("type") || typeId(vitem["type"]) != VariantType::ByteArray)
+            return false;
+        QByteArray typeStr = vitem["type"].toByteArray();
 
-		if(typeStr == "here")
-			item.type = Item::Here;
-		else if(typeStr == "keep-alive")
-			item.type = Item::KeepAlive;
-		else if(typeStr == "gone")
-			item.type = Item::Gone;
-		else if(typeStr == "grip")
-			item.type = Item::Grip;
-		else if(typeStr == "keep-alive-setup")
-			item.type = Item::KeepAliveSetup;
-		else if(typeStr == "cancel")
-			item.type = Item::Cancel;
-		else if(typeStr == "send")
-			item.type = Item::Send;
-		else if(typeStr == "need-keep-alive")
-			item.type = Item::NeedKeepAlive;
-		else if(typeStr == "subscribe")
-			item.type = Item::Subscribe;
-		else if(typeStr == "refresh")
-			item.type = Item::Refresh;
-		else if(typeStr == "close")
-			item.type = Item::Close;
-		else if(typeStr == "detach")
-			item.type = Item::Detach;
-		else if(typeStr == "ack")
-			item.type = Item::Ack;
-		else
-			return false;
+        if (typeStr == "here")
+            item.type = Item::Here;
+        else if (typeStr == "keep-alive")
+            item.type = Item::KeepAlive;
+        else if (typeStr == "gone")
+            item.type = Item::Gone;
+        else if (typeStr == "grip")
+            item.type = Item::Grip;
+        else if (typeStr == "keep-alive-setup")
+            item.type = Item::KeepAliveSetup;
+        else if (typeStr == "cancel")
+            item.type = Item::Cancel;
+        else if (typeStr == "send")
+            item.type = Item::Send;
+        else if (typeStr == "need-keep-alive")
+            item.type = Item::NeedKeepAlive;
+        else if (typeStr == "subscribe")
+            item.type = Item::Subscribe;
+        else if (typeStr == "refresh")
+            item.type = Item::Refresh;
+        else if (typeStr == "close")
+            item.type = Item::Close;
+        else if (typeStr == "detach")
+            item.type = Item::Detach;
+        else if (typeStr == "ack")
+            item.type = Item::Ack;
+        else
+            return false;
 
-		if(vitem.contains("req-id"))
-		{
-			if(typeId(vitem["req-id"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("req-id")) {
+            if (typeId(vitem["req-id"]) != VariantType::ByteArray)
+                return false;
 
-			item.requestId = vitem["req-id"].toByteArray();
-		}
+            item.requestId = vitem["req-id"].toByteArray();
+        }
 
-		if(vitem.contains("uri"))
-		{
-			if(typeId(vitem["uri"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("uri")) {
+            if (typeId(vitem["uri"]) != VariantType::ByteArray)
+                return false;
 
-			item.uri = Url::fromEncoded(vitem["uri"].toByteArray(), Url::StrictMode);
-		}
+            item.uri = Url::fromEncoded(vitem["uri"].toByteArray(), Url::StrictMode);
+        }
 
-		if(vitem.contains("content-type"))
-		{
-			if(typeId(vitem["content-type"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("content-type")) {
+            if (typeId(vitem["content-type"]) != VariantType::ByteArray)
+                return false;
 
-			QByteArray contentType = vitem["content-type"].toByteArray();
-			if(!contentType.isEmpty())
-				item.contentType = contentType;
-		}
+            QByteArray contentType = vitem["content-type"].toByteArray();
+            if (!contentType.isEmpty())
+                item.contentType = contentType;
+        }
 
-		if(vitem.contains("message"))
-		{
-			if(typeId(vitem["message"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("message")) {
+            if (typeId(vitem["message"]) != VariantType::ByteArray)
+                return false;
 
-			item.message = vitem["message"].toByteArray();
-		}
+            item.message = vitem["message"].toByteArray();
+        }
 
-		if(vitem.contains("queue"))
-		{
-			if(typeId(vitem["queue"]) != VariantType::Bool)
-				return false;
+        if (vitem.contains("queue")) {
+            if (typeId(vitem["queue"]) != VariantType::Bool)
+                return false;
 
-			item.queue = vitem["queue"].toBool();
-		}
+            item.queue = vitem["queue"].toBool();
+        }
 
-		if(vitem.contains("code"))
-		{
-			if(!canConvert(vitem["code"], VariantType::Int))
-				return false;
+        if (vitem.contains("code")) {
+            if (!canConvert(vitem["code"], VariantType::Int))
+                return false;
 
-			item.code = vitem["code"].toInt();
-		}
+            item.code = vitem["code"].toInt();
+        }
 
-		if(vitem.contains("reason"))
-		{
-			if(typeId(vitem["reason"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("reason")) {
+            if (typeId(vitem["reason"]) != VariantType::ByteArray)
+                return false;
 
-			item.reason = vitem["reason"].toByteArray();
-		}
+            item.reason = vitem["reason"].toByteArray();
+        }
 
-		if(vitem.contains("debug"))
-		{
-			if(typeId(vitem["debug"]) != VariantType::Bool)
-				return false;
+        if (vitem.contains("debug")) {
+            if (typeId(vitem["debug"]) != VariantType::Bool)
+                return false;
 
-			item.debug = vitem["debug"].toBool();
-		}
+            item.debug = vitem["debug"].toBool();
+        }
 
-		if(vitem.contains("route"))
-		{
-			if(typeId(vitem["route"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("route")) {
+            if (typeId(vitem["route"]) != VariantType::ByteArray)
+                return false;
 
-			QByteArray route = vitem["route"].toByteArray();
-			if(!route.isEmpty())
-				item.route = route;
-		}
+            QByteArray route = vitem["route"].toByteArray();
+            if (!route.isEmpty())
+                item.route = route;
+        }
 
-		if(vitem.contains("separate-stats"))
-		{
-			if(typeId(vitem["separate-stats"]) != VariantType::Bool)
-				return false;
+        if (vitem.contains("separate-stats")) {
+            if (typeId(vitem["separate-stats"]) != VariantType::Bool)
+                return false;
 
-			item.separateStats = vitem["separate-stats"].toBool();
-		}
+            item.separateStats = vitem["separate-stats"].toBool();
+        }
 
-		if(vitem.contains("channel-prefix"))
-		{
-			if(typeId(vitem["channel-prefix"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("channel-prefix")) {
+            if (typeId(vitem["channel-prefix"]) != VariantType::ByteArray)
+                return false;
 
-			QByteArray channelPrefix = vitem["channel-prefix"].toByteArray();
-			if(!channelPrefix.isEmpty())
-				item.channelPrefix = channelPrefix;
-		}
+            QByteArray channelPrefix = vitem["channel-prefix"].toByteArray();
+            if (!channelPrefix.isEmpty())
+                item.channelPrefix = channelPrefix;
+        }
 
-		if(vitem.contains("log-level"))
-		{
-			if(!canConvert(vitem["log-level"], VariantType::Int))
-				return false;
+        if (vitem.contains("log-level")) {
+            if (!canConvert(vitem["log-level"], VariantType::Int))
+                return false;
 
-			item.logLevel = vitem["log-level"].toInt();
-		}
+            item.logLevel = vitem["log-level"].toInt();
+        }
 
-		if(vitem.contains("trusted"))
-		{
-			if(typeId(vitem["trusted"]) != VariantType::Bool)
-				return false;
+        if (vitem.contains("trusted")) {
+            if (typeId(vitem["trusted"]) != VariantType::Bool)
+                return false;
 
-			item.trusted = vitem["trusted"].toBool();
-		}
+            item.trusted = vitem["trusted"].toBool();
+        }
 
-		if(vitem.contains("channel"))
-		{
-			if(typeId(vitem["channel"]) != VariantType::ByteArray)
-				return false;
+        if (vitem.contains("channel")) {
+            if (typeId(vitem["channel"]) != VariantType::ByteArray)
+                return false;
 
-			QByteArray channel = vitem["channel"].toByteArray();
-			if(!channel.isEmpty())
-				item.channel = channel;
-		}
+            QByteArray channel = vitem["channel"].toByteArray();
+            if (!channel.isEmpty())
+                item.channel = channel;
+        }
 
-		if(vitem.contains("ttl"))
-		{
-			if(!canConvert(vitem["ttl"], VariantType::Int))
-				return false;
+        if (vitem.contains("ttl")) {
+            if (!canConvert(vitem["ttl"], VariantType::Int))
+                return false;
 
-			item.ttl = vitem["ttl"].toInt();
-			if(item.ttl < 0)
-				item.ttl = 0;
-		}
+            item.ttl = vitem["ttl"].toInt();
+            if (item.ttl < 0)
+                item.ttl = 0;
+        }
 
-		if(vitem.contains("timeout"))
-		{
-			if(!canConvert(vitem["timeout"], VariantType::Int))
-				return false;
+        if (vitem.contains("timeout")) {
+            if (!canConvert(vitem["timeout"], VariantType::Int))
+                return false;
 
-			item.timeout = vitem["timeout"].toInt();
-			if(item.timeout < 0)
-				item.timeout = 0;
-		}
+            item.timeout = vitem["timeout"].toInt();
+            if (item.timeout < 0)
+                item.timeout = 0;
+        }
 
-		if(vitem.contains("keep-alive-mode"))
-		{
-			if(!canConvert(vitem["keep-alive-mode"], VariantType::ByteArray))
-				return false;
+        if (vitem.contains("keep-alive-mode")) {
+            if (!canConvert(vitem["keep-alive-mode"], VariantType::ByteArray))
+                return false;
 
-			QByteArray keepAliveMode = vitem["keep-alive-mode"].toByteArray();
-			if(!keepAliveMode.isEmpty())
-				item.keepAliveMode = keepAliveMode;
-		}
+            QByteArray keepAliveMode = vitem["keep-alive-mode"].toByteArray();
+            if (!keepAliveMode.isEmpty())
+                item.keepAliveMode = keepAliveMode;
+        }
 
-		items += item;
-	}
+        items += item;
+    }
 
-	return true;
+    return true;
 }

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -24,73 +24,68 @@
 #ifndef WSCONTROLPACKET_H
 #define WSCONTROLPACKET_H
 
+#include "url.h"
+#include "variant.h"
 #include <QByteArray>
 #include <QList>
-#include "variant.h"
-#include "url.h"
 
-class WsControlPacket
-{
+class WsControlPacket {
 public:
-	class Item
-	{
-	public:
-		enum Type
-		{
-			Here,
-			KeepAlive,
-			Gone,
-			Grip,
-			NeedKeepAlive,
-			Subscribe,
-			Cancel,
-			Send,
-			KeepAliveSetup,
-			Refresh,
-			Close,
-			Detach,
-			Ack
-		};
+    class Item {
+    public:
+        enum Type {
+            Here,
+            KeepAlive,
+            Gone,
+            Grip,
+            NeedKeepAlive,
+            Subscribe,
+            Cancel,
+            Send,
+            KeepAliveSetup,
+            Refresh,
+            Close,
+            Detach,
+            Ack
+        };
 
-		QByteArray cid;
-		Type type;
-		QByteArray requestId;
-		Url uri;
-		QByteArray contentType;
-		QByteArray message;
-		bool queue;
-		int code;
-		QByteArray reason;
-		bool debug;
-		QByteArray route;
-		bool separateStats;
-		QByteArray channelPrefix;
-		int logLevel;
-		bool trusted;
-		QByteArray channel;
-		int ttl;
-		int timeout;
-		QByteArray keepAliveMode;
+        QByteArray cid;
+        Type type;
+        QByteArray requestId;
+        Url uri;
+        QByteArray contentType;
+        QByteArray message;
+        bool queue;
+        int code;
+        QByteArray reason;
+        bool debug;
+        QByteArray route;
+        bool separateStats;
+        QByteArray channelPrefix;
+        int logLevel;
+        bool trusted;
+        QByteArray channel;
+        int ttl;
+        int timeout;
+        QByteArray keepAliveMode;
 
-		Item() :
-			type((Type)-1),
-			queue(false),
-			code(-1),
-			debug(false),
-			separateStats(false),
-			logLevel(-1),
-			trusted(false),
-			ttl(-1),
-			timeout(-1)
-		{
-		}
-	};
+        Item()
+            : type((Type)-1),
+              queue(false),
+              code(-1),
+              debug(false),
+              separateStats(false),
+              logLevel(-1),
+              trusted(false),
+              ttl(-1),
+              timeout(-1) {}
+    };
 
-	QByteArray from;
-	QList<Item> items;
+    QByteArray from;
+    QList<Item> items;
 
-	Variant toVariant() const;
-	bool fromVariant(const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/packet/zrpcrequestpacket.cpp
+++ b/src/core/packet/zrpcrequestpacket.cpp
@@ -26,58 +26,53 @@
 #include "qtcompat.h"
 #include "variant.h"
 
-Variant ZrpcRequestPacket::toVariant() const
-{
-	VariantHash obj;
+Variant ZrpcRequestPacket::toVariant() const {
+    VariantHash obj;
 
-	if(!from.isEmpty())
-		obj["from"] = from;
+    if (!from.isEmpty())
+        obj["from"] = from;
 
-	if(!id.isEmpty())
-		obj["id"] = id;
+    if (!id.isEmpty())
+        obj["id"] = id;
 
-	obj["method"] = method.toUtf8();
+    obj["method"] = method.toUtf8();
 
-	if(!args.isEmpty())
-		obj["args"] = args;
+    if (!args.isEmpty())
+        obj["args"] = args;
 
-	return obj;
+    return obj;
 }
 
-bool ZrpcRequestPacket::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
+bool ZrpcRequestPacket::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
 
-	VariantHash obj = in.toHash();
+    VariantHash obj = in.toHash();
 
-	if(obj.contains("from"))
-	{
-		if(typeId(obj["from"]) != VariantType::ByteArray)
-			return false;
+    if (obj.contains("from")) {
+        if (typeId(obj["from"]) != VariantType::ByteArray)
+            return false;
 
-		from = obj["from"].toByteArray();
-	}
+        from = obj["from"].toByteArray();
+    }
 
-	if(obj.contains("id"))
-	{
-		if(typeId(obj["id"]) != VariantType::ByteArray)
-			return false;
+    if (obj.contains("id")) {
+        if (typeId(obj["id"]) != VariantType::ByteArray)
+            return false;
 
-		id = obj["id"].toByteArray();
-	}
+        id = obj["id"].toByteArray();
+    }
 
-	if(!obj.contains("method") || typeId(obj["method"]) != VariantType::ByteArray)
-		return false;
-	method = QString::fromUtf8(obj["method"].toByteArray());
+    if (!obj.contains("method") || typeId(obj["method"]) != VariantType::ByteArray)
+        return false;
+    method = QString::fromUtf8(obj["method"].toByteArray());
 
-	if(obj.contains("args"))
-	{
-		if(typeId(obj["args"]) != VariantType::Hash)
-			return false;
+    if (obj.contains("args")) {
+        if (typeId(obj["args"]) != VariantType::Hash)
+            return false;
 
-		args = obj["args"].toHash();
-	}
+        args = obj["args"].toHash();
+    }
 
-	return true;
+    return true;
 }

--- a/src/core/packet/zrpcrequestpacket.h
+++ b/src/core/packet/zrpcrequestpacket.h
@@ -24,19 +24,18 @@
 #ifndef ZRPCREQUESTPACKET_H
 #define ZRPCREQUESTPACKET_H
 
-#include <QByteArray>
 #include "variant.h"
+#include <QByteArray>
 
-class ZrpcRequestPacket
-{
+class ZrpcRequestPacket {
 public:
-	QByteArray from;
-	QByteArray id;
-	QString method;
-	VariantHash args;
+    QByteArray from;
+    QByteArray id;
+    QString method;
+    VariantHash args;
 
-	Variant toVariant() const;
-	bool fromVariant(const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/packet/zrpcresponsepacket.cpp
+++ b/src/core/packet/zrpcresponsepacket.cpp
@@ -26,74 +26,64 @@
 #include "qtcompat.h"
 #include "variant.h"
 
-Variant ZrpcResponsePacket::toVariant() const
-{
-	VariantHash obj;
+Variant ZrpcResponsePacket::toVariant() const {
+    VariantHash obj;
 
-	if(!id.isEmpty())
-		obj["id"] = id;
+    if (!id.isEmpty())
+        obj["id"] = id;
 
-	obj["success"] = success;
+    obj["success"] = success;
 
-	if(success)
-	{
-		if(typeId(value) == VariantType::String)
-			obj["value"] = value.toString().toUtf8();
-		else
-			obj["value"] = value;
-	}
-	else
-	{
-		obj["condition"] = condition;
+    if (success) {
+        if (typeId(value) == VariantType::String)
+            obj["value"] = value.toString().toUtf8();
+        else
+            obj["value"] = value;
+    } else {
+        obj["condition"] = condition;
 
-		if(value.isValid())
-		{
-			if(typeId(value) == VariantType::String)
-				obj["value"] = value.toString().toUtf8();
-			else
-				obj["value"] = value;
-		}
-	}
+        if (value.isValid()) {
+            if (typeId(value) == VariantType::String)
+                obj["value"] = value.toString().toUtf8();
+            else
+                obj["value"] = value;
+        }
+    }
 
-	return obj;
+    return obj;
 }
 
-bool ZrpcResponsePacket::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
+bool ZrpcResponsePacket::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
 
-	VariantHash obj = in.toHash();
+    VariantHash obj = in.toHash();
 
-	if(obj.contains("id"))
-	{
-		if(typeId(obj["id"]) != VariantType::ByteArray)
-			return false;
+    if (obj.contains("id")) {
+        if (typeId(obj["id"]) != VariantType::ByteArray)
+            return false;
 
-		id = obj["id"].toByteArray();
-	}
+        id = obj["id"].toByteArray();
+    }
 
-	if(!obj.contains("success") || typeId(obj["success"]) != VariantType::Bool)
-		return false;
-	success = obj["success"].toBool();
+    if (!obj.contains("success") || typeId(obj["success"]) != VariantType::Bool)
+        return false;
+    success = obj["success"].toBool();
 
-	value.clear();
-	condition.clear();
-	if(success)
-	{
-		if(!obj.contains("value"))
-			return false;
-		value = obj["value"];
-	}
-	else
-	{
-		if(!obj.contains("condition") || typeId(obj["condition"]) != VariantType::ByteArray)
-			return false;
-		condition = obj["condition"].toByteArray();
+    value.clear();
+    condition.clear();
+    if (success) {
+        if (!obj.contains("value"))
+            return false;
+        value = obj["value"];
+    } else {
+        if (!obj.contains("condition") || typeId(obj["condition"]) != VariantType::ByteArray)
+            return false;
+        condition = obj["condition"].toByteArray();
 
-		if(obj.contains("value"))
-			value = obj["value"];
-	}
+        if (obj.contains("value"))
+            value = obj["value"];
+    }
 
-	return true;
+    return true;
 }

--- a/src/core/packet/zrpcresponsepacket.h
+++ b/src/core/packet/zrpcresponsepacket.h
@@ -23,24 +23,20 @@
 #ifndef ZRPCRESPONSEPACKET_H
 #define ZRPCRESPONSEPACKET_H
 
-#include <QByteArray>
 #include "variant.h"
+#include <QByteArray>
 
-class ZrpcResponsePacket
-{
+class ZrpcResponsePacket {
 public:
-	QByteArray id;
-	bool success;
-	Variant value;
-	QByteArray condition;
+    QByteArray id;
+    bool success;
+    Variant value;
+    QByteArray condition;
 
-	ZrpcResponsePacket() :
-		success(false)
-	{
-	}
+    ZrpcResponsePacket() : success(false) {}
 
-	Variant toVariant() const;
-	bool fromVariant(const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/processquit.cpp
+++ b/src/core/processquit.cpp
@@ -22,155 +22,134 @@
 
 #include "processquit.h"
 
-#include <signal.h>
-#include <unistd.h>
+#include "socketnotifier.h"
 #include <QGlobalStatic>
 #include <QMutex>
-#include "socketnotifier.h"
+#include <signal.h>
+#include <unistd.h>
 
 Q_GLOBAL_STATIC(QMutex, pq_mutex)
 static ProcessQuit *g_pq = nullptr;
 
-class ProcessQuit::Private
-{
+class ProcessQuit::Private {
 public:
-	ProcessQuit *q;
-	Connection activatedConnection;
+    ProcessQuit *q;
+    Connection activatedConnection;
 
-	bool done;
-	int sig_pipe[2];
-	std::unique_ptr<SocketNotifier> sig_notifier;
+    bool done;
+    int sig_pipe[2];
+    std::unique_ptr<SocketNotifier> sig_notifier;
 
-	Private(ProcessQuit *_q) :
-		q(_q)
-	{
-		done = false;
+    Private(ProcessQuit *_q) : q(_q) {
+        done = false;
 
-		if(pipe(sig_pipe) == -1)
-		{
-			// No support then
-			return;
-		}
+        if (pipe(sig_pipe) == -1) {
+            // No support then
+            return;
+        }
 
-		sig_notifier = std::make_unique<SocketNotifier>(sig_pipe[0], SocketNotifier::Read);
-		activatedConnection = sig_notifier->activated.connect(boost::bind(&Private::sig_activated, this, boost::placeholders::_1));
-		sig_notifier->clearReadiness(SocketNotifier::Read);
-		unixWatchAdd(SIGINT);
-		unixWatchAdd(SIGHUP);
-		unixWatchAdd(SIGTERM);
-	}
+        sig_notifier = std::make_unique<SocketNotifier>(sig_pipe[0], SocketNotifier::Read);
+        activatedConnection = sig_notifier->activated.connect(
+            boost::bind(&Private::sig_activated, this, boost::placeholders::_1));
+        sig_notifier->clearReadiness(SocketNotifier::Read);
+        unixWatchAdd(SIGINT);
+        unixWatchAdd(SIGHUP);
+        unixWatchAdd(SIGTERM);
+    }
 
-	~Private()
-	{
-		unixWatchRemove(SIGINT);
-		unixWatchRemove(SIGHUP);
-		unixWatchRemove(SIGTERM);
-		activatedConnection.disconnect();
-		sig_notifier.reset();
-		close(sig_pipe[0]);
-		close(sig_pipe[1]);
-	}
+    ~Private() {
+        unixWatchRemove(SIGINT);
+        unixWatchRemove(SIGHUP);
+        unixWatchRemove(SIGTERM);
+        activatedConnection.disconnect();
+        sig_notifier.reset();
+        close(sig_pipe[0]);
+        close(sig_pipe[1]);
+    }
 
-	static void unixHandler(int sig)
-	{
-		Q_UNUSED(sig);
-		unsigned char c = 0;
-		if(sig == SIGHUP)
-			c = 1;
-		if(::write(g_pq->d->sig_pipe[1], &c, 1) == -1)
-		{
-			// TODO: error handling?
-			return;
-		}
-	}
+    static void unixHandler(int sig) {
+        Q_UNUSED(sig);
+        unsigned char c = 0;
+        if (sig == SIGHUP)
+            c = 1;
+        if (::write(g_pq->d->sig_pipe[1], &c, 1) == -1) {
+            // TODO: error handling?
+            return;
+        }
+    }
 
-	void unixWatchAdd(int sig)
-	{
-		struct sigaction sa;
-		sigaction(sig, NULL, &sa);
-		// If the signal is ignored, don't take it over.  This is
-		// recommended by the glibc manual
-		if(sa.sa_handler == SIG_IGN)
-			return;
-		sigemptyset(&(sa.sa_mask));
-		sa.sa_flags = 0;
-		sa.sa_handler = unixHandler;
-		sigaction(sig, &sa, 0);
-	}
+    void unixWatchAdd(int sig) {
+        struct sigaction sa;
+        sigaction(sig, NULL, &sa);
+        // If the signal is ignored, don't take it over.  This is
+        // recommended by the glibc manual
+        if (sa.sa_handler == SIG_IGN)
+            return;
+        sigemptyset(&(sa.sa_mask));
+        sa.sa_flags = 0;
+        sa.sa_handler = unixHandler;
+        sigaction(sig, &sa, 0);
+    }
 
-	void unixWatchRemove(int sig)
-	{
-		struct sigaction sa;
-		sigaction(sig, NULL, &sa);
-		// Ignored means we skipped it earlier, so we should
-		// skip it again
-		if(sa.sa_handler == SIG_IGN)
-			return;
-		sigemptyset(&(sa.sa_mask));
-		sa.sa_flags = 0;
-		sa.sa_handler = SIG_DFL;
-		sigaction(sig, &sa, 0);
-	}
+    void unixWatchRemove(int sig) {
+        struct sigaction sa;
+        sigaction(sig, NULL, &sa);
+        // Ignored means we skipped it earlier, so we should
+        // skip it again
+        if (sa.sa_handler == SIG_IGN)
+            return;
+        sigemptyset(&(sa.sa_mask));
+        sa.sa_flags = 0;
+        sa.sa_handler = SIG_DFL;
+        sigaction(sig, &sa, 0);
+    }
 
-	void sig_activated(int)
-	{
-		sig_notifier->clearReadiness(SocketNotifier::Read);
+    void sig_activated(int) {
+        sig_notifier->clearReadiness(SocketNotifier::Read);
 
-		unsigned char c;
-		if(::read(sig_pipe[0], &c, 1) == -1)
-		{
-			// TODO: error handling?
-			return;
-		}
+        unsigned char c;
+        if (::read(sig_pipe[0], &c, 1) == -1) {
+            // TODO: error handling?
+            return;
+        }
 
-		if(c == 1) // SIGHUP
-		{
-			q->hup();
-			return;
-		}
+        if (c == 1) // SIGHUP
+        {
+            q->hup();
+            return;
+        }
 
-		do_emit();
-	}
+        do_emit();
+    }
 
 private:
-	void do_emit()
-	{
-		// Only signal once
-		if(!done)
-		{
-			done = true;
-			q->quit();
-		}
-	}
+    void do_emit() {
+        // Only signal once
+        if (!done) {
+            done = true;
+            q->quit();
+        }
+    }
 };
 
-ProcessQuit::ProcessQuit()
-{
-	d = new Private(this);
+ProcessQuit::ProcessQuit() { d = new Private(this); }
+
+ProcessQuit::~ProcessQuit() { delete d; }
+
+ProcessQuit *ProcessQuit::instance() {
+    QMutexLocker locker(pq_mutex());
+    if (!g_pq)
+        g_pq = new ProcessQuit;
+    return g_pq;
 }
 
-ProcessQuit::~ProcessQuit()
-{
-	delete d;
+void ProcessQuit::reset() {
+    QMutexLocker locker(pq_mutex());
+    if (g_pq)
+        g_pq->d->done = false;
 }
 
-ProcessQuit *ProcessQuit::instance()
-{
-	QMutexLocker locker(pq_mutex());
-	if(!g_pq)
-		g_pq = new ProcessQuit;
-	return g_pq;
-}
-
-void ProcessQuit::reset()
-{
-	QMutexLocker locker(pq_mutex());
-	if(g_pq)
-		g_pq->d->done = false;
-}
-
-void ProcessQuit::cleanup()
-{
-	delete g_pq;
-	g_pq = nullptr;
+void ProcessQuit::cleanup() {
+    delete g_pq;
+    g_pq = nullptr;
 }

--- a/src/core/processquit.h
+++ b/src/core/processquit.h
@@ -32,59 +32,78 @@ using Connection = boost::signals2::scoped_connection;
 /**
    \brief Listens for termination requests
 
-   ProcessQuit listens for requests to terminate the application process.  These are the signals SIGINT, SIGHUP, and SIGTERM.
+   ProcessQuit listens for requests to terminate the application process.  These
+are the signals SIGINT, SIGHUP, and SIGTERM.
 
-   For GUI programs, ProcessQuit is not a substitute for QSessionManager.  The only safe way to handle termination of a GUI program in the usual way is to use QSessionManager.  However, ProcessQuit does give additional benefit to GUI programs that might be terminated unconventionally, so it can't hurt to support both.
+   For GUI programs, ProcessQuit is not a substitute for QSessionManager.  The
+only safe way to handle termination of a GUI program in the usual way is to use
+QSessionManager.  However, ProcessQuit does give additional benefit to GUI
+programs that might be terminated unconventionally, so it can't hurt to support
+both.
 
-   When a termination request is received, the application should exit gracefully, and generally without user interaction.  Otherwise, it is at risk of being terminated outside of its control.
+   When a termination request is received, the application should exit
+gracefully, and generally without user interaction.  Otherwise, it is at risk of
+being terminated outside of its control.
 
    Using ProcessQuit is easy, and it usually amounts to a single line:
    \code
 myapp.connect(ProcessQuit::instance(), SIGNAL(quit()), SLOT(do_quit()));
    \endcode
 
-   Calling instance() returns a pointer to the global ProcessQuit instance, which will be created if necessary.  The quit() signal is emitted when a request to terminate is received.    The quit() signal is only emitted once, future termination requests are ignored.  Call reset() to allow the quit() signal to be emitted again.
+   Calling instance() returns a pointer to the global ProcessQuit instance,
+which will be created if necessary.  The quit() signal is emitted when a request
+to terminate is received.    The quit() signal is only emitted once, future
+termination requests are ignored.  Call reset() to allow the quit() signal to be
+emitted again.
 */
-class ProcessQuit
-{
+class ProcessQuit {
 public:
-	/**
-	   \brief Returns the global ProcessQuit instance
+    /**
+       \brief Returns the global ProcessQuit instance
 
-	   If the global instance does not exist yet, it will be created, and the termination handlers will be installed.
+       If the global instance does not exist yet, it will be created, and the
+       termination handlers will be installed.
 
-	   \sa cleanup
-	*/
-	static ProcessQuit *instance();
+       \sa cleanup
+    */
+    static ProcessQuit *instance();
 
-	/**
-	   \brief Allows the quit() signal to be emitted again
+    /**
+       \brief Allows the quit() signal to be emitted again
 
-	   ProcessQuit only emits the quit() signal once, so that if a user repeatedly presses Ctrl-C or sends SIGTERM, your shutdown slot will not be called multiple times.  This is normally the desired behavior, but if you are ignoring the termination request then you may want to allow future notifications.  Calling this function will allow the quit() signal to be emitted again, if a new termination request arrives.
+       ProcessQuit only emits the quit() signal once, so that if a user repeatedly
+       presses Ctrl-C or sends SIGTERM, your shutdown slot will not be called
+       multiple times.  This is normally the desired behavior, but if you are
+       ignoring the termination request then you may want to allow future
+       notifications.  Calling this function will allow the quit() signal to be
+       emitted again, if a new termination request arrives.
 
-	   \sa quit
-	*/
-	static void reset();
+       \sa quit
+    */
+    static void reset();
 
-	/**
-	   \brief Frees all resources used by ProcessQuit
+    /**
+       \brief Frees all resources used by ProcessQuit
 
-	   This function will free any resources used by ProcessQuit, including the global instance, and the termination handlers will be uninstalled (reverted to default).  Future termination requests will cause the application to exit abruptly.
+       This function will free any resources used by ProcessQuit, including the
+       global instance, and the termination handlers will be uninstalled (reverted
+       to default).  Future termination requests will cause the application to
+       exit abruptly.
 
-	   \sa instance
-	*/
-	static void cleanup();
+       \sa instance
+    */
+    static void cleanup();
 
-	Signal quit;
-	Signal hup;
+    Signal quit;
+    Signal hup;
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 
-	ProcessQuit();
-	~ProcessQuit();
+    ProcessQuit();
+    ~ProcessQuit();
 };
 
 #endif

--- a/src/core/qtcompat.h
+++ b/src/core/qtcompat.h
@@ -27,31 +27,29 @@
 #include <QVariant>
 
 namespace VariantType {
-	enum Type {
-		Invalid = QMetaType::UnknownType,
-		Bool = QMetaType::Bool,
-		Int = QMetaType::Int,
-		Double = QMetaType::Double,
-		LongLong = QMetaType::LongLong,
-		String = QMetaType::QString,
-		ByteArray = QMetaType::QByteArray,
-		Hash = QMetaType::QVariantHash,
-		Map = QMetaType::QVariantMap,
-		List = QMetaType::QVariantList
-	};
+enum Type {
+    Invalid = QMetaType::UnknownType,
+    Bool = QMetaType::Bool,
+    Int = QMetaType::Int,
+    Double = QMetaType::Double,
+    LongLong = QMetaType::LongLong,
+    String = QMetaType::QString,
+    ByteArray = QMetaType::QByteArray,
+    Hash = QMetaType::QVariantHash,
+    Map = QMetaType::QVariantMap,
+    List = QMetaType::QVariantList
+};
 }
 
-inline VariantType::Type typeId(const QVariant &v)
-{
+inline VariantType::Type typeId(const QVariant &v) {
 #if QT_VERSION >= 0x060000
-	return (VariantType::Type)v.typeId();
+    return (VariantType::Type)v.typeId();
 #else
-	return (VariantType::Type)v.type();
+    return (VariantType::Type)v.type();
 #endif
 }
 
-inline bool canConvert(const QVariant &v, VariantType::Type type)
-{
+inline bool canConvert(const QVariant &v, VariantType::Type type) {
 #if QT_VERSION >= 0x060000
     return v.canConvert(QMetaType((QMetaType::Type)type));
 #else

--- a/src/core/reactor.cpp
+++ b/src/core/reactor.cpp
@@ -16,20 +16,13 @@
 
 #include "reactor.h"
 
-Reactor::Reactor(int registrationsMax) :
-	inner_(ffi::reactor_create(registrationsMax))
-{
-}
+Reactor::Reactor(int registrationsMax) : inner_(ffi::reactor_create(registrationsMax)) {}
 
-Reactor::~Reactor()
-{
-	ffi::reactor_destroy(inner_);
-}
+Reactor::~Reactor() { ffi::reactor_destroy(inner_); }
 
-bool Reactor::poll(std::optional<int> ms)
-{
-	if(ffi::reactor_poll(inner_, ms.value_or(-1)) != 0)
-		return false;
+bool Reactor::poll(std::optional<int> ms) {
+    if (ffi::reactor_poll(inner_, ms.value_or(-1)) != 0)
+        return false;
 
-	return true;
+    return true;
 }

--- a/src/core/reactor.h
+++ b/src/core/reactor.h
@@ -17,19 +17,18 @@
 #ifndef REACTOR_H
 #define REACTOR_H
 
-#include <optional>
 #include "rust/bindings.h"
+#include <optional>
 
-class Reactor
-{
+class Reactor {
 public:
-	Reactor(int registrationsMax);
-	~Reactor();
+    Reactor(int registrationsMax);
+    ~Reactor();
 
-	bool poll(std::optional<int> ms);
+    bool poll(std::optional<int> ms);
 
 private:
-	ffi::Reactor *inner_;
+    ffi::Reactor *inner_;
 };
 
 #endif

--- a/src/core/readwrite.h
+++ b/src/core/readwrite.h
@@ -20,23 +20,22 @@
 #include <QByteArray>
 #include <boost/signals2.hpp>
 
-class ReadWrite
-{
+class ReadWrite {
 public:
-	virtual ~ReadWrite() = default;
+    virtual ~ReadWrite() = default;
 
-	// Size < 0 means default read size
-	// returns buffer of bytes read. Null buffer means error. Empty means end
-	virtual QByteArray read(int size = -1) = 0;
+    // Size < 0 means default read size
+    // returns buffer of bytes read. Null buffer means error. Empty means end
+    virtual QByteArray read(int size = -1) = 0;
 
-	// Returns amount accepted, or -1 for error
-	virtual int write(const QByteArray &buf) = 0;
+    // Returns amount accepted, or -1 for error
+    virtual int write(const QByteArray &buf) = 0;
 
-	// Returns errno of latest operation
-	virtual int errorCondition() const = 0;
+    // Returns errno of latest operation
+    virtual int errorCondition() const = 0;
 
-	boost::signals2::signal<void()> readReady;
-	boost::signals2::signal<void()> writeReady;
+    boost::signals2::signal<void()> readReady;
+    boost::signals2::signal<void()> writeReady;
 };
 
 #endif

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -23,180 +23,146 @@
 
 #include "settings.h"
 
+#include "config.h"
+#include "qtcompat.h"
+#include "variant.h"
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QSettings>
-#include "qtcompat.h"
-#include "variant.h"
-#include "config.h"
 
-Settings::Settings(const QString &fileName) :
-	include_(0),
-	portOffset_(0)
-{
-	main_ = new QSettings(fileName, QSettings::IniFormat);
+Settings::Settings(const QString &fileName) : include_(0), portOffset_(0) {
+    main_ = new QSettings(fileName, QSettings::IniFormat);
 
-	libdir_ = valueRaw("global/libdir").toString();
-	if(libdir_.isEmpty())
-	{
-		if(QFile::exists("src/bin/pushpin.rs"))
-		{
-			// Running in tree
-			libdir_ = QFileInfo("src").absoluteFilePath();
-		}
-		else
-		{
-			// Use compiled value
-			libdir_ = Config::get().libDir;
-		}
-	}
+    libdir_ = valueRaw("global/libdir").toString();
+    if (libdir_.isEmpty()) {
+        if (QFile::exists("src/bin/pushpin.rs")) {
+            // Running in tree
+            libdir_ = QFileInfo("src").absoluteFilePath();
+        } else {
+            // Use compiled value
+            libdir_ = Config::get().libDir;
+        }
+    }
 
-	rundir_ = valueRaw("global/rundir").toString();
-	if(rundir_.isEmpty())
-	{
-		// Fallback to runner section (deprecated)
-		rundir_ = valueRaw("runner/rundir").toString();
-	}
+    rundir_ = valueRaw("global/rundir").toString();
+    if (rundir_.isEmpty()) {
+        // Fallback to runner section (deprecated)
+        rundir_ = valueRaw("runner/rundir").toString();
+    }
 
-	ipcPrefix_ = valueRaw("global/ipc_prefix", "pushpin-").toString();
-	portOffset_ = valueRaw("global/port_offset", 0).toInt();
+    ipcPrefix_ = valueRaw("global/ipc_prefix", "pushpin-").toString();
+    portOffset_ = valueRaw("global/port_offset", 0).toInt();
 
-	QString includeFile = valueRaw("global/include").toString();
+    QString includeFile = valueRaw("global/include").toString();
 
-	// if include is exactly "internal.conf", rewrite relative to libdir
-	// TODO: remove this hack at next major version
-	if(includeFile == "internal.conf")
-		includeFile = "{libdir}/internal.conf";
+    // if include is exactly "internal.conf", rewrite relative to libdir
+    // TODO: remove this hack at next major version
+    if (includeFile == "internal.conf")
+        includeFile = "{libdir}/internal.conf";
 
-	includeFile = resolveVars(includeFile);
+    includeFile = resolveVars(includeFile);
 
-	if(!includeFile.isEmpty())
-	{
-		// If include is a relative path, then use it relative to the config file location
-		QFileInfo fi(includeFile);
-		if(fi.isRelative())
-			includeFile = QFileInfo(QFileInfo(fileName).absoluteDir(), includeFile).filePath();
+    if (!includeFile.isEmpty()) {
+        // If include is a relative path, then use it relative to the config file
+        // location
+        QFileInfo fi(includeFile);
+        if (fi.isRelative())
+            includeFile = QFileInfo(QFileInfo(fileName).absoluteDir(), includeFile).filePath();
 
-		include_ = new QSettings(includeFile, QSettings::IniFormat);
-	}
+        include_ = new QSettings(includeFile, QSettings::IniFormat);
+    }
 }
 
-Settings::~Settings()
-{
-	delete include_;
-	delete main_;
+Settings::~Settings() {
+    delete include_;
+    delete main_;
 }
 
-QString Settings::resolveVars(const QString &in) const
-{
-	QString out = in;
-	out.replace("{libdir}", libdir_);
-	out.replace("{rundir}", rundir_);
-	out.replace("{ipc_prefix}", ipcPrefix_);
+QString Settings::resolveVars(const QString &in) const {
+    QString out = in;
+    out.replace("{libdir}", libdir_);
+    out.replace("{rundir}", rundir_);
+    out.replace("{ipc_prefix}", ipcPrefix_);
 
-	// Adjust tcp ports
-	int at = 0;
-	while(true)
-	{
-		at = out.indexOf("tcp://", at);
-		if(at == -1)
-			break;
+    // Adjust tcp ports
+    int at = 0;
+    while (true) {
+        at = out.indexOf("tcp://", at);
+        if (at == -1)
+            break;
 
-		at = out.indexOf(':', at + 6);
-		if(at == -1)
-			break;
+        at = out.indexOf(':', at + 6);
+        if (at == -1)
+            break;
 
-		int start = at + 1;
-		for(at = start; at < out.length(); ++at)
-		{
-			if(!out[at].isDigit())
-				break;
-		}
+        int start = at + 1;
+        for (at = start; at < out.length(); ++at) {
+            if (!out[at].isDigit())
+                break;
+        }
 
-		bool ok;
-		int x = out.mid(start, at - start).toInt(&ok);
-		if(!ok)
-			break;
+        bool ok;
+        int x = out.mid(start, at - start).toInt(&ok);
+        if (!ok)
+            break;
 
-		x += portOffset_;
+        x += portOffset_;
 
-		out.replace(start, at, QString::number(x));
-	}
+        out.replace(start, at, QString::number(x));
+    }
 
-	return out;
+    return out;
 }
 
-bool Settings::contains(const QString &key) const
-{
-	if(main_->contains(key))
-		return true;
+bool Settings::contains(const QString &key) const {
+    if (main_->contains(key))
+        return true;
 
-	if(include_)
-		return include_->contains(key);
+    if (include_)
+        return include_->contains(key);
 
-	return false;
+    return false;
 }
 
-Variant Settings::valueRaw(const QString &key, const Variant &defaultValue) const
-{
-	if(include_)
-	{
-		if(main_->contains(key))
-			return main_->value(key);
-		else
-			return include_->value(key, defaultValue);
-	}
-	else
-		return main_->value(key, defaultValue);
+Variant Settings::valueRaw(const QString &key, const Variant &defaultValue) const {
+    if (include_) {
+        if (main_->contains(key))
+            return main_->value(key);
+        else
+            return include_->value(key, defaultValue);
+    } else
+        return main_->value(key, defaultValue);
 }
 
-Variant Settings::value(const QString &key, const Variant &defaultValue) const
-{
-	Variant v = valueRaw(key, defaultValue);
-	if(v.isValid())
-	{
-		if(typeId(v) == VariantType::String)
-		{
-			v = resolveVars(v.toString());
-		}
-		else if(typeId(v) == VariantType::List)
-		{
-			QStringList oldList = v.toStringList();
-			QStringList newList;
-			foreach(QString s, oldList)
-				newList += resolveVars(s);
-			v = newList;
-		}
-	}
+Variant Settings::value(const QString &key, const Variant &defaultValue) const {
+    Variant v = valueRaw(key, defaultValue);
+    if (v.isValid()) {
+        if (typeId(v) == VariantType::String) {
+            v = resolveVars(v.toString());
+        } else if (typeId(v) == VariantType::List) {
+            QStringList oldList = v.toStringList();
+            QStringList newList;
+            foreach (QString s, oldList)
+                newList += resolveVars(s);
+            v = newList;
+        }
+    }
 
-	return v;
+    return v;
 }
 
-int Settings::adjustedPort(const QString &key, int defaultValue) const
-{
-	int x = value(key, Variant(defaultValue)).toInt();
-	if(x > 0)
-		x += portOffset_;
-	return x;
+int Settings::adjustedPort(const QString &key, int defaultValue) const {
+    int x = value(key, Variant(defaultValue)).toInt();
+    if (x > 0)
+        x += portOffset_;
+    return x;
 }
 
-QString Settings::ipcPrefix() const
-{
-	return ipcPrefix_;
-}
+QString Settings::ipcPrefix() const { return ipcPrefix_; }
 
-int Settings::portOffset() const
-{
-	return portOffset_;
-}
+int Settings::portOffset() const { return portOffset_; }
 
-void Settings::setIpcPrefix(const QString &s)
-{
-	ipcPrefix_ = s;
-}
+void Settings::setIpcPrefix(const QString &s) { ipcPrefix_ = s; }
 
-void Settings::setPortOffset(int x)
-{
-	portOffset_ = x;
-}
+void Settings::setPortOffset(int x) { portOffset_ = x; }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -23,37 +23,37 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-#include <QString>
 #include "variant.h"
+#include <QString>
 
 class QSettings;
 
-/// Stores the application settings loaded from the command line arguments and the config file
-class Settings
-{
+/// Stores the application settings loaded from the command line arguments and
+/// the config file
+class Settings {
 public:
-	Settings(const QString &fileName);
-	~Settings();
+    Settings(const QString &fileName);
+    ~Settings();
 
-	bool contains(const QString &key) const;
-	Variant valueRaw(const QString &key, const Variant &defaultValue = Variant()) const;
-	Variant value(const QString &key, const Variant &defaultValue = Variant()) const;
-	int adjustedPort(const QString &key, int defaultValue = -1) const;
+    bool contains(const QString &key) const;
+    Variant valueRaw(const QString &key, const Variant &defaultValue = Variant()) const;
+    Variant value(const QString &key, const Variant &defaultValue = Variant()) const;
+    int adjustedPort(const QString &key, int defaultValue = -1) const;
 
-	QString ipcPrefix() const;
-	int portOffset() const;
-	void setIpcPrefix(const QString &s);
-	void setPortOffset(int x);
+    QString ipcPrefix() const;
+    int portOffset() const;
+    void setIpcPrefix(const QString &s);
+    void setPortOffset(int x);
 
 private:
-	QSettings *main_;
-	QSettings *include_;
-	QString libdir_;
-	QString rundir_;
-	QString ipcPrefix_;
-	int portOffset_;
+    QSettings *main_;
+    QSettings *include_;
+    QString libdir_;
+    QString rundir_;
+    QString ipcPrefix_;
+    int portOffset_;
 
-	QString resolveVars(const QString &in) const;
+    QString resolveVars(const QString &in) const;
 };
 
 #endif

--- a/src/core/simplehttpserver.cpp
+++ b/src/core/simplehttpserver.cpp
@@ -23,650 +23,542 @@
 
 #include "simplehttpserver.h"
 
-#include <assert.h>
-#include <QFile>
-#include <QFileInfo>
-#include "log.h"
 #include "defercall.h"
+#include "httpheaders.h"
+#include "log.h"
 #include "tcplistener.h"
 #include "tcpstream.h"
 #include "unixlistener.h"
 #include "unixstream.h"
-#include "httpheaders.h"
+#include <QFile>
+#include <QFileInfo>
+#include <assert.h>
 
-class SimpleHttpRequest::Private
-{
+class SimpleHttpRequest::Private {
 public:
-	enum State
-	{
-		ReadHeader,
-		ReadBody,
-		WriteBody,
-		WaitForWritten,
-		Closed,
-		Finished,
-	};
+    enum State {
+        ReadHeader,
+        ReadBody,
+        WriteBody,
+        WaitForWritten,
+        Closed,
+        Finished,
+    };
 
-	SimpleHttpRequest *q;
-	std::unique_ptr<ReadWrite> stream;
-	State state;
-	QByteArray inBuf;
-	QByteArray outBuf;
-	bool version1dot0;
-	QString method;
-	QByteArray uri;
-	HttpHeaders reqHeaders;
-	QByteArray reqBody;
-	int contentLength;
-	int headersSizeMax;
-	int bodySizeMax;
-	DeferCall deferCall;
+    SimpleHttpRequest *q;
+    std::unique_ptr<ReadWrite> stream;
+    State state;
+    QByteArray inBuf;
+    QByteArray outBuf;
+    bool version1dot0;
+    QString method;
+    QByteArray uri;
+    HttpHeaders reqHeaders;
+    QByteArray reqBody;
+    int contentLength;
+    int headersSizeMax;
+    int bodySizeMax;
+    DeferCall deferCall;
 
-	Private(SimpleHttpRequest *_q, int headersSizeMax, int bodySizeMax) :
-		q(_q),
-		state(ReadHeader),
-		version1dot0(false),
-		contentLength(0),
-		headersSizeMax(headersSizeMax),
-		bodySizeMax(bodySizeMax)
-	{
-	}
+    Private(SimpleHttpRequest *_q, int headersSizeMax, int bodySizeMax)
+        : q(_q),
+          state(ReadHeader),
+          version1dot0(false),
+          contentLength(0),
+          headersSizeMax(headersSizeMax),
+          bodySizeMax(bodySizeMax) {}
 
-	~Private()
-	{
-		cleanup();
-	}
+    ~Private() { cleanup(); }
 
-	void cleanup()
-	{
-		stream.reset();
-	}
+    void cleanup() { stream.reset(); }
 
-	void start(std::unique_ptr<ReadWrite> _stream)
-	{
-		stream = std::move(_stream);
+    void start(std::unique_ptr<ReadWrite> _stream) {
+        stream = std::move(_stream);
 
-		stream->readReady.connect(boost::bind(&Private::stream_readReady, this));
-		stream->writeReady.connect(boost::bind(&Private::stream_writeReady, this));
+        stream->readReady.connect(boost::bind(&Private::stream_readReady, this));
+        stream->writeReady.connect(boost::bind(&Private::stream_writeReady, this));
 
-		deferCall.defer([&] { process(); });
-	}
+        deferCall.defer([&] { process(); });
+    }
 
-	void respond(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		if(state != WriteBody)
-			return;
+    void respond(int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body) {
+        if (state != WriteBody)
+            return;
 
-		HttpHeaders outHeaders = headers;
-		outHeaders.removeAll("Connection");
-		outHeaders.removeAll("Transfer-Encoding");
-		outHeaders.removeAll("Content-Length");
+        HttpHeaders outHeaders = headers;
+        outHeaders.removeAll("Connection");
+        outHeaders.removeAll("Transfer-Encoding");
+        outHeaders.removeAll("Content-Length");
 
-		outHeaders += HttpHeader("Connection", "close");
-		outHeaders += HttpHeader("Content-Length", QByteArray::number(body.size()));
+        outHeaders += HttpHeader("Connection", "close");
+        outHeaders += HttpHeader("Content-Length", QByteArray::number(body.size()));
 
-		QByteArray respData = "HTTP/";
-		if(version1dot0)
-			respData += "1.0 ";
-		else
-			respData += "1.1 ";
-		respData += QByteArray::number(code) + " " + reason + "\r\n";
-		foreach(const HttpHeader &h, outHeaders)
-			respData += (h.first + ": " + h.second + "\r\n").asQByteArray();
-		respData += "\r\n";
-		respData += body;
+        QByteArray respData = "HTTP/";
+        if (version1dot0)
+            respData += "1.0 ";
+        else
+            respData += "1.1 ";
+        respData += QByteArray::number(code) + " " + reason + "\r\n";
+        foreach (const HttpHeader &h, outHeaders)
+            respData += (h.first + ": " + h.second + "\r\n").asQByteArray();
+        respData += "\r\n";
+        respData += body;
 
-		state = WaitForWritten;
+        state = WaitForWritten;
 
-		outBuf += respData;
+        outBuf += respData;
 
-		deferCall.defer([&] { process(); });
-	}
+        deferCall.defer([&] { process(); });
+    }
 
-	void respond(int code, const QByteArray &reason, const QString &body)
-	{
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "text/plain");
+    void respond(int code, const QByteArray &reason, const QString &body) {
+        HttpHeaders headers;
+        headers += HttpHeader("Content-Type", "text/plain");
 
-		respond(code, reason, headers, body.toUtf8());
-	}
+        respond(code, reason, headers, body.toUtf8());
+    }
 
-	Signal ready;
+    Signal ready;
 
 private:
-	void respondError(int code, const QByteArray &reason, const QString &body)
-	{
-		state = WriteBody;
-		respond(code, reason, body + '\n');
-	}
+    void respondError(int code, const QByteArray &reason, const QString &body) {
+        state = WriteBody;
+        respond(code, reason, body + '\n');
+    }
 
-	void respondBadRequest(const QString &body)
-	{
-		respondError(400, "Bad Request", body);
-	}
+    void respondBadRequest(const QString &body) { respondError(400, "Bad Request", body); }
 
-	void respondLengthRequired(const QString &body)
-	{
-		respondError(411, "Length Required", body);
-	}
+    void respondLengthRequired(const QString &body) { respondError(411, "Length Required", body); }
 
-	bool processHeaderData(const QByteArray &headerData)
-	{
-		QList<QByteArray> lines;
-		int at = 0;
-		while(at < headerData.size())
-		{
-			int end = headerData.indexOf("\n", at);
-			assert(end != -1);
+    bool processHeaderData(const QByteArray &headerData) {
+        QList<QByteArray> lines;
+        int at = 0;
+        while (at < headerData.size()) {
+            int end = headerData.indexOf("\n", at);
+            assert(end != -1);
 
-			if(end > at && headerData[end - 1] == '\r')
-				lines += headerData.mid(at, end - at - 1);
-			else
-				lines += headerData.mid(at, end - at);
-			at = end + 1;
-		}
+            if (end > at && headerData[end - 1] == '\r')
+                lines += headerData.mid(at, end - at - 1);
+            else
+                lines += headerData.mid(at, end - at);
+            at = end + 1;
+        }
 
-		if(lines.isEmpty())
-			return false;
+        if (lines.isEmpty())
+            return false;
 
-		QByteArray requestLine = lines[0];
+        QByteArray requestLine = lines[0];
 
-		at = requestLine.indexOf(' ');
-		if(at == -1)
-			return false;
+        at = requestLine.indexOf(' ');
+        if (at == -1)
+            return false;
 
-		method = QString::fromLatin1(requestLine.mid(0, at));
-		if(method.isEmpty())
-			return false;
+        method = QString::fromLatin1(requestLine.mid(0, at));
+        if (method.isEmpty())
+            return false;
 
-		++at;
-		int end = requestLine.indexOf(' ', at);
-		if(end == -1)
-			return false;
+        ++at;
+        int end = requestLine.indexOf(' ', at);
+        if (end == -1)
+            return false;
 
-		uri = requestLine.mid(at, end - at);
+        uri = requestLine.mid(at, end - at);
 
-		QByteArray versionStr = requestLine.mid(end + 1);
-		if(versionStr == "HTTP/1.0")
-			version1dot0 = true;
+        QByteArray versionStr = requestLine.mid(end + 1);
+        if (versionStr == "HTTP/1.0")
+            version1dot0 = true;
 
-		for(int n = 1; n < lines.count(); ++n)
-		{
-			const QByteArray &line = lines[n];
-			end = line.indexOf(':');
-			if(end == -1)
-				continue;
+        for (int n = 1; n < lines.count(); ++n) {
+            const QByteArray &line = lines[n];
+            end = line.indexOf(':');
+            if (end == -1)
+                continue;
 
-			// Skip first space
-			at = end + 1;
-			if(at < line.length() && line[at] == ' ')
-				++at;
+            // Skip first space
+            at = end + 1;
+            if (at < line.length() && line[at] == ' ')
+                ++at;
 
-			QByteArray name = line.mid(0, end);
-			QByteArray val = line.mid(at);
+            QByteArray name = line.mid(0, end);
+            QByteArray val = line.mid(at);
 
-			reqHeaders += HttpHeader(name, val);
-		}
+            reqHeaders += HttpHeader(name, val);
+        }
 
-		//log_debug("httpserver: IN method=[%s] uri=[%s] 1.1=%s", qPrintable(method), uri.data(), version1dot0 ? "no" : "yes");
-		//foreach(const HttpHeader &h, reqHeaders)
-		//	log_debug("httpserver:   [%s] [%s]", h.first.data(), h.second.data());
-		log_debug("httpserver: IN %s %s", qPrintable(method), uri.data());
+        // log_debug("httpserver: IN method=[%s] uri=[%s] 1.1=%s",
+        // qPrintable(method), uri.data(), version1dot0 ? "no" : "yes");
+        // foreach(const HttpHeader &h, reqHeaders)
+        //	log_debug("httpserver:   [%s] [%s]", h.first.data(), h.second.data());
+        log_debug("httpserver: IN %s %s", qPrintable(method), uri.data());
 
-		return true;
-	}
+        return true;
+    }
 
-	void error(const QString &msg)
-	{
-		log_debug("httpserver error: %s", qPrintable(msg));
+    void error(const QString &msg) {
+        log_debug("httpserver error: %s", qPrintable(msg));
 
-		doFinish();
-	}
+        doFinish();
+    }
 
-	void doFinish()
-	{
-		cleanup();
-		state = Closed;
-	}
+    void doFinish() {
+        cleanup();
+        state = Closed;
+    }
 
-	// Return false if more I/O needed to make progress
-	bool step()
-	{
-		if(state == ReadHeader)
-		{
-			QByteArray buf = stream->read(headersSizeMax - inBuf.size());
+    // Return false if more I/O needed to make progress
+    bool step() {
+        if (state == ReadHeader) {
+            QByteArray buf = stream->read(headersSizeMax - inBuf.size());
 
-			if(buf.isNull())
-			{
-				int e = stream->errorCondition();
-				if(e == EAGAIN)
-					return false;
+            if (buf.isNull()) {
+                int e = stream->errorCondition();
+                if (e == EAGAIN)
+                    return false;
 
-				error(QString("read error: %1").arg(e));
-				return true;
-			}
+                error(QString("read error: %1").arg(e));
+                return true;
+            }
 
-			if(buf.isEmpty())
-			{
-				error("client closed unexpectedly");
-				return true;
-			}
+            if (buf.isEmpty()) {
+                error("client closed unexpectedly");
+                return true;
+            }
 
-			inBuf += buf;
+            inBuf += buf;
 
-			// Look for double newline
-			int at = -1;
-			int next = 0;
-			for(int n = 0; n < inBuf.size(); ++n)
-			{
-				if(n + 1 < inBuf.size() && qstrncmp(inBuf.data() + n, "\n\n", 2) == 0)
-				{
-					at = n + 1;
-					next = n + 2;
-					break;
-				}
-				else if(n + 2 < inBuf.size() && qstrncmp(inBuf.data() + n, "\n\r\n", 3) == 0)
-				{
-					at = n + 1;
-					next = n + 3;
-					break;
-				}
-			}
+            // Look for double newline
+            int at = -1;
+            int next = 0;
+            for (int n = 0; n < inBuf.size(); ++n) {
+                if (n + 1 < inBuf.size() && qstrncmp(inBuf.data() + n, "\n\n", 2) == 0) {
+                    at = n + 1;
+                    next = n + 2;
+                    break;
+                } else if (n + 2 < inBuf.size() && qstrncmp(inBuf.data() + n, "\n\r\n", 3) == 0) {
+                    at = n + 1;
+                    next = n + 3;
+                    break;
+                }
+            }
 
-			if(at != -1)
-			{
-				QByteArray headerData = inBuf.mid(0, at);
-				reqBody = inBuf.mid(next);
-				inBuf.clear();
+            if (at != -1) {
+                QByteArray headerData = inBuf.mid(0, at);
+                reqBody = inBuf.mid(next);
+                inBuf.clear();
 
-				if(!processHeaderData(headerData))
-				{
-					respondBadRequest("Failed to parse request header.");
-					return true;
-				}
+                if (!processHeaderData(headerData)) {
+                    respondBadRequest("Failed to parse request header.");
+                    return true;
+                }
 
-				bool methodAssumesBody = (method != "HEAD" && method != "GET" && method != "DELETE" && method != "OPTIONS");
-				if(!reqHeaders.contains("Content-Length") && (reqHeaders.contains("Transfer-Encoding") || methodAssumesBody))
-				{
-					respondLengthRequired("Request requires Content-Length.");
-					return true;
-				}
+                bool methodAssumesBody = (method != "HEAD" && method != "GET" &&
+                                          method != "DELETE" && method != "OPTIONS");
+                if (!reqHeaders.contains("Content-Length") &&
+                    (reqHeaders.contains("Transfer-Encoding") || methodAssumesBody)) {
+                    respondLengthRequired("Request requires Content-Length.");
+                    return true;
+                }
 
-				if(reqHeaders.contains("Content-Length"))
-				{
-					bool ok;
-					contentLength = reqHeaders.get("Content-Length").asQByteArray().toInt(&ok);
-					if(!ok)
-					{
-						respondBadRequest("Bad Content-Length.");
-						return true;
-					}
+                if (reqHeaders.contains("Content-Length")) {
+                    bool ok;
+                    contentLength = reqHeaders.get("Content-Length").asQByteArray().toInt(&ok);
+                    if (!ok) {
+                        respondBadRequest("Bad Content-Length.");
+                        return true;
+                    }
 
-					if(contentLength > bodySizeMax)
-					{
-						respondBadRequest("Request body too large.");
-						return true;
-					}
+                    if (contentLength > bodySizeMax) {
+                        respondBadRequest("Request body too large.");
+                        return true;
+                    }
 
-					if(reqHeaders.get("Expect") == "100-continue")
-					{
-						QByteArray respData = "HTTP/";
-						if(version1dot0)
-							respData += "1.0 ";
-						else
-							respData += "1.1 ";
-						respData += "100 Continue\r\n\r\n";
+                    if (reqHeaders.get("Expect") == "100-continue") {
+                        QByteArray respData = "HTTP/";
+                        if (version1dot0)
+                            respData += "1.0 ";
+                        else
+                            respData += "1.1 ";
+                        respData += "100 Continue\r\n\r\n";
 
-						outBuf += respData;
-					}
+                        outBuf += respData;
+                    }
 
-					state = ReadBody;
-					return true;
-				}
-				else
-				{
-					state = WriteBody;
-					ready();
-				}
-			}
-			else if(inBuf.size() >= headersSizeMax)
-			{
-				inBuf.clear();
-				respondBadRequest("Request header too large.");
-				return true;
-			}
-		}
-		else if(state == ReadBody)
-		{
-			// Write 100 continue
-			if(!outBuf.isEmpty())
-			{
-				int ret = stream->write(outBuf);
+                    state = ReadBody;
+                    return true;
+                } else {
+                    state = WriteBody;
+                    ready();
+                }
+            } else if (inBuf.size() >= headersSizeMax) {
+                inBuf.clear();
+                respondBadRequest("Request header too large.");
+                return true;
+            }
+        } else if (state == ReadBody) {
+            // Write 100 continue
+            if (!outBuf.isEmpty()) {
+                int ret = stream->write(outBuf);
 
-				if(ret < 0)
-				{
-					int e = stream->errorCondition();
-					if(e == EAGAIN)
-						return false;
+                if (ret < 0) {
+                    int e = stream->errorCondition();
+                    if (e == EAGAIN)
+                        return false;
 
-					error(QString("write error: %1").arg(e));
-					return true;
-				}
+                    error(QString("write error: %1").arg(e));
+                    return true;
+                }
 
-				outBuf = outBuf.mid(ret);
-				return true;
-			}
+                outBuf = outBuf.mid(ret);
+                return true;
+            }
 
-			if(reqBody.size() < contentLength)
-			{
-				QByteArray buf = stream->read(bodySizeMax - reqBody.size() + 1);
+            if (reqBody.size() < contentLength) {
+                QByteArray buf = stream->read(bodySizeMax - reqBody.size() + 1);
 
-				if(buf.isNull())
-				{
-					int e = stream->errorCondition();
-					if(e == EAGAIN)
-						return false;
+                if (buf.isNull()) {
+                    int e = stream->errorCondition();
+                    if (e == EAGAIN)
+                        return false;
 
-					error(QString("read error: %1").arg(e));
-					return true;
-				}
+                    error(QString("read error: %1").arg(e));
+                    return true;
+                }
 
-				if(buf.isEmpty())
-				{
-					error("client closed unexpectedly");
-					return true;
-				}
+                if (buf.isEmpty()) {
+                    error("client closed unexpectedly");
+                    return true;
+                }
 
-				reqBody += buf;
-			}
+                reqBody += buf;
+            }
 
-			if(reqBody.size() > contentLength)
-			{
-				respondBadRequest("Request body exceeded Content-Length.");
-				return true;
-			}
+            if (reqBody.size() > contentLength) {
+                respondBadRequest("Request body exceeded Content-Length.");
+                return true;
+            }
 
-			if(reqBody.size() == contentLength)
-			{
-				state = WriteBody;
-				ready();
-			}
-		}
-		else if(state == WaitForWritten)
-		{
-			if(outBuf.isEmpty())
-			{
-				doFinish();
-				return true;
-			}
+            if (reqBody.size() == contentLength) {
+                state = WriteBody;
+                ready();
+            }
+        } else if (state == WaitForWritten) {
+            if (outBuf.isEmpty()) {
+                doFinish();
+                return true;
+            }
 
-			int ret = stream->write(outBuf);
+            int ret = stream->write(outBuf);
 
-			if(ret < 0)
-			{
-				int e = stream->errorCondition();
-				if(e == EAGAIN)
-					return false;
+            if (ret < 0) {
+                int e = stream->errorCondition();
+                if (e == EAGAIN)
+                    return false;
 
-				error(QString("write error: %1").arg(e));
-				return true;
-			}
+                error(QString("write error: %1").arg(e));
+                return true;
+            }
 
-			outBuf = outBuf.mid(ret);
-		}
+            outBuf = outBuf.mid(ret);
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	void process()
-	{
-		while((state == ReadHeader || state == ReadBody || state == WaitForWritten) && step()) {}
+    void process() {
+        while ((state == ReadHeader || state == ReadBody || state == WaitForWritten) && step()) {
+        }
 
-		if(state == Closed)
-		{
-			state = Finished;
-			q->finished();
-		}
-	}
+        if (state == Closed) {
+            state = Finished;
+            q->finished();
+        }
+    }
 
-	void stream_readReady()
-	{
-		process();
-	}
+    void stream_readReady() { process(); }
 
-	void stream_writeReady()
-	{
-		process();
-	}
+    void stream_writeReady() { process(); }
 };
 
-SimpleHttpRequest::SimpleHttpRequest(int headersSizeMax, int bodySizeMax)
-{
-	d = new Private(this, headersSizeMax, bodySizeMax);
+SimpleHttpRequest::SimpleHttpRequest(int headersSizeMax, int bodySizeMax) {
+    d = new Private(this, headersSizeMax, bodySizeMax);
 }
 
-SimpleHttpRequest::~SimpleHttpRequest()
-{
-	delete d;
+SimpleHttpRequest::~SimpleHttpRequest() { delete d; }
+
+QString SimpleHttpRequest::requestMethod() const { return d->method; }
+
+QByteArray SimpleHttpRequest::requestUri() const { return d->uri; }
+
+HttpHeaders SimpleHttpRequest::requestHeaders() const { return d->reqHeaders; }
+
+QByteArray SimpleHttpRequest::requestBody() const { return d->reqBody; }
+
+void SimpleHttpRequest::respond(int code, const QByteArray &reason, const HttpHeaders &headers,
+                                const QByteArray &body) {
+    d->respond(code, reason, headers, body);
 }
 
-QString SimpleHttpRequest::requestMethod() const
-{
-	return d->method;
+void SimpleHttpRequest::respond(int code, const QByteArray &reason, const QString &body) {
+    d->respond(code, reason, body);
 }
 
-QByteArray SimpleHttpRequest::requestUri() const
-{
-	return d->uri;
-}
-
-HttpHeaders SimpleHttpRequest::requestHeaders() const
-{
-	return d->reqHeaders;
-}
-
-QByteArray SimpleHttpRequest::requestBody() const
-{
-	return d->reqBody;
-}
-
-void SimpleHttpRequest::respond(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	d->respond(code, reason, headers, body);
-}
-
-void SimpleHttpRequest::respond(int code, const QByteArray &reason, const QString &body)
-{
-	d->respond(code, reason, body);
-}
-
-class SimpleHttpServerPrivate
-{
+class SimpleHttpServerPrivate {
 public:
-	SimpleHttpServer *q;
-	void *listener;
-	bool local;
-	QSet<SimpleHttpRequest*> accepting;
-	QList<SimpleHttpRequest*> pending;
-	QSet<SimpleHttpRequest*> active;
-	int connectionsMax;
-	int headersSizeMax;
-	int bodySizeMax;
-	map<SimpleHttpRequest*, Connection> finishedConnections;
-	map<SimpleHttpRequest*, Connection> readyConnections;
-	DeferCall deferCall;
+    SimpleHttpServer *q;
+    void *listener;
+    bool local;
+    QSet<SimpleHttpRequest *> accepting;
+    QList<SimpleHttpRequest *> pending;
+    QSet<SimpleHttpRequest *> active;
+    int connectionsMax;
+    int headersSizeMax;
+    int bodySizeMax;
+    map<SimpleHttpRequest *, Connection> finishedConnections;
+    map<SimpleHttpRequest *, Connection> readyConnections;
+    DeferCall deferCall;
 
-	SimpleHttpServerPrivate(int connectionsMax, int headersSizeMax, int bodySizeMax, SimpleHttpServer *_q) :
-		q(_q),
-		listener(nullptr),
-		local(false),
-		connectionsMax(connectionsMax),
-		headersSizeMax(headersSizeMax),
-		bodySizeMax(bodySizeMax)
-	{
-	}
+    SimpleHttpServerPrivate(int connectionsMax, int headersSizeMax, int bodySizeMax,
+                            SimpleHttpServer *_q)
+        : q(_q),
+          listener(nullptr),
+          local(false),
+          connectionsMax(connectionsMax),
+          headersSizeMax(headersSizeMax),
+          bodySizeMax(bodySizeMax) {}
 
-	~SimpleHttpServerPrivate()
-	{
-		qDeleteAll(pending);
-		qDeleteAll(accepting);
+    ~SimpleHttpServerPrivate() {
+        qDeleteAll(pending);
+        qDeleteAll(accepting);
 
-		if(listener)
-		{
-			if(local)
-				delete ((UnixListener *)listener);
-			else
-				delete ((TcpListener *)listener);
-		}
-	}
+        if (listener) {
+            if (local)
+                delete ((UnixListener *)listener);
+            else
+                delete ((TcpListener *)listener);
+        }
+    }
 
-	bool canAccept() const
-	{
-		return (accepting.count() + pending.count() + active.count() < connectionsMax);
-	}
+    bool canAccept() const {
+        return (accepting.count() + pending.count() + active.count() < connectionsMax);
+    }
 
-	bool listen(const QHostAddress &addr, int port)
-	{
-		assert(!listener);
+    bool listen(const QHostAddress &addr, int port) {
+        assert(!listener);
 
-		TcpListener *l = new TcpListener;
-		l->streamsReady.connect(boost::bind(&SimpleHttpServerPrivate::listener_streamsReady, this));
-		if(!l->bind(addr, port))
-		{
-			delete l;
+        TcpListener *l = new TcpListener;
+        l->streamsReady.connect(boost::bind(&SimpleHttpServerPrivate::listener_streamsReady, this));
+        if (!l->bind(addr, port)) {
+            delete l;
 
-			return false;
-		}
+            return false;
+        }
 
-		listener = l;
-		local = false;
+        listener = l;
+        local = false;
 
-		deferCall.defer([&] { listener_streamsReady(); });
+        deferCall.defer([&] { listener_streamsReady(); });
 
-		return true;
-	}
+        return true;
+    }
 
-	bool listenLocal(const QString &name)
-	{
-		assert(!listener);
+    bool listenLocal(const QString &name) {
+        assert(!listener);
 
-		QFileInfo fi(name);
-		QString filePath = fi.absoluteFilePath();
+        QFileInfo fi(name);
+        QString filePath = fi.absoluteFilePath();
 
-		QFile::remove(filePath);
+        QFile::remove(filePath);
 
-		UnixListener *l = new UnixListener;
-		l->streamsReady.connect(boost::bind(&SimpleHttpServerPrivate::listener_streamsReady, this));
-		if(!l->bind(name))
-		{
-			delete l;
+        UnixListener *l = new UnixListener;
+        l->streamsReady.connect(boost::bind(&SimpleHttpServerPrivate::listener_streamsReady, this));
+        if (!l->bind(name)) {
+            delete l;
 
-			return false;
-		}
+            return false;
+        }
 
-		listener = l;
-		local = true;
+        listener = l;
+        local = true;
 
-		deferCall.defer([&] { listener_streamsReady(); });
+        deferCall.defer([&] { listener_streamsReady(); });
 
-		return true;
-	}
+        return true;
+    }
 
-	void listener_streamsReady()
-	{
-		while(canAccept())
-		{
-			std::unique_ptr<ReadWrite> s;
+    void listener_streamsReady() {
+        while (canAccept()) {
+            std::unique_ptr<ReadWrite> s;
 
-			if(local)
-			{
-				UnixListener *l = (UnixListener *)listener;
-				s = l->accept();
-				if(!s && l->errorCondition() == EAGAIN)
-					break;
-			}
-			else
-			{
-				TcpListener *l = (TcpListener *)listener;
-				s = l->accept();
-				if(!s && l->errorCondition() == EAGAIN)
-					break;
-			}
+            if (local) {
+                UnixListener *l = (UnixListener *)listener;
+                s = l->accept();
+                if (!s && l->errorCondition() == EAGAIN)
+                    break;
+            } else {
+                TcpListener *l = (TcpListener *)listener;
+                s = l->accept();
+                if (!s && l->errorCondition() == EAGAIN)
+                    break;
+            }
 
-			if(s)
-			{
-				SimpleHttpRequest *req = new SimpleHttpRequest(headersSizeMax, bodySizeMax);
-				readyConnections[req] = req->d->ready.connect(boost::bind(&SimpleHttpServerPrivate::req_ready, this, req->d->q));
-				finishedConnections[req] = req->finished.connect(boost::bind(&SimpleHttpServerPrivate::req_finished, this, req));
-				accepting += req;
-				req->d->start(std::move(s));
-			}
-		}
-	}
+            if (s) {
+                SimpleHttpRequest *req = new SimpleHttpRequest(headersSizeMax, bodySizeMax);
+                readyConnections[req] = req->d->ready.connect(
+                    boost::bind(&SimpleHttpServerPrivate::req_ready, this, req->d->q));
+                finishedConnections[req] = req->finished.connect(
+                    boost::bind(&SimpleHttpServerPrivate::req_finished, this, req));
+                accepting += req;
+                req->d->start(std::move(s));
+            }
+        }
+    }
 
-	void req_ready(SimpleHttpRequest *req)
-	{
-		accepting.remove(req);
-		pending += req;
+    void req_ready(SimpleHttpRequest *req) {
+        accepting.remove(req);
+        pending += req;
 
-		q->requestReady();
-	}
+        q->requestReady();
+    }
 
-	void req_finished(SimpleHttpRequest *req)
-	{
-		bool del = false;
+    void req_finished(SimpleHttpRequest *req) {
+        bool del = false;
 
-		if(active.contains(req))
-		{
-			active.remove(req);
-		}
-		else
-		{
-			pending.removeAll(req);
-			accepting.remove(req);
-			del = true;
-		}
+        if (active.contains(req)) {
+            active.remove(req);
+        } else {
+            pending.removeAll(req);
+            accepting.remove(req);
+            del = true;
+        }
 
-		readyConnections.erase(req);
-		finishedConnections.erase(req);
+        readyConnections.erase(req);
+        finishedConnections.erase(req);
 
-		if(del)
-			delete req;
+        if (del)
+            delete req;
 
-		// Try to accept more
-		listener_streamsReady();
-	}
+        // Try to accept more
+        listener_streamsReady();
+    }
 };
 
-SimpleHttpServer::SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax)
-{
-	d = new SimpleHttpServerPrivate(connectionsMax, headersSizeMax, bodySizeMax, this);
+SimpleHttpServer::SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax) {
+    d = new SimpleHttpServerPrivate(connectionsMax, headersSizeMax, bodySizeMax, this);
 }
 
-SimpleHttpServer::~SimpleHttpServer()
-{
-	delete d;
-}
+SimpleHttpServer::~SimpleHttpServer() { delete d; }
 
-bool SimpleHttpServer::listen(const QHostAddress &addr, int port)
-{
-	return d->listen(addr, port);
-}
+bool SimpleHttpServer::listen(const QHostAddress &addr, int port) { return d->listen(addr, port); }
 
-bool SimpleHttpServer::listenLocal(const QString &name)
-{
-	return d->listenLocal(name);
-}
+bool SimpleHttpServer::listenLocal(const QString &name) { return d->listenLocal(name); }
 
-SimpleHttpRequest *SimpleHttpServer::takeNext()
-{
-	if(!d->pending.isEmpty())
-	{
-		SimpleHttpRequest *req = d->pending.takeFirst();
-		d->active += req;
+SimpleHttpRequest *SimpleHttpServer::takeNext() {
+    if (!d->pending.isEmpty()) {
+        SimpleHttpRequest *req = d->pending.takeFirst();
+        d->active += req;
 
-		return req;
-	}
-	else
-		return nullptr;
+        return req;
+    } else
+        return nullptr;
 }

--- a/src/core/simplehttpserver.h
+++ b/src/core/simplehttpserver.h
@@ -38,45 +38,44 @@ class HttpHeaders;
 
 class SimpleHttpServerPrivate;
 
-class SimpleHttpRequest
-{
+class SimpleHttpRequest {
 public:
-	~SimpleHttpRequest();
+    ~SimpleHttpRequest();
 
-	QString requestMethod() const;
-	QByteArray requestUri() const;
-	HttpHeaders requestHeaders() const;
-	QByteArray requestBody() const;
+    QString requestMethod() const;
+    QByteArray requestUri() const;
+    HttpHeaders requestHeaders() const;
+    QByteArray requestBody() const;
 
-	void respond(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
-	void respond(int code, const QByteArray &reason, const QString &body);
+    void respond(int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body);
+    void respond(int code, const QByteArray &reason, const QString &body);
 
-	Signal finished;
+    Signal finished;
 
 private:
-	class Private;
-	friend class Private;
-	friend class SimpleHttpServerPrivate;
-	Private *d;
+    class Private;
+    friend class Private;
+    friend class SimpleHttpServerPrivate;
+    Private *d;
 
-	SimpleHttpRequest(int headersSizeMax, int bodySizeMax);
+    SimpleHttpRequest(int headersSizeMax, int bodySizeMax);
 };
 
-class SimpleHttpServer
-{
+class SimpleHttpServer {
 public:
-	SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax);
-	~SimpleHttpServer();
+    SimpleHttpServer(int connectionsMax, int headersSizeMax, int bodySizeMax);
+    ~SimpleHttpServer();
 
-	bool listen(const QHostAddress &addr, int port);
-	bool listenLocal(const QString &name);
-	SimpleHttpRequest *takeNext();
+    bool listen(const QHostAddress &addr, int port);
+    bool listenLocal(const QString &name);
+    SimpleHttpRequest *takeNext();
 
-	Signal requestReady;
+    Signal requestReady;
 
 private:
-	friend class SimpleHttpServerPrivate;
-	SimpleHttpServerPrivate *d;
+    friend class SimpleHttpServerPrivate;
+    SimpleHttpServerPrivate *d;
 };
 
 #endif

--- a/src/core/socketnotifier.cpp
+++ b/src/core/socketnotifier.cpp
@@ -16,162 +16,141 @@
 
 #include "socketnotifier.h"
 
-#include <assert.h>
 #include "defercall.h"
 #include "event.h"
 #include "eventloop.h"
+#include <assert.h>
 
-SocketNotifier::SocketNotifier(int socket, uint8_t interest) :
-	socket_(socket),
-	readEnabled_(true),
-	writeEnabled_(true),
-	readInner_(nullptr),
-	writeInner_(nullptr),
-	readiness_(0),
-	loop_(EventLoop::instance()),
-	regId_(-1)
-{
-	assert((interest & Read) || (interest & Write));
+SocketNotifier::SocketNotifier(int socket, uint8_t interest)
+    : socket_(socket),
+      readEnabled_(true),
+      writeEnabled_(true),
+      readInner_(nullptr),
+      writeInner_(nullptr),
+      readiness_(0),
+      loop_(EventLoop::instance()),
+      regId_(-1) {
+    assert((interest & Read) || (interest & Write));
 
-	// Start by assuming ready
-	readiness_ = interest;
+    // Start by assuming ready
+    readiness_ = interest;
 
-	if(loop_)
-	{
-		// If the rust-based eventloop is available, use it
+    if (loop_) {
+        // If the rust-based eventloop is available, use it
 
-		uint8_t einterest = 0;
+        uint8_t einterest = 0;
 
-		if(interest & Read)
-			einterest |= Event::Readable;
+        if (interest & Read)
+            einterest |= Event::Readable;
 
-		if(interest & Write)
-			einterest |= Event::Writable;
+        if (interest & Write)
+            einterest |= Event::Writable;
 
-		regId_ = loop_->registerFd(socket_, einterest, SocketNotifier::cb_fd_activated, this);
-		assert(regId_ >= 0);
-	}
-	else
-	{
-		// Else fall back to qt eventloop
+        regId_ = loop_->registerFd(socket_, einterest, SocketNotifier::cb_fd_activated, this);
+        assert(regId_ >= 0);
+    } else {
+        // Else fall back to qt eventloop
 
-		if(interest & Read)
-		{
-			readInner_ = new QSocketNotifier(socket, QSocketNotifier::Read);
-			readInnerConnection_ = QObject::connect(readInner_, &QSocketNotifier::activated, [=](int socket) {
-				innerReadActivated(socket);
-			});
+        if (interest & Read) {
+            readInner_ = new QSocketNotifier(socket, QSocketNotifier::Read);
+            readInnerConnection_ =
+                QObject::connect(readInner_, &QSocketNotifier::activated,
+                                 [=](int socket) { innerReadActivated(socket); });
 
-			// Start out disabled. Will enable when initial readiness cleared
-			readInner_->setEnabled(false);
-		}
+            // Start out disabled. Will enable when initial readiness cleared
+            readInner_->setEnabled(false);
+        }
 
-		if(interest & Write)
-		{
-			writeInner_ = new QSocketNotifier(socket, QSocketNotifier::Write);
-			writeInnerConnection_ = QObject::connect(writeInner_, &QSocketNotifier::activated, [=](int socket) {
-				innerWriteActivated(socket);
-			});
+        if (interest & Write) {
+            writeInner_ = new QSocketNotifier(socket, QSocketNotifier::Write);
+            writeInnerConnection_ =
+                QObject::connect(writeInner_, &QSocketNotifier::activated,
+                                 [=](int socket) { innerWriteActivated(socket); });
 
-			// Start out disabled. Will enable when initial readiness cleared
-			writeInner_->setEnabled(false);
-		}
-	}
+            // Start out disabled. Will enable when initial readiness cleared
+            writeInner_->setEnabled(false);
+        }
+    }
 }
 
-SocketNotifier::~SocketNotifier()
-{
-	if(readInner_)
-	{
-		readInner_->setEnabled(false);
+SocketNotifier::~SocketNotifier() {
+    if (readInner_) {
+        readInner_->setEnabled(false);
 
-		QObject::disconnect(readInnerConnection_);
-		readInner_->setParent(0);
-		DeferCall::deleteLater(readInner_);
-	}
+        QObject::disconnect(readInnerConnection_);
+        readInner_->setParent(0);
+        DeferCall::deleteLater(readInner_);
+    }
 
-	if(writeInner_)
-	{
-		writeInner_->setEnabled(false);
+    if (writeInner_) {
+        writeInner_->setEnabled(false);
 
-		QObject::disconnect(writeInnerConnection_);
-		writeInner_->setParent(0);
-		DeferCall::deleteLater(writeInner_);
-	}
+        QObject::disconnect(writeInnerConnection_);
+        writeInner_->setParent(0);
+        DeferCall::deleteLater(writeInner_);
+    }
 
-	if(regId_ >= 0)
-		loop_->deregister(regId_);
+    if (regId_ >= 0)
+        loop_->deregister(regId_);
 }
 
-void SocketNotifier::setReadEnabled(bool enable)
-{
-	readEnabled_ = enable;
+void SocketNotifier::setReadEnabled(bool enable) { readEnabled_ = enable; }
+
+void SocketNotifier::setWriteEnabled(bool enable) { writeEnabled_ = enable; }
+
+void SocketNotifier::clearReadiness(uint8_t readiness) {
+    readiness_ &= ~readiness;
+
+    if (readInner_ && !(readiness_ & Read))
+        readInner_->setEnabled(true);
+
+    if (writeInner_ && !(readiness_ & Write))
+        writeInner_->setEnabled(true);
 }
 
-void SocketNotifier::setWriteEnabled(bool enable)
-{
-	writeEnabled_ = enable;
+void SocketNotifier::innerReadActivated(int socket) {
+    Q_UNUSED(socket);
+
+    // QSocketNotifier is level-triggered. Disable until readiness cleared
+    readInner_->setEnabled(false);
+
+    apply(Read);
 }
 
-void SocketNotifier::clearReadiness(uint8_t readiness)
-{
-	readiness_ &= ~readiness;
+void SocketNotifier::innerWriteActivated(int socket) {
+    Q_UNUSED(socket);
 
-	if(readInner_ && !(readiness_ & Read))
-		readInner_->setEnabled(true);
+    // QSocketNotifier is level-triggered. Disable until readiness cleared
+    writeInner_->setEnabled(false);
 
-	if(writeInner_ && !(readiness_ & Write))
-		writeInner_->setEnabled(true);
+    apply(Write);
 }
 
-void SocketNotifier::innerReadActivated(int socket)
-{
-	Q_UNUSED(socket);
+void SocketNotifier::apply(uint8_t readiness) {
+    // Calculate which bits went from 0->1
+    uint8_t changes = readiness & ~readiness_;
 
-	// QSocketNotifier is level-triggered. Disable until readiness cleared
-	readInner_->setEnabled(false);
+    readiness_ |= readiness;
 
-	apply(Read);
+    if ((readEnabled_ && (changes & Read)) || (writeEnabled_ && (changes & Write)))
+        activated(socket_, changes);
 }
 
-void SocketNotifier::innerWriteActivated(int socket)
-{
-	Q_UNUSED(socket);
+void SocketNotifier::cb_fd_activated(void *ctx, uint8_t ereadiness) {
+    SocketNotifier *self = (SocketNotifier *)ctx;
 
-	// QSocketNotifier is level-triggered. Disable until readiness cleared
-	writeInner_->setEnabled(false);
-
-	apply(Write);
+    self->fd_activated(ereadiness);
 }
 
-void SocketNotifier::apply(uint8_t readiness)
-{
-	// Calculate which bits went from 0->1
-	uint8_t changes = readiness & ~readiness_;
+void SocketNotifier::fd_activated(uint8_t ereadiness) {
+    uint8_t readiness = 0;
 
-	readiness_ |= readiness;
+    if (ereadiness & Event::Readable)
+        readiness |= Read;
 
-	if((readEnabled_ && (changes & Read)) || (writeEnabled_ && (changes & Write)))
-		activated(socket_, changes);
-}
+    if (ereadiness & Event::Writable)
+        readiness |= Write;
 
-void SocketNotifier::cb_fd_activated(void *ctx, uint8_t ereadiness)
-{
-	SocketNotifier *self = (SocketNotifier *)ctx;
-
-	self->fd_activated(ereadiness);
-}
-
-void SocketNotifier::fd_activated(uint8_t ereadiness)
-{
-	uint8_t readiness = 0;
-
-	if(ereadiness & Event::Readable)
-		readiness |= Read;
-
-	if(ereadiness & Event::Writable)
-		readiness |= Write;
-
-	if(readiness)
-		apply(readiness);
+    if (readiness)
+        apply(readiness);
 }

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -22,53 +22,51 @@
 
 class EventLoop;
 
-class SocketNotifier
-{
+class SocketNotifier {
 public:
-	enum Interest
-	{
-		Read = 0x01,
-		Write = 0x02,
-	};
+    enum Interest {
+        Read = 0x01,
+        Write = 0x02,
+    };
 
-	// Initializes notifier with interest and considers the socket ready for
-	// the specified interest. Readiness must be cleared via clearReadiness()
-	// in order for the activated signal to be emitted. The expected way to
-	// use this class is to initialize it, perform I/O until progress can no
-	// longer be made, clear readiness, then await the signal.
-	SocketNotifier(int socket, uint8_t interest);
+    // Initializes notifier with interest and considers the socket ready for
+    // the specified interest. Readiness must be cleared via clearReadiness()
+    // in order for the activated signal to be emitted. The expected way to
+    // use this class is to initialize it, perform I/O until progress can no
+    // longer be made, clear readiness, then await the signal.
+    SocketNotifier(int socket, uint8_t interest);
 
-	~SocketNotifier();
+    ~SocketNotifier();
 
-	bool isReadEnabled() const { return readEnabled_; }
-	bool isWriteEnabled() const { return writeEnabled_; }
-	int socket() const { return socket_; }
+    bool isReadEnabled() const { return readEnabled_; }
+    bool isWriteEnabled() const { return writeEnabled_; }
+    int socket() const { return socket_; }
 
-	void setReadEnabled(bool enable);
-	void setWriteEnabled(bool enable);
+    void setReadEnabled(bool enable);
+    void setWriteEnabled(bool enable);
 
-	uint8_t readiness() const { return readiness_; }
-	void clearReadiness(uint8_t readiness);
+    uint8_t readiness() const { return readiness_; }
+    void clearReadiness(uint8_t readiness);
 
-	boost::signals2::signal<void(int, uint8_t)> activated;
+    boost::signals2::signal<void(int, uint8_t)> activated;
 
 private:
-	int socket_;
-	bool readEnabled_;
-	bool writeEnabled_;
-	QSocketNotifier *readInner_;
-	QSocketNotifier *writeInner_;
-	QMetaObject::Connection readInnerConnection_;
-	QMetaObject::Connection writeInnerConnection_;
-	uint8_t readiness_;
-	EventLoop *loop_;
-	int regId_;
+    int socket_;
+    bool readEnabled_;
+    bool writeEnabled_;
+    QSocketNotifier *readInner_;
+    QSocketNotifier *writeInner_;
+    QMetaObject::Connection readInnerConnection_;
+    QMetaObject::Connection writeInnerConnection_;
+    uint8_t readiness_;
+    EventLoop *loop_;
+    int regId_;
 
-	void innerReadActivated(int socket);
-	void innerWriteActivated(int socket);
-	void apply(uint8_t readiness);
-	static void cb_fd_activated(void *ctx, uint8_t readiness);
-	void fd_activated(uint8_t readiness);
+    void innerReadActivated(int socket);
+    void innerWriteActivated(int socket);
+    void apply(uint8_t readiness);
+    static void cb_fd_activated(void *ctx, uint8_t readiness);
+    void fd_activated(uint8_t readiness);
 };
 
 #endif

--- a/src/core/stats.cpp
+++ b/src/core/stats.cpp
@@ -24,10 +24,9 @@
 
 namespace Stats {
 
-void Counters::add(const Counters &other)
-{
-    for(int n = 0; n < STATS_COUNTERS_MAX; ++n)
+void Counters::add(const Counters &other) {
+    for (int n = 0; n < STATS_COUNTERS_MAX; ++n)
         inc((Counter)n, other._values[n]);
 }
 
-}
+} // namespace Stats

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -33,43 +33,34 @@ namespace Stats {
 
 // keep in sync with STATS_COUNTERS_MAX above
 enum Counter {
-    ClientHeaderBytesReceived  =  0,
-    ClientHeaderBytesSent      =  1,
-    ClientContentBytesReceived =  2,
-    ClientContentBytesSent     =  3,
-    ClientMessagesReceived     =  4,
-    ClientMessagesSent         =  5,
-    ServerHeaderBytesReceived  =  6,
-    ServerHeaderBytesSent      =  7,
-    ServerContentBytesReceived =  8,
-    ServerContentBytesSent     =  9,
-    ServerMessagesReceived     = 10,
-    ServerMessagesSent         = 11,
+    ClientHeaderBytesReceived = 0,
+    ClientHeaderBytesSent = 1,
+    ClientContentBytesReceived = 2,
+    ClientContentBytesSent = 3,
+    ClientMessagesReceived = 4,
+    ClientMessagesSent = 5,
+    ServerHeaderBytesReceived = 6,
+    ServerHeaderBytesSent = 7,
+    ServerContentBytesReceived = 8,
+    ServerContentBytesSent = 9,
+    ServerMessagesReceived = 10,
+    ServerMessagesSent = 11,
 };
 
-class Counters
-{
+class Counters {
 public:
-    Counters()
-    {
-        reset();
-    }
+    Counters() { reset(); }
 
-    bool isEmpty() const
-    {
-        return _empty;
-    }
+    bool isEmpty() const { return _empty; }
 
-    void reset()
-    {
-        for(int n = 0; n < STATS_COUNTERS_MAX; ++n)
+    void reset() {
+        for (int n = 0; n < STATS_COUNTERS_MAX; ++n)
             _values[n] = 0;
 
         _empty = true;
     }
 
-    uint32_t get(Counter c)
-    {
+    uint32_t get(Counter c) {
         int index = (int)c;
 
         assert(index >= 0 && index < STATS_COUNTERS_MAX);
@@ -77,15 +68,14 @@ public:
         return _values[index];
     }
 
-    void inc(Counter c, uint32_t count = 1)
-    {
+    void inc(Counter c, uint32_t count = 1) {
         int index = (int)c;
 
         assert(index >= 0 && index < STATS_COUNTERS_MAX);
 
         _values[index] += count;
 
-        if(count > 0)
+        if (count > 0)
             _empty = false;
     }
 
@@ -96,6 +86,6 @@ private:
     bool _empty;
 };
 
-}
+} // namespace Stats
 
 #endif

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -23,21 +23,21 @@
 
 #include "statsmanager.h"
 
-#include <assert.h>
-#include <QVector>
+#include "defercall.h"
+#include "httpheaders.h"
+#include "log.h"
+#include "simplehttpserver.h"
+#include "timer.h"
+#include "timerwheel.h"
+#include "tnetstring.h"
+#include "variant.h"
+#include "zmqsocket.h"
+#include "zutil.h"
 #include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include "zmqsocket.h"
-#include "timerwheel.h"
-#include "log.h"
-#include "defercall.h"
-#include "tnetstring.h"
-#include "variant.h"
-#include "httpheaders.h"
-#include "simplehttpserver.h"
-#include "zutil.h"
-#include "timer.h"
+#include <QVector>
+#include <assert.h>
 
 // Make this somewhat big since PUB is lossy
 #define OUT_HWM 200000
@@ -51,2074 +51,1825 @@
 
 #define TICK_DURATION_MS 10
 
-static int64_t durationToTicksRoundDown(int64_t msec)
-{
-	return msec / TICK_DURATION_MS;
-}
+static int64_t durationToTicksRoundDown(int64_t msec) { return msec / TICK_DURATION_MS; }
 
-static int64_t durationToTicksRoundUp(int64_t msec)
-{
-	return (msec + TICK_DURATION_MS - 1) / TICK_DURATION_MS;
+static int64_t durationToTicksRoundUp(int64_t msec) {
+    return (msec + TICK_DURATION_MS - 1) / TICK_DURATION_MS;
 }
-class StatsManager::Private
-{
+class StatsManager::Private {
 public:
-	class TimerBase
-	{
-	public:
-		enum Type
-		{
-			Connection,
-			ExternalConnection,
-			Subscription,
-		};
-
-		Type timerType;
-		int timerId;
-
-		TimerBase() :
-			timerId(-1)
-		{
-		}
-	};
-
-	class ConnectionInfo : public TimerBase
-	{
-	public:
-		QByteArray id;
-		QByteArray routeId;
-		ConnectionType type;
-		QHostAddress peerAddress;
-		bool ssl;
-		int64_t lastRefresh;
-		int refreshBucket;
-		bool linger;
-		int64_t lastReport;
-		int64_t retrySeq;
-		QByteArray from; // External or linger source
-		int ttl; // External
-		int64_t lastActive; // External
-
-		ConnectionInfo() :
-			ssl(false),
-			lastRefresh(-1),
-			refreshBucket(-1),
-			linger(false),
-			lastReport(-1),
-			retrySeq(-1),
-			ttl(-1),
-			lastActive(-1)
-		{
-		}
-	};
-
-	class Subscription : public TimerBase
-	{
-	public:
-		QString mode;
-		QString channel;
-		uint32_t subscriberCount;
-		int64_t lastRefresh;
-		int refreshBucket;
-		bool linger;
-
-		Subscription() :
-			subscriberCount(0),
-			lastRefresh(-1),
-			refreshBucket(-1),
-			linger(false)
-		{
-		}
-	};
-
-	class ConnectionsMax
-	{
-	public:
-		int retrySeq;
-		uint32_t currentValue;
-		uint32_t maxValue;
-		uint32_t lastSentValue;
-		int64_t lastSentTime;
-
-		ConnectionsMax() :
-			retrySeq(-1),
-			currentValue(0),
-			maxValue(0),
-			lastSentValue(0),
-			lastSentTime(-1)
-		{
-		}
-
-		uint32_t valueToSend()
-		{
-			if(maxValue > lastSentValue)
-				return maxValue;
-			else
-				return currentValue;
-		}
-	};
-
-	class ExternalConnectionsMax
-	{
-	public:
-		uint64_t value;
-		int64_t expires;
-
-		ExternalConnectionsMax() :
-			value(0),
-			expires(0)
-		{
-		}
-	};
-
-	class ConnectionsMaxes
-	{
-	public:
-		QHash<QByteArray, ConnectionsMax> maxes;
-		QSet<QByteArray> needSend;
-		int64_t lastRefresh;
-
-		ConnectionsMaxes() :
-			lastRefresh(0)
-		{
-		}
-	};
-
-	class ExternalConnectionsMaxes
-	{
-	public:
-		QHash<QByteArray, ExternalConnectionsMax> maxes;
-
-		uint32_t total() const
-		{
-			uint32_t count = 0;
-
-			QHashIterator<QByteArray, ExternalConnectionsMax> it(maxes);
-			while(it.hasNext())
-			{
-				it.next();
-				const ExternalConnectionsMax &cm = it.value();
-
-				count += cm.value;
-			}
-
-			return count;
-		}
-	};
-
-	class RetryInfo
-	{
-	public:
-		uint64_t nextSeq;
-		QMap<uint64_t, ConnectionInfo*> connectionInfoBySeq;
-
-		RetryInfo() :
-			nextSeq(0)
-		{
-		}
-	};
-
-	class Report
-	{
-	public:
-		QByteArray routeId;
-		uint32_t connectionsMax;
-		bool connectionsMaxStale;
-		uint32_t connectionsMinutes;
-		uint32_t messagesReceived;
-		uint32_t messagesSent;
-		uint32_t httpResponseMessagesSent;
-		int blocksReceived;
-		int blocksSent;
-		uint32_t requestsReceived;
-		Stats::Counters counters;
-		int64_t lastUpdate;
-		int64_t startTime;
-		QHash<QByteArray, Report> externalReports;
-
-		Report() :
-			connectionsMax(0),
-			connectionsMaxStale(true),
-			connectionsMinutes(0),
-			messagesReceived(0),
-			messagesSent(0),
-			httpResponseMessagesSent(0),
-			blocksReceived(-1),
-			blocksSent(-1),
-			requestsReceived(0),
-			lastUpdate(-1),
-			startTime(-1)
-		{
-		}
-
-		bool isEmpty() const
-		{
-			return (connectionsMax == 0 &&
-				connectionsMinutes == 0 &&
-				messagesReceived == 0 &&
-				messagesSent == 0 &&
-				httpResponseMessagesSent == 0 &&
-				blocksReceived <= 0 &&
-				blocksSent <= 0 &&
-				requestsReceived == 0 &&
-				counters.isEmpty());
-		}
-
-		uint32_t externalConnectionsMinutes() const
-		{
-			uint32_t count = 0;
-
-			QHashIterator<QByteArray, Report> it(externalReports);
-			while(it.hasNext())
-			{
-				it.next();
-				const Report &r = it.value();
-
-				count += r.connectionsMinutes;
-			}
-
-			return count;
-		}
-
-		void addConnectionsMinutes(uint32_t mins, int64_t now)
-		{
-			connectionsMinutes += mins;
-
-			lastUpdate = now;
-		}
-
-		void addMessageReceived(int blocks, int64_t now)
-		{
-			++messagesReceived;
-
-			if(blocks > 0)
-			{
-				if(blocksReceived < 0)
-					blocksReceived = 0;
-
-				blocksReceived += blocks;
-			}
-
-			lastUpdate = now;
-		}
-
-		void addMessageSent(const QString &transport, int blocks, int64_t now)
-		{
-			++messagesSent;
-
-			if(transport == "http-response")
-				++httpResponseMessagesSent;
-
-			if(blocks > 0)
-			{
-				if(blocksSent < 0)
-					blocksSent = 0;
-
-				blocksSent += blocks;
-			}
-
-			lastUpdate = now;
-		}
-
-		void addRequestsReceived(uint32_t count, int64_t now)
-		{
-			requestsReceived += count;
-
-			lastUpdate = now;
-		}
-
-		void incCounter(Stats::Counter c, uint32_t count, int64_t now)
-		{
-			counters.inc(c, count);
-
-			lastUpdate = now;
-		}
-
-		void addCounters(const Stats::Counters &other, int64_t now)
-		{
-			counters.add(other);
-
-			lastUpdate = now;
-		}
-	};
-
-	class Counts
-	{
-	public:
-		uint32_t requestsReceived;
-
-		Counts() :
-			requestsReceived(0)
-		{
-		}
-
-		bool isEmpty()
-		{
-			return (requestsReceived == 0);
-		}
-	};
-
-	class PrometheusMetric
-	{
-	public:
-		enum Type
-		{
-			RequestReceived,
-			ConnectionConnected,
-			ConnectionMinute,
-			MessageReceived,
-			MessageSent
-		};
-
-		Type mtype;
-		QString name;
-		QString type;
-		QString help;
-
-		PrometheusMetric(Type _mtype, const QString &_name, const QString &_type, const QString &_help) :
-			mtype(_mtype),
-			name(_name),
-			type(_type),
-			help(_help)
-		{
-		}
-	};
-
-	typedef QPair<QString, QString> SubscriptionKey;
-
-	StatsManager *q;
-	int connectionsMax;
-	int subscriptionsMax;
-	QByteArray instanceId;
-	int ipcFileMode;
-	QString spec;
-	Format outputFormat;
-	bool connectionSend;
-	bool connectionsMaxSend;
-	int connectionTtl;
-	int connectionsMaxTtl;
-	int connectionLinger;
-	int subscriptionTtl;
-	int subscriptionLinger;
-	int reportInterval;
-	std::unique_ptr<ZmqSocket> sock;
-	std::unique_ptr<SimpleHttpServer> prometheusServer;
-	int prometheusConnectionsMax;
-	QString prometheusPrefix;
-	QList<PrometheusMetric> prometheusMetrics;
-	QHash<QByteArray, uint32_t> routeActivity;
-	QHash<QByteArray, ConnectionInfo*> connectionInfoById;
-	QHash<QByteArray, QSet<ConnectionInfo*> > connectionInfoByRoute;
-	QHash<QByteArray, RetryInfo> retryInfoBySource;
-	QVector<QSet<ConnectionInfo*> > connectionInfoRefreshBuckets;
-	int currentConnectionInfoRefreshBucket;
-	QHash<QByteArray, QHash<QByteArray, ConnectionInfo*> > externalConnectionInfoByFrom;
-	QHash<QByteArray, QSet<ConnectionInfo*> > externalConnectionInfoByRoute;
-	QHash<SubscriptionKey, Subscription*> subscriptionsByKey;
-	QVector<QSet<Subscription*> > subscriptionRefreshBuckets;
-	int currentSubscriptionRefreshBucket;
-	ConnectionsMaxes connectionsMaxes;
-	QHash<QByteArray, ExternalConnectionsMaxes> externalConnectionsMaxes;
-	TimerWheel wheel;
-	int64_t startTime;
-	QHash<QByteArray, Report*> reports;
-	Counts combinedCounts;
-	Report combinedReport;
-	std::unique_ptr<Timer> activityTimer;
-	std::unique_ptr<Timer> reportTimer;
-	std::unique_ptr<Timer> refreshTimer;
-	std::unique_ptr<Timer> externalConnectionsMaxTimer;
-	Connection activityTimerConnection;
-	Connection reportTimerConnection;
-	Connection refreshTimerConnection;
-	Connection externalConnectionsMaxTimerConnection;
-	Connection promServerConnection;
-
-	Private(StatsManager *_q, int _connectionsMax, int _subscriptionsMax, int _prometheusConnectionsMax) :
-		q(_q),
-		connectionsMax(_connectionsMax),
-		subscriptionsMax(_subscriptionsMax),
-		ipcFileMode(-1),
-		outputFormat(TnetStringFormat),
-		connectionSend(false),
-		connectionsMaxSend(false),
-		connectionTtl(120 * 1000),
-		connectionsMaxTtl(60 * 1000),
-		connectionLinger(60 * 1000),
-		subscriptionTtl(60 * 1000),
-		subscriptionLinger(60 * 1000),
-		reportInterval(10 * 1000),
-		prometheusConnectionsMax(_prometheusConnectionsMax),
-		currentConnectionInfoRefreshBucket(0),
-		currentSubscriptionRefreshBucket(0),
-		wheel(TimerWheel((_connectionsMax * 2) + _subscriptionsMax))
-	{
-		activityTimer = std::make_unique<Timer>();
-		activityTimerConnection = activityTimer->timeout.connect(boost::bind(&Private::activity_timeout, this));
-		activityTimer->setSingleShot(true);
-
-		refreshTimer = std::make_unique<Timer>();
-		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
-		refreshTimer->start(REFRESH_INTERVAL);
-
-		externalConnectionsMaxTimer = std::make_unique<Timer>();
-		externalConnectionsMaxTimerConnection = externalConnectionsMaxTimer->timeout.connect(boost::bind(&Private::externalConnectionsMax_timeout, this));
-		externalConnectionsMaxTimer->start(EXTERNAL_CONNECTIONS_MAX_INTERVAL);
-
-		setupConnectionBuckets();
-		setupSubscriptionBuckets();
-
-		prometheusMetrics += PrometheusMetric(PrometheusMetric::RequestReceived, "request_received", "counter", "Number of requests received");
-		prometheusMetrics += PrometheusMetric(PrometheusMetric::ConnectionConnected, "connection_connected", "gauge", "Number of concurrent connections");
-		prometheusMetrics += PrometheusMetric(PrometheusMetric::ConnectionMinute, "connection_minute", "counter", "Number of minutes clients have been connected");
-		prometheusMetrics += PrometheusMetric(PrometheusMetric::MessageReceived, "message_received", "counter", "Number of messages received by the publish API");
-		prometheusMetrics += PrometheusMetric(PrometheusMetric::MessageSent,"message_sent", "counter", "Number of messages sent to clients");
-
-		startTime = QDateTime::currentMSecsSinceEpoch();
-
-		connectionsMaxes.lastRefresh = startTime;
-	}
-
-	~Private()
-	{
-		qDeleteAll(connectionInfoById);
-
-		QMutableHashIterator<QByteArray, QHash<QByteArray, ConnectionInfo*> > it(externalConnectionInfoByFrom);
-		while(it.hasNext())
-		{
-			it.next();
-			qDeleteAll(it.value());
-		}
-
-		qDeleteAll(subscriptionsByKey);
-
-		qDeleteAll(reports);
-	}
-
-	bool setupSock()
-	{
-		sock.reset();
-
-		sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
-
-		sock->setHwm(OUT_HWM);
-		sock->setWriteQueueEnabled(false);
-		sock->setShutdownWaitTime(0);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(sock.get(), spec, true, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		return true;
-	}
-
-	bool setPrometheusPort(const QString &portStr)
-	{
-		assert(!prometheusServer);
-
-		prometheusServer = std::make_unique<SimpleHttpServer>(prometheusConnectionsMax, 8192, 8192);
-		promServerConnection = prometheusServer->requestReady.connect(boost::bind(&Private::prometheus_requestReady, this));
-
-		if(portStr.startsWith("ipc://"))
-		{
-			if(!prometheusServer->listenLocal(portStr.mid(6)))
-			{
-				promServerConnection.disconnect();
-				prometheusServer.reset();
-
-				return false;
-			}
-		}
-		else
-		{
-			QHostAddress addr;
-			int port = -1;
-
-			int pos = portStr.indexOf(':');
-			if(pos >= 0)
-			{
-				addr = QHostAddress(portStr.mid(0, pos));
-				port = portStr.mid(pos + 1).toInt();
-			}
-			else
-			{
-				port = portStr.toInt();
-			}
-
-			if(!prometheusServer->listen(addr, port))
-			{
-				promServerConnection.disconnect();
-				prometheusServer.reset();
-
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	void setupConnectionBuckets()
-	{
-		int shouldProcessTime = SHOULD_PROCESS_TIME(connectionTtl);
-		QVector<QSet<ConnectionInfo*> > newBuckets(qMax(shouldProcessTime / REFRESH_INTERVAL, 1));
-
-		// Rebalance (NOTE: this algorithm is not optimal)
-		int nextBucketIndex = 0;
-		for(int n = 0; n < connectionInfoRefreshBuckets.count(); ++n)
-		{
-			foreach(ConnectionInfo *c, connectionInfoRefreshBuckets[n])
-			{
-				newBuckets[nextBucketIndex++] += c;
-				if(nextBucketIndex >= newBuckets.count())
-					nextBucketIndex = 0;
-			}
-		}
-
-		connectionInfoRefreshBuckets = newBuckets;
-		currentConnectionInfoRefreshBucket = 0;
-	}
-
-	void setupSubscriptionBuckets()
-	{
-		int shouldProcessTime = SHOULD_PROCESS_TIME(subscriptionTtl);
-		QVector<QSet<Subscription*> > newBuckets(qMax(shouldProcessTime / REFRESH_INTERVAL, 1));
-
-		// Rebalance (NOTE: this algorithm is not optimal)
-		int nextBucketIndex = 0;
-		for(int n = 0; n < subscriptionRefreshBuckets.count(); ++n)
-		{
-			foreach(Subscription *s, subscriptionRefreshBuckets[n])
-			{
-				newBuckets[nextBucketIndex++] += s;
-				if(nextBucketIndex >= newBuckets.count())
-					nextBucketIndex = 0;
-			}
-		}
-
-		subscriptionRefreshBuckets = newBuckets;
-		currentSubscriptionRefreshBucket = 0;
-	}
-
-	void setupReportTimer()
-	{
-		if(reportInterval > 0 && !reportTimer)
-		{
-			reportTimer = std::make_unique<Timer>();
-			reportTimerConnection = reportTimer->timeout.connect(boost::bind(&Private::report_timeout, this));
-			reportTimer->start(reportInterval);
-		}
-		else if(reportInterval <= 0 && reportTimer)
-		{
-			reportTimerConnection.disconnect();
-			reportTimer.reset();
-		}
-	}
-
-	int smallestConnectionInfoRefreshBucket()
-	{
-		int best = -1;
-		int bestSize = 0;
-
-		for(int n = 0; n < connectionInfoRefreshBuckets.count(); ++n)
-		{
-			if(best == -1 || connectionInfoRefreshBuckets[n].count() < bestSize)
-			{
-				best = n;
-				bestSize = connectionInfoRefreshBuckets[n].count();
-			}
-		}
-
-		return best;
-	}
-
-	int smallestSubscriptionRefreshBucket()
-	{
-		int best = -1;
-		int bestSize = 0;
-
-		for(int n = 0; n < subscriptionRefreshBuckets.count(); ++n)
-		{
-			if(best == -1 || subscriptionRefreshBuckets[n].count() < bestSize)
-			{
-				best = n;
-				bestSize = subscriptionRefreshBuckets[n].count();
-			}
-		}
-
-		return best;
-	}
-
-	void wheelAdd(int64_t timeoutTime, TimerBase *obj)
-	{
-		if(timeoutTime < startTime)
-		{
-			timeoutTime = startTime;
-		}
-
-		if(obj->timerId >= 0)
-		{
-			wheel.remove(obj->timerId);
-		}
-
-		int id = wheel.add(durationToTicksRoundUp(timeoutTime - startTime), (size_t)obj);
-		assert(id >= 0);
-
-		obj->timerId = id;
-	}
-
-	void wheelRemove(TimerBase *obj)
-	{
-		if(obj->timerId >= 0)
-		{
-			wheel.remove(obj->timerId);
-		}
-
-		obj->timerId = -1;
-	}
-
-	void insertConnection(ConnectionInfo *c)
-	{
-		connectionInfoById[c->id] = c;
-
-		QSet<ConnectionInfo*> &cs = connectionInfoByRoute[c->routeId];
-		cs += c;
-
-		assert(c->lastRefresh >= 0);
-		wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(connectionTtl), c);
-
-		c->refreshBucket = smallestConnectionInfoRefreshBucket();
-		connectionInfoRefreshBuckets[c->refreshBucket] += c;
-	}
-
-	void removeConnection(ConnectionInfo *c)
-	{
-		connectionInfoById.remove(c->id);
-
-		if(connectionInfoByRoute.contains(c->routeId))
-		{
-			QSet<ConnectionInfo*> &cs = connectionInfoByRoute[c->routeId];
-			cs.remove(c);
-
-			if(cs.isEmpty())
-				connectionInfoByRoute.remove(c->routeId);
-		}
-
-		if(c->retrySeq >= 0)
-		{
-			RetryInfo &ri = retryInfoBySource[c->from];
-			ri.connectionInfoBySeq.remove(c->retrySeq);
-
-			// FIXME: we keep the source entry even when there are no more
-			// connections, to avoid resetting the seq value. If there is
-			// a lot of proxy instance churn, retryInfoBySource could
-			// fill up with unused entries that will never be cleaned up.
-		}
-
-		if(c->lastRefresh >= 0)
-		{
-			wheelRemove(c);
-			connectionInfoRefreshBuckets[c->refreshBucket].remove(c);
-		}
-	}
-
-	void insertExternalConnection(ConnectionInfo *c)
-	{
-		QHash<QByteArray, ConnectionInfo*> &extConnectionInfoById = externalConnectionInfoByFrom[c->from];
-		extConnectionInfoById[c->id] = c;
-
-		QSet<ConnectionInfo*> &cs = externalConnectionInfoByRoute[c->routeId];
-		cs += c;
-
-		assert(c->lastActive >= 0);
-		wheelAdd(c->lastActive + connectionTtl, c);
-
-		assert(c->lastRefresh == -1);
-		assert(c->refreshBucket == -1);
-	}
-
-	void removeExternalConnection(ConnectionInfo *c)
-	{
-		assert(externalConnectionInfoByFrom.contains(c->from));
-
-		QHash<QByteArray, ConnectionInfo*> &extConnectionInfoById = externalConnectionInfoByFrom[c->from];
-		extConnectionInfoById.remove(c->id);
-
-		if(extConnectionInfoById.isEmpty())
-			externalConnectionInfoByFrom.remove(c->from);
-
-		if(externalConnectionInfoByRoute.contains(c->routeId))
-		{
-			QSet<ConnectionInfo*> &cs = externalConnectionInfoByRoute[c->routeId];
-			cs.remove(c);
-
-			if(cs.isEmpty())
-				externalConnectionInfoByRoute.remove(c->routeId);
-		}
-
-		wheelRemove(c);
-	}
-
-	void removeLingeringConnections(const QByteArray &source, uint64_t retrySeq)
-	{
-		if(!retryInfoBySource.contains(source))
-			return;
-
-		RetryInfo &ri = retryInfoBySource[source];
-
-		// Invalid retry seq
-		if(retrySeq >= ri.nextSeq)
-			return;
-
-		QList<ConnectionInfo*> toRemove;
-
-		QMap<uint64_t, ConnectionInfo*>::iterator it = ri.connectionInfoBySeq.find(retrySeq);
-		while(it != ri.connectionInfoBySeq.end())
-		{
-			toRemove += it.value();
-
-			if(it == ri.connectionInfoBySeq.begin())
-				break;
-
-			--it;
-		}
-
-		foreach(ConnectionInfo *c, toRemove)
-		{
-			removeConnection(c);
-			delete c;
-		}
-	}
-
-	void insertSubscription(Subscription *s)
-	{
-		SubscriptionKey subKey(s->mode, s->channel);
-
-		subscriptionsByKey[subKey] = s;
-
-		assert(s->lastRefresh >= 0);
-		wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(subscriptionTtl), s);
-
-		s->refreshBucket = smallestSubscriptionRefreshBucket();
-		subscriptionRefreshBuckets[s->refreshBucket] += s;
-	}
-
-	void removeSubscription(Subscription *s)
-	{
-		SubscriptionKey subKey(s->mode, s->channel);
-
-		subscriptionsByKey.remove(subKey);
-
-		if(s->lastRefresh >= 0)
-		{
-			wheelRemove(s);
-			subscriptionRefreshBuckets[s->refreshBucket].remove(s);
-		}
-	}
-
-	Report *getOrCreateReport(const QByteArray &routeId)
-	{
-		Report *report = reports.value(routeId);
-		if(!report)
-		{
-			report = new Report;
-			report->routeId = routeId;
-			report->startTime = QDateTime::currentMSecsSinceEpoch();
-			reports[routeId] = report;
-		}
-
-		return report;
-	}
-
-	void removeReport(Report *report)
-	{
-		// Subtract the current total from the combined report
-		combinedReport.connectionsMax -= report->connectionsMax;
-
-		reports.remove(report->routeId);
-	}
-
-	ConnectionsMax & getOrCreateConnectionsMax(const QByteArray &routeId)
-	{
-		if(!connectionsMaxes.maxes.contains(routeId))
-			connectionsMaxes.maxes.insert(routeId, ConnectionsMax());
-
-		return connectionsMaxes.maxes[routeId];
-	}
-
-	void write(const StatsPacket &packet)
-	{
-		assert(sock);
-
-		QByteArray prefix;
-		if(packet.type == StatsPacket::Activity)
-			prefix = "activity";
-		else if(packet.type == StatsPacket::Message)
-			prefix = "message";
-		else if(packet.type == StatsPacket::Connected || packet.type == StatsPacket::Disconnected)
-			prefix = "conn";
-		else if(packet.type == StatsPacket::Subscribed || packet.type == StatsPacket::Unsubscribed)
-			prefix = "sub";
-		else if(packet.type == StatsPacket::Report)
-			prefix = "report";
-		else if(packet.type == StatsPacket::Counts)
-			prefix = "counts";
-		else // ConnectionsMax
-			prefix = "conn-max";
-
-		Variant vpacket = packet.toVariant();
-
-		QByteArray buf;
-		if(outputFormat == TnetStringFormat)
-		{
-			buf = prefix + " T" + TnetString::fromVariant(vpacket);
-		}
-		else if(outputFormat == JsonFormat)
-		{
-			QJsonObject obj = QJsonObject::fromVariantHash(vpacket.toHash());
-			buf = prefix + " J" + QJsonDocument(obj).toJson(QJsonDocument::Compact);
-		}
-
-		if(!buf.isEmpty())
-		{
-			if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-				log_debug("stats: OUT %s %s", prefix.data(), qPrintable(TnetString::variantToString(vpacket, -1)));
-
-			sock->write(QList<QByteArray>() << buf);
-		}
-	}
-
-	void sendActivity(const QByteArray &routeId, uint32_t count)
-	{
-		if(!sock)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Activity;
-		p.from = instanceId;
-		p.route = routeId;
-		p.count = count;
-		write(p);
-	}
-
-	void sendMessage(const QString &channel, const QString &itemId, const QString &transport, uint32_t count, int blocks)
-	{
-		if(!sock)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Message;
-		p.from = instanceId;
-		p.channel = channel.toUtf8();
-		p.itemId = itemId.toUtf8();
-		p.count = count;
-		p.blocks = blocks;
-		p.transport = transport.toUtf8();
-		write(p);
-	}
-
-	void sendConnected(ConnectionInfo *c)
-	{
-		if(!sock || !connectionSend)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Connected;
-		p.from = instanceId;
-		p.route = c->routeId;
-		p.connectionId = c->id;
-		if(c->type == WebSocket)
-			p.connectionType = StatsPacket::WebSocket;
-		else
-			p.connectionType = StatsPacket::Http;
-		p.peerAddress = c->peerAddress;
-		p.ssl = c->ssl;
-		p.ttl = connectionTtl / 1000;
-		write(p);
-	}
-
-	void sendDisconnected(ConnectionInfo *c)
-	{
-		if(!sock || !connectionSend)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Disconnected;
-		p.from = instanceId;
-		p.route = c->routeId;
-		p.connectionId = c->id;
-		write(p);
-	}
-
-	void sendSubscribed(Subscription *s)
-	{
-		if(!sock)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Subscribed;
-		p.from = instanceId;
-		p.mode = s->mode.toUtf8();
-		p.channel = s->channel.toUtf8();
-		p.ttl = subscriptionTtl / 1000;
-		p.subscribers = s->subscriberCount;
-		write(p);
-	}
-
-	void sendUnsubscribed(Subscription *s)
-	{
-		if(!sock)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Unsubscribed;
-		p.from = instanceId;
-		p.mode = s->mode.toUtf8();
-		p.channel = s->channel.toUtf8();
-		write(p);
-	}
-
-	void sendCounts(const Counts &counts)
-	{
-		if(!sock)
-			return;
-
-		StatsPacket p;
-		p.type = StatsPacket::Counts;
-		p.from = instanceId;
-		p.requestsReceived = counts.requestsReceived;
-		write(p);
-	}
-
-	void sendConnectionsMax(const QByteArray &routeId, ConnectionsMax *cm, int64_t now)
-	{
-		q->connMax(getConnMaxPacket(routeId, cm, now));
-	}
-
-	void updateConnectionsMax(const QByteArray &routeId, int64_t now)
-	{
-		uint32_t localConns = connectionInfoByRoute.value(routeId).count();
-		uint32_t extConns = externalConnectionInfoByRoute.value(routeId).count();
-
-		uint32_t extConnsMax = 0;
-		if(externalConnectionsMaxes.contains(routeId))
-			extConnsMax = externalConnectionsMaxes[routeId].total();
-
-		uint32_t conns = localConns + extConns + extConnsMax;
-
-		if(connectionsMaxSend)
-		{
-			ConnectionsMax &cm = getOrCreateConnectionsMax(routeId);
-
-			cm.currentValue = conns;
-			cm.maxValue = qMax(cm.maxValue, conns);
-
-			if(cm.valueToSend() != cm.lastSentValue)
-			{
-				connectionsMaxes.needSend.insert(routeId);
-
-				if(!activityTimer->isActive())
-					activityTimer->start(ACTIVITY_TIMEOUT);
-			}
-			else
-			{
-				connectionsMaxes.needSend.remove(routeId);
-			}
-		}
-
-		if(reportInterval > 0)
-		{
-			Report *report = getOrCreateReport(routeId);
-
-			// Subtract the current total from the combined report
-			combinedReport.connectionsMax -= report->connectionsMax;
-
-			// Update the individual report
-			if(report->connectionsMaxStale)
-			{
-				report->connectionsMax = conns;
-				report->connectionsMaxStale = false;
-			}
-			else
-				report->connectionsMax = qMax(report->connectionsMax, conns);
-
-			report->lastUpdate = now;
-
-			// Add the new total to the combined report
-			combinedReport.connectionsMax += report->connectionsMax;
-			combinedReport.lastUpdate = now;
-		}
-	}
-
-	void updateConnectionsMinutes(ConnectionInfo *c, int64_t now)
-	{
-		// Ignore lingering connections
-		if(c->linger)
-			return;
-
-		Report *report = getOrCreateReport(c->routeId);
-
-		int mins = (now - c->lastReport) / 60000;
-		if(mins > 0)
-		{
-			// Only advance as much as we've read
-			c->lastReport += mins * 60000;
-
-			report->addConnectionsMinutes(mins, now);
-			combinedReport.addConnectionsMinutes(mins, now);
-		}
-	}
-
-	void handleExpirations(int64_t now)
-	{
-		QList<QByteArray> refreshedConnIds;
-		QSet<QByteArray> routesUpdated;
-
-		for(int i = 0; i < EXPIRE_MAX; ++i)
-		{
-			TimerWheel::Expired expired = wheel.takeExpired();
-
-			if(expired.key < 0)
-			{
-				break;
-			}
-
-			TimerBase *obj = (TimerBase *)expired.userData;
-
-			obj->timerId = -1;
-
-			switch(obj->timerType)
-			{
-				case TimerBase::Type::Connection:
-				{
-					ConnectionInfo *c = static_cast<ConnectionInfo*>(obj);
-
-					if(c->linger)
-					{
-						// In linger mode, next refresh is set to the time we should
-						// delete the connection rather than refresh
-
-						connectionInfoRefreshBuckets[c->refreshBucket].remove(c);
-						c->lastRefresh = -1;
-
-						// Note: we don't send a disconnect message when the
-						// linger expires. The assumption is that the handler
-						// owns the connection now
-
-						removeConnection(c);
-						delete c;
-					}
-					else
-					{
-						c->lastRefresh = now;
-						wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(connectionTtl), c);
-
-						refreshedConnIds += c->id;
-
-						updateConnectionsMinutes(c, now);
-						sendConnected(c);
-					}
-
-					break;
-				}
-				case TimerBase::Type::ExternalConnection:
-				{
-					ConnectionInfo *c = static_cast<ConnectionInfo*>(obj);
-
-					routesUpdated += c->routeId;
-					updateConnectionsMinutes(c, now);
-					removeExternalConnection(c);
-					delete c;
-
-					break;
-				}
-				case TimerBase::Type::Subscription:
-				{
-					Subscription *s = static_cast<Subscription*>(obj);
-
-					if(s->linger)
-					{
-						// In linger mode, next refresh is set to the time we should
-						// delete the subscription rather than refresh
-
-						subscriptionRefreshBuckets[s->refreshBucket].remove(s);
-						s->lastRefresh = -1;
-
-						QString mode = s->mode;
-						QString channel = s->channel;
-
-						sendUnsubscribed(s);
-						removeSubscription(s);
-						delete s;
-
-						q->unsubscribed(mode, channel);
-					}
-					else
-					{
-						s->lastRefresh = now;
-						wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(subscriptionTtl), s);
-
-						sendSubscribed(s);
-					}
-
-					break;
-				}
-			}
-		}
-
-		if(!refreshedConnIds.isEmpty())
-			q->connectionsRefreshed(refreshedConnIds);
-
-		foreach(const QByteArray &routeId, routesUpdated)
-			updateConnectionsMax(routeId, now);
-	}
-
-	void refreshConnections(int64_t now)
-	{
-		QList<QByteArray> refreshedIds;
-
-		// Process the current bucket
-		const QSet<ConnectionInfo*> &bucket = connectionInfoRefreshBuckets[currentConnectionInfoRefreshBucket];
-		foreach(ConnectionInfo *c, bucket)
-		{
-			// Don't bucket-process lingered connections
-			if(c->linger)
-				continue;
-
-			c->lastRefresh = now;
-			wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(connectionTtl), c);
-
-			refreshedIds += c->id;
-
-			updateConnectionsMinutes(c, now);
-			sendConnected(c);
-		}
-
-		if(!refreshedIds.isEmpty())
-			q->connectionsRefreshed(refreshedIds);
-
-		++currentConnectionInfoRefreshBucket;
-		if(currentConnectionInfoRefreshBucket >= connectionInfoRefreshBuckets.count())
-			currentConnectionInfoRefreshBucket = 0;
-	}
-
-	void refreshSubscriptions(int64_t now)
-	{
-		// Process the current bucket
-		const QSet<Subscription*> &bucket = subscriptionRefreshBuckets[currentSubscriptionRefreshBucket];
-		foreach(Subscription *s, bucket)
-		{
-			// Don't bucket-process lingered subscriptions
-			if(s->linger)
-				continue;
-
-			s->lastRefresh = now;
-			wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(subscriptionTtl), s);
-
-			sendSubscribed(s);
-		}
-
-		++currentSubscriptionRefreshBucket;
-		if(currentSubscriptionRefreshBucket >= subscriptionRefreshBuckets.count())
-			currentSubscriptionRefreshBucket = 0;
-	}
-
-	void refreshConnectionsMaxes(int64_t now)
-	{
-		if(now < connectionsMaxes.lastRefresh + (connectionsMaxTtl * 3 / 4))
-			return;
-
-		connectionsMaxes.lastRefresh = now;
-
-		QList<QByteArray> toRemove;
-
-		QMutableHashIterator<QByteArray, ConnectionsMax> it(connectionsMaxes.maxes);
-		while(it.hasNext())
-		{
-			it.next();
-			const QByteArray &routeId = it.key();
-			ConnectionsMax &cm = it.value();
-
-			if(cm.valueToSend() == 0)
-			{
-				if(cm.lastSentTime >= 0 && now >= cm.lastSentTime + connectionsMaxTtl)
-					toRemove += routeId;
-
-				continue;
-			}
-
-			sendConnectionsMax(routeId, &cm, now);
-		}
-
-		foreach(const QByteArray &routeId, toRemove)
-			connectionsMaxes.maxes.remove(routeId);
-	}
-
-	void expireExternalConnectionsMaxes(int64_t now)
-	{
-		QMutableHashIterator<QByteArray, ExternalConnectionsMaxes> it(externalConnectionsMaxes);
-		while(it.hasNext())
-		{
-			it.next();
-			QHash<QByteArray, ExternalConnectionsMax> &maxesForRoute = it.value().maxes;
-
-			QMutableHashIterator<QByteArray, ExternalConnectionsMax> rit(maxesForRoute);
-			while(rit.hasNext())
-			{
-				rit.next();
-				ExternalConnectionsMax &cm = rit.value();
-
-				if(now >= cm.expires)
-					rit.remove();
-			}
-
-			if(maxesForRoute.isEmpty())
-				it.remove();
-		}
-	}
-
-	void mergeExternalConnectionsMax(const StatsPacket &packet, int64_t now)
-	{
-		if(packet.retrySeq >= 0)
-			removeLingeringConnections(packet.from, (uint64_t)packet.retrySeq);
-
-		QHash<QByteArray, ExternalConnectionsMax> &maxes = externalConnectionsMaxes[packet.route].maxes;
-
-		if(!maxes.contains(packet.from))
-			maxes.insert(packet.from, ExternalConnectionsMax());
-
-		ExternalConnectionsMax &cm = maxes[packet.from];
-
-		cm.value = (uint32_t)qMax(packet.connectionsMax, 0);
-		cm.expires = now + (qMax(packet.ttl, 0) * 1000);
-
-		updateConnectionsMax(packet.route, now);
-	}
-
-	void mergeExternalReport(const StatsPacket &packet, bool includeConnections)
-	{
-		if(reportInterval <= 0)
-			return;
-
-		Report *report = getOrCreateReport(packet.route);
-
-		Stats::Counters counters;
-
-		counters.inc(Stats::ClientHeaderBytesReceived, qMax(packet.clientHeaderBytesReceived, 0));
-		counters.inc(Stats::ClientHeaderBytesSent, qMax(packet.clientHeaderBytesSent, 0));
-		counters.inc(Stats::ClientContentBytesReceived, qMax(packet.clientContentBytesReceived, 0));
-		counters.inc(Stats::ClientContentBytesSent, qMax(packet.clientContentBytesSent, 0));
-		counters.inc(Stats::ClientMessagesReceived, qMax(packet.clientMessagesReceived, 0));
-		counters.inc(Stats::ClientMessagesSent, qMax(packet.clientMessagesSent, 0));
-		counters.inc(Stats::ServerHeaderBytesReceived, qMax(packet.serverHeaderBytesReceived, 0));
-		counters.inc(Stats::ServerHeaderBytesSent, qMax(packet.serverHeaderBytesSent, 0));
-		counters.inc(Stats::ServerContentBytesReceived, qMax(packet.serverContentBytesReceived, 0));
-		counters.inc(Stats::ServerContentBytesSent, qMax(packet.serverContentBytesSent, 0));
-		counters.inc(Stats::ServerMessagesReceived, qMax(packet.serverMessagesReceived, 0));
-		counters.inc(Stats::ServerMessagesSent, qMax(packet.serverMessagesSent, 0));
-
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-		report->addCounters(counters, now);
-		combinedReport.addCounters(counters, now);
-
-		if(includeConnections)
-		{
-			if(!report->externalReports.contains(packet.from))
-				report->externalReports[packet.from] = Report();
-
-			Report &r = report->externalReports[packet.from];
-
-			int mins = qMax(packet.connectionsMinutes, 0);
-
-			r.connectionsMinutes += mins;
-			combinedReport.addConnectionsMinutes(mins, now);
-		}
-	}
-
-	StatsPacket reportToPacket(Report *report, const QByteArray &routeId, int64_t now)
-	{
-		if(report->connectionsMaxStale)
-			updateConnectionsMax(routeId, now);
-
-		StatsPacket p;
-		p.type = StatsPacket::Report;
-		p.from = instanceId;
-		p.route = routeId;
-
-		p.connectionsMax = report->connectionsMax;
-		p.connectionsMinutes = report->connectionsMinutes + report->externalConnectionsMinutes();
-		p.messagesReceived = report->messagesReceived;
-		p.messagesSent = report->messagesSent;
-		p.httpResponseMessagesSent = report->httpResponseMessagesSent;
-		p.blocksReceived = report->blocksReceived;
-		p.blocksSent = report->blocksSent;
-		p.duration = now - report->startTime;
-
-		p.clientHeaderBytesReceived = report->counters.get(Stats::ClientHeaderBytesReceived);
-		p.clientHeaderBytesSent = report->counters.get(Stats::ClientHeaderBytesSent);
-		p.clientContentBytesReceived = report->counters.get(Stats::ClientContentBytesReceived);
-		p.clientContentBytesSent = report->counters.get(Stats::ClientContentBytesSent);
-		p.clientMessagesReceived = report->counters.get(Stats::ClientMessagesReceived);
-		p.clientMessagesSent = report->counters.get(Stats::ClientMessagesSent);
-		p.serverHeaderBytesReceived = report->counters.get(Stats::ServerHeaderBytesReceived);
-		p.serverHeaderBytesSent = report->counters.get(Stats::ServerHeaderBytesSent);
-		p.serverContentBytesReceived = report->counters.get(Stats::ServerContentBytesReceived);
-		p.serverContentBytesSent = report->counters.get(Stats::ServerContentBytesSent);
-		p.serverMessagesReceived = report->counters.get(Stats::ServerMessagesReceived);
-		p.serverMessagesSent = report->counters.get(Stats::ServerMessagesSent);
-
-		report->startTime = now;
-		report->connectionsMaxStale = true;
-		report->connectionsMinutes = 0;
-		report->messagesReceived = 0;
-		report->messagesSent = 0;
-		report->httpResponseMessagesSent = 0;
-		report->blocksReceived = -1;
-		report->blocksSent = -1;
-		report->counters.reset();
-		report->externalReports.clear();
-
-		return p;
-	}
-
-	void flushReport(const QByteArray &routeId)
-	{
-		Report *report = getOrCreateReport(routeId);
-
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-		StatsPacket p = reportToPacket(report, routeId, now);
-
-		if(report->isEmpty())
-		{
-			removeReport(report);
-			delete report;
-		}
-
-		if(sock)
-			write(p);
-
-		q->reported(QList<StatsPacket>() << p);
-	}
-
-	StatsPacket getConnMaxPacket(const QByteArray &routeId, ConnectionsMax *cm, int64_t now)
-	{
-		uint32_t value = cm->valueToSend();
-
-		StatsPacket p;
-		p.type = StatsPacket::ConnectionsMax;
-		p.from = instanceId;
-		p.route = routeId;
-		p.connectionsMax = value;
-		p.ttl = connectionsMaxTtl / 1000;
-		p.retrySeq = cm->retrySeq;
-
-		cm->lastSentValue = value;
-		cm->lastSentTime = now;
-		cm->maxValue = cm->currentValue;
-
-		return p;
-	}
+    class TimerBase {
+    public:
+        enum Type {
+            Connection,
+            ExternalConnection,
+            Subscription,
+        };
+
+        Type timerType;
+        int timerId;
+
+        TimerBase() : timerId(-1) {}
+    };
+
+    class ConnectionInfo : public TimerBase {
+    public:
+        QByteArray id;
+        QByteArray routeId;
+        ConnectionType type;
+        QHostAddress peerAddress;
+        bool ssl;
+        int64_t lastRefresh;
+        int refreshBucket;
+        bool linger;
+        int64_t lastReport;
+        int64_t retrySeq;
+        QByteArray from;    // External or linger source
+        int ttl;            // External
+        int64_t lastActive; // External
+
+        ConnectionInfo()
+            : ssl(false),
+              lastRefresh(-1),
+              refreshBucket(-1),
+              linger(false),
+              lastReport(-1),
+              retrySeq(-1),
+              ttl(-1),
+              lastActive(-1) {}
+    };
+
+    class Subscription : public TimerBase {
+    public:
+        QString mode;
+        QString channel;
+        uint32_t subscriberCount;
+        int64_t lastRefresh;
+        int refreshBucket;
+        bool linger;
+
+        Subscription() : subscriberCount(0), lastRefresh(-1), refreshBucket(-1), linger(false) {}
+    };
+
+    class ConnectionsMax {
+    public:
+        int retrySeq;
+        uint32_t currentValue;
+        uint32_t maxValue;
+        uint32_t lastSentValue;
+        int64_t lastSentTime;
+
+        ConnectionsMax()
+            : retrySeq(-1), currentValue(0), maxValue(0), lastSentValue(0), lastSentTime(-1) {}
+
+        uint32_t valueToSend() {
+            if (maxValue > lastSentValue)
+                return maxValue;
+            else
+                return currentValue;
+        }
+    };
+
+    class ExternalConnectionsMax {
+    public:
+        uint64_t value;
+        int64_t expires;
+
+        ExternalConnectionsMax() : value(0), expires(0) {}
+    };
+
+    class ConnectionsMaxes {
+    public:
+        QHash<QByteArray, ConnectionsMax> maxes;
+        QSet<QByteArray> needSend;
+        int64_t lastRefresh;
+
+        ConnectionsMaxes() : lastRefresh(0) {}
+    };
+
+    class ExternalConnectionsMaxes {
+    public:
+        QHash<QByteArray, ExternalConnectionsMax> maxes;
+
+        uint32_t total() const {
+            uint32_t count = 0;
+
+            QHashIterator<QByteArray, ExternalConnectionsMax> it(maxes);
+            while (it.hasNext()) {
+                it.next();
+                const ExternalConnectionsMax &cm = it.value();
+
+                count += cm.value;
+            }
+
+            return count;
+        }
+    };
+
+    class RetryInfo {
+    public:
+        uint64_t nextSeq;
+        QMap<uint64_t, ConnectionInfo *> connectionInfoBySeq;
+
+        RetryInfo() : nextSeq(0) {}
+    };
+
+    class Report {
+    public:
+        QByteArray routeId;
+        uint32_t connectionsMax;
+        bool connectionsMaxStale;
+        uint32_t connectionsMinutes;
+        uint32_t messagesReceived;
+        uint32_t messagesSent;
+        uint32_t httpResponseMessagesSent;
+        int blocksReceived;
+        int blocksSent;
+        uint32_t requestsReceived;
+        Stats::Counters counters;
+        int64_t lastUpdate;
+        int64_t startTime;
+        QHash<QByteArray, Report> externalReports;
+
+        Report()
+            : connectionsMax(0),
+              connectionsMaxStale(true),
+              connectionsMinutes(0),
+              messagesReceived(0),
+              messagesSent(0),
+              httpResponseMessagesSent(0),
+              blocksReceived(-1),
+              blocksSent(-1),
+              requestsReceived(0),
+              lastUpdate(-1),
+              startTime(-1) {}
+
+        bool isEmpty() const {
+            return (connectionsMax == 0 && connectionsMinutes == 0 && messagesReceived == 0 &&
+                    messagesSent == 0 && httpResponseMessagesSent == 0 && blocksReceived <= 0 &&
+                    blocksSent <= 0 && requestsReceived == 0 && counters.isEmpty());
+        }
+
+        uint32_t externalConnectionsMinutes() const {
+            uint32_t count = 0;
+
+            QHashIterator<QByteArray, Report> it(externalReports);
+            while (it.hasNext()) {
+                it.next();
+                const Report &r = it.value();
+
+                count += r.connectionsMinutes;
+            }
+
+            return count;
+        }
+
+        void addConnectionsMinutes(uint32_t mins, int64_t now) {
+            connectionsMinutes += mins;
+
+            lastUpdate = now;
+        }
+
+        void addMessageReceived(int blocks, int64_t now) {
+            ++messagesReceived;
+
+            if (blocks > 0) {
+                if (blocksReceived < 0)
+                    blocksReceived = 0;
+
+                blocksReceived += blocks;
+            }
+
+            lastUpdate = now;
+        }
+
+        void addMessageSent(const QString &transport, int blocks, int64_t now) {
+            ++messagesSent;
+
+            if (transport == "http-response")
+                ++httpResponseMessagesSent;
+
+            if (blocks > 0) {
+                if (blocksSent < 0)
+                    blocksSent = 0;
+
+                blocksSent += blocks;
+            }
+
+            lastUpdate = now;
+        }
+
+        void addRequestsReceived(uint32_t count, int64_t now) {
+            requestsReceived += count;
+
+            lastUpdate = now;
+        }
+
+        void incCounter(Stats::Counter c, uint32_t count, int64_t now) {
+            counters.inc(c, count);
+
+            lastUpdate = now;
+        }
+
+        void addCounters(const Stats::Counters &other, int64_t now) {
+            counters.add(other);
+
+            lastUpdate = now;
+        }
+    };
+
+    class Counts {
+    public:
+        uint32_t requestsReceived;
+
+        Counts() : requestsReceived(0) {}
+
+        bool isEmpty() { return (requestsReceived == 0); }
+    };
+
+    class PrometheusMetric {
+    public:
+        enum Type {
+            RequestReceived,
+            ConnectionConnected,
+            ConnectionMinute,
+            MessageReceived,
+            MessageSent
+        };
+
+        Type mtype;
+        QString name;
+        QString type;
+        QString help;
+
+        PrometheusMetric(Type _mtype, const QString &_name, const QString &_type,
+                         const QString &_help)
+            : mtype(_mtype), name(_name), type(_type), help(_help) {}
+    };
+
+    typedef QPair<QString, QString> SubscriptionKey;
+
+    StatsManager *q;
+    int connectionsMax;
+    int subscriptionsMax;
+    QByteArray instanceId;
+    int ipcFileMode;
+    QString spec;
+    Format outputFormat;
+    bool connectionSend;
+    bool connectionsMaxSend;
+    int connectionTtl;
+    int connectionsMaxTtl;
+    int connectionLinger;
+    int subscriptionTtl;
+    int subscriptionLinger;
+    int reportInterval;
+    std::unique_ptr<ZmqSocket> sock;
+    std::unique_ptr<SimpleHttpServer> prometheusServer;
+    int prometheusConnectionsMax;
+    QString prometheusPrefix;
+    QList<PrometheusMetric> prometheusMetrics;
+    QHash<QByteArray, uint32_t> routeActivity;
+    QHash<QByteArray, ConnectionInfo *> connectionInfoById;
+    QHash<QByteArray, QSet<ConnectionInfo *>> connectionInfoByRoute;
+    QHash<QByteArray, RetryInfo> retryInfoBySource;
+    QVector<QSet<ConnectionInfo *>> connectionInfoRefreshBuckets;
+    int currentConnectionInfoRefreshBucket;
+    QHash<QByteArray, QHash<QByteArray, ConnectionInfo *>> externalConnectionInfoByFrom;
+    QHash<QByteArray, QSet<ConnectionInfo *>> externalConnectionInfoByRoute;
+    QHash<SubscriptionKey, Subscription *> subscriptionsByKey;
+    QVector<QSet<Subscription *>> subscriptionRefreshBuckets;
+    int currentSubscriptionRefreshBucket;
+    ConnectionsMaxes connectionsMaxes;
+    QHash<QByteArray, ExternalConnectionsMaxes> externalConnectionsMaxes;
+    TimerWheel wheel;
+    int64_t startTime;
+    QHash<QByteArray, Report *> reports;
+    Counts combinedCounts;
+    Report combinedReport;
+    std::unique_ptr<Timer> activityTimer;
+    std::unique_ptr<Timer> reportTimer;
+    std::unique_ptr<Timer> refreshTimer;
+    std::unique_ptr<Timer> externalConnectionsMaxTimer;
+    Connection activityTimerConnection;
+    Connection reportTimerConnection;
+    Connection refreshTimerConnection;
+    Connection externalConnectionsMaxTimerConnection;
+    Connection promServerConnection;
+
+    Private(StatsManager *_q, int _connectionsMax, int _subscriptionsMax,
+            int _prometheusConnectionsMax)
+        : q(_q),
+          connectionsMax(_connectionsMax),
+          subscriptionsMax(_subscriptionsMax),
+          ipcFileMode(-1),
+          outputFormat(TnetStringFormat),
+          connectionSend(false),
+          connectionsMaxSend(false),
+          connectionTtl(120 * 1000),
+          connectionsMaxTtl(60 * 1000),
+          connectionLinger(60 * 1000),
+          subscriptionTtl(60 * 1000),
+          subscriptionLinger(60 * 1000),
+          reportInterval(10 * 1000),
+          prometheusConnectionsMax(_prometheusConnectionsMax),
+          currentConnectionInfoRefreshBucket(0),
+          currentSubscriptionRefreshBucket(0),
+          wheel(TimerWheel((_connectionsMax * 2) + _subscriptionsMax)) {
+        activityTimer = std::make_unique<Timer>();
+        activityTimerConnection =
+            activityTimer->timeout.connect(boost::bind(&Private::activity_timeout, this));
+        activityTimer->setSingleShot(true);
+
+        refreshTimer = std::make_unique<Timer>();
+        refreshTimerConnection =
+            refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
+        refreshTimer->start(REFRESH_INTERVAL);
+
+        externalConnectionsMaxTimer = std::make_unique<Timer>();
+        externalConnectionsMaxTimerConnection = externalConnectionsMaxTimer->timeout.connect(
+            boost::bind(&Private::externalConnectionsMax_timeout, this));
+        externalConnectionsMaxTimer->start(EXTERNAL_CONNECTIONS_MAX_INTERVAL);
+
+        setupConnectionBuckets();
+        setupSubscriptionBuckets();
+
+        prometheusMetrics += PrometheusMetric(PrometheusMetric::RequestReceived, "request_received",
+                                              "counter", "Number of requests received");
+        prometheusMetrics +=
+            PrometheusMetric(PrometheusMetric::ConnectionConnected, "connection_connected", "gauge",
+                             "Number of concurrent connections");
+        prometheusMetrics +=
+            PrometheusMetric(PrometheusMetric::ConnectionMinute, "connection_minute", "counter",
+                             "Number of minutes clients have been connected");
+        prometheusMetrics +=
+            PrometheusMetric(PrometheusMetric::MessageReceived, "message_received", "counter",
+                             "Number of messages received by the publish API");
+        prometheusMetrics += PrometheusMetric(PrometheusMetric::MessageSent, "message_sent",
+                                              "counter", "Number of messages sent to clients");
+
+        startTime = QDateTime::currentMSecsSinceEpoch();
+
+        connectionsMaxes.lastRefresh = startTime;
+    }
+
+    ~Private() {
+        qDeleteAll(connectionInfoById);
+
+        QMutableHashIterator<QByteArray, QHash<QByteArray, ConnectionInfo *>> it(
+            externalConnectionInfoByFrom);
+        while (it.hasNext()) {
+            it.next();
+            qDeleteAll(it.value());
+        }
+
+        qDeleteAll(subscriptionsByKey);
+
+        qDeleteAll(reports);
+    }
+
+    bool setupSock() {
+        sock.reset();
+
+        sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
+
+        sock->setHwm(OUT_HWM);
+        sock->setWriteQueueEnabled(false);
+        sock->setShutdownWaitTime(0);
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(sock.get(), spec, true, ipcFileMode, &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        return true;
+    }
+
+    bool setPrometheusPort(const QString &portStr) {
+        assert(!prometheusServer);
+
+        prometheusServer = std::make_unique<SimpleHttpServer>(prometheusConnectionsMax, 8192, 8192);
+        promServerConnection = prometheusServer->requestReady.connect(
+            boost::bind(&Private::prometheus_requestReady, this));
+
+        if (portStr.startsWith("ipc://")) {
+            if (!prometheusServer->listenLocal(portStr.mid(6))) {
+                promServerConnection.disconnect();
+                prometheusServer.reset();
+
+                return false;
+            }
+        } else {
+            QHostAddress addr;
+            int port = -1;
+
+            int pos = portStr.indexOf(':');
+            if (pos >= 0) {
+                addr = QHostAddress(portStr.mid(0, pos));
+                port = portStr.mid(pos + 1).toInt();
+            } else {
+                port = portStr.toInt();
+            }
+
+            if (!prometheusServer->listen(addr, port)) {
+                promServerConnection.disconnect();
+                prometheusServer.reset();
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    void setupConnectionBuckets() {
+        int shouldProcessTime = SHOULD_PROCESS_TIME(connectionTtl);
+        QVector<QSet<ConnectionInfo *>> newBuckets(qMax(shouldProcessTime / REFRESH_INTERVAL, 1));
+
+        // Rebalance (NOTE: this algorithm is not optimal)
+        int nextBucketIndex = 0;
+        for (int n = 0; n < connectionInfoRefreshBuckets.count(); ++n) {
+            foreach (ConnectionInfo *c, connectionInfoRefreshBuckets[n]) {
+                newBuckets[nextBucketIndex++] += c;
+                if (nextBucketIndex >= newBuckets.count())
+                    nextBucketIndex = 0;
+            }
+        }
+
+        connectionInfoRefreshBuckets = newBuckets;
+        currentConnectionInfoRefreshBucket = 0;
+    }
+
+    void setupSubscriptionBuckets() {
+        int shouldProcessTime = SHOULD_PROCESS_TIME(subscriptionTtl);
+        QVector<QSet<Subscription *>> newBuckets(qMax(shouldProcessTime / REFRESH_INTERVAL, 1));
+
+        // Rebalance (NOTE: this algorithm is not optimal)
+        int nextBucketIndex = 0;
+        for (int n = 0; n < subscriptionRefreshBuckets.count(); ++n) {
+            foreach (Subscription *s, subscriptionRefreshBuckets[n]) {
+                newBuckets[nextBucketIndex++] += s;
+                if (nextBucketIndex >= newBuckets.count())
+                    nextBucketIndex = 0;
+            }
+        }
+
+        subscriptionRefreshBuckets = newBuckets;
+        currentSubscriptionRefreshBucket = 0;
+    }
+
+    void setupReportTimer() {
+        if (reportInterval > 0 && !reportTimer) {
+            reportTimer = std::make_unique<Timer>();
+            reportTimerConnection =
+                reportTimer->timeout.connect(boost::bind(&Private::report_timeout, this));
+            reportTimer->start(reportInterval);
+        } else if (reportInterval <= 0 && reportTimer) {
+            reportTimerConnection.disconnect();
+            reportTimer.reset();
+        }
+    }
+
+    int smallestConnectionInfoRefreshBucket() {
+        int best = -1;
+        int bestSize = 0;
+
+        for (int n = 0; n < connectionInfoRefreshBuckets.count(); ++n) {
+            if (best == -1 || connectionInfoRefreshBuckets[n].count() < bestSize) {
+                best = n;
+                bestSize = connectionInfoRefreshBuckets[n].count();
+            }
+        }
+
+        return best;
+    }
+
+    int smallestSubscriptionRefreshBucket() {
+        int best = -1;
+        int bestSize = 0;
+
+        for (int n = 0; n < subscriptionRefreshBuckets.count(); ++n) {
+            if (best == -1 || subscriptionRefreshBuckets[n].count() < bestSize) {
+                best = n;
+                bestSize = subscriptionRefreshBuckets[n].count();
+            }
+        }
+
+        return best;
+    }
+
+    void wheelAdd(int64_t timeoutTime, TimerBase *obj) {
+        if (timeoutTime < startTime) {
+            timeoutTime = startTime;
+        }
+
+        if (obj->timerId >= 0) {
+            wheel.remove(obj->timerId);
+        }
+
+        int id = wheel.add(durationToTicksRoundUp(timeoutTime - startTime), (size_t)obj);
+        assert(id >= 0);
+
+        obj->timerId = id;
+    }
+
+    void wheelRemove(TimerBase *obj) {
+        if (obj->timerId >= 0) {
+            wheel.remove(obj->timerId);
+        }
+
+        obj->timerId = -1;
+    }
+
+    void insertConnection(ConnectionInfo *c) {
+        connectionInfoById[c->id] = c;
+
+        QSet<ConnectionInfo *> &cs = connectionInfoByRoute[c->routeId];
+        cs += c;
+
+        assert(c->lastRefresh >= 0);
+        wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(connectionTtl), c);
+
+        c->refreshBucket = smallestConnectionInfoRefreshBucket();
+        connectionInfoRefreshBuckets[c->refreshBucket] += c;
+    }
+
+    void removeConnection(ConnectionInfo *c) {
+        connectionInfoById.remove(c->id);
+
+        if (connectionInfoByRoute.contains(c->routeId)) {
+            QSet<ConnectionInfo *> &cs = connectionInfoByRoute[c->routeId];
+            cs.remove(c);
+
+            if (cs.isEmpty())
+                connectionInfoByRoute.remove(c->routeId);
+        }
+
+        if (c->retrySeq >= 0) {
+            RetryInfo &ri = retryInfoBySource[c->from];
+            ri.connectionInfoBySeq.remove(c->retrySeq);
+
+            // FIXME: we keep the source entry even when there are no more
+            // connections, to avoid resetting the seq value. If there is
+            // a lot of proxy instance churn, retryInfoBySource could
+            // fill up with unused entries that will never be cleaned up.
+        }
+
+        if (c->lastRefresh >= 0) {
+            wheelRemove(c);
+            connectionInfoRefreshBuckets[c->refreshBucket].remove(c);
+        }
+    }
+
+    void insertExternalConnection(ConnectionInfo *c) {
+        QHash<QByteArray, ConnectionInfo *> &extConnectionInfoById =
+            externalConnectionInfoByFrom[c->from];
+        extConnectionInfoById[c->id] = c;
+
+        QSet<ConnectionInfo *> &cs = externalConnectionInfoByRoute[c->routeId];
+        cs += c;
+
+        assert(c->lastActive >= 0);
+        wheelAdd(c->lastActive + connectionTtl, c);
+
+        assert(c->lastRefresh == -1);
+        assert(c->refreshBucket == -1);
+    }
+
+    void removeExternalConnection(ConnectionInfo *c) {
+        assert(externalConnectionInfoByFrom.contains(c->from));
+
+        QHash<QByteArray, ConnectionInfo *> &extConnectionInfoById =
+            externalConnectionInfoByFrom[c->from];
+        extConnectionInfoById.remove(c->id);
+
+        if (extConnectionInfoById.isEmpty())
+            externalConnectionInfoByFrom.remove(c->from);
+
+        if (externalConnectionInfoByRoute.contains(c->routeId)) {
+            QSet<ConnectionInfo *> &cs = externalConnectionInfoByRoute[c->routeId];
+            cs.remove(c);
+
+            if (cs.isEmpty())
+                externalConnectionInfoByRoute.remove(c->routeId);
+        }
+
+        wheelRemove(c);
+    }
+
+    void removeLingeringConnections(const QByteArray &source, uint64_t retrySeq) {
+        if (!retryInfoBySource.contains(source))
+            return;
+
+        RetryInfo &ri = retryInfoBySource[source];
+
+        // Invalid retry seq
+        if (retrySeq >= ri.nextSeq)
+            return;
+
+        QList<ConnectionInfo *> toRemove;
+
+        QMap<uint64_t, ConnectionInfo *>::iterator it = ri.connectionInfoBySeq.find(retrySeq);
+        while (it != ri.connectionInfoBySeq.end()) {
+            toRemove += it.value();
+
+            if (it == ri.connectionInfoBySeq.begin())
+                break;
+
+            --it;
+        }
+
+        foreach (ConnectionInfo *c, toRemove) {
+            removeConnection(c);
+            delete c;
+        }
+    }
+
+    void insertSubscription(Subscription *s) {
+        SubscriptionKey subKey(s->mode, s->channel);
+
+        subscriptionsByKey[subKey] = s;
+
+        assert(s->lastRefresh >= 0);
+        wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(subscriptionTtl), s);
+
+        s->refreshBucket = smallestSubscriptionRefreshBucket();
+        subscriptionRefreshBuckets[s->refreshBucket] += s;
+    }
+
+    void removeSubscription(Subscription *s) {
+        SubscriptionKey subKey(s->mode, s->channel);
+
+        subscriptionsByKey.remove(subKey);
+
+        if (s->lastRefresh >= 0) {
+            wheelRemove(s);
+            subscriptionRefreshBuckets[s->refreshBucket].remove(s);
+        }
+    }
+
+    Report *getOrCreateReport(const QByteArray &routeId) {
+        Report *report = reports.value(routeId);
+        if (!report) {
+            report = new Report;
+            report->routeId = routeId;
+            report->startTime = QDateTime::currentMSecsSinceEpoch();
+            reports[routeId] = report;
+        }
+
+        return report;
+    }
+
+    void removeReport(Report *report) {
+        // Subtract the current total from the combined report
+        combinedReport.connectionsMax -= report->connectionsMax;
+
+        reports.remove(report->routeId);
+    }
+
+    ConnectionsMax &getOrCreateConnectionsMax(const QByteArray &routeId) {
+        if (!connectionsMaxes.maxes.contains(routeId))
+            connectionsMaxes.maxes.insert(routeId, ConnectionsMax());
+
+        return connectionsMaxes.maxes[routeId];
+    }
+
+    void write(const StatsPacket &packet) {
+        assert(sock);
+
+        QByteArray prefix;
+        if (packet.type == StatsPacket::Activity)
+            prefix = "activity";
+        else if (packet.type == StatsPacket::Message)
+            prefix = "message";
+        else if (packet.type == StatsPacket::Connected || packet.type == StatsPacket::Disconnected)
+            prefix = "conn";
+        else if (packet.type == StatsPacket::Subscribed || packet.type == StatsPacket::Unsubscribed)
+            prefix = "sub";
+        else if (packet.type == StatsPacket::Report)
+            prefix = "report";
+        else if (packet.type == StatsPacket::Counts)
+            prefix = "counts";
+        else // ConnectionsMax
+            prefix = "conn-max";
+
+        Variant vpacket = packet.toVariant();
+
+        QByteArray buf;
+        if (outputFormat == TnetStringFormat) {
+            buf = prefix + " T" + TnetString::fromVariant(vpacket);
+        } else if (outputFormat == JsonFormat) {
+            QJsonObject obj = QJsonObject::fromVariantHash(vpacket.toHash());
+            buf = prefix + " J" + QJsonDocument(obj).toJson(QJsonDocument::Compact);
+        }
+
+        if (!buf.isEmpty()) {
+            if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+                log_debug("stats: OUT %s %s", prefix.data(),
+                          qPrintable(TnetString::variantToString(vpacket, -1)));
+
+            sock->write(QList<QByteArray>() << buf);
+        }
+    }
+
+    void sendActivity(const QByteArray &routeId, uint32_t count) {
+        if (!sock)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Activity;
+        p.from = instanceId;
+        p.route = routeId;
+        p.count = count;
+        write(p);
+    }
+
+    void sendMessage(const QString &channel, const QString &itemId, const QString &transport,
+                     uint32_t count, int blocks) {
+        if (!sock)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Message;
+        p.from = instanceId;
+        p.channel = channel.toUtf8();
+        p.itemId = itemId.toUtf8();
+        p.count = count;
+        p.blocks = blocks;
+        p.transport = transport.toUtf8();
+        write(p);
+    }
+
+    void sendConnected(ConnectionInfo *c) {
+        if (!sock || !connectionSend)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Connected;
+        p.from = instanceId;
+        p.route = c->routeId;
+        p.connectionId = c->id;
+        if (c->type == WebSocket)
+            p.connectionType = StatsPacket::WebSocket;
+        else
+            p.connectionType = StatsPacket::Http;
+        p.peerAddress = c->peerAddress;
+        p.ssl = c->ssl;
+        p.ttl = connectionTtl / 1000;
+        write(p);
+    }
+
+    void sendDisconnected(ConnectionInfo *c) {
+        if (!sock || !connectionSend)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Disconnected;
+        p.from = instanceId;
+        p.route = c->routeId;
+        p.connectionId = c->id;
+        write(p);
+    }
+
+    void sendSubscribed(Subscription *s) {
+        if (!sock)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Subscribed;
+        p.from = instanceId;
+        p.mode = s->mode.toUtf8();
+        p.channel = s->channel.toUtf8();
+        p.ttl = subscriptionTtl / 1000;
+        p.subscribers = s->subscriberCount;
+        write(p);
+    }
+
+    void sendUnsubscribed(Subscription *s) {
+        if (!sock)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Unsubscribed;
+        p.from = instanceId;
+        p.mode = s->mode.toUtf8();
+        p.channel = s->channel.toUtf8();
+        write(p);
+    }
+
+    void sendCounts(const Counts &counts) {
+        if (!sock)
+            return;
+
+        StatsPacket p;
+        p.type = StatsPacket::Counts;
+        p.from = instanceId;
+        p.requestsReceived = counts.requestsReceived;
+        write(p);
+    }
+
+    void sendConnectionsMax(const QByteArray &routeId, ConnectionsMax *cm, int64_t now) {
+        q->connMax(getConnMaxPacket(routeId, cm, now));
+    }
+
+    void updateConnectionsMax(const QByteArray &routeId, int64_t now) {
+        uint32_t localConns = connectionInfoByRoute.value(routeId).count();
+        uint32_t extConns = externalConnectionInfoByRoute.value(routeId).count();
+
+        uint32_t extConnsMax = 0;
+        if (externalConnectionsMaxes.contains(routeId))
+            extConnsMax = externalConnectionsMaxes[routeId].total();
+
+        uint32_t conns = localConns + extConns + extConnsMax;
+
+        if (connectionsMaxSend) {
+            ConnectionsMax &cm = getOrCreateConnectionsMax(routeId);
+
+            cm.currentValue = conns;
+            cm.maxValue = qMax(cm.maxValue, conns);
+
+            if (cm.valueToSend() != cm.lastSentValue) {
+                connectionsMaxes.needSend.insert(routeId);
+
+                if (!activityTimer->isActive())
+                    activityTimer->start(ACTIVITY_TIMEOUT);
+            } else {
+                connectionsMaxes.needSend.remove(routeId);
+            }
+        }
+
+        if (reportInterval > 0) {
+            Report *report = getOrCreateReport(routeId);
+
+            // Subtract the current total from the combined report
+            combinedReport.connectionsMax -= report->connectionsMax;
+
+            // Update the individual report
+            if (report->connectionsMaxStale) {
+                report->connectionsMax = conns;
+                report->connectionsMaxStale = false;
+            } else
+                report->connectionsMax = qMax(report->connectionsMax, conns);
+
+            report->lastUpdate = now;
+
+            // Add the new total to the combined report
+            combinedReport.connectionsMax += report->connectionsMax;
+            combinedReport.lastUpdate = now;
+        }
+    }
+
+    void updateConnectionsMinutes(ConnectionInfo *c, int64_t now) {
+        // Ignore lingering connections
+        if (c->linger)
+            return;
+
+        Report *report = getOrCreateReport(c->routeId);
+
+        int mins = (now - c->lastReport) / 60000;
+        if (mins > 0) {
+            // Only advance as much as we've read
+            c->lastReport += mins * 60000;
+
+            report->addConnectionsMinutes(mins, now);
+            combinedReport.addConnectionsMinutes(mins, now);
+        }
+    }
+
+    void handleExpirations(int64_t now) {
+        QList<QByteArray> refreshedConnIds;
+        QSet<QByteArray> routesUpdated;
+
+        for (int i = 0; i < EXPIRE_MAX; ++i) {
+            TimerWheel::Expired expired = wheel.takeExpired();
+
+            if (expired.key < 0) {
+                break;
+            }
+
+            TimerBase *obj = (TimerBase *)expired.userData;
+
+            obj->timerId = -1;
+
+            switch (obj->timerType) {
+            case TimerBase::Type::Connection: {
+                ConnectionInfo *c = static_cast<ConnectionInfo *>(obj);
+
+                if (c->linger) {
+                    // In linger mode, next refresh is set to the time we should
+                    // delete the connection rather than refresh
+
+                    connectionInfoRefreshBuckets[c->refreshBucket].remove(c);
+                    c->lastRefresh = -1;
+
+                    // Note: we don't send a disconnect message when the
+                    // linger expires. The assumption is that the handler
+                    // owns the connection now
+
+                    removeConnection(c);
+                    delete c;
+                } else {
+                    c->lastRefresh = now;
+                    wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(connectionTtl), c);
+
+                    refreshedConnIds += c->id;
+
+                    updateConnectionsMinutes(c, now);
+                    sendConnected(c);
+                }
+
+                break;
+            }
+            case TimerBase::Type::ExternalConnection: {
+                ConnectionInfo *c = static_cast<ConnectionInfo *>(obj);
+
+                routesUpdated += c->routeId;
+                updateConnectionsMinutes(c, now);
+                removeExternalConnection(c);
+                delete c;
+
+                break;
+            }
+            case TimerBase::Type::Subscription: {
+                Subscription *s = static_cast<Subscription *>(obj);
+
+                if (s->linger) {
+                    // In linger mode, next refresh is set to the time we should
+                    // delete the subscription rather than refresh
+
+                    subscriptionRefreshBuckets[s->refreshBucket].remove(s);
+                    s->lastRefresh = -1;
+
+                    QString mode = s->mode;
+                    QString channel = s->channel;
+
+                    sendUnsubscribed(s);
+                    removeSubscription(s);
+                    delete s;
+
+                    q->unsubscribed(mode, channel);
+                } else {
+                    s->lastRefresh = now;
+                    wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(subscriptionTtl), s);
+
+                    sendSubscribed(s);
+                }
+
+                break;
+            }
+            }
+        }
+
+        if (!refreshedConnIds.isEmpty())
+            q->connectionsRefreshed(refreshedConnIds);
+
+        foreach (const QByteArray &routeId, routesUpdated)
+            updateConnectionsMax(routeId, now);
+    }
+
+    void refreshConnections(int64_t now) {
+        QList<QByteArray> refreshedIds;
+
+        // Process the current bucket
+        const QSet<ConnectionInfo *> &bucket =
+            connectionInfoRefreshBuckets[currentConnectionInfoRefreshBucket];
+        foreach (ConnectionInfo *c, bucket) {
+            // Don't bucket-process lingered connections
+            if (c->linger)
+                continue;
+
+            c->lastRefresh = now;
+            wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(connectionTtl), c);
+
+            refreshedIds += c->id;
+
+            updateConnectionsMinutes(c, now);
+            sendConnected(c);
+        }
+
+        if (!refreshedIds.isEmpty())
+            q->connectionsRefreshed(refreshedIds);
+
+        ++currentConnectionInfoRefreshBucket;
+        if (currentConnectionInfoRefreshBucket >= connectionInfoRefreshBuckets.count())
+            currentConnectionInfoRefreshBucket = 0;
+    }
+
+    void refreshSubscriptions(int64_t now) {
+        // Process the current bucket
+        const QSet<Subscription *> &bucket =
+            subscriptionRefreshBuckets[currentSubscriptionRefreshBucket];
+        foreach (Subscription *s, bucket) {
+            // Don't bucket-process lingered subscriptions
+            if (s->linger)
+                continue;
+
+            s->lastRefresh = now;
+            wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(subscriptionTtl), s);
+
+            sendSubscribed(s);
+        }
+
+        ++currentSubscriptionRefreshBucket;
+        if (currentSubscriptionRefreshBucket >= subscriptionRefreshBuckets.count())
+            currentSubscriptionRefreshBucket = 0;
+    }
+
+    void refreshConnectionsMaxes(int64_t now) {
+        if (now < connectionsMaxes.lastRefresh + (connectionsMaxTtl * 3 / 4))
+            return;
+
+        connectionsMaxes.lastRefresh = now;
+
+        QList<QByteArray> toRemove;
+
+        QMutableHashIterator<QByteArray, ConnectionsMax> it(connectionsMaxes.maxes);
+        while (it.hasNext()) {
+            it.next();
+            const QByteArray &routeId = it.key();
+            ConnectionsMax &cm = it.value();
+
+            if (cm.valueToSend() == 0) {
+                if (cm.lastSentTime >= 0 && now >= cm.lastSentTime + connectionsMaxTtl)
+                    toRemove += routeId;
+
+                continue;
+            }
+
+            sendConnectionsMax(routeId, &cm, now);
+        }
+
+        foreach (const QByteArray &routeId, toRemove)
+            connectionsMaxes.maxes.remove(routeId);
+    }
+
+    void expireExternalConnectionsMaxes(int64_t now) {
+        QMutableHashIterator<QByteArray, ExternalConnectionsMaxes> it(externalConnectionsMaxes);
+        while (it.hasNext()) {
+            it.next();
+            QHash<QByteArray, ExternalConnectionsMax> &maxesForRoute = it.value().maxes;
+
+            QMutableHashIterator<QByteArray, ExternalConnectionsMax> rit(maxesForRoute);
+            while (rit.hasNext()) {
+                rit.next();
+                ExternalConnectionsMax &cm = rit.value();
+
+                if (now >= cm.expires)
+                    rit.remove();
+            }
+
+            if (maxesForRoute.isEmpty())
+                it.remove();
+        }
+    }
+
+    void mergeExternalConnectionsMax(const StatsPacket &packet, int64_t now) {
+        if (packet.retrySeq >= 0)
+            removeLingeringConnections(packet.from, (uint64_t)packet.retrySeq);
+
+        QHash<QByteArray, ExternalConnectionsMax> &maxes =
+            externalConnectionsMaxes[packet.route].maxes;
+
+        if (!maxes.contains(packet.from))
+            maxes.insert(packet.from, ExternalConnectionsMax());
+
+        ExternalConnectionsMax &cm = maxes[packet.from];
+
+        cm.value = (uint32_t)qMax(packet.connectionsMax, 0);
+        cm.expires = now + (qMax(packet.ttl, 0) * 1000);
+
+        updateConnectionsMax(packet.route, now);
+    }
+
+    void mergeExternalReport(const StatsPacket &packet, bool includeConnections) {
+        if (reportInterval <= 0)
+            return;
+
+        Report *report = getOrCreateReport(packet.route);
+
+        Stats::Counters counters;
+
+        counters.inc(Stats::ClientHeaderBytesReceived, qMax(packet.clientHeaderBytesReceived, 0));
+        counters.inc(Stats::ClientHeaderBytesSent, qMax(packet.clientHeaderBytesSent, 0));
+        counters.inc(Stats::ClientContentBytesReceived, qMax(packet.clientContentBytesReceived, 0));
+        counters.inc(Stats::ClientContentBytesSent, qMax(packet.clientContentBytesSent, 0));
+        counters.inc(Stats::ClientMessagesReceived, qMax(packet.clientMessagesReceived, 0));
+        counters.inc(Stats::ClientMessagesSent, qMax(packet.clientMessagesSent, 0));
+        counters.inc(Stats::ServerHeaderBytesReceived, qMax(packet.serverHeaderBytesReceived, 0));
+        counters.inc(Stats::ServerHeaderBytesSent, qMax(packet.serverHeaderBytesSent, 0));
+        counters.inc(Stats::ServerContentBytesReceived, qMax(packet.serverContentBytesReceived, 0));
+        counters.inc(Stats::ServerContentBytesSent, qMax(packet.serverContentBytesSent, 0));
+        counters.inc(Stats::ServerMessagesReceived, qMax(packet.serverMessagesReceived, 0));
+        counters.inc(Stats::ServerMessagesSent, qMax(packet.serverMessagesSent, 0));
+
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+        report->addCounters(counters, now);
+        combinedReport.addCounters(counters, now);
+
+        if (includeConnections) {
+            if (!report->externalReports.contains(packet.from))
+                report->externalReports[packet.from] = Report();
+
+            Report &r = report->externalReports[packet.from];
+
+            int mins = qMax(packet.connectionsMinutes, 0);
+
+            r.connectionsMinutes += mins;
+            combinedReport.addConnectionsMinutes(mins, now);
+        }
+    }
+
+    StatsPacket reportToPacket(Report *report, const QByteArray &routeId, int64_t now) {
+        if (report->connectionsMaxStale)
+            updateConnectionsMax(routeId, now);
+
+        StatsPacket p;
+        p.type = StatsPacket::Report;
+        p.from = instanceId;
+        p.route = routeId;
+
+        p.connectionsMax = report->connectionsMax;
+        p.connectionsMinutes = report->connectionsMinutes + report->externalConnectionsMinutes();
+        p.messagesReceived = report->messagesReceived;
+        p.messagesSent = report->messagesSent;
+        p.httpResponseMessagesSent = report->httpResponseMessagesSent;
+        p.blocksReceived = report->blocksReceived;
+        p.blocksSent = report->blocksSent;
+        p.duration = now - report->startTime;
+
+        p.clientHeaderBytesReceived = report->counters.get(Stats::ClientHeaderBytesReceived);
+        p.clientHeaderBytesSent = report->counters.get(Stats::ClientHeaderBytesSent);
+        p.clientContentBytesReceived = report->counters.get(Stats::ClientContentBytesReceived);
+        p.clientContentBytesSent = report->counters.get(Stats::ClientContentBytesSent);
+        p.clientMessagesReceived = report->counters.get(Stats::ClientMessagesReceived);
+        p.clientMessagesSent = report->counters.get(Stats::ClientMessagesSent);
+        p.serverHeaderBytesReceived = report->counters.get(Stats::ServerHeaderBytesReceived);
+        p.serverHeaderBytesSent = report->counters.get(Stats::ServerHeaderBytesSent);
+        p.serverContentBytesReceived = report->counters.get(Stats::ServerContentBytesReceived);
+        p.serverContentBytesSent = report->counters.get(Stats::ServerContentBytesSent);
+        p.serverMessagesReceived = report->counters.get(Stats::ServerMessagesReceived);
+        p.serverMessagesSent = report->counters.get(Stats::ServerMessagesSent);
+
+        report->startTime = now;
+        report->connectionsMaxStale = true;
+        report->connectionsMinutes = 0;
+        report->messagesReceived = 0;
+        report->messagesSent = 0;
+        report->httpResponseMessagesSent = 0;
+        report->blocksReceived = -1;
+        report->blocksSent = -1;
+        report->counters.reset();
+        report->externalReports.clear();
+
+        return p;
+    }
+
+    void flushReport(const QByteArray &routeId) {
+        Report *report = getOrCreateReport(routeId);
+
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+        StatsPacket p = reportToPacket(report, routeId, now);
+
+        if (report->isEmpty()) {
+            removeReport(report);
+            delete report;
+        }
+
+        if (sock)
+            write(p);
+
+        q->reported(QList<StatsPacket>() << p);
+    }
+
+    StatsPacket getConnMaxPacket(const QByteArray &routeId, ConnectionsMax *cm, int64_t now) {
+        uint32_t value = cm->valueToSend();
+
+        StatsPacket p;
+        p.type = StatsPacket::ConnectionsMax;
+        p.from = instanceId;
+        p.route = routeId;
+        p.connectionsMax = value;
+        p.ttl = connectionsMaxTtl / 1000;
+        p.retrySeq = cm->retrySeq;
+
+        cm->lastSentValue = value;
+        cm->lastSentTime = now;
+        cm->maxValue = cm->currentValue;
+
+        return p;
+    }
 
 private:
-	void activity_timeout()
-	{
-		QHashIterator<QByteArray, uint32_t> it(routeActivity);
-		while(it.hasNext())
-		{
-			it.next();
-			sendActivity(it.key(), it.value());
-		}
+    void activity_timeout() {
+        QHashIterator<QByteArray, uint32_t> it(routeActivity);
+        while (it.hasNext()) {
+            it.next();
+            sendActivity(it.key(), it.value());
+        }
 
-		routeActivity.clear();
+        routeActivity.clear();
 
-		if(!combinedCounts.isEmpty())
-		{
-			sendCounts(combinedCounts);
+        if (!combinedCounts.isEmpty()) {
+            sendCounts(combinedCounts);
 
-			combinedCounts = Counts();
-		}
+            combinedCounts = Counts();
+        }
 
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
 
-		QSet<QByteArray> needSendNext;
+        QSet<QByteArray> needSendNext;
 
-		foreach(const QByteArray &routeId, connectionsMaxes.needSend)
-		{
-			ConnectionsMax &cm = connectionsMaxes.maxes[routeId];
+        foreach (const QByteArray &routeId, connectionsMaxes.needSend) {
+            ConnectionsMax &cm = connectionsMaxes.maxes[routeId];
 
-			if(cm.valueToSend() == cm.lastSentValue)
-				continue;
+            if (cm.valueToSend() == cm.lastSentValue)
+                continue;
 
-			sendConnectionsMax(routeId, &cm, now);
+            sendConnectionsMax(routeId, &cm, now);
 
-			if(cm.valueToSend() != cm.lastSentValue)
-				needSendNext.insert(routeId);
-		}
+            if (cm.valueToSend() != cm.lastSentValue)
+                needSendNext.insert(routeId);
+        }
 
-		connectionsMaxes.needSend = needSendNext;
+        connectionsMaxes.needSend = needSendNext;
 
-		if(!connectionsMaxes.needSend.isEmpty() && !activityTimer->isActive())
-			activityTimer->start(ACTIVITY_TIMEOUT);
-	}
+        if (!connectionsMaxes.needSend.isEmpty() && !activityTimer->isActive())
+            activityTimer->start(ACTIVITY_TIMEOUT);
+    }
 
-	void report_timeout()
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
+    void report_timeout() {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
 
-		QList<StatsPacket> reportPackets;
-		QList<Report*> toDelete;
+        QList<StatsPacket> reportPackets;
+        QList<Report *> toDelete;
 
-		// Note: here we iterate over all reports, which will be one per
-		// route ID. This could become a problem if there are thousands
-		// of route IDs (at which point we can consider bucketing)
-		QHashIterator<QByteArray, Report*> it(reports);
-		while(it.hasNext())
-		{
-			it.next();
+        // Note: here we iterate over all reports, which will be one per
+        // route ID. This could become a problem if there are thousands
+        // of route IDs (at which point we can consider bucketing)
+        QHashIterator<QByteArray, Report *> it(reports);
+        while (it.hasNext()) {
+            it.next();
 
-			const QByteArray &routeId = it.key();
-			Report *report = it.value();
+            const QByteArray &routeId = it.key();
+            Report *report = it.value();
 
-			StatsPacket p = reportToPacket(report, routeId, now);
+            StatsPacket p = reportToPacket(report, routeId, now);
 
-			if(report->isEmpty())
-			{
-				// If report is empty, we can throw it out after sending
-				toDelete += report;
-			}
+            if (report->isEmpty()) {
+                // If report is empty, we can throw it out after sending
+                toDelete += report;
+            }
 
-			if(sock)
-				write(p);
+            if (sock)
+                write(p);
 
-			reportPackets += p;
-		}
+            reportPackets += p;
+        }
 
-		foreach(Report *report, toDelete)
-		{
-			removeReport(report);
-			delete report;
-		}
+        foreach (Report *report, toDelete) {
+            removeReport(report);
+            delete report;
+        }
 
-		if(!reportPackets.isEmpty())
-			q->reported(reportPackets);
-	}
+        if (!reportPackets.isEmpty())
+            q->reported(reportPackets);
+    }
 
-	void refresh_timeout()
-	{
-		int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+    void refresh_timeout() {
+        int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
 
-		// Time must go forward
-		if(currentTime > startTime)
-		{
-			uint64_t currentTicks = (uint64_t)durationToTicksRoundDown(currentTime - startTime);
+        // Time must go forward
+        if (currentTime > startTime) {
+            uint64_t currentTicks = (uint64_t)durationToTicksRoundDown(currentTime - startTime);
 
-			wheel.update(currentTicks);
-		}
+            wheel.update(currentTicks);
+        }
 
-		handleExpirations(currentTime);
+        handleExpirations(currentTime);
 
-		refreshConnections(currentTime);
-		refreshSubscriptions(currentTime);
-		refreshConnectionsMaxes(currentTime);
-	}
+        refreshConnections(currentTime);
+        refreshSubscriptions(currentTime);
+        refreshConnectionsMaxes(currentTime);
+    }
 
-	void externalConnectionsMax_timeout()
-	{
-		int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+    void externalConnectionsMax_timeout() {
+        int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
 
-		expireExternalConnectionsMaxes(currentTime);
-	}
+        expireExternalConnectionsMaxes(currentTime);
+    }
 
-	void prometheus_requestReady()
-	{
-		SimpleHttpRequest *req = prometheusServer->takeNext();
+    void prometheus_requestReady() {
+        SimpleHttpRequest *req = prometheusServer->takeNext();
 
-		QString data;
+        QString data;
 
-		foreach(const PrometheusMetric &m, prometheusMetrics)
-		{
-			Variant value;
+        foreach (const PrometheusMetric &m, prometheusMetrics) {
+            Variant value;
 
-			switch(m.mtype)
-			{
-				case PrometheusMetric::RequestReceived: value = Variant(combinedReport.requestsReceived); break;
-				case PrometheusMetric::ConnectionConnected: value = Variant(combinedReport.connectionsMax); break;
-				case PrometheusMetric::ConnectionMinute: value = Variant(combinedReport.connectionsMinutes); break;
-				case PrometheusMetric::MessageReceived: value = Variant(combinedReport.messagesReceived); break;
-				case PrometheusMetric::MessageSent: value = Variant(combinedReport.messagesSent); break;
-			}
+            switch (m.mtype) {
+            case PrometheusMetric::RequestReceived:
+                value = Variant(combinedReport.requestsReceived);
+                break;
+            case PrometheusMetric::ConnectionConnected:
+                value = Variant(combinedReport.connectionsMax);
+                break;
+            case PrometheusMetric::ConnectionMinute:
+                value = Variant(combinedReport.connectionsMinutes);
+                break;
+            case PrometheusMetric::MessageReceived:
+                value = Variant(combinedReport.messagesReceived);
+                break;
+            case PrometheusMetric::MessageSent:
+                value = Variant(combinedReport.messagesSent);
+                break;
+            }
 
-			if(value.isNull())
-				continue;
+            if (value.isNull())
+                continue;
 
-			data += QString(
-			"# HELP %1%2 %3\n"
-			"# TYPE %4%5 %6\n"
-			"%7%8 %9\n"
-			).arg(prometheusPrefix, m.name, m.help, prometheusPrefix, m.name, m.type, prometheusPrefix, m.name, value.toString());
-		}
+            data += QString("# HELP %1%2 %3\n"
+                            "# TYPE %4%5 %6\n"
+                            "%7%8 %9\n")
+                        .arg(prometheusPrefix, m.name, m.help, prometheusPrefix, m.name, m.type,
+                             prometheusPrefix, m.name, value.toString());
+        }
 
-		req->finished.connect([=] { DeferCall::deleteLater(req); });
+        req->finished.connect([=] { DeferCall::deleteLater(req); });
 
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "text/plain");
-		req->respond(200, "OK", headers, data.toUtf8());
-	}
+        HttpHeaders headers;
+        headers += HttpHeader("Content-Type", "text/plain");
+        req->respond(200, "OK", headers, data.toUtf8());
+    }
 };
 
-StatsManager::StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax)
-{
-	d = new Private(this, connectionsMax, subscriptionsMax, prometheusConnectionsMax);
+StatsManager::StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax) {
+    d = new Private(this, connectionsMax, subscriptionsMax, prometheusConnectionsMax);
 }
 
-StatsManager::~StatsManager()
-{
-	delete d;
+StatsManager::~StatsManager() { delete d; }
+
+void StatsManager::setInstanceId(const QByteArray &instanceId) { d->instanceId = instanceId; }
+
+void StatsManager::setIpcFileMode(int mode) { d->ipcFileMode = mode; }
+
+bool StatsManager::setSpec(const QString &spec) {
+    d->spec = spec;
+    return d->setupSock();
 }
 
-void StatsManager::setInstanceId(const QByteArray &instanceId)
-{
-	d->instanceId = instanceId;
+bool StatsManager::connectionSendEnabled() const { return d->connectionSend; }
+
+void StatsManager::setConnectionSendEnabled(bool enabled) { d->connectionSend = enabled; }
+
+void StatsManager::setConnectionsMaxSendEnabled(bool enabled) { d->connectionsMaxSend = enabled; }
+
+void StatsManager::setConnectionTtl(int secs) {
+    d->connectionTtl = secs * 1000;
+    d->setupConnectionBuckets();
 }
 
-void StatsManager::setIpcFileMode(int mode)
-{
-	d->ipcFileMode = mode;
+void StatsManager::setConnectionsMaxTtl(int secs) { d->connectionsMaxTtl = secs * 1000; }
+
+void StatsManager::setSubscriptionTtl(int secs) {
+    d->subscriptionTtl = secs * 1000;
+    d->setupSubscriptionBuckets();
 }
 
-bool StatsManager::setSpec(const QString &spec)
-{
-	d->spec = spec;
-	return d->setupSock();
+void StatsManager::setSubscriptionLinger(int secs) { d->subscriptionLinger = secs * 1000; }
+
+void StatsManager::setReportInterval(int secs) {
+    d->reportInterval = secs * 1000;
+    d->setupReportTimer();
 }
 
-bool StatsManager::connectionSendEnabled() const
-{
-	return d->connectionSend;
+void StatsManager::setOutputFormat(Format format) { d->outputFormat = format; }
+
+bool StatsManager::setPrometheusPort(const QString &port) { return d->setPrometheusPort(port); }
+
+void StatsManager::setPrometheusPrefix(const QString &prefix) { d->prometheusPrefix = prefix; }
+
+void StatsManager::addActivity(const QByteArray &routeId, uint32_t count) {
+    if (d->routeActivity.contains(routeId))
+        d->routeActivity[routeId] += count;
+    else
+        d->routeActivity[routeId] = count;
+
+    if (!d->activityTimer->isActive())
+        d->activityTimer->start(ACTIVITY_TIMEOUT);
 }
 
-void StatsManager::setConnectionSendEnabled(bool enabled)
-{
-	d->connectionSend = enabled;
+void StatsManager::addMessage(const QString &channel, const QString &itemId,
+                              const QString &transport, uint32_t count, int blocks) {
+    d->sendMessage(channel, itemId, transport, count, blocks);
 }
 
-void StatsManager::setConnectionsMaxSendEnabled(bool enabled)
-{
-	d->connectionsMaxSend = enabled;
+void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId,
+                                 ConnectionType type, const QHostAddress &peerAddress, bool ssl,
+                                 bool quiet, int reportOffset) {
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+    bool replacing = false;
+    int64_t lastReport = now;
+
+    if (reportOffset >= 0)
+        lastReport -= reportOffset;
+
+    if (d->reportInterval > 0) {
+        // Check if this connection should replace a lingering external one
+        // note: this iterates over all the known external sources, which at
+        // at the time of this writing is almost certainly just 1 (a single
+        // pushpin-proxy source).
+        QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo *>> it(
+            d->externalConnectionInfoByFrom);
+        while (it.hasNext()) {
+            it.next();
+            const QHash<QByteArray, Private::ConnectionInfo *> &extConnectionInfoById = it.value();
+
+            Private::ConnectionInfo *other = extConnectionInfoById.value(id);
+            if (other) {
+                replacing = true;
+                lastReport = other->lastReport;
+
+                d->removeExternalConnection(other);
+                delete other;
+
+                break;
+            }
+        }
+    }
+
+    // If we already had an entry, silently overwrite it. This can
+    // happen if we sent an accepted connection off to the handler,
+    // kept it lingering in our table, and then the handler passed
+    // it back to us for retrying
+    Private::ConnectionInfo *c = d->connectionInfoById.value(id);
+    if (c) {
+        replacing = true;
+        lastReport = c->lastReport;
+
+        d->removeConnection(c);
+        delete c;
+    }
+
+    c = new Private::ConnectionInfo;
+    c->timerType = Private::TimerBase::Type::Connection;
+    c->id = id;
+    c->routeId = routeId;
+    c->type = type;
+    c->peerAddress = peerAddress;
+    c->ssl = ssl;
+    c->lastRefresh = now;
+    c->lastReport = lastReport;
+    d->insertConnection(c);
+
+    d->updateConnectionsMax(c->routeId, now);
+
+    if (d->reportInterval > 0) {
+        // Only immediately count a minute if an offset wasn't set and we weren't
+        // replacing
+        if (reportOffset < 0 && !replacing) {
+            Private::Report *report = d->getOrCreateReport(c->routeId);
+
+            // Minutes are rounded up so count one immediately
+            report->addConnectionsMinutes(1, now);
+            d->combinedReport.addConnectionsMinutes(1, now);
+        }
+    }
+
+    if (!quiet)
+        d->sendConnected(c);
 }
 
-void StatsManager::setConnectionTtl(int secs)
-{
-	d->connectionTtl = secs * 1000;
-	d->setupConnectionBuckets();
+int StatsManager::removeConnection(const QByteArray &id, bool linger, const QByteArray &source) {
+    Private::ConnectionInfo *c = d->connectionInfoById.value(id);
+    if (!c)
+        return 0;
+
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    QByteArray routeId = c->routeId;
+    int unreportedTime = 0;
+
+    if (d->reportInterval > 0)
+        d->updateConnectionsMinutes(c, now);
+
+    if (linger) {
+        if (!c->linger) {
+            c->linger = true;
+
+            if (!d->retryInfoBySource.contains(source))
+                d->retryInfoBySource.insert(source, Private::RetryInfo());
+
+            Private::RetryInfo &ri = d->retryInfoBySource[source];
+
+            c->from = source;
+            c->retrySeq = (int64_t)ri.nextSeq++;
+
+            ri.connectionInfoBySeq.insert((uint64_t)c->retrySeq, c);
+
+            // Hack to ensure full linger time honored by refresh processing
+            int64_t lingerStartTime =
+                now + (d->connectionLinger - SHOULD_PROCESS_TIME(d->connectionTtl));
+
+            c->lastRefresh = lingerStartTime;
+            d->wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(d->connectionTtl), c);
+        }
+    } else {
+        if (now >= c->lastReport)
+            unreportedTime = now - c->lastReport;
+
+        d->sendDisconnected(c);
+        d->removeConnection(c);
+        delete c;
+    }
+
+    d->updateConnectionsMax(routeId, now);
+
+    return unreportedTime;
 }
 
-void StatsManager::setConnectionsMaxTtl(int secs)
-{
-	d->connectionsMaxTtl = secs * 1000;
+void StatsManager::refreshConnection(const QByteArray &id) {
+    Private::ConnectionInfo *c = d->connectionInfoById.value(id);
+    if (!c)
+        return;
+
+    d->sendConnected(c);
 }
 
-void StatsManager::setSubscriptionTtl(int secs)
-{
-	d->subscriptionTtl = secs * 1000;
-	d->setupSubscriptionBuckets();
+void StatsManager::addSubscription(const QString &mode, const QString &channel,
+                                   uint32_t subscriberCount) {
+    Private::SubscriptionKey subKey(mode, channel);
+    Private::Subscription *s = d->subscriptionsByKey.value(subKey);
+    if (!s) {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+        // Add the subscription if we didn't have it
+        s = new Private::Subscription;
+        s->timerType = Private::TimerBase::Type::Subscription;
+        s->mode = mode;
+        s->channel = channel;
+        s->subscriberCount = subscriberCount;
+        s->lastRefresh = now;
+        d->insertSubscription(s);
+
+        d->sendSubscribed(s);
+    } else {
+        uint32_t oldSubscriberCount = s->subscriberCount;
+
+        s->subscriberCount = subscriberCount;
+
+        if (s->linger) {
+            int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+            // If this was a lingering subscription, return it to normal
+            s->linger = false;
+
+            s->lastRefresh = now;
+            d->wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(d->subscriptionTtl), s);
+
+            d->sendSubscribed(s);
+        } else if (s->subscriberCount != oldSubscriberCount) {
+            int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+            // Process soon
+            s->lastRefresh = now - SHOULD_PROCESS_TIME(d->subscriptionTtl);
+            d->wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(d->subscriptionTtl), s);
+        }
+    }
 }
 
-void StatsManager::setSubscriptionLinger(int secs)
-{
-	d->subscriptionLinger = secs * 1000;
+void StatsManager::removeSubscription(const QString &mode, const QString &channel, bool linger) {
+    Private::SubscriptionKey subKey(mode, channel);
+    Private::Subscription *s = d->subscriptionsByKey.value(subKey);
+    if (!s)
+        return;
+
+    if (linger) {
+        if (!s->linger) {
+            int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+            s->linger = true;
+
+            // Hack to ensure full linger time honored by refresh processing
+            int64_t lingerStartTime =
+                now + (d->subscriptionLinger - SHOULD_PROCESS_TIME(d->subscriptionTtl));
+
+            s->lastRefresh = lingerStartTime;
+            d->wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(d->subscriptionTtl), s);
+        }
+    } else {
+        d->sendUnsubscribed(s);
+        d->removeSubscription(s);
+        delete s;
+
+        unsubscribed(mode, channel);
+    }
 }
 
-void StatsManager::setReportInterval(int secs)
-{
-	d->reportInterval = secs * 1000;
-	d->setupReportTimer();
+void StatsManager::addMessageReceived(const QByteArray &routeId, int blocks) {
+    if (d->reportInterval <= 0)
+        return;
+
+    Private::Report *report = d->getOrCreateReport(routeId);
+
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+    report->addMessageReceived(blocks, now);
+    d->combinedReport.addMessageReceived(blocks, now);
 }
 
-void StatsManager::setOutputFormat(Format format)
-{
-	d->outputFormat = format;
+void StatsManager::addMessageSent(const QByteArray &routeId, const QString &transport, int blocks) {
+    if (d->reportInterval <= 0)
+        return;
+
+    Private::Report *report = d->getOrCreateReport(routeId);
+
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+    report->addMessageSent(transport, blocks, now);
+    d->combinedReport.addMessageSent(transport, blocks, now);
 }
 
-bool StatsManager::setPrometheusPort(const QString &port)
-{
-	return d->setPrometheusPort(port);
+void StatsManager::incCounter(const QByteArray &routeId, Stats::Counter c, uint32_t count) {
+    if (d->reportInterval <= 0)
+        return;
+
+    Private::Report *report = d->getOrCreateReport(routeId);
+
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+    report->incCounter(c, count, now);
+    d->combinedReport.incCounter(c, count, now);
 }
 
-void StatsManager::setPrometheusPrefix(const QString &prefix)
-{
-	d->prometheusPrefix = prefix;
+void StatsManager::addRequestsReceived(uint32_t count) {
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+    d->combinedCounts.requestsReceived += count;
+    d->combinedReport.addRequestsReceived(count, now);
+
+    if (!d->activityTimer->isActive())
+        d->activityTimer->start(ACTIVITY_TIMEOUT);
 }
 
-void StatsManager::addActivity(const QByteArray &routeId, uint32_t count)
-{
-	if(d->routeActivity.contains(routeId))
-		d->routeActivity[routeId] += count;
-	else
-		d->routeActivity[routeId] = count;
-
-	if(!d->activityTimer->isActive())
-		d->activityTimer->start(ACTIVITY_TIMEOUT);
+bool StatsManager::checkConnection(const QByteArray &id) const {
+    return d->connectionInfoById.contains(id);
 }
 
-void StatsManager::addMessage(const QString &channel, const QString &itemId, const QString &transport, uint32_t count, int blocks)
-{
-	d->sendMessage(channel, itemId, transport, count, blocks);
+bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeConnectionReport) {
+    if (d->reportInterval <= 0)
+        return false;
+
+    if (packet.type == StatsPacket::Connected || packet.type == StatsPacket::Disconnected) {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+        bool replacing = false;
+        int64_t lastReport = now;
+
+        if (packet.type == StatsPacket::Connected) {
+            // Is there a local connection with the same ID?
+            Private::ConnectionInfo *c = d->connectionInfoById.value(packet.connectionId);
+            if (c) {
+                // If there is a non-lingering local connection, ignore the packet
+                if (!c->linger) {
+                    return false;
+                }
+
+                // Otherwise, remove local connection and it will be replaced with
+                // external
+
+                replacing = true;
+                lastReport = c->lastReport;
+
+                d->removeConnection(c);
+                delete c;
+            }
+        }
+
+        // If the connection exists under a different from address, remove it.
+        // note: this iterates over all the known external sources, which at
+        // at the time of this writing is almost certainly just 1 (a single
+        // pushpin-proxy source).
+        QList<Private::ConnectionInfo *> toDelete;
+        QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo *>> it(
+            d->externalConnectionInfoByFrom);
+        while (it.hasNext()) {
+            it.next();
+            const QByteArray &from = it.key();
+
+            if (from == packet.from)
+                continue;
+
+            const QHash<QByteArray, Private::ConnectionInfo *> &extConnectionInfoById = it.value();
+
+            Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
+            if (c)
+                toDelete += c;
+        }
+        foreach (Private::ConnectionInfo *c, toDelete) {
+            d->removeExternalConnection(c);
+            delete c;
+        }
+
+        QHash<QByteArray, Private::ConnectionInfo *> &extConnectionInfoById =
+            d->externalConnectionInfoByFrom[packet.from];
+
+        if (packet.type == StatsPacket::Connected) {
+            // Add/update
+            Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
+            if (!c) {
+                c = new Private::ConnectionInfo;
+                c->timerType = Private::TimerBase::Type::ExternalConnection;
+                c->id = packet.connectionId;
+                c->routeId = packet.route;
+                c->type = packet.connectionType == StatsPacket::Http ? Http : WebSocket;
+                c->peerAddress = packet.peerAddress;
+                c->ssl = packet.ssl;
+                c->lastReport = lastReport;
+                c->from = packet.from;
+                c->lastActive = now;
+                d->insertExternalConnection(c);
+
+                d->updateConnectionsMax(c->routeId, now);
+
+                // Only count a minute if we weren't replacing
+                if (!replacing) {
+                    Private::Report *report = d->getOrCreateReport(c->routeId);
+
+                    // Minutes are rounded up so count one immediately
+                    report->addConnectionsMinutes(1, now);
+                    d->combinedReport.addConnectionsMinutes(1, now);
+                }
+            } else {
+                c->ttl = packet.ttl;
+
+                c->lastActive = now;
+                d->wheelAdd(c->lastActive + d->connectionTtl, c);
+            }
+
+            d->updateConnectionsMinutes(c, now);
+        } else // Disconnected
+        {
+            Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
+            if (c) {
+                QByteArray routeId = c->routeId;
+
+                d->updateConnectionsMinutes(c, now);
+                d->removeExternalConnection(c);
+                delete c;
+
+                d->updateConnectionsMax(routeId, now);
+            }
+        }
+
+        return replacing;
+    } else if (packet.type == StatsPacket::ConnectionsMax) {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+        d->mergeExternalConnectionsMax(packet, now);
+
+        return true;
+    } else if (packet.type == StatsPacket::Report) {
+        d->mergeExternalReport(packet, mergeConnectionReport);
+
+        return true;
+    }
+
+    return false;
 }
 
-void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId, ConnectionType type, const QHostAddress &peerAddress, bool ssl, bool quiet, int reportOffset)
-{
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
+void StatsManager::sendPacket(const StatsPacket &packet) {
+    if (!d->sock)
+        return;
 
-	bool replacing = false;
-	int64_t lastReport = now;
-
-	if(reportOffset >= 0)
-		lastReport -= reportOffset;
-
-	if(d->reportInterval > 0)
-	{
-		// Check if this connection should replace a lingering external one
-		// note: this iterates over all the known external sources, which at
-		// at the time of this writing is almost certainly just 1 (a single
-		// pushpin-proxy source).
-		QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo*> > it(d->externalConnectionInfoByFrom);
-		while(it.hasNext())
-		{
-			it.next();
-			const QHash<QByteArray, Private::ConnectionInfo*> &extConnectionInfoById = it.value();
-
-			Private::ConnectionInfo *other = extConnectionInfoById.value(id);
-			if(other)
-			{
-				replacing = true;
-				lastReport = other->lastReport;
-
-				d->removeExternalConnection(other);
-				delete other;
-
-				break;
-			}
-		}
-	}
-
-	// If we already had an entry, silently overwrite it. This can
-	// happen if we sent an accepted connection off to the handler,
-	// kept it lingering in our table, and then the handler passed
-	// it back to us for retrying
-	Private::ConnectionInfo *c = d->connectionInfoById.value(id);
-	if(c)
-	{
-		replacing = true;
-		lastReport = c->lastReport;
-
-		d->removeConnection(c);
-		delete c;
-	}
-
-	c = new Private::ConnectionInfo;
-	c->timerType = Private::TimerBase::Type::Connection;
-	c->id = id;
-	c->routeId = routeId;
-	c->type = type;
-	c->peerAddress = peerAddress;
-	c->ssl = ssl;
-	c->lastRefresh = now;
-	c->lastReport = lastReport;
-	d->insertConnection(c);
-
-	d->updateConnectionsMax(c->routeId, now);
-
-	if(d->reportInterval > 0)
-	{
-		// Only immediately count a minute if an offset wasn't set and we weren't replacing
-		if(reportOffset < 0 && !replacing)
-		{
-			Private::Report *report = d->getOrCreateReport(c->routeId);
-
-			// Minutes are rounded up so count one immediately
-			report->addConnectionsMinutes(1, now);
-			d->combinedReport.addConnectionsMinutes(1, now);
-		}
-	}
-
-	if(!quiet)
-		d->sendConnected(c);
+    StatsPacket p = packet;
+    p.from = d->instanceId;
+    d->write(p);
 }
 
-int StatsManager::removeConnection(const QByteArray &id, bool linger, const QByteArray &source)
-{
-	Private::ConnectionInfo *c = d->connectionInfoById.value(id);
-	if(!c)
-		return 0;
+void StatsManager::flushReport(const QByteArray &routeId) { d->flushReport(routeId); }
 
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
-	QByteArray routeId = c->routeId;
-	int unreportedTime = 0;
+int64_t StatsManager::lastRetrySeq(const QByteArray &source) const {
+    if (!d->retryInfoBySource.contains(source))
+        return -1;
 
-	if(d->reportInterval > 0)
-		d->updateConnectionsMinutes(c, now);
+    Private::RetryInfo &ri = d->retryInfoBySource[source];
 
-	if(linger)
-	{
-		if(!c->linger)
-		{
-			c->linger = true;
-
-			if(!d->retryInfoBySource.contains(source))
-				d->retryInfoBySource.insert(source, Private::RetryInfo());
-
-			Private::RetryInfo &ri = d->retryInfoBySource[source];
-
-			c->from = source;
-			c->retrySeq = (int64_t)ri.nextSeq++;
-
-			ri.connectionInfoBySeq.insert((uint64_t)c->retrySeq, c);
-
-			// Hack to ensure full linger time honored by refresh processing
-			int64_t lingerStartTime = now + (d->connectionLinger - SHOULD_PROCESS_TIME(d->connectionTtl));
-
-			c->lastRefresh = lingerStartTime;
-			d->wheelAdd(c->lastRefresh + SHOULD_PROCESS_TIME(d->connectionTtl), c);
-		}
-	}
-	else
-	{
-		if(now >= c->lastReport)
-			unreportedTime = now - c->lastReport;
-
-		d->sendDisconnected(c);
-		d->removeConnection(c);
-		delete c;
-	}
-
-	d->updateConnectionsMax(routeId, now);
-
-	return unreportedTime;
+    return ((int64_t)ri.nextSeq) - 1;
 }
 
-void StatsManager::refreshConnection(const QByteArray &id)
-{
-	Private::ConnectionInfo *c = d->connectionInfoById.value(id);
-	if(!c)
-		return;
+StatsPacket StatsManager::getConnMaxPacket(const QByteArray &routeId) {
+    Private::ConnectionsMax &cm = d->getOrCreateConnectionsMax(routeId);
 
-	d->sendConnected(c);
+    int64_t now = QDateTime::currentMSecsSinceEpoch();
+
+    return d->getConnMaxPacket(routeId, &cm, now);
 }
 
-void StatsManager::addSubscription(const QString &mode, const QString &channel, uint32_t subscriberCount)
-{
-	Private::SubscriptionKey subKey(mode, channel);
-	Private::Subscription *s = d->subscriptionsByKey.value(subKey);
-	if(!s)
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
+void StatsManager::setRetrySeq(const QByteArray &routeId, int value) {
+    Private::ConnectionsMax &cm = d->getOrCreateConnectionsMax(routeId);
 
-		// Add the subscription if we didn't have it
-		s = new Private::Subscription;
-		s->timerType = Private::TimerBase::Type::Subscription;
-		s->mode = mode;
-		s->channel = channel;
-		s->subscriberCount = subscriberCount;
-		s->lastRefresh = now;
-		d->insertSubscription(s);
-
-		d->sendSubscribed(s);
-	}
-	else
-	{
-		uint32_t oldSubscriberCount = s->subscriberCount;
-
-		s->subscriberCount = subscriberCount;
-
-		if(s->linger)
-		{
-			int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-			// If this was a lingering subscription, return it to normal
-			s->linger = false;
-
-			s->lastRefresh = now;
-			d->wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(d->subscriptionTtl), s);
-
-			d->sendSubscribed(s);
-		}
-		else if(s->subscriberCount != oldSubscriberCount)
-		{
-			int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-			// Process soon
-			s->lastRefresh = now - SHOULD_PROCESS_TIME(d->subscriptionTtl);
-			d->wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(d->subscriptionTtl), s);
-		}
-	}
-}
-
-void StatsManager::removeSubscription(const QString &mode, const QString &channel, bool linger)
-{
-	Private::SubscriptionKey subKey(mode, channel);
-	Private::Subscription *s = d->subscriptionsByKey.value(subKey);
-	if(!s)
-		return;
-
-	if(linger)
-	{
-		if(!s->linger)
-		{
-			int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-			s->linger = true;
-
-			// Hack to ensure full linger time honored by refresh processing
-			int64_t lingerStartTime = now + (d->subscriptionLinger - SHOULD_PROCESS_TIME(d->subscriptionTtl));
-
-			s->lastRefresh = lingerStartTime;
-			d->wheelAdd(s->lastRefresh + SHOULD_PROCESS_TIME(d->subscriptionTtl), s);
-		}
-	}
-	else
-	{
-		d->sendUnsubscribed(s);
-		d->removeSubscription(s);
-		delete s;
-
-		unsubscribed(mode, channel);
-	}
-}
-
-void StatsManager::addMessageReceived(const QByteArray &routeId, int blocks)
-{
-	if(d->reportInterval <= 0)
-		return;
-
-	Private::Report *report = d->getOrCreateReport(routeId);
-
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-	report->addMessageReceived(blocks, now);
-	d->combinedReport.addMessageReceived(blocks, now);
-}
-
-void StatsManager::addMessageSent(const QByteArray &routeId, const QString &transport, int blocks)
-{
-	if(d->reportInterval <= 0)
-		return;
-
-	Private::Report *report = d->getOrCreateReport(routeId);
-
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-	report->addMessageSent(transport, blocks, now);
-	d->combinedReport.addMessageSent(transport, blocks, now);
-}
-
-void StatsManager::incCounter(const QByteArray &routeId, Stats::Counter c, uint32_t count)
-{
-	if(d->reportInterval <= 0)
-		return;
-
-	Private::Report *report = d->getOrCreateReport(routeId);
-
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-	report->incCounter(c, count, now);
-	d->combinedReport.incCounter(c, count, now);
-}
-
-void StatsManager::addRequestsReceived(uint32_t count)
-{
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-	d->combinedCounts.requestsReceived += count;
-	d->combinedReport.addRequestsReceived(count, now);
-
-	if(!d->activityTimer->isActive())
-		d->activityTimer->start(ACTIVITY_TIMEOUT);
-}
-
-bool StatsManager::checkConnection(const QByteArray &id) const
-{
-	return d->connectionInfoById.contains(id);
-}
-
-bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeConnectionReport)
-{
-	if(d->reportInterval <= 0)
-		return false;
-
-	if(packet.type == StatsPacket::Connected || packet.type == StatsPacket::Disconnected)
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-		bool replacing = false;
-		int64_t lastReport = now;
-
-		if(packet.type == StatsPacket::Connected)
-		{
-			// Is there a local connection with the same ID?
-			Private::ConnectionInfo *c = d->connectionInfoById.value(packet.connectionId);
-			if(c)
-			{
-				// If there is a non-lingering local connection, ignore the packet
-				if(!c->linger)
-				{
-					return false;
-				}
-
-				// Otherwise, remove local connection and it will be replaced with external
-
-				replacing = true;
-				lastReport = c->lastReport;
-
-				d->removeConnection(c);
-				delete c;
-			}
-		}
-
-		// If the connection exists under a different from address, remove it.
-		// note: this iterates over all the known external sources, which at
-		// at the time of this writing is almost certainly just 1 (a single
-		// pushpin-proxy source).
-		QList<Private::ConnectionInfo*> toDelete;
-		QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo*> > it(d->externalConnectionInfoByFrom);
-		while(it.hasNext())
-		{
-			it.next();
-			const QByteArray &from = it.key();
-
-			if(from == packet.from)
-				continue;
-
-			const QHash<QByteArray, Private::ConnectionInfo*> &extConnectionInfoById = it.value();
-
-			Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
-			if(c)
-				toDelete += c;
-		}
-		foreach(Private::ConnectionInfo *c, toDelete)
-		{
-			d->removeExternalConnection(c);
-			delete c;
-		}
-
-		QHash<QByteArray, Private::ConnectionInfo*> &extConnectionInfoById = d->externalConnectionInfoByFrom[packet.from];
-
-		if(packet.type == StatsPacket::Connected)
-		{
-			// Add/update
-			Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
-			if(!c)
-			{
-				c = new Private::ConnectionInfo;
-				c->timerType = Private::TimerBase::Type::ExternalConnection;
-				c->id = packet.connectionId;
-				c->routeId = packet.route;
-				c->type = packet.connectionType == StatsPacket::Http ? Http : WebSocket;
-				c->peerAddress = packet.peerAddress;
-				c->ssl = packet.ssl;
-				c->lastReport = lastReport;
-				c->from = packet.from;
-				c->lastActive = now;
-				d->insertExternalConnection(c);
-
-				d->updateConnectionsMax(c->routeId, now);
-
-				// Only count a minute if we weren't replacing
-				if(!replacing)
-				{
-					Private::Report *report = d->getOrCreateReport(c->routeId);
-
-					// Minutes are rounded up so count one immediately
-					report->addConnectionsMinutes(1, now);
-					d->combinedReport.addConnectionsMinutes(1, now);
-				}
-			}
-			else
-			{
-				c->ttl = packet.ttl;
-
-				c->lastActive = now;
-				d->wheelAdd(c->lastActive + d->connectionTtl, c);
-			}
-
-			d->updateConnectionsMinutes(c, now);
-		}
-		else // Disconnected
-		{
-			Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
-			if(c)
-			{
-				QByteArray routeId = c->routeId;
-
-				d->updateConnectionsMinutes(c, now);
-				d->removeExternalConnection(c);
-				delete c;
-
-				d->updateConnectionsMax(routeId, now);
-			}
-		}
-
-		return replacing;
-	}
-	else if(packet.type == StatsPacket::ConnectionsMax)
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-		d->mergeExternalConnectionsMax(packet, now);
-
-		return true;
-	}
-	else if(packet.type == StatsPacket::Report)
-	{
-		d->mergeExternalReport(packet, mergeConnectionReport);
-
-		return true;
-	}
-
-	return false;
-}
-
-void StatsManager::sendPacket(const StatsPacket &packet)
-{
-	if(!d->sock)
-		return;
-
-	StatsPacket p = packet;
-	p.from = d->instanceId;
-	d->write(p);
-}
-
-void StatsManager::flushReport(const QByteArray &routeId)
-{
-	d->flushReport(routeId);
-}
-
-int64_t StatsManager::lastRetrySeq(const QByteArray &source) const
-{
-	if(!d->retryInfoBySource.contains(source))
-		return -1;
-
-	Private::RetryInfo &ri = d->retryInfoBySource[source];
-
-	return ((int64_t)ri.nextSeq) - 1;
-}
-
-StatsPacket StatsManager::getConnMaxPacket(const QByteArray &routeId)
-{
-	Private::ConnectionsMax &cm = d->getOrCreateConnectionsMax(routeId);
-
-	int64_t now = QDateTime::currentMSecsSinceEpoch();
-
-	return d->getConnMaxPacket(routeId, &cm, now);
-}
-
-void StatsManager::setRetrySeq(const QByteArray &routeId, int value)
-{
-	Private::ConnectionsMax &cm = d->getOrCreateConnectionsMax(routeId);
-
-	cm.retrySeq = value;
+    cm.retrySeq = value;
 }

--- a/src/core/statsmanager.h
+++ b/src/core/statsmanager.h
@@ -30,95 +30,91 @@
 
 class QHostAddress;
 
-/// Collects and reports statistics via ZeroMQ (internal) and Prometheus (external) on:
+/// Collects and reports statistics via ZeroMQ (internal) and Prometheus
+/// (external) on:
 /// - Connections
 /// - Subscriptions
 /// - Messages sent/received
-class StatsManager
-{
+class StatsManager {
 public:
-	enum ConnectionType
-	{
-		Http,
-		WebSocket
-	};
+    enum ConnectionType { Http, WebSocket };
 
-	enum Format
-	{
-		TnetStringFormat,
-		JsonFormat
-	};
+    enum Format { TnetStringFormat, JsonFormat };
 
-	StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax);
-	~StatsManager();
+    StatsManager(int connectionsMax, int subscriptionsMax, int prometheusConnectionsMax);
+    ~StatsManager();
 
-	bool connectionSendEnabled() const;
+    bool connectionSendEnabled() const;
 
-	void setInstanceId(const QByteArray &instanceId);
-	void setIpcFileMode(int mode);
-	bool setSpec(const QString &spec);
-	void setConnectionSendEnabled(bool enabled);
-	void setConnectionsMaxSendEnabled(bool enabled);
-	void setConnectionTtl(int secs);
-	void setConnectionsMaxTtl(int secs);
-	void setSubscriptionTtl(int secs);
-	void setSubscriptionLinger(int secs);
-	void setReportInterval(int secs);
-	void setOutputFormat(Format format);
-	bool setPrometheusPort(const QString &port);
-	void setPrometheusPrefix(const QString &prefix);
+    void setInstanceId(const QByteArray &instanceId);
+    void setIpcFileMode(int mode);
+    bool setSpec(const QString &spec);
+    void setConnectionSendEnabled(bool enabled);
+    void setConnectionsMaxSendEnabled(bool enabled);
+    void setConnectionTtl(int secs);
+    void setConnectionsMaxTtl(int secs);
+    void setSubscriptionTtl(int secs);
+    void setSubscriptionLinger(int secs);
+    void setReportInterval(int secs);
+    void setOutputFormat(Format format);
+    bool setPrometheusPort(const QString &port);
+    void setPrometheusPrefix(const QString &prefix);
 
-	// RouteId may be empty for non-identified route
+    // RouteId may be empty for non-identified route
 
-	void addActivity(const QByteArray &routeId, uint32_t count = 1);
-	void addMessage(const QString &channel, const QString &itemId, const QString &transport, uint32_t count = 1, int blocks = -1);
+    void addActivity(const QByteArray &routeId, uint32_t count = 1);
+    void addMessage(const QString &channel, const QString &itemId, const QString &transport,
+                    uint32_t count = 1, int blocks = -1);
 
-	void addConnection(const QByteArray &id, const QByteArray &routeId, ConnectionType type, const QHostAddress &peerAddress, bool ssl, bool quiet, int reportOffset = -1);
-	int removeConnection(const QByteArray &id, bool linger, const QByteArray &source = QByteArray()); // Return unreported time
+    void addConnection(const QByteArray &id, const QByteArray &routeId, ConnectionType type,
+                       const QHostAddress &peerAddress, bool ssl, bool quiet,
+                       int reportOffset = -1);
+    int removeConnection(const QByteArray &id, bool linger,
+                         const QByteArray &source = QByteArray()); // Return unreported time
 
-	// Manager automatically refreshes, but it may be useful to force a
-	// send before removing with linger
-	void refreshConnection(const QByteArray &id);
+    // Manager automatically refreshes, but it may be useful to force a
+    // send before removing with linger
+    void refreshConnection(const QByteArray &id);
 
-	void addSubscription(const QString &mode, const QString &channel, uint32_t subscriberCount);
+    void addSubscription(const QString &mode, const QString &channel, uint32_t subscriberCount);
 
-	// NOTE: may emit unsubscribed immediately (not DOR-DS)
-	void removeSubscription(const QString &mode, const QString &channel, bool linger);
+    // NOTE: may emit unsubscribed immediately (not DOR-DS)
+    void removeSubscription(const QString &mode, const QString &channel, bool linger);
 
-	// For reporting and combined
-	void addMessageReceived(const QByteArray &routeId, int blocks = -1);
-	void addMessageSent(const QByteArray &routeId, const QString &transport, int blocks = -1);
-	void incCounter(const QByteArray &routeId, Stats::Counter c, uint32_t count = 1);
+    // For reporting and combined
+    void addMessageReceived(const QByteArray &routeId, int blocks = -1);
+    void addMessageSent(const QByteArray &routeId, const QString &transport, int blocks = -1);
+    void incCounter(const QByteArray &routeId, Stats::Counter c, uint32_t count = 1);
 
-	// For combined only
-	void addRequestsReceived(uint32_t count);
+    // For combined only
+    void addRequestsReceived(uint32_t count);
 
-	bool checkConnection(const QByteArray &id) const;
+    bool checkConnection(const QByteArray &id) const;
 
-	// Conn, conn-max, and report packets received from the proxy should be
-	// passed into this method. returns true if the packet should not also be
-	// forwarded on
-	bool processExternalPacket(const StatsPacket &packet, bool mergeConnectionReport);
+    // Conn, conn-max, and report packets received from the proxy should be
+    // passed into this method. returns true if the packet should not also be
+    // forwarded on
+    bool processExternalPacket(const StatsPacket &packet, bool mergeConnectionReport);
 
-	// Directly send, for proxy->handler pass-through
-	void sendPacket(const StatsPacket &packet);
+    // Directly send, for proxy->handler pass-through
+    void sendPacket(const StatsPacket &packet);
 
-	void flushReport(const QByteArray &routeId);
+    void flushReport(const QByteArray &routeId);
 
-	int64_t lastRetrySeq(const QByteArray &source) const;
+    int64_t lastRetrySeq(const QByteArray &source) const;
 
-	StatsPacket getConnMaxPacket(const QByteArray &routeId);
-	void setRetrySeq(const QByteArray &routeId, int value);
+    StatsPacket getConnMaxPacket(const QByteArray &routeId);
+    void setRetrySeq(const QByteArray &routeId, int value);
 
-	boost::signals2::signal<void(const QList<QByteArray>&)> connectionsRefreshed;
-	boost::signals2::signal<void(const QString&, const QString&)> unsubscribed;
-	boost::signals2::signal<void(const QList<StatsPacket>&)> reported;
-	boost::signals2::signal<void(const StatsPacket&)> connMax;
+    boost::signals2::signal<void(const QList<QByteArray> &)> connectionsRefreshed;
+    boost::signals2::signal<void(const QString &, const QString &)> unsubscribed;
+    boost::signals2::signal<void(const QList<StatsPacket> &)> reported;
+    boost::signals2::signal<void(const StatsPacket &)> connMax;
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 };
 
 #endif

--- a/src/core/statusreasons.cpp
+++ b/src/core/statusreasons.cpp
@@ -22,83 +22,137 @@
 
 #include "statusreasons.h"
 
-#include <QByteArray>
 #include "variant.h"
+#include <QByteArray>
 
 namespace StatusReasons {
 
 // IANA assignments
 // http://www.iana.org/assignments/http-status-codes/http-status-codes.xml
 
-const char *getReasonRaw(int code)
-{
-	switch(code)
-	{
-		case 100: return "Continue";
-		case 101: return "Switching Protocols";
-		case 102: return "Processing";
-		case 200: return "OK";
-		case 201: return "Created";
-		case 202: return "Accepted";
-		case 203: return "Non-Authoritative Information";
-		case 204: return "No Content";
-		case 205: return "Reset Content";
-		case 206: return "Partial Content";
-		case 207: return "Multi-Status";
-		case 208: return "Already Reported";
-		case 226: return "IM Used";
-		case 300: return "Multiple Choices";
-		case 301: return "Moved Permanently";
-		case 302: return "Found";
-		case 303: return "See Other";
-		case 304: return "Not Modified";
-		case 305: return "Use Proxy";
-		case 306: return "Reserved";
-		case 307: return "Temporary Redirect";
-		case 308: return "Permanent Redirect";
-		case 400: return "Bad Request";
-		case 401: return "Unauthorized";
-		case 402: return "Payment Required";
-		case 403: return "Forbidden";
-		case 404: return "Not Found";
-		case 405: return "Method Not Allowed";
-		case 406: return "Not Acceptable";
-		case 407: return "Proxy Authentication Required";
-		case 408: return "Request Timeout";
-		case 409: return "Conflict";
-		case 410: return "Gone";
-		case 411: return "Length Required";
-		case 412: return "Precondition Failed";
-		case 413: return "Request Entity Too Large";
-		case 414: return "Request-URI Too Long";
-		case 415: return "Unsupported Media Type";
-		case 416: return "Requested Range Not Satisfiable";
-		case 417: return "Expectation Failed";
-		case 422: return "Unprocessable Entity";
-		case 423: return "Locked";
-		case 424: return "Failed Dependency";
-		case 426: return "Upgrade Required";
-		case 428: return "Precondition Required";
-		case 429: return "Too Many Requests";
-		case 431: return "Request Header Fields Too Large";
-		case 500: return "Internal Server Error";
-		case 501: return "Not Implemented";
-		case 502: return "Bad Gateway";
-		case 503: return "Service Unavailable";
-		case 504: return "Gateway Timeout";
-		case 505: return "HTTP Version Not Supported";
-		case 506: return "Variant Also Negotiates";
-		case 507: return "Insufficient Storage";
-		case 508: return "Loop Detected";
-		case 510: return "Not Extended";
-		case 511: return "Network Authentication Required";
-		default: return "Undefined Reason";
-	}
+const char *getReasonRaw(int code) {
+    switch (code) {
+    case 100:
+        return "Continue";
+    case 101:
+        return "Switching Protocols";
+    case 102:
+        return "Processing";
+    case 200:
+        return "OK";
+    case 201:
+        return "Created";
+    case 202:
+        return "Accepted";
+    case 203:
+        return "Non-Authoritative Information";
+    case 204:
+        return "No Content";
+    case 205:
+        return "Reset Content";
+    case 206:
+        return "Partial Content";
+    case 207:
+        return "Multi-Status";
+    case 208:
+        return "Already Reported";
+    case 226:
+        return "IM Used";
+    case 300:
+        return "Multiple Choices";
+    case 301:
+        return "Moved Permanently";
+    case 302:
+        return "Found";
+    case 303:
+        return "See Other";
+    case 304:
+        return "Not Modified";
+    case 305:
+        return "Use Proxy";
+    case 306:
+        return "Reserved";
+    case 307:
+        return "Temporary Redirect";
+    case 308:
+        return "Permanent Redirect";
+    case 400:
+        return "Bad Request";
+    case 401:
+        return "Unauthorized";
+    case 402:
+        return "Payment Required";
+    case 403:
+        return "Forbidden";
+    case 404:
+        return "Not Found";
+    case 405:
+        return "Method Not Allowed";
+    case 406:
+        return "Not Acceptable";
+    case 407:
+        return "Proxy Authentication Required";
+    case 408:
+        return "Request Timeout";
+    case 409:
+        return "Conflict";
+    case 410:
+        return "Gone";
+    case 411:
+        return "Length Required";
+    case 412:
+        return "Precondition Failed";
+    case 413:
+        return "Request Entity Too Large";
+    case 414:
+        return "Request-URI Too Long";
+    case 415:
+        return "Unsupported Media Type";
+    case 416:
+        return "Requested Range Not Satisfiable";
+    case 417:
+        return "Expectation Failed";
+    case 422:
+        return "Unprocessable Entity";
+    case 423:
+        return "Locked";
+    case 424:
+        return "Failed Dependency";
+    case 426:
+        return "Upgrade Required";
+    case 428:
+        return "Precondition Required";
+    case 429:
+        return "Too Many Requests";
+    case 431:
+        return "Request Header Fields Too Large";
+    case 500:
+        return "Internal Server Error";
+    case 501:
+        return "Not Implemented";
+    case 502:
+        return "Bad Gateway";
+    case 503:
+        return "Service Unavailable";
+    case 504:
+        return "Gateway Timeout";
+    case 505:
+        return "HTTP Version Not Supported";
+    case 506:
+        return "Variant Also Negotiates";
+    case 507:
+        return "Insufficient Storage";
+    case 508:
+        return "Loop Detected";
+    case 510:
+        return "Not Extended";
+    case 511:
+        return "Network Authentication Required";
+    default:
+        return "Undefined Reason";
+    }
 }
 
-QByteArray getReason(int code)
-{
-	return getReasonRaw(code);
-}
+QByteArray getReason(int code) { return getReasonRaw(code); }
 
-}
+} // namespace StatusReasons

--- a/src/core/tcplistener.cpp
+++ b/src/core/tcplistener.cpp
@@ -16,92 +16,76 @@
 
 #include "tcplistener.h"
 
-#include <assert.h>
 #include "socketnotifier.h"
+#include <assert.h>
 
-TcpListener::TcpListener() :
-	inner_(nullptr),
-	errorCondition_(0)
-{
+TcpListener::TcpListener() : inner_(nullptr), errorCondition_(0) {}
+
+TcpListener::~TcpListener() { reset(); }
+
+bool TcpListener::bind(const QHostAddress &addr, uint16_t port) {
+    reset();
+
+    QHostAddress a = addr;
+    if (a.isNull())
+        a = QHostAddress::Any;
+
+    QByteArray ip = a.toString().toUtf8();
+    errorCondition_ = 0;
+
+    inner_ = ffi::tcp_listener_bind(ip.data(), port, &errorCondition_);
+    if (!inner_)
+        return false;
+
+    int fd = ffi::tcp_listener_as_raw_fd(inner_);
+
+    sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
+    sn_->activated.connect(boost::bind(&TcpListener::sn_activated, this));
+    sn_->setReadEnabled(true);
+
+    return true;
 }
 
-TcpListener::~TcpListener()
-{
-	reset();
+std::tuple<QHostAddress, uint16_t> TcpListener::localAddress() const {
+    assert(inner_);
+
+    QByteArray ip(256, 0);
+    size_t ip_size = ip.size();
+    uint16_t port;
+    if (ffi::tcp_listener_local_addr(inner_, ip.data(), &ip_size, &port) != 0)
+        return {QHostAddress(), 0};
+
+    ip.resize(ip_size);
+    QHostAddress addr(QString::fromUtf8(ip));
+
+    return {addr, port};
 }
 
-bool TcpListener::bind(const QHostAddress &addr, uint16_t port)
-{
-	reset();
+std::unique_ptr<TcpStream> TcpListener::accept() {
+    assert(inner_);
 
-	QHostAddress a = addr;
-	if(a.isNull())
-		a = QHostAddress::Any;
+    errorCondition_ = 0;
 
-	QByteArray ip = a.toString().toUtf8();
-	errorCondition_ = 0;
+    ffi::TcpStream *s_inner = ffi::tcp_listener_accept(inner_, &errorCondition_);
+    if (!s_inner) {
+        if (errorCondition_ == EAGAIN)
+            sn_->clearReadiness(SocketNotifier::Read);
 
-	inner_ = ffi::tcp_listener_bind(ip.data(), port, &errorCondition_);
-	if(!inner_)
-		return false;
+        return std::unique_ptr<TcpStream>(); // Null
+    }
 
-	int fd = ffi::tcp_listener_as_raw_fd(inner_);
+    TcpStream *s = new TcpStream(s_inner);
 
-	sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
-	sn_->activated.connect(boost::bind(&TcpListener::sn_activated, this));
-	sn_->setReadEnabled(true);
-
-	return true;
+    return std::unique_ptr<TcpStream>(s);
 }
 
-std::tuple<QHostAddress, uint16_t> TcpListener::localAddress() const
-{
-	assert(inner_);
+void TcpListener::reset() {
+    sn_.reset();
 
-	QByteArray ip(256, 0);
-	size_t ip_size = ip.size();
-	uint16_t port;
-	if(ffi::tcp_listener_local_addr(inner_, ip.data(), &ip_size, &port) != 0)
-		return {QHostAddress(), 0};
-
-	ip.resize(ip_size);
-	QHostAddress addr(QString::fromUtf8(ip));
-
-	return {addr, port};
+    if (inner_) {
+        ffi::tcp_listener_destroy(inner_);
+        inner_ = nullptr;
+    }
 }
 
-std::unique_ptr<TcpStream> TcpListener::accept()
-{
-	assert(inner_);
-
-	errorCondition_ = 0;
-
-	ffi::TcpStream *s_inner = ffi::tcp_listener_accept(inner_, &errorCondition_);
-	if(!s_inner)
-	{
-		if(errorCondition_ == EAGAIN)
-			sn_->clearReadiness(SocketNotifier::Read);
-
-		return std::unique_ptr<TcpStream>(); // Null
-	}
-
-	TcpStream *s = new TcpStream(s_inner);
-
-	return std::unique_ptr<TcpStream>(s);
-}
-
-void TcpListener::reset()
-{
-	sn_.reset();
-
-	if(inner_)
-	{
-		ffi::tcp_listener_destroy(inner_);
-		inner_ = nullptr;
-	}
-}
-
-void TcpListener::sn_activated()
-{
-	streamsReady();
-}
+void TcpListener::sn_activated() { streamsReady(); }

--- a/src/core/tcplistener.h
+++ b/src/core/tcplistener.h
@@ -17,38 +17,37 @@
 #ifndef TCPLISTENER_H
 #define TCPLISTENER_H
 
-#include <memory>
-#include <QHostAddress>
-#include <boost/signals2.hpp>
 #include "rust/bindings.h"
 #include "tcpstream.h"
+#include <QHostAddress>
+#include <boost/signals2.hpp>
+#include <memory>
 
 class SocketNotifier;
 
-class TcpListener
-{
+class TcpListener {
 public:
-	TcpListener();
-	~TcpListener();
+    TcpListener();
+    ~TcpListener();
 
-	// Disable copying
-	TcpListener(const TcpListener &) = delete;
-	TcpListener & operator=(const TcpListener &) = delete;
+    // Disable copying
+    TcpListener(const TcpListener &) = delete;
+    TcpListener &operator=(const TcpListener &) = delete;
 
-	bool bind(const QHostAddress &addr, uint16_t port);
-	std::tuple<QHostAddress, uint16_t> localAddress() const;
-	std::unique_ptr<TcpStream> accept();
-	int errorCondition() const { return errorCondition_; }
+    bool bind(const QHostAddress &addr, uint16_t port);
+    std::tuple<QHostAddress, uint16_t> localAddress() const;
+    std::unique_ptr<TcpStream> accept();
+    int errorCondition() const { return errorCondition_; }
 
-	boost::signals2::signal<void()> streamsReady;
+    boost::signals2::signal<void()> streamsReady;
 
 private:
-	ffi::TcpListener *inner_;
-	std::unique_ptr<SocketNotifier> sn_;
-	int errorCondition_;
+    ffi::TcpListener *inner_;
+    std::unique_ptr<SocketNotifier> sn_;
+    int errorCondition_;
 
-	void reset();
-	void sn_activated();
+    void reset();
+    void sn_activated();
 };
 
 #endif

--- a/src/core/tcpstream.cpp
+++ b/src/core/tcpstream.cpp
@@ -16,136 +16,120 @@
 
 #include "tcpstream.h"
 
-#include <assert.h>
-#include <QHostAddress>
 #include "socketnotifier.h"
+#include <QHostAddress>
+#include <assert.h>
 
 #define DEFAULT_READ_SIZE 16384
 
-TcpStream::TcpStream() :
-	inner_(nullptr),
-	errorCondition_(0)
-{
+TcpStream::TcpStream() : inner_(nullptr), errorCondition_(0) {}
+
+TcpStream::TcpStream(ffi::TcpStream *inner)
+    : inner_(inner),
+      errorCondition_(0),
+      alive_(std::make_shared<std::monostate>(std::monostate{})) {
+    setupNotifier();
 }
 
-TcpStream::TcpStream(ffi::TcpStream *inner) :
-	inner_(inner),
-	errorCondition_(0),
-	alive_(std::make_shared<std::monostate>(std::monostate{}))
-{
-	setupNotifier();
+TcpStream::~TcpStream() { reset(); }
+
+bool TcpStream::connect(const QHostAddress &addr, uint16_t port) {
+    reset();
+
+    QByteArray ip = addr.toString().toUtf8();
+    errorCondition_ = 0;
+
+    inner_ = ffi::tcp_stream_connect(ip.data(), port, &errorCondition_);
+    if (!inner_)
+        return false;
+
+    setupNotifier();
+
+    return true;
 }
 
-TcpStream::~TcpStream()
-{
-	reset();
+bool TcpStream::checkConnected() {
+    assert(inner_);
+
+    errorCondition_ = 0;
+
+    if (ffi::tcp_stream_check_connected(inner_, &errorCondition_) != 0)
+        return false;
+
+    return true;
 }
 
-bool TcpStream::connect(const QHostAddress &addr, uint16_t port)
-{
-	reset();
+QByteArray TcpStream::read(int size) {
+    assert(inner_);
 
-	QByteArray ip = addr.toString().toUtf8();
-	errorCondition_ = 0;
+    if (size < 0)
+        size = DEFAULT_READ_SIZE;
 
-	inner_ = ffi::tcp_stream_connect(ip.data(), port, &errorCondition_);
-	if(!inner_)
-		return false;
+    QByteArray buf(size, 0);
+    errorCondition_ = 0;
 
-	setupNotifier();
+    int ret = ffi::tcp_stream_read(inner_, (uint8_t *)buf.data(), buf.size(), &errorCondition_);
 
-	return true;
+    if (ret < 0) {
+        if (errorCondition_ == EAGAIN)
+            sn_->clearReadiness(SocketNotifier::Read);
+
+        return QByteArray();
+    }
+
+    buf.resize(ret);
+
+    return buf;
 }
 
-bool TcpStream::checkConnected()
-{
-	assert(inner_);
+int TcpStream::write(const QByteArray &buf) {
+    assert(inner_);
 
-	errorCondition_ = 0;
+    errorCondition_ = 0;
 
-	if(ffi::tcp_stream_check_connected(inner_, &errorCondition_) != 0)
-		return false;
+    int ret = ffi::tcp_stream_write(inner_, (const uint8_t *)buf.constData(), buf.size(),
+                                    &errorCondition_);
 
-	return true;
+    if (ret < 0) {
+        if (errorCondition_ == EAGAIN)
+            sn_->clearReadiness(SocketNotifier::Write);
+
+        return -1;
+    }
+
+    return ret;
 }
 
-QByteArray TcpStream::read(int size)
-{
-	assert(inner_);
+void TcpStream::reset() {
+    sn_.reset();
 
-	if(size < 0)
-		size = DEFAULT_READ_SIZE;
-
-	QByteArray buf(size, 0);
-	errorCondition_ = 0;
-
-	int ret = ffi::tcp_stream_read(inner_, (uint8_t *)buf.data(), buf.size(), &errorCondition_);
-
-	if(ret < 0)
-	{
-		if(errorCondition_ == EAGAIN)
-			sn_->clearReadiness(SocketNotifier::Read);
-
-		return QByteArray();
-	}
-
-	buf.resize(ret);
-
-	return buf;
+    if (inner_) {
+        ffi::tcp_stream_destroy(inner_);
+        inner_ = nullptr;
+    }
 }
 
-int TcpStream::write(const QByteArray &buf)
-{
-	assert(inner_);
+void TcpStream::setupNotifier() {
+    int fd = ffi::tcp_stream_as_raw_fd(inner_);
 
-	errorCondition_ = 0;
-
-	int ret = ffi::tcp_stream_write(inner_, (const uint8_t *)buf.constData(), buf.size(), &errorCondition_);
-
-	if(ret < 0)
-	{
-		if(errorCondition_ == EAGAIN)
-			sn_->clearReadiness(SocketNotifier::Write);
-
-		return -1;
-	}
-
-	return ret;
+    sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read | SocketNotifier::Write);
+    sn_->activated.connect(boost::bind(&TcpStream::sn_activated, this, boost::placeholders::_1,
+                                       boost::placeholders::_2));
+    sn_->setReadEnabled(true);
+    sn_->setWriteEnabled(true);
 }
 
-void TcpStream::reset()
-{
-	sn_.reset();
+void TcpStream::sn_activated(int socket, uint8_t readiness) {
+    Q_UNUSED(socket);
 
-	if(inner_)
-	{
-		ffi::tcp_stream_destroy(inner_);
-		inner_ = nullptr;
-	}
-}
+    std::weak_ptr<std::monostate> self = alive_;
 
-void TcpStream::setupNotifier()
-{
-	int fd = ffi::tcp_stream_as_raw_fd(inner_);
+    if (readiness & SocketNotifier::Read)
+        readReady();
 
-	sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read | SocketNotifier::Write);
-	sn_->activated.connect(boost::bind(&TcpStream::sn_activated, this, boost::placeholders::_1, boost::placeholders::_2));
-	sn_->setReadEnabled(true);
-	sn_->setWriteEnabled(true);
-}
+    if (self.expired())
+        return;
 
-void TcpStream::sn_activated(int socket, uint8_t readiness)
-{
-	Q_UNUSED(socket);
-
-	std::weak_ptr<std::monostate> self = alive_;
-
-	if(readiness & SocketNotifier::Read)
-		readReady();
-
-	if(self.expired())
-		return;
-
-	if(readiness & SocketNotifier::Write)
-		writeReady();
+    if (readiness & SocketNotifier::Write)
+        writeReady();
 }

--- a/src/core/tcpstream.h
+++ b/src/core/tcpstream.h
@@ -17,51 +17,50 @@
 #ifndef TCPSTREAM_H
 #define TCPSTREAM_H
 
-#include <memory>
-#include <variant>
+#include "readwrite.h"
+#include "rust/bindings.h"
 #include <QByteArray>
 #include <boost/signals2.hpp>
-#include "rust/bindings.h"
-#include "readwrite.h"
+#include <memory>
+#include <variant>
 
 class QHostAddress;
 
 class SocketNotifier;
 
-class TcpStream : public ReadWrite
-{
+class TcpStream : public ReadWrite {
 public:
-	TcpStream();
-	~TcpStream();
+    TcpStream();
+    ~TcpStream();
 
-	// Disable copying
-	TcpStream(const TcpStream &) = delete;
-	TcpStream & operator=(const TcpStream &) = delete;
+    // Disable copying
+    TcpStream(const TcpStream &) = delete;
+    TcpStream &operator=(const TcpStream &) = delete;
 
-	// Returns true if connection starting, false on error
-	bool connect(const QHostAddress &addr, uint16_t port);
+    // Returns true if connection starting, false on error
+    bool connect(const QHostAddress &addr, uint16_t port);
 
-	// Returns true if connected, false on error. If errorCondition() returns
-	// ENOTCONN, then it is not fatal and the socket is still connecting
-	bool checkConnected();
+    // Returns true if connected, false on error. If errorCondition() returns
+    // ENOTCONN, then it is not fatal and the socket is still connecting
+    bool checkConnected();
 
-	// Reimplemented
-	virtual QByteArray read(int size = -1);
-	virtual int write(const QByteArray &buf);
-	virtual int errorCondition() const { return errorCondition_; }
+    // Reimplemented
+    virtual QByteArray read(int size = -1);
+    virtual int write(const QByteArray &buf);
+    virtual int errorCondition() const { return errorCondition_; }
 
 private:
-	friend class TcpListener;
+    friend class TcpListener;
 
-	ffi::TcpStream *inner_;
-	std::unique_ptr<SocketNotifier> sn_;
-	int errorCondition_;
-	std::shared_ptr<std::monostate> alive_;
+    ffi::TcpStream *inner_;
+    std::unique_ptr<SocketNotifier> sn_;
+    int errorCondition_;
+    std::shared_ptr<std::monostate> alive_;
 
-	TcpStream(ffi::TcpStream *inner);
-	void reset();
-	void setupNotifier();
-	void sn_activated(int socket, uint8_t readiness);
+    TcpStream(ffi::TcpStream *inner);
+    void reset();
+    void setupNotifier();
+    void sn_activated(int socket, uint8_t readiness);
 };
 
 #endif

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -20,274 +20,241 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <chrono>
-#include <thread>
-#include <QHostAddress>
-#include "test.h"
+#include "tcpstream.h"
 #include "eventloop.h"
 #include "tcplistener.h"
-#include "tcpstream.h"
+#include "test.h"
+#include <QHostAddress>
+#include <chrono>
+#include <thread>
 
 using namespace std::chrono_literals;
 
-static void runAccept(std::function<void ()> loop_wait)
-{
-	TcpListener l;
-	TEST_ASSERT(l.bind(QHostAddress("127.0.0.1"), 0));
+static void runAccept(std::function<void()> loop_wait) {
+    TcpListener l;
+    TEST_ASSERT(l.bind(QHostAddress("127.0.0.1"), 0));
 
-	auto [addr, port] = l.localAddress();
+    auto [addr, port] = l.localAddress();
 
-	// Start by assuming operations are possible
-	bool streamsReady = true;
+    // Start by assuming operations are possible
+    bool streamsReady = true;
 
-	l.streamsReady.connect([&] {
-		streamsReady = true;
-	});
+    l.streamsReady.connect([&] { streamsReady = true; });
 
-	std::unique_ptr<TcpStream> s = l.accept();
-	TEST_ASSERT(!s);
-	TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
-	streamsReady = false;
+    std::unique_ptr<TcpStream> s = l.accept();
+    TEST_ASSERT(!s);
+    TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
+    streamsReady = false;
 
-	TcpStream client;
-	TEST_ASSERT(client.connect(addr, port));
+    TcpStream client;
+    TEST_ASSERT(client.connect(addr, port));
 
-	// Start by assuming operations are possible
-	bool clientWriteReady = true;
+    // Start by assuming operations are possible
+    bool clientWriteReady = true;
 
-	client.writeReady.connect([&] {
-		clientWriteReady = true;
-	});
+    client.writeReady.connect([&] { clientWriteReady = true; });
 
-	while(!streamsReady)
-		loop_wait();
+    while (!streamsReady)
+        loop_wait();
 
-	s = l.accept();
-	TEST_ASSERT(s);
+    s = l.accept();
+    TEST_ASSERT(s);
 
-	while(!client.checkConnected())
-	{
-		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
+    while (!client.checkConnected()) {
+        TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		clientWriteReady = false;
-		while(!clientWriteReady)
-			loop_wait();
-	}
+        clientWriteReady = false;
+        while (!clientWriteReady)
+            loop_wait();
+    }
 }
 
-static void runIo(std::function<void ()> loop_wait)
-{
-	TcpListener l;
-	TEST_ASSERT(l.bind(QHostAddress("127.0.0.1"), 0));
+static void runIo(std::function<void()> loop_wait) {
+    TcpListener l;
+    TEST_ASSERT(l.bind(QHostAddress("127.0.0.1"), 0));
 
-	auto [addr, port] = l.localAddress();
+    auto [addr, port] = l.localAddress();
 
-	// Start by assuming operations are possible
-	bool streamsReady = true;
+    // Start by assuming operations are possible
+    bool streamsReady = true;
 
-	l.streamsReady.connect([&] {
-		streamsReady = true;
-	});
+    l.streamsReady.connect([&] { streamsReady = true; });
 
-	TcpStream client;
-	TEST_ASSERT(client.connect(addr, port));
+    TcpStream client;
+    TEST_ASSERT(client.connect(addr, port));
 
-	// Start by assuming operations are possible
-	bool clientReadReady = true;
-	bool clientWriteReady = true;
+    // Start by assuming operations are possible
+    bool clientReadReady = true;
+    bool clientWriteReady = true;
 
-	client.readReady.connect([&] {
-		clientReadReady = true;
-	});
+    client.readReady.connect([&] { clientReadReady = true; });
 
-	client.writeReady.connect([&] {
-		clientWriteReady = true;
-	});
+    client.writeReady.connect([&] { clientWriteReady = true; });
 
-	std::unique_ptr<TcpStream> s;
-	while(!s)
-	{
-		s = l.accept();
+    std::unique_ptr<TcpStream> s;
+    while (!s) {
+        s = l.accept();
 
-		if(!s)
-		{
-			TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
+        if (!s) {
+            TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
 
-			streamsReady = false;
-			while(!streamsReady)
-				loop_wait();
-		}
-	}
+            streamsReady = false;
+            while (!streamsReady)
+                loop_wait();
+        }
+    }
 
-	// Start by assuming operations are possible
-	bool readReady = true;
-	bool writeReady = true;
+    // Start by assuming operations are possible
+    bool readReady = true;
+    bool writeReady = true;
 
-	s->readReady.connect([&] {
-		readReady = true;
-	});
+    s->readReady.connect([&] { readReady = true; });
 
-	s->writeReady.connect([&] {
-		writeReady = true;
-	});
+    s->writeReady.connect([&] { writeReady = true; });
 
-	while(!client.checkConnected())
-	{
-		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
+    while (!client.checkConnected()) {
+        TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		clientWriteReady = false;
-		while(!clientWriteReady)
-			loop_wait();
-	}
+        clientWriteReady = false;
+        while (!clientWriteReady)
+            loop_wait();
+    }
 
-	TEST_ASSERT(s->read().isNull());
-	TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
-	readReady = false;
+    TEST_ASSERT(s->read().isNull());
+    TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+    readReady = false;
 
-	TEST_ASSERT_EQ(client.write("hello\n"), 6);
+    TEST_ASSERT_EQ(client.write("hello\n"), 6);
 
-	QByteArray received;
-	while(!received.contains('\n'))
-	{
-		QByteArray buf = s->read();
+    QByteArray received;
+    while (!received.contains('\n')) {
+        QByteArray buf = s->read();
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
 
-			readReady = false;
-			while(!readReady)
-				loop_wait();
+            readReady = false;
+            while (!readReady)
+                loop_wait();
 
-			continue;
-		}
+            continue;
+        }
 
-		TEST_ASSERT(!buf.isEmpty());
+        TEST_ASSERT(!buf.isEmpty());
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	TEST_ASSERT_EQ(received, "hello\n");
+    TEST_ASSERT_EQ(received, "hello\n");
 
-	QByteArray written;
-	received.clear();
+    QByteArray written;
+    received.clear();
 
-	// Write until we fill the system buffer
-	while(true)
-	{
-		QByteArray chunk(100000, 'a');
-		int ret = s->write(chunk);
+    // Write until we fill the system buffer
+    while (true) {
+        QByteArray chunk(100000, 'a');
+        int ret = s->write(chunk);
 
-		if(ret < 0)
-		{
-			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
-			writeReady = false;
-			break;
-		}
+        if (ret < 0) {
+            TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+            writeReady = false;
+            break;
+        }
 
-		written += chunk.mid(0, ret);
-	}
+        written += chunk.mid(0, ret);
+    }
 
-	// Wait for some bytes on the client side
-	while(received.isEmpty())
-	{
-		QByteArray buf = client.read(100000);
+    // Wait for some bytes on the client side
+    while (received.isEmpty()) {
+        QByteArray buf = client.read(100000);
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-			clientReadReady = false;
-			while(!clientReadReady)
-				loop_wait();
+            clientReadReady = false;
+            while (!clientReadReady)
+                loop_wait();
 
-			continue;
-		}
+            continue;
+        }
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	// Now read as much as possible on the client side. This helps the
-	// server side gain writability sooner
-	while(true)
-	{
-		QByteArray buf = client.read(100000);
+    // Now read as much as possible on the client side. This helps the
+    // server side gain writability sooner
+    while (true) {
+        QByteArray buf = client.read(100000);
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
-			clientReadReady = false;
-			break;
-		}
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+            clientReadReady = false;
+            break;
+        }
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	// Wait for writability
-	while(!writeReady)
-		loop_wait();
+    // Wait for writability
+    while (!writeReady)
+        loop_wait();
 
-	// Write more
-	{
-		QByteArray chunk(100000, 'a');
-		int ret = s->write(chunk);
-		TEST_ASSERT(ret > 0);
+    // Write more
+    {
+        QByteArray chunk(100000, 'a');
+        int ret = s->write(chunk);
+        TEST_ASSERT(ret > 0);
 
-		written += chunk.mid(0, ret);
-	}
+        written += chunk.mid(0, ret);
+    }
 
-	// Close the server side
-	s.reset();
+    // Close the server side
+    s.reset();
 
-	// Read until closed on the client side
-	while(true)
-	{
-		QByteArray buf = client.read(100000);
+    // Read until closed on the client side
+    while (true) {
+        QByteArray buf = client.read(100000);
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-			clientReadReady = false;
-			while(!clientReadReady)
-				loop_wait();
+            clientReadReady = false;
+            while (!clientReadReady)
+                loop_wait();
 
-			continue;
-		}
+            continue;
+        }
 
-		if(buf.isEmpty())
-			break;
+        if (buf.isEmpty())
+            break;
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	TEST_ASSERT_EQ(received, written);
+    TEST_ASSERT_EQ(received, written);
 }
 
-static void accept()
-{
-	EventLoop loop(100);
+static void accept() {
+    EventLoop loop(100);
 
-	runAccept([&] {
-		std::this_thread::sleep_for(10ms);
-		loop.step();
-	});
+    runAccept([&] {
+        std::this_thread::sleep_for(10ms);
+        loop.step();
+    });
 }
 
-static void io()
-{
-	EventLoop loop(100);
+static void io() {
+    EventLoop loop(100);
 
-	runIo([&] {
-		std::this_thread::sleep_for(10ms);
-		loop.step();
-	});
+    runIo([&] {
+        std::this_thread::sleep_for(10ms);
+        loop.step();
+    });
 }
 
-extern "C" int tcpstream_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(accept());
-	TEST_CATCH(io());
+extern "C" int tcpstream_test(ffi::TestException *out_ex) {
+    TEST_CATCH(accept());
+    TEST_CATCH(io());
 
-	return 0;
+    return 0;
 }

--- a/src/core/test.cpp
+++ b/src/core/test.cpp
@@ -21,23 +21,21 @@
 
 #include "test.h"
 
+#include "eventloop.h"
 #include <chrono>
 #include <thread>
-#include "eventloop.h"
 
 using namespace std::chrono_literals;
 
-void test_with_event_loop(std::function<void (std::function<void (int)>)> f)
-{
-	EventLoop loop(100);
+void test_with_event_loop(std::function<void(std::function<void(int)>)> f) {
+    EventLoop loop(100);
 
-	auto loop_wait = [&](int ms) {
-		for(int i = ms; i > 0; i -= 10)
-		{
-			std::this_thread::sleep_for(10ms);
-			loop.step();
-		}
-	};
+    auto loop_wait = [&](int ms) {
+        for (int i = ms; i > 0; i -= 10) {
+            std::this_thread::sleep_for(10ms);
+            loop.step();
+        }
+    };
 
-	f(loop_wait);
+    f(loop_wait);
 }

--- a/src/core/test.h
+++ b/src/core/test.h
@@ -22,78 +22,78 @@
 #ifndef PUSHPIN_TEST_H
 #define PUSHPIN_TEST_H
 
-#include <string.h>
-#include <QtTest/QtTest>
 #include "rust/bindings.h"
+#include <QtTest/QtTest>
+#include <string.h>
 
-class TestException
-{
+class TestException {
 public:
     std::string file;
     int line;
     std::string message;
 
-    TestException(const std::string &file, int line, const std::string &message) :
-        file(file),
-        line(line),
-        message(message)
-    {
-    }
+    TestException(const std::string &file, int line, const std::string &message)
+        : file(file), line(line), message(message) {}
 
-    void toFfi(ffi::TestException *dest) const
-    {
+    void toFfi(ffi::TestException *dest) const {
         ffi::test_exception_set(dest, file.c_str(), line, message.c_str());
     }
 };
 
-inline void test_assert(bool cond, const char *condStr, const char *file, int line)
-{
-    if(!cond)
+inline void test_assert(bool cond, const char *condStr, const char *file, int line) {
+    if (!cond)
         throw TestException(file, line, std::string("assertion failed: ") + condStr);
 }
 
 // Uses QtTest to stringify values
-template <typename T>
-inline std::string test_value_to_string(const T &value)
-{
+template <typename T> inline std::string test_value_to_string(const T &value) {
     char *s = QTest::toString(value);
-    if(!s)
+    if (!s)
         return std::string("<no output format>");
 
     std::string out(s);
-    delete [] s;
+    delete[] s;
     return out;
 }
 
 template <typename T1, typename T2>
-inline void test_assert_eq(const T1 &left, const T2 &right, const char *file, int line)
-{
-    if(!(left == right))
-    {
+inline void test_assert_eq(const T1 &left, const T2 &right, const char *file, int line) {
+    if (!(left == right)) {
         std::string leftStr = test_value_to_string(left);
         std::string rightStr = test_value_to_string(right);
-        throw TestException(file, line, std::string("assertion `left == right` failed\n  left: ") + leftStr + std::string("\n right: ") + rightStr);
+        throw TestException(file, line,
+                            std::string("assertion `left == right` failed\n  left: ") + leftStr +
+                                std::string("\n right: ") + rightStr);
     }
 }
 
-// If cond is false, throws an exception with similar message as rust's assert macro
-#define TEST_ASSERT(cond) \
-do {\
-    test_assert(static_cast<bool>(cond), #cond, __FILE__, __LINE__);\
-} while (false)
+// If cond is false, throws an exception with similar message as rust's assert
+// macro
+#define TEST_ASSERT(cond)                                                                          \
+    do {                                                                                           \
+        test_assert(static_cast<bool>(cond), #cond, __FILE__, __LINE__);                           \
+    } while (false)
 
-// if left != right, throws an exception with similar message as rust's assert_eq macro
-#define TEST_ASSERT_EQ(left, right) \
-do {\
-    test_assert_eq(left, right, __FILE__, __LINE__);\
-} while (false)
+// if left != right, throws an exception with similar message as rust's
+// assert_eq macro
+#define TEST_ASSERT_EQ(left, right)                                                                \
+    do {                                                                                           \
+        test_assert_eq(left, right, __FILE__, __LINE__);                                           \
+    } while (false)
 
-// for running a test and catching an exception if any. expects local variable ffi::TestException* out_ex to exist
-#define TEST_CATCH(statement) try { statement; } catch(const TestException &ex) { ex.toFfi(out_ex); return 1; }
+// for running a test and catching an exception if any. expects local variable
+// ffi::TestException* out_ex to exist
+#define TEST_CATCH(statement)                                                                      \
+    try {                                                                                          \
+        statement;                                                                                 \
+    } catch (const TestException &ex) {                                                            \
+        ex.toFfi(out_ex);                                                                          \
+        return 1;                                                                                  \
+    }
 
 // Expects a test function that takes a wait function as an argument. The wait
 // function can be used by the test to wait for a number of milliseconds while
 // the event loop runs.
-void test_with_event_loop(std::function<void (std::function<void (int)>)> f);
+void test_with_event_loop(std::function<void(std::function<void(int)>)> f);
 
 #endif

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -23,276 +23,217 @@
 
 #include "timer.h"
 
-#include <assert.h>
+#include "eventloop.h"
+#include "timerwheel.h"
 #include <QDateTime>
 #include <QTimer>
-#include "timerwheel.h"
-#include "eventloop.h"
+#include <assert.h>
 
 #define TICK_DURATION_MS 10
 #define UPDATE_TICKS_MAX 1000
 #define EXPIRES_PER_CYCLE_MAX 100
 
-static int64_t durationToTicksRoundDown(int64_t msec)
-{
-	return msec / TICK_DURATION_MS;
+static int64_t durationToTicksRoundDown(int64_t msec) { return msec / TICK_DURATION_MS; }
+
+static int64_t durationToTicksRoundUp(int64_t msec) {
+    return (msec + TICK_DURATION_MS - 1) / TICK_DURATION_MS;
 }
 
-static int64_t durationToTicksRoundUp(int64_t msec)
-{
-	return (msec + TICK_DURATION_MS - 1) / TICK_DURATION_MS;
-}
+static int64_t ticksToDuration(int64_t ticks) { return ticks * TICK_DURATION_MS; }
 
-static int64_t ticksToDuration(int64_t ticks)
-{
-	return ticks * TICK_DURATION_MS;
-}
-
-class TimerManager
-{
+class TimerManager {
 public:
-	TimerManager(int capacity);
+    TimerManager(int capacity);
 
-	int add(int msec, Timer *r);
-	void remove(int key);
+    int add(int msec, Timer *r);
+    void remove(int key);
 
 private:
-	TimerWheel wheel_;
-	int64_t startTime_;
-	uint64_t currentTicks_;
-	std::unique_ptr<QTimer> t_;
+    TimerWheel wheel_;
+    int64_t startTime_;
+    uint64_t currentTicks_;
+    std::unique_ptr<QTimer> t_;
 
-	void t_timeout();
-	void updateTimeout(int64_t currentTime);
+    void t_timeout();
+    void updateTimeout(int64_t currentTime);
 };
 
-TimerManager::TimerManager(int capacity) :
-	wheel_(TimerWheel(capacity))
-{
-	startTime_ = QDateTime::currentMSecsSinceEpoch();
-	currentTicks_ = 0;
+TimerManager::TimerManager(int capacity) : wheel_(TimerWheel(capacity)) {
+    startTime_ = QDateTime::currentMSecsSinceEpoch();
+    currentTicks_ = 0;
 
-	t_ = std::make_unique<QTimer>();
+    t_ = std::make_unique<QTimer>();
 
-	// safe to not track, since t_ can't outlive this
-	QObject::connect(t_.get(), &QTimer::timeout, [=] {
-		t_timeout();
-	});
+    // safe to not track, since t_ can't outlive this
+    QObject::connect(t_.get(), &QTimer::timeout, [=] { t_timeout(); });
 
-	t_->setSingleShot(true);
+    t_->setSingleShot(true);
 }
 
-int TimerManager::add(int msec, Timer *r)
-{
-	int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+int TimerManager::add(int msec, Timer *r) {
+    int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
 
-	int64_t expiresTicks;
-	if(msec <= 0)
-	{
-		// For timeouts of zero, set immediate expiration with no rounding up
-		expiresTicks = currentTicks_;
-	}
-	else
-	{
-		// expireTime must be >= startTime_
-		int64_t expireTime = qMax(currentTime + msec, startTime_);
+    int64_t expiresTicks;
+    if (msec <= 0) {
+        // For timeouts of zero, set immediate expiration with no rounding up
+        expiresTicks = currentTicks_;
+    } else {
+        // expireTime must be >= startTime_
+        int64_t expireTime = qMax(currentTime + msec, startTime_);
 
-		expiresTicks = durationToTicksRoundUp(expireTime - startTime_);
-	}
+        expiresTicks = durationToTicksRoundUp(expireTime - startTime_);
+    }
 
-	int id = wheel_.add(expiresTicks, (size_t)r);
+    int id = wheel_.add(expiresTicks, (size_t)r);
 
-	if(id >= 0)
-	{
-		updateTimeout(currentTime);
-	}
+    if (id >= 0) {
+        updateTimeout(currentTime);
+    }
 
-	return id;
+    return id;
 }
 
-void TimerManager::remove(int key)
-{
-	wheel_.remove(key);
+void TimerManager::remove(int key) {
+    wheel_.remove(key);
 
-	int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+    int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
 
-	updateTimeout(currentTime);
+    updateTimeout(currentTime);
 }
 
-void TimerManager::t_timeout()
-{
-	int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+void TimerManager::t_timeout() {
+    int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
 
-	// Time must go forward
-	if(currentTime > startTime_)
-	{
-		currentTicks_ = (uint64_t)durationToTicksRoundDown(currentTime - startTime_);
+    // Time must go forward
+    if (currentTime > startTime_) {
+        currentTicks_ = (uint64_t)durationToTicksRoundDown(currentTime - startTime_);
 
-		wheel_.update(currentTicks_);
-	}
+        wheel_.update(currentTicks_);
+    }
 
-	for(int i = 0; i < EXPIRES_PER_CYCLE_MAX; ++i)
-	{
-		TimerWheel::Expired expired = wheel_.takeExpired();
+    for (int i = 0; i < EXPIRES_PER_CYCLE_MAX; ++i) {
+        TimerWheel::Expired expired = wheel_.takeExpired();
 
-		if(expired.key < 0)
-		{
-			break;
-		}
+        if (expired.key < 0) {
+            break;
+        }
 
-		Timer *r = (Timer *)expired.userData;
+        Timer *r = (Timer *)expired.userData;
 
-		r->timerReady();
-	}
+        r->timerReady();
+    }
 
-	updateTimeout(currentTime);
+    updateTimeout(currentTime);
 }
 
-void TimerManager::updateTimeout(int64_t currentTime)
-{
-	int64_t timeoutTicks = wheel_.timeout();
+void TimerManager::updateTimeout(int64_t currentTime) {
+    int64_t timeoutTicks = wheel_.timeout();
 
-	if(timeoutTicks >= 0)
-	{
-		// currentTime must be >= startTime_
-		currentTime = qMax(currentTime, startTime_);
+    if (timeoutTicks >= 0) {
+        // currentTime must be >= startTime_
+        currentTime = qMax(currentTime, startTime_);
 
-		uint64_t currentTicks = (uint64_t)durationToTicksRoundDown(currentTime - startTime_);
+        uint64_t currentTicks = (uint64_t)durationToTicksRoundDown(currentTime - startTime_);
 
-		// Time must go forward
-		currentTicks = qMax(currentTicks, currentTicks_);
+        // Time must go forward
+        currentTicks = qMax(currentTicks, currentTicks_);
 
-		int64_t ticksSinceWheelUpdate = (int64_t)(currentTicks - currentTicks_);
+        int64_t ticksSinceWheelUpdate = (int64_t)(currentTicks - currentTicks_);
 
-		// Reduce the timeout by the time already elapsed
-		timeoutTicks = qMax(timeoutTicks - ticksSinceWheelUpdate, (int64_t)0);
+        // Reduce the timeout by the time already elapsed
+        timeoutTicks = qMax(timeoutTicks - ticksSinceWheelUpdate, (int64_t)0);
 
-		// Cap the timeout so the wheel is regularly updated
-		int64_t maxTimeoutTicks = qMax(UPDATE_TICKS_MAX - ticksSinceWheelUpdate, (int64_t)0);
-		timeoutTicks = qMin(timeoutTicks, maxTimeoutTicks);
+        // Cap the timeout so the wheel is regularly updated
+        int64_t maxTimeoutTicks = qMax(UPDATE_TICKS_MAX - ticksSinceWheelUpdate, (int64_t)0);
+        timeoutTicks = qMin(timeoutTicks, maxTimeoutTicks);
 
-		int msec = ticksToDuration(timeoutTicks);
+        int msec = ticksToDuration(timeoutTicks);
 
-		t_->start(msec);
-	}
-	else
-	{
-		t_->stop();
-	}
+        t_->start(msec);
+    } else {
+        t_->stop();
+    }
 }
 
 static thread_local TimerManager *g_manager = 0;
 
-Timer::Timer() :
-	loop_(EventLoop::instance()),
-	singleShot_(false),
-	interval_(0),
-	timerId_(-1)
-{
+Timer::Timer() : loop_(EventLoop::instance()), singleShot_(false), interval_(0), timerId_(-1) {}
+
+Timer::~Timer() { stop(); }
+
+bool Timer::isActive() const { return (timerId_ >= 0); }
+
+void Timer::setSingleShot(bool singleShot) { singleShot_ = singleShot; }
+
+void Timer::setInterval(int msec) { interval_ = msec; }
+
+void Timer::start(int msec) {
+    setInterval(msec);
+    start();
 }
 
-Timer::~Timer()
-{
-	stop();
+void Timer::start() {
+    stop();
+
+    if (loop_) {
+        // If the rust-based eventloop is available, use it
+
+        int id = loop_->registerTimer(interval_, Timer::cb_timer_activated, this);
+        assert(id >= 0);
+
+        timerId_ = id;
+    } else {
+        // Else fall back to qt eventloop
+
+        // Must call Timer::init first
+        assert(g_manager);
+
+        int id = g_manager->add(interval_, this);
+        assert(id >= 0);
+
+        timerId_ = id;
+    }
 }
 
-bool Timer::isActive() const
-{
-	return (timerId_ >= 0);
+void Timer::stop() {
+    if (timerId_ >= 0) {
+        if (loop_) {
+            loop_->deregister(timerId_);
+        } else {
+            assert(g_manager);
+
+            g_manager->remove(timerId_);
+        }
+
+        timerId_ = -1;
+    }
 }
 
-void Timer::setSingleShot(bool singleShot)
-{
-	singleShot_ = singleShot;
+void Timer::cb_timer_activated(void *ctx, uint8_t readiness) {
+    Q_UNUSED(readiness);
+
+    Timer *self = (Timer *)ctx;
+
+    self->timerReady();
 }
 
-void Timer::setInterval(int msec)
-{
-	interval_ = msec;
+void Timer::timerReady() {
+    timerId_ = -1;
+
+    if (!singleShot_) {
+        start();
+    }
+
+    timeout();
 }
 
-void Timer::start(int msec)
-{
-	setInterval(msec);
-	start();
+void Timer::init(int capacity) {
+    assert(!g_manager);
+
+    g_manager = new TimerManager(capacity);
 }
 
-void Timer::start()
-{
-	stop();
-
-	if(loop_)
-	{
-		// If the rust-based eventloop is available, use it
-
-		int id = loop_->registerTimer(interval_, Timer::cb_timer_activated, this);
-		assert(id >= 0);
-
-		timerId_ = id;
-	}
-	else
-	{
-		// Else fall back to qt eventloop
-
-		// Must call Timer::init first
-		assert(g_manager);
-
-		int id = g_manager->add(interval_, this);
-		assert(id >= 0);
-
-		timerId_ = id;
-	}
-}
-
-void Timer::stop()
-{
-	if(timerId_ >= 0)
-	{
-		if(loop_)
-		{
-			loop_->deregister(timerId_);
-		}
-		else
-		{
-			assert(g_manager);
-
-			g_manager->remove(timerId_);
-		}
-
-		timerId_ = -1;
-	}
-}
-
-void Timer::cb_timer_activated(void *ctx, uint8_t readiness)
-{
-	Q_UNUSED(readiness);
-
-	Timer *self = (Timer *)ctx;
-
-	self->timerReady();
-}
-
-void Timer::timerReady()
-{
-	timerId_ = -1;
-
-	if(!singleShot_)
-	{
-		start();
-	}
-
-	timeout();
-}
-
-void Timer::init(int capacity)
-{
-	assert(!g_manager);
-
-	g_manager = new TimerManager(capacity);
-}
-
-void Timer::deinit()
-{
-	delete g_manager;
-	g_manager = 0;
+void Timer::deinit() {
+    delete g_manager;
+    g_manager = 0;
 }

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -31,38 +31,37 @@ using Signal = boost::signals2::signal<void()>;
 class EventLoop;
 class TimerManager;
 
-class Timer
-{
+class Timer {
 public:
-	Timer();
-	~Timer();
+    Timer();
+    ~Timer();
 
-	bool isActive() const;
+    bool isActive() const;
 
-	void setSingleShot(bool singleShot);
-	void setInterval(int msec);
-	void start(int msec);
-	void start();
-	void stop();
+    void setSingleShot(bool singleShot);
+    void setInterval(int msec);
+    void start(int msec);
+    void start();
+    void stop();
 
-	// Initialization is thread local
-	static void init(int capacity);
+    // Initialization is thread local
+    static void init(int capacity);
 
-	// Only call if there are no active timers
-	static void deinit();
+    // Only call if there are no active timers
+    static void deinit();
 
-	Signal timeout;
+    Signal timeout;
 
 private:
-	friend class TimerManager;
+    friend class TimerManager;
 
-	EventLoop *loop_;
-	bool singleShot_;
-	int interval_;
-	int timerId_;
+    EventLoop *loop_;
+    bool singleShot_;
+    int interval_;
+    int timerId_;
 
-	static void cb_timer_activated(void *ctx, uint8_t readiness);
-	void timerReady();
+    static void cb_timer_activated(void *ctx, uint8_t readiness);
+    void timerReady();
 };
 
 #endif

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -20,51 +20,48 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
 #include "timer.h"
 #include "eventloop.h"
+#include "test.h"
 
 // loop_advance should process enough events to cause the timers to
 // Activate, without sleeping, in order to prove timeouts of zero are
 // processed immediately
-static int runZeroTimeout(std::function<void ()> loop_advance)
-{
-	Timer t;
-	t.setSingleShot(true);
+static int runZeroTimeout(std::function<void()> loop_advance) {
+    Timer t;
+    t.setSingleShot(true);
 
-	int count = 0;
+    int count = 0;
 
-	t.timeout.connect([&] {
-		++count;
-		if(count < 2)
-			t.start(0);
-	});
+    t.timeout.connect([&] {
+        ++count;
+        if (count < 2)
+            t.start(0);
+    });
 
-	t.start(0);
+    t.start(0);
 
-	loop_advance();
+    loop_advance();
 
-	return count;
+    return count;
 }
 
-static void zeroTimeout()
-{
-	EventLoop loop(1);
+static void zeroTimeout() {
+    EventLoop loop(1);
 
-	int count = runZeroTimeout([&] {
-		// Activate the first timer and queue the second
-		loop.step();
+    int count = runZeroTimeout([&] {
+        // Activate the first timer and queue the second
+        loop.step();
 
-		// Activate the second
-		loop.step();
-	});
+        // Activate the second
+        loop.step();
+    });
 
-	TEST_ASSERT_EQ(count, 2);
+    TEST_ASSERT_EQ(count, 2);
 }
 
-extern "C" int timer_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(zeroTimeout());
+extern "C" int timer_test(ffi::TestException *out_ex) {
+    TEST_CATCH(zeroTimeout());
 
-	return 0;
+    return 0;
 }

--- a/src/core/timerwheel.cpp
+++ b/src/core/timerwheel.cpp
@@ -24,43 +24,26 @@
 
 #include "rust/bindings.h"
 
-TimerWheel::TimerWheel(int capacity)
-{
-	raw_ = ffi::timer_wheel_create(capacity);
+TimerWheel::TimerWheel(int capacity) { raw_ = ffi::timer_wheel_create(capacity); }
+
+TimerWheel::~TimerWheel() { ffi::timer_wheel_destroy(raw_); }
+
+int TimerWheel::add(uint64_t expires, size_t userData) {
+    return ffi::timer_add(raw_, expires, userData);
 }
 
-TimerWheel::~TimerWheel()
-{
-	ffi::timer_wheel_destroy(raw_);
-}
+void TimerWheel::remove(int key) { ffi::timer_remove(raw_, key); }
 
-int TimerWheel::add(uint64_t expires, size_t userData)
-{
-	return ffi::timer_add(raw_, expires, userData);
-}
+int64_t TimerWheel::timeout() const { return ffi::timer_wheel_timeout(raw_); }
 
-void TimerWheel::remove(int key)
-{
-	ffi::timer_remove(raw_, key);
-}
+void TimerWheel::update(uint64_t curtime) { ffi::timer_wheel_update(raw_, curtime); }
 
-int64_t TimerWheel::timeout() const
-{
-	return ffi::timer_wheel_timeout(raw_);
-}
+TimerWheel::Expired TimerWheel::takeExpired() {
+    ffi::ExpiredTimer ret = ffi::timer_wheel_take_expired(raw_);
 
-void TimerWheel::update(uint64_t curtime)
-{
-	ffi::timer_wheel_update(raw_, curtime);
-}
+    Expired expired;
+    expired.key = ret.key;
+    expired.userData = ret.user_data;
 
-TimerWheel::Expired TimerWheel::takeExpired()
-{
-	ffi::ExpiredTimer ret = ffi::timer_wheel_take_expired(raw_);
-
-	Expired expired;
-	expired.key = ret.key;
-	expired.userData = ret.user_data;
-
-	return expired;
+    return expired;
 }

--- a/src/core/timerwheel.h
+++ b/src/core/timerwheel.h
@@ -26,40 +26,38 @@
 #include <QPair>
 
 namespace ffi {
-	struct TimerWheel;
+struct TimerWheel;
 }
 
-class TimerWheel
-{
+class TimerWheel {
 public:
-	class Expired
-	{
-	public:
-		int key; // <0 if invalid
-		size_t userData;
-	};
+    class Expired {
+    public:
+        int key; // <0 if invalid
+        size_t userData;
+    };
 
-	TimerWheel(int capacity);
-	~TimerWheel();
+    TimerWheel(int capacity);
+    ~TimerWheel();
 
-	// Disable copying
-	TimerWheel(const TimerWheel &) = delete;
-	TimerWheel & operator=(const TimerWheel &) = delete;
+    // Disable copying
+    TimerWheel(const TimerWheel &) = delete;
+    TimerWheel &operator=(const TimerWheel &) = delete;
 
-	// Returns <0 if no capacity
-	int add(uint64_t expires, size_t userData);
+    // Returns <0 if no capacity
+    int add(uint64_t expires, size_t userData);
 
-	void remove(int key);
+    void remove(int key);
 
-	// Returns <0 if no timers
-	int64_t timeout() const;
+    // Returns <0 if no timers
+    int64_t timeout() const;
 
-	void update(uint64_t curtime);
+    void update(uint64_t curtime);
 
-	Expired takeExpired();
+    Expired takeExpired();
 
 private:
-	ffi::TimerWheel *raw_;
+    ffi::TimerWheel *raw_;
 };
 
 #endif

--- a/src/core/tnetstring.cpp
+++ b/src/core/tnetstring.cpp
@@ -21,443 +21,410 @@
 
 #include "tnetstring.h"
 
-#include <assert.h>
 #include "cowbytearray.h"
 #include "qtcompat.h"
 #include "variant.h"
+#include <assert.h>
 
 namespace TnetString {
 
-QByteArray fromByteArray(const QByteArray &in)
-{
-	return QByteArray::number(in.size()) + ':' + in + ',';
+QByteArray fromByteArray(const QByteArray &in) {
+    return QByteArray::number(in.size()) + ':' + in + ',';
 }
 
-QByteArray fromInt(int64_t in)
-{
-	QByteArray val = QByteArray::number(in);
-	return QByteArray::number(val.size()) + ':' + val + '#';
+QByteArray fromInt(int64_t in) {
+    QByteArray val = QByteArray::number(in);
+    return QByteArray::number(val.size()) + ':' + val + '#';
 }
 
-QByteArray fromDouble(double in)
-{
-	QByteArray val = QByteArray::number(in);
-	return QByteArray::number(val.size()) + ':' + val + '^';
+QByteArray fromDouble(double in) {
+    QByteArray val = QByteArray::number(in);
+    return QByteArray::number(val.size()) + ':' + val + '^';
 }
 
-QByteArray fromBool(bool in)
-{
-	QByteArray val = in ? "true" : "false";
-	return QByteArray::number(val.size()) + ':' + val + '!';
+QByteArray fromBool(bool in) {
+    QByteArray val = in ? "true" : "false";
+    return QByteArray::number(val.size()) + ':' + val + '!';
 }
 
-QByteArray fromNull()
-{
-	return QByteArray("0:~");
+QByteArray fromNull() { return QByteArray("0:~"); }
+
+QByteArray fromVariant(const Variant &in) {
+    switch (typeId(in)) {
+    case VariantType::ByteArray:
+        return fromByteArray(in.toByteArray());
+    case VariantType::Double:
+        return fromDouble(in.toDouble());
+    case VariantType::Bool:
+        return fromBool(in.toBool());
+    case VariantType::Invalid:
+        return fromNull();
+    case VariantType::Hash:
+        return fromHash(in.toHash());
+    case VariantType::List:
+        return fromList(in.toList());
+    default:
+        if (canConvert(in, VariantType::LongLong))
+            return fromInt(in.toLongLong());
+
+        // Unsupported type
+        assert(0);
+        return QByteArray();
+    }
 }
 
-QByteArray fromVariant(const Variant &in)
-{
-	switch(typeId(in))
-	{
-		case VariantType::ByteArray:
-			return fromByteArray(in.toByteArray());
-		case VariantType::Double:
-			return fromDouble(in.toDouble());
-		case VariantType::Bool:
-			return fromBool(in.toBool());
-		case VariantType::Invalid:
-			return fromNull();
-		case VariantType::Hash:
-			return fromHash(in.toHash());
-		case VariantType::List:
-			return fromList(in.toList());
-		default:
-			if(canConvert(in, VariantType::LongLong))
-				return fromInt(in.toLongLong());
-
-			// Unsupported type
-			assert(0);
-			return QByteArray();
-	}
+QByteArray fromHash(const VariantHash &in) {
+    QByteArray val;
+    for (auto it = in.constBegin(); it != in.constEnd(); ++it) {
+        val += fromByteArray(it.key().toUtf8());
+        val += fromVariant(it.value());
+    }
+    return QByteArray::number(val.size()) + ':' + val + '}';
 }
 
-QByteArray fromHash(const VariantHash &in)
-{
-	QByteArray val;
-	for(auto it = in.constBegin(); it != in.constEnd(); ++it)
-	{
-		val += fromByteArray(it.key().toUtf8());
-		val += fromVariant(it.value());
-	}
-	return QByteArray::number(val.size()) + ':' + val + '}';
+QByteArray fromList(const VariantList &in) {
+    QByteArray val;
+    for (const Variant &v : in)
+        val += fromVariant(v);
+    return QByteArray::number(val.size()) + ':' + val + ']';
 }
 
-QByteArray fromList(const VariantList &in)
-{
-	QByteArray val;
-	for(const Variant &v : in)
-		val += fromVariant(v);
-	return QByteArray::number(val.size()) + ':' + val + ']';
+bool check(const QByteArray &in, int offset, Type *type, int *dataOffset, int *dataSize) {
+    int at = in.indexOf(':', offset);
+    if (at == -1)
+        return false;
+
+    bool ok;
+    int size = in.mid(offset, at - offset).toInt(&ok);
+    if (!ok || size < 0)
+        return false;
+
+    char typeChar = in[at + 1 + size];
+    Type type_;
+    switch (typeChar) {
+    case ',':
+        type_ = ByteArray;
+        break;
+    case '#':
+        type_ = Int;
+        break;
+    case '^':
+        type_ = Double;
+        break;
+    case '!':
+        type_ = Bool;
+        break;
+    case '~':
+        type_ = Null;
+        break;
+    case '}':
+        type_ = Hash;
+        break;
+    case ']':
+        type_ = List;
+        break;
+    default:
+        return false;
+    }
+
+    *type = type_;
+    *dataOffset = at + 1;
+    *dataSize = size;
+    return true;
 }
 
-bool check(const QByteArray &in, int offset, Type *type, int *dataOffset, int *dataSize)
-{
-	int at = in.indexOf(':', offset);
-	if(at == -1)
-		return false;
-
-	bool ok;
-	int size = in.mid(offset, at - offset).toInt(&ok);
-	if(!ok || size < 0)
-		return false;
-
-	char typeChar = in[at + 1 + size];
-	Type type_;
-	switch(typeChar)
-	{
-		case ',': type_ = ByteArray; break;
-		case '#': type_ = Int; break;
-		case '^': type_ = Double; break;
-		case '!': type_ = Bool; break;
-		case '~': type_ = Null; break;
-		case '}': type_ = Hash; break;
-		case ']': type_ = List; break;
-		default: return false;
-	}
-
-	*type = type_;
-	*dataOffset = at + 1;
-	*dataSize = size;
-	return true;
+QByteArray toByteArray(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(offset);
+    if (ok)
+        *ok = true;
+    return in.mid(dataOffset, dataSize);
 }
 
-QByteArray toByteArray(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(offset);
-	if(ok)
-		*ok = true;
-	return in.mid(dataOffset, dataSize);
+int64_t toInt(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(offset);
+    QByteArray val = in.mid(dataOffset, dataSize);
+    bool ok_;
+    int64_t x = val.toLongLong(&ok_);
+    if (!ok_)
+        x = 0;
+    if (ok)
+        *ok = ok_;
+    return x;
 }
 
-int64_t toInt(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(offset);
-	QByteArray val = in.mid(dataOffset, dataSize);
-	bool ok_;
-	int64_t x = val.toLongLong(&ok_);
-	if(!ok_)
-		x = 0;
-	if(ok)
-		*ok = ok_;
-	return x;
+double toDouble(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(offset);
+    QByteArray val = in.mid(dataOffset, dataSize);
+    bool ok_;
+    double x = val.toDouble(&ok_);
+    if (!ok_)
+        x = 0;
+    if (ok)
+        *ok = ok_;
+    return x;
 }
 
-double toDouble(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(offset);
-	QByteArray val = in.mid(dataOffset, dataSize);
-	bool ok_;
-	double x = val.toDouble(&ok_);
-	if(!ok_)
-		x = 0;
-	if(ok)
-		*ok = ok_;
-	return x;
+bool toBool(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(offset);
+    QByteArray val = in.mid(dataOffset, dataSize);
+    if (val == "true") {
+        if (ok)
+            *ok = true;
+        return true;
+    } else if (val == "false") {
+        if (ok)
+            *ok = true;
+        return false;
+    }
+
+    if (ok)
+        *ok = false;
+    return false;
 }
 
-bool toBool(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(offset);
-	QByteArray val = in.mid(dataOffset, dataSize);
-	if(val == "true")
-	{
-		if(ok)
-			*ok = true;
-		return true;
-	}
-	else if(val == "false")
-	{
-		if(ok)
-			*ok = true;
-		return false;
-	}
-
-	if(ok)
-		*ok = false;
-	return false;
+void toNull(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(in);
+    Q_UNUSED(offset);
+    Q_UNUSED(dataOffset);
+    Q_UNUSED(dataSize);
+    *ok = true;
 }
 
-void toNull(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(in);
-	Q_UNUSED(offset);
-	Q_UNUSED(dataOffset);
-	Q_UNUSED(dataSize);
-	*ok = true;
+Variant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize,
+                  bool *ok) {
+    Variant val;
+    bool ok_ = false;
+    switch (type) {
+    case ByteArray:
+        val = toByteArray(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    case Int:
+        val = (qint64)toInt(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    case Double:
+        val = toDouble(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    case Bool:
+        val = toBool(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    case Null:
+        toNull(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    case Hash:
+        val = toHash(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    case List:
+        val = toList(in, offset, dataOffset, dataSize, &ok_);
+        break;
+    }
+
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return Variant();
+    }
+
+    if (ok)
+        *ok = true;
+    return val;
 }
 
-Variant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok)
-{
-	Variant val;
-	bool ok_ = false;
-	switch(type)
-	{
-		case ByteArray:
-			val = toByteArray(in, offset, dataOffset, dataSize, &ok_);
-			break;
-		case Int:
-			val = (qint64)toInt(in, offset, dataOffset, dataSize, &ok_);
-			break;
-		case Double:
-			val = toDouble(in, offset, dataOffset, dataSize, &ok_);
-			break;
-		case Bool:
-			val = toBool(in, offset, dataOffset, dataSize, &ok_);
-			break;
-		case Null:
-			toNull(in, offset, dataOffset, dataSize, &ok_);
-			break;
-		case Hash:
-			val = toHash(in, offset, dataOffset, dataSize, &ok_);
-			break;
-		case List:
-			val = toList(in, offset, dataOffset, dataSize, &ok_);
-			break;
-	}
+Variant toVariant(const QByteArray &in, int offset, bool *ok) {
+    Type type;
+    int dataOffset;
+    int dataSize;
+    if (!check(in, offset, &type, &dataOffset, &dataSize)) {
+        if (ok)
+            *ok = false;
+        return Variant();
+    }
 
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return Variant();
-	}
-
-	if(ok)
-		*ok = true;
-	return val;
+    return toVariant(in, offset, type, dataOffset, dataSize, ok);
 }
 
-Variant toVariant(const QByteArray &in, int offset, bool *ok)
-{
-	Type type;
-	int dataOffset;
-	int dataSize;
-	if(!check(in, offset, &type, &dataOffset, &dataSize))
-	{
-		if(ok)
-			*ok = false;
-		return Variant();
-	}
-
-	return toVariant(in, offset, type, dataOffset, dataSize, ok);
+Variant toVariant(const CowByteArray &in, int offset, bool *ok) {
+    return toVariant(in.asQByteArray(), offset, ok);
 }
 
-Variant toVariant(const CowByteArray &in, int offset, bool *ok)
-{
-	return toVariant(in.asQByteArray(), offset, ok);
+VariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(offset);
+
+    VariantHash out;
+
+    int at = dataOffset;
+    while (at < dataSize + dataOffset) {
+        Type itype;
+        int ioffset;
+        int isize;
+        if (!check(in, at, &itype, &ioffset, &isize)) {
+            if (ok)
+                *ok = false;
+            return VariantHash();
+        }
+
+        if (itype != ByteArray) {
+            if (ok)
+                *ok = false;
+            return VariantHash();
+        }
+
+        bool ok_;
+        QByteArray key = toByteArray(in, at, ioffset, isize, &ok_);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return VariantHash();
+        }
+
+        at = ioffset + isize + 1; // Position to value
+
+        if (!check(in, at, &itype, &ioffset, &isize)) {
+            if (ok)
+                *ok = false;
+            return VariantHash();
+        }
+
+        Variant val = toVariant(in, at, itype, ioffset, isize, &ok_);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return VariantHash();
+        }
+
+        out[QString::fromUtf8(key)] = val;
+        at = ioffset + isize + 1; // Position to next item
+    }
+
+    if (ok)
+        *ok = true;
+    return out;
 }
 
-VariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(offset);
+VariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok) {
+    Q_UNUSED(offset);
 
-	VariantHash out;
+    VariantList out;
 
-	int at = dataOffset;
-	while(at < dataSize + dataOffset)
-	{
-		Type itype;
-		int ioffset;
-		int isize;
-		if(!check(in, at, &itype, &ioffset, &isize))
-		{
-			if(ok)
-				*ok = false;
-			return VariantHash();
-		}
+    int at = dataOffset;
+    while (at < dataOffset + dataSize) {
+        Type itype;
+        int ioffset;
+        int isize;
+        if (!check(in, at, &itype, &ioffset, &isize)) {
+            if (ok)
+                *ok = false;
+            return VariantList();
+        }
 
-		if(itype != ByteArray)
-		{
-			if(ok)
-				*ok = false;
-			return VariantHash();
-		}
+        bool ok_;
+        Variant val = toVariant(in, at, itype, ioffset, isize, &ok_);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return VariantList();
+        }
 
-		bool ok_;
-		QByteArray key = toByteArray(in, at, ioffset, isize, &ok_);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return VariantHash();
-		}
+        out += val;
+        at = ioffset + isize + 1; // Position to next item
+    }
 
-		at = ioffset + isize + 1; // Position to value
-
-		if(!check(in, at, &itype, &ioffset, &isize))
-		{
-			if(ok)
-				*ok = false;
-			return VariantHash();
-		}
-
-		Variant val = toVariant(in, at, itype, ioffset, isize, &ok_);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return VariantHash();
-		}
-
-		out[QString::fromUtf8(key)] = val;
-		at = ioffset + isize + 1; // Position to next item
-	}
-
-	if(ok)
-		*ok = true;
-	return out;
+    if (ok)
+        *ok = true;
+    return out;
 }
 
-VariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok)
-{
-	Q_UNUSED(offset);
-
-	VariantList out;
-
-	int at = dataOffset;
-	while(at < dataOffset + dataSize)
-	{
-		Type itype;
-		int ioffset;
-		int isize;
-		if(!check(in, at, &itype, &ioffset, &isize))
-		{
-			if(ok)
-				*ok = false;
-			return VariantList();
-		}
-
-		bool ok_;
-		Variant val = toVariant(in, at, itype, ioffset, isize, &ok_);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return VariantList();
-		}
-
-		out += val;
-		at = ioffset + isize + 1; // Position to next item
-	}
-
-	if(ok)
-		*ok = true;
-	return out;
+QString byteArrayToEscapedString(const QByteArray &in) {
+    QString out;
+    for (int n = 0; n < in.size(); ++n) {
+        char c = in[n];
+        if (c == '\\')
+            out += "\\\\";
+        else if (c == '\"')
+            out += "\\\"";
+        else if (c == '\n')
+            out += "\\n";
+        else if (c >= 0x20 && c < 0x7f)
+            out += QChar::fromLatin1(c);
+        else
+            out += QString::asprintf("\\x%02x", (unsigned char)c);
+    }
+    return out;
 }
 
-QString byteArrayToEscapedString(const QByteArray &in)
-{
-	QString out;
-	for(int n = 0; n < in.size(); ++n)
-	{
-		char c = in[n];
-		if(c == '\\')
-			out += "\\\\";
-		else if(c == '\"')
-			out += "\\\"";
-		else if(c == '\n')
-			out += "\\n";
-		else if(c >= 0x20 && c < 0x7f)
-			out += QChar::fromLatin1(c);
-		else
-			out += QString::asprintf("\\x%02x", (unsigned char)c);
-	}
-	return out;
+QString variantToString(const Variant &in, int indent) {
+    QString out;
+
+    VariantType::Type type = typeId(in);
+    if (type == VariantType::Hash) {
+        VariantHash hash = in.toHash();
+
+        out += '{';
+        if (indent >= 0)
+            out += '\n';
+        else
+            out += ' ';
+
+        for (auto it = hash.constBegin(); it != hash.constEnd(); ++it) {
+            if (indent >= 0)
+                out += QString(indent + 2, ' ');
+
+            out += '\"' + byteArrayToEscapedString(it.key().toUtf8()) +
+                   "\": " + variantToString(it.value(), indent >= 0 ? indent + 2 : -1);
+            auto next_it = it;
+            ++next_it;
+            if (next_it != hash.constEnd())
+                out += ',';
+
+            if (indent >= 0)
+                out += '\n';
+            else
+                out += ' ';
+        }
+
+        if (indent >= 0)
+            out += QString(indent, ' ');
+        out += '}';
+    } else if (type == VariantType::List) {
+        VariantList list = in.toList();
+
+        out += '[';
+        if (indent >= 0)
+            out += '\n';
+        else
+            out += ' ';
+
+        for (int n = 0; n < list.count(); ++n) {
+            if (indent >= 0)
+                out += QString(indent + 2, ' ');
+
+            out += variantToString(list[n], indent >= 0 ? indent + 2 : -1);
+            if (n + 1 < list.count())
+                out += ',';
+
+            if (indent >= 0)
+                out += '\n';
+            else
+                out += ' ';
+        }
+
+        if (indent >= 0)
+            out += QString(indent, ' ');
+        out += ']';
+    } else if (type == VariantType::ByteArray) {
+        QByteArray val = in.toByteArray();
+        out += '\"' + byteArrayToEscapedString(val) + '\"';
+    } else if (type == VariantType::Double)
+        out += QString::number(in.toDouble());
+    else if (type == VariantType::Bool)
+        out += in.toBool() ? "true" : "false";
+    else if (type == VariantType::Invalid)
+        out += "null";
+    else if (canConvert(in, VariantType::LongLong))
+        out += QString::number(in.toLongLong());
+    else
+        out += QString("<unknown: %1>").arg((int)type);
+
+    return out;
 }
 
-QString variantToString(const Variant &in, int indent)
-{
-	QString out;
-
-	VariantType::Type type = typeId(in);
-	if(type == VariantType::Hash)
-	{
-		VariantHash hash = in.toHash();
-
-		out += '{';
-		if(indent >= 0)
-			out += '\n';
-		else
-			out += ' ';
-
-		for(auto it = hash.constBegin(); it != hash.constEnd(); ++it)
-		{
-			if(indent >= 0)
-				out += QString(indent + 2, ' ');
-
-			out += '\"' + byteArrayToEscapedString(it.key().toUtf8()) + "\": " + variantToString(it.value(), indent >= 0 ? indent + 2 : -1);
-			auto next_it = it;
-			++next_it;
-			if(next_it != hash.constEnd())
-				out += ',';
-
-			if(indent >= 0)
-				out += '\n';
-			else
-				out += ' ';
-		}
-
-		if(indent >= 0)
-			out += QString(indent, ' ');
-		out += '}';
-	}
-	else if(type == VariantType::List)
-	{
-		VariantList list = in.toList();
-
-		out += '[';
-		if(indent >= 0)
-			out += '\n';
-		else
-			out += ' ';
-
-		for(int n = 0; n < list.count(); ++n)
-		{
-			if(indent >= 0)
-				out += QString(indent + 2, ' ');
-
-			out += variantToString(list[n], indent >= 0 ? indent + 2 : -1);
-			if(n + 1 < list.count())
-				out += ',';
-
-			if(indent >= 0)
-				out += '\n';
-			else
-				out += ' ';
-		}
-
-		if(indent >= 0)
-			out += QString(indent, ' ');
-		out += ']';
-	}
-	else if(type == VariantType::ByteArray)
-	{
-		QByteArray val = in.toByteArray();
-		out += '\"' + byteArrayToEscapedString(val) + '\"';
-	}
-	else if(type == VariantType::Double)
-		out += QString::number(in.toDouble());
-	else if(type == VariantType::Bool)
-		out += in.toBool() ? "true" : "false";
-	else if(type == VariantType::Invalid)
-		out += "null";
-	else if(canConvert(in, VariantType::LongLong))
-		out += QString::number(in.toLongLong());
-	else
-		out += QString("<unknown: %1>").arg((int)type);
-
-	return out;
-}
-
-}
+} // namespace TnetString

--- a/src/core/tnetstring.h
+++ b/src/core/tnetstring.h
@@ -27,16 +27,7 @@ class CowByteArray;
 
 namespace TnetString {
 
-enum Type
-{
-	ByteArray,
-	Int,
-	Double,
-	Bool,
-	Null,
-	Hash,
-	List
-};
+enum Type { ByteArray, Int, Double, Bool, Null, Hash, List };
 
 QByteArray fromByteArray(const QByteArray &in);
 QByteArray fromInt(int64_t in);
@@ -48,14 +39,16 @@ QByteArray fromList(const VariantList &in);
 QByteArray fromVariant(const Variant &in);
 
 bool check(const QByteArray &in, int offset, Type *type, int *dataOffset, int *dataSize);
-QByteArray toByteArray(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
+QByteArray toByteArray(const QByteArray &in, int offset, int dataOffset, int dataSize,
+                       bool *ok = 0);
 int64_t toInt(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 double toDouble(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 bool toBool(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 void toNull(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 VariantHash toHash(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
 VariantList toList(const QByteArray &in, int offset, int dataOffset, int dataSize, bool *ok = 0);
-Variant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize, bool *ok = 0);
+Variant toVariant(const QByteArray &in, int offset, Type type, int dataOffset, int dataSize,
+                  bool *ok = 0);
 Variant toVariant(const QByteArray &in, int offset = 0, bool *ok = 0);
 Variant toVariant(const CowByteArray &in, int offset = 0, bool *ok = 0);
 
@@ -64,6 +57,6 @@ QString byteArrayToEscapedString(const QByteArray &in);
 // Pass >= 0 for pretty print, -1 for compact
 QString variantToString(const Variant &in, int indent = 0);
 
-}
+} // namespace TnetString
 
 #endif

--- a/src/core/unixlistener.cpp
+++ b/src/core/unixlistener.cpp
@@ -18,68 +18,54 @@
 
 #include "socketnotifier.h"
 
-UnixListener::UnixListener() :
-	inner_(nullptr)
-{
+UnixListener::UnixListener() : inner_(nullptr) {}
+
+UnixListener::~UnixListener() { reset(); }
+
+bool UnixListener::bind(const QString &path) {
+    reset();
+
+    QByteArray p = path.toUtf8();
+    errorCondition_ = 0;
+
+    inner_ = ffi::unix_listener_bind(p.data(), &errorCondition_);
+    if (!inner_)
+        return false;
+
+    int fd = ffi::unix_listener_as_raw_fd(inner_);
+
+    sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
+    sn_->activated.connect(boost::bind(&UnixListener::sn_activated, this));
+    sn_->setReadEnabled(true);
+
+    return true;
 }
 
-UnixListener::~UnixListener()
-{
-	reset();
+std::unique_ptr<UnixStream> UnixListener::accept() {
+    assert(inner_);
+
+    errorCondition_ = 0;
+
+    ffi::UnixStream *s_inner = ffi::unix_listener_accept(inner_, &errorCondition_);
+    if (!s_inner) {
+        if (errorCondition_ == EAGAIN)
+            sn_->clearReadiness(SocketNotifier::Read);
+
+        return std::unique_ptr<UnixStream>(); // Null
+    }
+
+    UnixStream *s = new UnixStream(s_inner);
+
+    return std::unique_ptr<UnixStream>(s);
 }
 
-bool UnixListener::bind(const QString &path)
-{
-	reset();
+void UnixListener::reset() {
+    sn_.reset();
 
-	QByteArray p = path.toUtf8();
-	errorCondition_ = 0;
-
-	inner_ = ffi::unix_listener_bind(p.data(), &errorCondition_);
-	if(!inner_)
-		return false;
-
-	int fd = ffi::unix_listener_as_raw_fd(inner_);
-
-	sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read);
-	sn_->activated.connect(boost::bind(&UnixListener::sn_activated, this));
-	sn_->setReadEnabled(true);
-
-	return true;
+    if (inner_) {
+        ffi::unix_listener_destroy(inner_);
+        inner_ = nullptr;
+    }
 }
 
-std::unique_ptr<UnixStream> UnixListener::accept()
-{
-	assert(inner_);
-
-	errorCondition_ = 0;
-
-	ffi::UnixStream *s_inner = ffi::unix_listener_accept(inner_, &errorCondition_);
-	if(!s_inner)
-	{
-		if(errorCondition_ == EAGAIN)
-			sn_->clearReadiness(SocketNotifier::Read);
-
-		return std::unique_ptr<UnixStream>(); // Null
-	}
-
-	UnixStream *s = new UnixStream(s_inner);
-
-	return std::unique_ptr<UnixStream>(s);
-}
-
-void UnixListener::reset()
-{
-	sn_.reset();
-
-	if(inner_)
-	{
-		ffi::unix_listener_destroy(inner_);
-		inner_ = nullptr;
-	}
-}
-
-void UnixListener::sn_activated()
-{
-	streamsReady();
-}
+void UnixListener::sn_activated() { streamsReady(); }

--- a/src/core/unixlistener.h
+++ b/src/core/unixlistener.h
@@ -17,37 +17,36 @@
 #ifndef UNIXLISTENER_H
 #define UNIXLISTENER_H
 
-#include <memory>
-#include <QHostAddress>
-#include <boost/signals2.hpp>
 #include "rust/bindings.h"
 #include "unixstream.h"
+#include <QHostAddress>
+#include <boost/signals2.hpp>
+#include <memory>
 
 class SocketNotifier;
 
-class UnixListener
-{
+class UnixListener {
 public:
-	UnixListener();
-	~UnixListener();
+    UnixListener();
+    ~UnixListener();
 
-	// Disable copying
-	UnixListener(const UnixListener &) = delete;
-	UnixListener & operator=(const UnixListener &) = delete;
+    // Disable copying
+    UnixListener(const UnixListener &) = delete;
+    UnixListener &operator=(const UnixListener &) = delete;
 
-	bool bind(const QString &path);
-	std::unique_ptr<UnixStream> accept();
-	int errorCondition() const { return errorCondition_; }
+    bool bind(const QString &path);
+    std::unique_ptr<UnixStream> accept();
+    int errorCondition() const { return errorCondition_; }
 
-	boost::signals2::signal<void()> streamsReady;
+    boost::signals2::signal<void()> streamsReady;
 
 private:
-	ffi::UnixListener *inner_;
-	std::unique_ptr<SocketNotifier> sn_;
-	int errorCondition_;
+    ffi::UnixListener *inner_;
+    std::unique_ptr<SocketNotifier> sn_;
+    int errorCondition_;
 
-	void reset();
-	void sn_activated();
+    void reset();
+    void sn_activated();
 };
 
 #endif

--- a/src/core/unixstream.cpp
+++ b/src/core/unixstream.cpp
@@ -20,130 +20,114 @@
 
 #define DEFAULT_READ_SIZE 16384
 
-UnixStream::UnixStream() :
-	inner_(nullptr),
-	errorCondition_(0)
-{
+UnixStream::UnixStream() : inner_(nullptr), errorCondition_(0) {}
+
+UnixStream::UnixStream(ffi::UnixStream *inner)
+    : inner_(inner),
+      errorCondition_(0),
+      alive_(std::make_shared<std::monostate>(std::monostate{})) {
+    setupNotifier();
 }
 
-UnixStream::UnixStream(ffi::UnixStream *inner) :
-	inner_(inner),
-	errorCondition_(0),
-	alive_(std::make_shared<std::monostate>(std::monostate{}))
-{
-	setupNotifier();
+UnixStream::~UnixStream() { reset(); }
+
+bool UnixStream::connect(const QString &path) {
+    reset();
+
+    QByteArray p = path.toUtf8();
+    errorCondition_ = 0;
+
+    inner_ = ffi::unix_stream_connect(p.data(), &errorCondition_);
+    if (!inner_)
+        return false;
+
+    setupNotifier();
+
+    return true;
 }
 
-UnixStream::~UnixStream()
-{
-	reset();
+bool UnixStream::checkConnected() {
+    assert(inner_);
+
+    errorCondition_ = 0;
+
+    if (ffi::unix_stream_check_connected(inner_, &errorCondition_) != 0)
+        return false;
+
+    return true;
 }
 
-bool UnixStream::connect(const QString &path)
-{
-	reset();
+QByteArray UnixStream::read(int size) {
+    assert(inner_);
 
-	QByteArray p = path.toUtf8();
-	errorCondition_ = 0;
+    if (size < 0)
+        size = DEFAULT_READ_SIZE;
 
-	inner_ = ffi::unix_stream_connect(p.data(), &errorCondition_);
-	if(!inner_)
-		return false;
+    QByteArray buf(size, 0);
+    errorCondition_ = 0;
 
-	setupNotifier();
+    int ret = ffi::unix_stream_read(inner_, (uint8_t *)buf.data(), buf.size(), &errorCondition_);
 
-	return true;
+    if (ret < 0) {
+        if (errorCondition_ == EAGAIN)
+            sn_->clearReadiness(SocketNotifier::Read);
+
+        return QByteArray();
+    }
+
+    buf.resize(ret);
+
+    return buf;
 }
 
-bool UnixStream::checkConnected()
-{
-	assert(inner_);
+int UnixStream::write(const QByteArray &buf) {
+    assert(inner_);
 
-	errorCondition_ = 0;
+    errorCondition_ = 0;
 
-	if(ffi::unix_stream_check_connected(inner_, &errorCondition_) != 0)
-		return false;
+    int ret = ffi::unix_stream_write(inner_, (const uint8_t *)buf.constData(), buf.size(),
+                                     &errorCondition_);
 
-	return true;
+    if (ret < 0) {
+        if (errorCondition_ == EAGAIN)
+            sn_->clearReadiness(SocketNotifier::Write);
+
+        return -1;
+    }
+
+    return ret;
 }
 
-QByteArray UnixStream::read(int size)
-{
-	assert(inner_);
+void UnixStream::reset() {
+    sn_.reset();
 
-	if(size < 0)
-		size = DEFAULT_READ_SIZE;
-
-	QByteArray buf(size, 0);
-	errorCondition_ = 0;
-
-	int ret = ffi::unix_stream_read(inner_, (uint8_t *)buf.data(), buf.size(), &errorCondition_);
-
-	if(ret < 0)
-	{
-		if(errorCondition_ == EAGAIN)
-			sn_->clearReadiness(SocketNotifier::Read);
-
-		return QByteArray();
-	}
-
-	buf.resize(ret);
-
-	return buf;
+    if (inner_) {
+        ffi::unix_stream_destroy(inner_);
+        inner_ = nullptr;
+    }
 }
 
-int UnixStream::write(const QByteArray &buf)
-{
-	assert(inner_);
+void UnixStream::setupNotifier() {
+    int fd = ffi::unix_stream_as_raw_fd(inner_);
 
-	errorCondition_ = 0;
-
-	int ret = ffi::unix_stream_write(inner_, (const uint8_t *)buf.constData(), buf.size(), &errorCondition_);
-
-	if(ret < 0)
-	{
-		if(errorCondition_ == EAGAIN)
-			sn_->clearReadiness(SocketNotifier::Write);
-
-		return -1;
-	}
-
-	return ret;
+    sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read | SocketNotifier::Write);
+    sn_->activated.connect(boost::bind(&UnixStream::sn_activated, this, boost::placeholders::_1,
+                                       boost::placeholders::_2));
+    sn_->setReadEnabled(true);
+    sn_->setWriteEnabled(true);
 }
 
-void UnixStream::reset()
-{
-	sn_.reset();
+void UnixStream::sn_activated(int socket, uint8_t readiness) {
+    Q_UNUSED(socket);
 
-	if(inner_)
-	{
-		ffi::unix_stream_destroy(inner_);
-		inner_ = nullptr;
-	}
-}
+    std::weak_ptr<std::monostate> self = alive_;
 
-void UnixStream::setupNotifier()
-{
-	int fd = ffi::unix_stream_as_raw_fd(inner_);
+    if (readiness & SocketNotifier::Read)
+        readReady();
 
-	sn_ = std::make_unique<SocketNotifier>(fd, SocketNotifier::Read | SocketNotifier::Write);
-	sn_->activated.connect(boost::bind(&UnixStream::sn_activated, this, boost::placeholders::_1, boost::placeholders::_2));
-	sn_->setReadEnabled(true);
-	sn_->setWriteEnabled(true);
-}
+    if (self.expired())
+        return;
 
-void UnixStream::sn_activated(int socket, uint8_t readiness)
-{
-	Q_UNUSED(socket);
-
-	std::weak_ptr<std::monostate> self = alive_;
-
-	if(readiness & SocketNotifier::Read)
-		readReady();
-
-	if(self.expired())
-		return;
-
-	if(readiness & SocketNotifier::Write)
-		writeReady();
+    if (readiness & SocketNotifier::Write)
+        writeReady();
 }

--- a/src/core/unixstream.h
+++ b/src/core/unixstream.h
@@ -17,49 +17,48 @@
 #ifndef UNIXSTREAM_H
 #define UNIXSTREAM_H
 
-#include <memory>
-#include <variant>
+#include "readwrite.h"
+#include "rust/bindings.h"
 #include <QByteArray>
 #include <boost/signals2.hpp>
-#include "rust/bindings.h"
-#include "readwrite.h"
+#include <memory>
+#include <variant>
 
 class SocketNotifier;
 
-class UnixStream : public ReadWrite
-{
+class UnixStream : public ReadWrite {
 public:
-	UnixStream();
-	~UnixStream();
+    UnixStream();
+    ~UnixStream();
 
-	// Disable copying
-	UnixStream(const UnixStream &) = delete;
-	UnixStream & operator=(const UnixStream &) = delete;
+    // Disable copying
+    UnixStream(const UnixStream &) = delete;
+    UnixStream &operator=(const UnixStream &) = delete;
 
-	// Returns true if connection starting, false on error
-	bool connect(const QString &path);
+    // Returns true if connection starting, false on error
+    bool connect(const QString &path);
 
-	// Returns true if connected, false on error. If errorCondition() returns
-	// ENOTCONN, then it is not fatal and the socket is still connecting
-	bool checkConnected();
+    // Returns true if connected, false on error. If errorCondition() returns
+    // ENOTCONN, then it is not fatal and the socket is still connecting
+    bool checkConnected();
 
-	// Reimplemented
-	virtual QByteArray read(int size = -1);
-	virtual int write(const QByteArray &buf);
-	virtual int errorCondition() const { return errorCondition_; }
+    // Reimplemented
+    virtual QByteArray read(int size = -1);
+    virtual int write(const QByteArray &buf);
+    virtual int errorCondition() const { return errorCondition_; }
 
 private:
-	friend class UnixListener;
+    friend class UnixListener;
 
-	ffi::UnixStream *inner_;
-	std::unique_ptr<SocketNotifier> sn_;
-	int errorCondition_;
-	std::shared_ptr<std::monostate> alive_;
+    ffi::UnixStream *inner_;
+    std::unique_ptr<SocketNotifier> sn_;
+    int errorCondition_;
+    std::shared_ptr<std::monostate> alive_;
 
-	UnixStream(ffi::UnixStream *inner);
-	void reset();
-	void setupNotifier();
-	void sn_activated(int socket, uint8_t readiness);
+    UnixStream(ffi::UnixStream *inner);
+    void reset();
+    void setupNotifier();
+    void sn_activated(int socket, uint8_t readiness);
 };
 
 #endif

--- a/src/core/unixstreamtest.cpp
+++ b/src/core/unixstreamtest.cpp
@@ -20,282 +20,249 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "unixstream.h"
+#include "eventloop.h"
+#include "test.h"
+#include "unixlistener.h"
+#include <QHostAddress>
 #include <chrono>
 #include <thread>
-#include <QHostAddress>
-#include "test.h"
-#include "eventloop.h"
-#include "unixlistener.h"
-#include "unixstream.h"
 
 using namespace std::chrono_literals;
 
-static void runAccept(std::function<void ()> loop_wait)
-{
-	// Remove existing pipe file
-	QDir outDir(qgetenv("OUT_DIR"));
-	QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
-	QString path = workDir.filePath("test-cpp-unixstream");
-	QFile::remove(path);
+static void runAccept(std::function<void()> loop_wait) {
+    // Remove existing pipe file
+    QDir outDir(qgetenv("OUT_DIR"));
+    QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+    QString path = workDir.filePath("test-cpp-unixstream");
+    QFile::remove(path);
 
-	UnixListener l;
-	TEST_ASSERT(l.bind(path));
+    UnixListener l;
+    TEST_ASSERT(l.bind(path));
 
-	// Start by assuming operations are possible
-	bool streamsReady = true;
+    // Start by assuming operations are possible
+    bool streamsReady = true;
 
-	l.streamsReady.connect([&] {
-		streamsReady = true;
-	});
+    l.streamsReady.connect([&] { streamsReady = true; });
 
-	std::unique_ptr<UnixStream> s = l.accept();
-	TEST_ASSERT(!s);
-	TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
-	streamsReady = false;
+    std::unique_ptr<UnixStream> s = l.accept();
+    TEST_ASSERT(!s);
+    TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
+    streamsReady = false;
 
-	UnixStream client;
-	TEST_ASSERT(client.connect(path));
+    UnixStream client;
+    TEST_ASSERT(client.connect(path));
 
-	// Start by assuming operations are possible
-	bool clientWriteReady = true;
+    // Start by assuming operations are possible
+    bool clientWriteReady = true;
 
-	client.writeReady.connect([&] {
-		clientWriteReady = true;
-	});
+    client.writeReady.connect([&] { clientWriteReady = true; });
 
-	while(!streamsReady)
-		loop_wait();
+    while (!streamsReady)
+        loop_wait();
 
-	s = l.accept();
-	TEST_ASSERT(s);
+    s = l.accept();
+    TEST_ASSERT(s);
 
-	while(!client.checkConnected())
-	{
-		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
+    while (!client.checkConnected()) {
+        TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		clientWriteReady = false;
-		while(!clientWriteReady)
-			loop_wait();
-	}
+        clientWriteReady = false;
+        while (!clientWriteReady)
+            loop_wait();
+    }
 }
 
-static void runIo(std::function<void ()> loop_wait)
-{
-	// Remove existing pipe file
-	QDir outDir(qgetenv("OUT_DIR"));
-	QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
-	QString path = workDir.filePath("test-cpp-unixstream");
-	QFile::remove(path);
+static void runIo(std::function<void()> loop_wait) {
+    // Remove existing pipe file
+    QDir outDir(qgetenv("OUT_DIR"));
+    QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+    QString path = workDir.filePath("test-cpp-unixstream");
+    QFile::remove(path);
 
-	UnixListener l;
-	TEST_ASSERT(l.bind(path));
+    UnixListener l;
+    TEST_ASSERT(l.bind(path));
 
-	// Start by assuming operations are possible
-	bool streamsReady = true;
+    // Start by assuming operations are possible
+    bool streamsReady = true;
 
-	l.streamsReady.connect([&] {
-		streamsReady = true;
-	});
+    l.streamsReady.connect([&] { streamsReady = true; });
 
-	UnixStream client;
-	TEST_ASSERT(client.connect(path));
+    UnixStream client;
+    TEST_ASSERT(client.connect(path));
 
-	// Start by assuming operations are possible
-	bool clientReadReady = true;
-	bool clientWriteReady = true;
+    // Start by assuming operations are possible
+    bool clientReadReady = true;
+    bool clientWriteReady = true;
 
-	client.readReady.connect([&] {
-		clientReadReady = true;
-	});
+    client.readReady.connect([&] { clientReadReady = true; });
 
-	client.writeReady.connect([&] {
-		clientWriteReady = true;
-	});
+    client.writeReady.connect([&] { clientWriteReady = true; });
 
-	std::unique_ptr<UnixStream> s;
-	while(!s)
-	{
-		s = l.accept();
+    std::unique_ptr<UnixStream> s;
+    while (!s) {
+        s = l.accept();
 
-		if(!s)
-		{
-			TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
+        if (!s) {
+            TEST_ASSERT_EQ(l.errorCondition(), EAGAIN);
 
-			streamsReady = false;
-			while(!streamsReady)
-				loop_wait();
-		}
-	}
+            streamsReady = false;
+            while (!streamsReady)
+                loop_wait();
+        }
+    }
 
-	// Start by assuming operations are possible
-	bool readReady = true;
-	bool writeReady = true;
+    // Start by assuming operations are possible
+    bool readReady = true;
+    bool writeReady = true;
 
-	s->readReady.connect([&] {
-		readReady = true;
-	});
+    s->readReady.connect([&] { readReady = true; });
 
-	s->writeReady.connect([&] {
-		writeReady = true;
-	});
+    s->writeReady.connect([&] { writeReady = true; });
 
-	while(!client.checkConnected())
-	{
-		TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
+    while (!client.checkConnected()) {
+        TEST_ASSERT_EQ(client.errorCondition(), ENOTCONN);
 
-		clientWriteReady = false;
-		while(!clientWriteReady)
-			loop_wait();
-	}
+        clientWriteReady = false;
+        while (!clientWriteReady)
+            loop_wait();
+    }
 
-	TEST_ASSERT(s->read().isNull());
-	TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
-	readReady = false;
+    TEST_ASSERT(s->read().isNull());
+    TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+    readReady = false;
 
-	TEST_ASSERT_EQ(client.write("hello\n"), 6);
+    TEST_ASSERT_EQ(client.write("hello\n"), 6);
 
-	QByteArray received;
-	while(!received.contains('\n'))
-	{
-		QByteArray buf = s->read();
+    QByteArray received;
+    while (!received.contains('\n')) {
+        QByteArray buf = s->read();
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
 
-			readReady = false;
-			while(!readReady)
-				loop_wait();
+            readReady = false;
+            while (!readReady)
+                loop_wait();
 
-			continue;
-		}
+            continue;
+        }
 
-		TEST_ASSERT(!buf.isEmpty());
+        TEST_ASSERT(!buf.isEmpty());
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	TEST_ASSERT_EQ(received, "hello\n");
+    TEST_ASSERT_EQ(received, "hello\n");
 
-	QByteArray written;
-	received.clear();
+    QByteArray written;
+    received.clear();
 
-	// Write until we fill the system buffer
-	while(true)
-	{
-		QByteArray chunk(100000, 'a');
-		int ret = s->write(chunk);
+    // Write until we fill the system buffer
+    while (true) {
+        QByteArray chunk(100000, 'a');
+        int ret = s->write(chunk);
 
-		if(ret < 0)
-		{
-			TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
-			writeReady = false;
-			break;
-		}
+        if (ret < 0) {
+            TEST_ASSERT_EQ(s->errorCondition(), EAGAIN);
+            writeReady = false;
+            break;
+        }
 
-		written += chunk.mid(0, ret);
-	}
+        written += chunk.mid(0, ret);
+    }
 
-	// Wait for some bytes on the client side
-	while(received.isEmpty())
-	{
-		QByteArray buf = client.read(100000);
+    // Wait for some bytes on the client side
+    while (received.isEmpty()) {
+        QByteArray buf = client.read(100000);
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-			clientReadReady = false;
-			while(!clientReadReady)
-				loop_wait();
+            clientReadReady = false;
+            while (!clientReadReady)
+                loop_wait();
 
-			continue;
-		}
+            continue;
+        }
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	// Now read as much as possible on the client side. This helps the
-	// server side gain writability sooner
-	while(true)
-	{
-		QByteArray buf = client.read(100000);
+    // Now read as much as possible on the client side. This helps the
+    // server side gain writability sooner
+    while (true) {
+        QByteArray buf = client.read(100000);
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
-			clientReadReady = false;
-			break;
-		}
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+            clientReadReady = false;
+            break;
+        }
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	// Wait for writability
-	while(!writeReady)
-		loop_wait();
+    // Wait for writability
+    while (!writeReady)
+        loop_wait();
 
-	// Write more
-	{
-		QByteArray chunk(100000, 'a');
-		int ret = s->write(chunk);
-		TEST_ASSERT(ret > 0);
+    // Write more
+    {
+        QByteArray chunk(100000, 'a');
+        int ret = s->write(chunk);
+        TEST_ASSERT(ret > 0);
 
-		written += chunk.mid(0, ret);
-	}
+        written += chunk.mid(0, ret);
+    }
 
-	// Close the server side
-	s.reset();
+    // Close the server side
+    s.reset();
 
-	// Read until closed on the client side
-	while(true)
-	{
-		QByteArray buf = client.read(100000);
+    // Read until closed on the client side
+    while (true) {
+        QByteArray buf = client.read(100000);
 
-		if(buf.isNull())
-		{
-			TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
+        if (buf.isNull()) {
+            TEST_ASSERT_EQ(client.errorCondition(), EAGAIN);
 
-			clientReadReady = false;
-			while(!clientReadReady)
-				loop_wait();
+            clientReadReady = false;
+            while (!clientReadReady)
+                loop_wait();
 
-			continue;
-		}
+            continue;
+        }
 
-		if(buf.isEmpty())
-			break;
+        if (buf.isEmpty())
+            break;
 
-		received += buf;
-	}
+        received += buf;
+    }
 
-	TEST_ASSERT_EQ(received, written);
+    TEST_ASSERT_EQ(received, written);
 }
 
-static void accept()
-{
-	EventLoop loop(100);
+static void accept() {
+    EventLoop loop(100);
 
-	runAccept([&] {
-		std::this_thread::sleep_for(10ms);
-		loop.step();
-	});
+    runAccept([&] {
+        std::this_thread::sleep_for(10ms);
+        loop.step();
+    });
 }
 
-static void io()
-{
-	EventLoop loop(100);
+static void io() {
+    EventLoop loop(100);
 
-	runIo([&] {
-		std::this_thread::sleep_for(10ms);
-		loop.step();
-	});
+    runIo([&] {
+        std::this_thread::sleep_for(10ms);
+        loop.step();
+    });
 }
 
-extern "C" int unixstream_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(accept());
-	TEST_CATCH(io());
+extern "C" int unixstream_test(ffi::TestException *out_ex) {
+    TEST_CATCH(accept());
+    TEST_CATCH(io());
 
-	return 0;
+    return 0;
 }

--- a/src/core/url.h
+++ b/src/core/url.h
@@ -19,7 +19,8 @@
 
 #include <QUrl>
 
-// Type alias for URL handling - this will be replaced with a custom implementation later
+// Type alias for URL handling - this will be replaced with a custom
+// implementation later
 using Url = QUrl;
 
 #endif // URL_H

--- a/src/core/uuidutil.cpp
+++ b/src/core/uuidutil.cpp
@@ -26,12 +26,11 @@
 
 namespace UuidUtil {
 
-QByteArray createUuid()
-{
-	QByteArray out = QUuid::createUuid().toString().toLatin1();
-	if(out[0] == '{' && out[out.length() - 1] == '}')
-		out = out.mid(1, out.length() - 2);
-	return out;
+QByteArray createUuid() {
+    QByteArray out = QUuid::createUuid().toString().toLatin1();
+    if (out[0] == '{' && out[out.length() - 1] == '}')
+        out = out.mid(1, out.length() - 2);
+    return out;
 }
 
-}
+} // namespace UuidUtil

--- a/src/core/variant.h
+++ b/src/core/variant.h
@@ -23,11 +23,11 @@
 #ifndef VARIANT_H
 #define VARIANT_H
 
-#include <QVariant>
-#include <QHash>
-#include <QMap>
-#include <QList>
 #include "qtcompat.h"
+#include <QHash>
+#include <QList>
+#include <QMap>
+#include <QVariant>
 
 using Variant = QVariant;
 using VariantHash = QVariantHash;
@@ -35,6 +35,7 @@ using VariantMap = QVariantMap;
 using VariantList = QVariantList;
 
 // Note: typeId() and canConvert() functions are already provided by qtcompat.h
-// Since Variant = QVariant (alias), those functions work directly with our types
+// Since Variant = QVariant (alias), those functions work directly with our
+// types
 
 #endif

--- a/src/core/websocket.h
+++ b/src/core/websocket.h
@@ -24,100 +24,82 @@
 #ifndef WEBSOCKET_H
 #define WEBSOCKET_H
 
+#include "httpheaders.h"
 #include "url.h"
 #include <QHostAddress>
-#include "httpheaders.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 
-class WebSocket
-{
+class WebSocket {
 public:
-	enum State
-	{
-		Idle,
-		Connecting,
-		Connected,
-		Closing
-	};
+    enum State { Idle, Connecting, Connected, Closing };
 
-	enum ErrorCondition
-	{
-		ErrorGeneric,
-		ErrorPolicy,
-		ErrorConnect,
-		ErrorConnectTimeout,
-		ErrorTls,
-		ErrorRejected,
-		ErrorTimeout,
-		ErrorUnavailable
-	};
+    enum ErrorCondition {
+        ErrorGeneric,
+        ErrorPolicy,
+        ErrorConnect,
+        ErrorConnectTimeout,
+        ErrorTls,
+        ErrorRejected,
+        ErrorTimeout,
+        ErrorUnavailable
+    };
 
-	class Frame
-	{
-	public:
-		enum Type
-		{
-			Continuation,
-			Text,
-			Binary,
-			Ping,
-			Pong
-		};
+    class Frame {
+    public:
+        enum Type { Continuation, Text, Binary, Ping, Pong };
 
-		Type type;
-		QByteArray data;
-		bool more;
+        Type type;
+        QByteArray data;
+        bool more;
 
-		Frame(Type _type, const QByteArray &_data, bool _more) :
-			type(_type),
-			data(_data),
-			more(_more)
-		{
-		}
-	};
+        Frame(Type _type, const QByteArray &_data, bool _more)
+            : type(_type), data(_data), more(_more) {}
+    };
 
-	virtual ~WebSocket() = default;
+    virtual ~WebSocket() = default;
 
-	virtual QHostAddress peerAddress() const = 0;
+    virtual QHostAddress peerAddress() const = 0;
 
-	virtual void setConnectHost(const QString &host) = 0;
-	virtual void setConnectPort(int port) = 0;
-	virtual void setIgnorePolicies(bool on) = 0;
-	virtual void setTrustConnectHost(bool on) = 0;
-	virtual void setIgnoreTlsErrors(bool on) = 0;
-	virtual void setClientCert(const QString &cert, const QString &key) = 0;
+    virtual void setConnectHost(const QString &host) = 0;
+    virtual void setConnectPort(int port) = 0;
+    virtual void setIgnorePolicies(bool on) = 0;
+    virtual void setTrustConnectHost(bool on) = 0;
+    virtual void setIgnoreTlsErrors(bool on) = 0;
+    virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
-	virtual void start(const Url &uri, const HttpHeaders &headers) = 0;
+    virtual void start(const Url &uri, const HttpHeaders &headers) = 0;
 
-	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers) = 0;
-	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body) = 0;
+    virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers) = 0;
+    virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                              const QByteArray &body) = 0;
 
-	virtual State state() const = 0;
-	virtual Url requestUri() const = 0;
-	virtual HttpHeaders requestHeaders() const = 0;
-	virtual int responseCode() const = 0;
-	virtual QByteArray responseReason() const = 0;
-	virtual HttpHeaders responseHeaders() const = 0;
-	virtual QByteArray responseBody() const = 0;
-	virtual int framesAvailable() const = 0;
-	virtual int writeBytesAvailable() const = 0;
-	virtual int peerCloseCode() const = 0;
-	virtual QString peerCloseReason() const = 0;
-	virtual ErrorCondition errorCondition() const = 0;
+    virtual State state() const = 0;
+    virtual Url requestUri() const = 0;
+    virtual HttpHeaders requestHeaders() const = 0;
+    virtual int responseCode() const = 0;
+    virtual QByteArray responseReason() const = 0;
+    virtual HttpHeaders responseHeaders() const = 0;
+    virtual QByteArray responseBody() const = 0;
+    virtual int framesAvailable() const = 0;
+    virtual int writeBytesAvailable() const = 0;
+    virtual int peerCloseCode() const = 0;
+    virtual QString peerCloseReason() const = 0;
+    virtual ErrorCondition errorCondition() const = 0;
 
-	virtual void writeFrame(const Frame &frame) = 0;
-	virtual Frame readFrame() = 0;
-	virtual void close(int code = -1, const QString &reason = QString()) = 0;
+    virtual void writeFrame(const Frame &frame) = 0;
+    virtual Frame readFrame() = 0;
+    virtual void close(int code = -1, const QString &reason = QString()) = 0;
 
-	Signal connected;
-	Signal readyRead;
-	boost::signals2::signal<void(int, int)> framesWritten;
-	Signal writeBytesChanged;
-	Signal peerClosed; // Emitted only if peer closes before we do
-	Signal closed; // Emitted after peer acks our close, or immediately if we were acking
-	Signal error;
+    Signal connected;
+    Signal readyRead;
+    boost::signals2::signal<void(int, int)> framesWritten;
+    Signal writeBytesChanged;
+    Signal peerClosed; // Emitted only if peer closes before we do
+    Signal closed;     // Emitted after peer acks our close, or immediately if we were
+                       // acking
+    Signal error;
 };
 
 #endif

--- a/src/core/wscontrol.h
+++ b/src/core/wscontrol.h
@@ -25,12 +25,7 @@
 
 namespace WsControl {
 
-enum KeepAliveMode
-{
-	NoKeepAlive,
-	Idle,
-	Interval
-};
+enum KeepAliveMode { NoKeepAlive, Idle, Interval };
 
 }
 

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -23,20 +23,20 @@
 
 #include "zhttpmanager.h"
 
-#include <assert.h>
-#include <QStringList>
-#include <QHash>
 #include "cowbytearray.h"
-#include "zmqsocket.h"
-#include "zmqvalve.h"
+#include "log.h"
+#include "logutil.h"
+#include "timer.h"
 #include "tnetstring.h"
 #include "variant.h"
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
-#include "log.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
 #include "zutil.h"
-#include "logutil.h"
-#include "timer.h"
+#include <QHash>
+#include <QStringList>
+#include <assert.h>
 
 #define OUT_HWM 100
 #define IN_HWM 100
@@ -56,1263 +56,1154 @@
 // Needs to match the peer
 #define ZHTTP_IDS_MAX 128
 
-class ZhttpManager::Private
-{
+class ZhttpManager::Private {
 public:
-	enum SessionType
-	{
-		UnknownSession,
-		HttpSession,
-		WebSocketSession
-	};
-
-	class KeepAliveRegistration
-	{
-	public:
-		SessionType type;
-		union { ZhttpRequest *req; ZWebSocket *sock; } p;
-		int refreshBucket;
-	};
-
-	ZhttpManager *q;
-	QStringList client_out_specs;
-	QStringList client_out_stream_specs;
-	QStringList client_in_specs;
-	QStringList client_req_specs;
-	QStringList server_in_specs;
-	QStringList server_in_stream_specs;
-	QStringList server_out_specs;
-	std::unique_ptr<ZmqSocket> client_out_sock;
-	std::unique_ptr<ZmqSocket> client_out_stream_sock;
-	std::unique_ptr<ZmqSocket> client_in_sock;
-	std::unique_ptr<ZmqSocket> client_req_sock;
-	std::unique_ptr<ZmqSocket> server_in_sock;
-	std::unique_ptr<ZmqSocket> server_in_stream_sock;
-	std::unique_ptr<ZmqSocket> server_out_sock;
-	std::unique_ptr<ZmqValve> client_in_valve;
-	std::unique_ptr<ZmqValve> client_out_stream_valve;
-	std::unique_ptr<ZmqValve> server_in_valve;
-	std::unique_ptr<ZmqValve> server_in_stream_valve;
-	QByteArray instanceId;
-	int ipcFileMode;
-	bool doBind;
-	bool doProbe;
-	QHash<ZhttpRequest::Rid, ZhttpRequest*> clientReqsByRid;
-	QHash<ZhttpRequest::Rid, ZhttpRequest*> serverReqsByRid;
-	QList<ZhttpRequest*> serverPendingReqs;
-	QHash<ZWebSocket::Rid, ZWebSocket*> clientSocksByRid;
-	QHash<ZWebSocket::Rid, ZWebSocket*> serverSocksByRid;
-	QList<ZWebSocket*> serverPendingSocks;
-	std::unique_ptr<Timer> refreshTimer;
-	QHash<void*, KeepAliveRegistration*> keepAliveRegistrations;
-	QSet<KeepAliveRegistration*> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
-	int currentSessionRefreshBucket;
-	Connection cosConnection;
-	Connection cossConnection;
-	Connection sosConnection;
-	Connection rrConnection;
-	Connection clientConnection;
-	Connection clientOutStreamConnection;
-	Connection serverConnection;
-	Connection serverStreamConnection;
-	Connection refreshTimerConnection;
-
-	Private(ZhttpManager *_q) :
-		q(_q),
-		ipcFileMode(-1),
-		doBind(false),
-		doProbe(false),
-		currentSessionRefreshBucket(0)
-	{
-		refreshTimer = std::make_unique<Timer>();
-		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
-	}
-
-	~Private()
-	{
-		while(!serverPendingReqs.isEmpty())
-		{
-			ZhttpRequest *req = serverPendingReqs.takeFirst();
-			serverReqsByRid.remove(req->rid());
-			delete req;
-		}
-
-		while(!serverPendingSocks.isEmpty())
-		{
-			ZWebSocket *sock = serverPendingSocks.takeFirst();
-			serverSocksByRid.remove(sock->rid());
-			delete sock;
-		}
-
-		assert(clientReqsByRid.isEmpty());
-		assert(serverReqsByRid.isEmpty());
-		assert(clientSocksByRid.isEmpty());
-		assert(serverSocksByRid.isEmpty());
-		assert(keepAliveRegistrations.isEmpty());
-	}
-
-	bool setupClientOut()
-	{
-		cosConnection.disconnect();
-		rrConnection.disconnect();
-		client_req_sock.reset();
-		client_out_sock.reset();
-
-		client_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
-		cosConnection = client_out_sock->messagesWritten.connect(boost::bind(&Private::client_out_messagesWritten, this, boost::placeholders::_1));
-
-		client_out_sock->setHwm(OUT_HWM);
-		client_out_sock->setShutdownWaitTime(CLIENT_WAIT_TIME);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(client_out_sock.get(), client_out_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		return true;
-	}
-
-	bool setupClientOutStream()
-	{
-		rrConnection.disconnect();
-		cossConnection.disconnect();
-		client_req_sock.reset();
-		client_out_stream_valve.reset();
-		client_out_stream_sock.reset();
-
-		client_out_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		cossConnection = client_out_stream_sock->messagesWritten.connect(boost::bind(&Private::client_out_stream_messagesWritten, this, boost::placeholders::_1));
-
-		client_out_stream_sock->setIdentity(instanceId);
-		client_out_stream_sock->setWriteQueueEnabled(false);
-		client_out_stream_sock->setHwm(DEFAULT_HWM);
-		client_out_stream_sock->setShutdownWaitTime(CLIENT_STREAM_WAIT_TIME);
-		client_out_stream_sock->setImmediateEnabled(true);
-
-		if(doProbe)
-			client_out_stream_sock->setProbeRouterEnabled(true);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(client_out_stream_sock.get(), client_out_stream_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		client_out_stream_valve = std::make_unique<ZmqValve>(client_out_stream_sock.get());
-		clientOutStreamConnection = client_out_stream_valve->readyRead.connect(boost::bind(&Private::client_out_stream_readyRead, this, boost::placeholders::_1));
-
-		client_out_stream_valve->open();
-
-		return true;
-	}
-
-	bool setupClientIn()
-	{
-		rrConnection.disconnect();
-		client_req_sock.reset();
-		client_in_valve.reset();
-		client_in_sock.reset();
+    enum SessionType { UnknownSession, HttpSession, WebSocketSession };
+
+    class KeepAliveRegistration {
+    public:
+        SessionType type;
+        union {
+            ZhttpRequest *req;
+            ZWebSocket *sock;
+        } p;
+        int refreshBucket;
+    };
+
+    ZhttpManager *q;
+    QStringList client_out_specs;
+    QStringList client_out_stream_specs;
+    QStringList client_in_specs;
+    QStringList client_req_specs;
+    QStringList server_in_specs;
+    QStringList server_in_stream_specs;
+    QStringList server_out_specs;
+    std::unique_ptr<ZmqSocket> client_out_sock;
+    std::unique_ptr<ZmqSocket> client_out_stream_sock;
+    std::unique_ptr<ZmqSocket> client_in_sock;
+    std::unique_ptr<ZmqSocket> client_req_sock;
+    std::unique_ptr<ZmqSocket> server_in_sock;
+    std::unique_ptr<ZmqSocket> server_in_stream_sock;
+    std::unique_ptr<ZmqSocket> server_out_sock;
+    std::unique_ptr<ZmqValve> client_in_valve;
+    std::unique_ptr<ZmqValve> client_out_stream_valve;
+    std::unique_ptr<ZmqValve> server_in_valve;
+    std::unique_ptr<ZmqValve> server_in_stream_valve;
+    QByteArray instanceId;
+    int ipcFileMode;
+    bool doBind;
+    bool doProbe;
+    QHash<ZhttpRequest::Rid, ZhttpRequest *> clientReqsByRid;
+    QHash<ZhttpRequest::Rid, ZhttpRequest *> serverReqsByRid;
+    QList<ZhttpRequest *> serverPendingReqs;
+    QHash<ZWebSocket::Rid, ZWebSocket *> clientSocksByRid;
+    QHash<ZWebSocket::Rid, ZWebSocket *> serverSocksByRid;
+    QList<ZWebSocket *> serverPendingSocks;
+    std::unique_ptr<Timer> refreshTimer;
+    QHash<void *, KeepAliveRegistration *> keepAliveRegistrations;
+    QSet<KeepAliveRegistration *> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
+    int currentSessionRefreshBucket;
+    Connection cosConnection;
+    Connection cossConnection;
+    Connection sosConnection;
+    Connection rrConnection;
+    Connection clientConnection;
+    Connection clientOutStreamConnection;
+    Connection serverConnection;
+    Connection serverStreamConnection;
+    Connection refreshTimerConnection;
+
+    Private(ZhttpManager *_q)
+        : q(_q), ipcFileMode(-1), doBind(false), doProbe(false), currentSessionRefreshBucket(0) {
+        refreshTimer = std::make_unique<Timer>();
+        refreshTimerConnection =
+            refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
+    }
+
+    ~Private() {
+        while (!serverPendingReqs.isEmpty()) {
+            ZhttpRequest *req = serverPendingReqs.takeFirst();
+            serverReqsByRid.remove(req->rid());
+            delete req;
+        }
+
+        while (!serverPendingSocks.isEmpty()) {
+            ZWebSocket *sock = serverPendingSocks.takeFirst();
+            serverSocksByRid.remove(sock->rid());
+            delete sock;
+        }
+
+        assert(clientReqsByRid.isEmpty());
+        assert(serverReqsByRid.isEmpty());
+        assert(clientSocksByRid.isEmpty());
+        assert(serverSocksByRid.isEmpty());
+        assert(keepAliveRegistrations.isEmpty());
+    }
+
+    bool setupClientOut() {
+        cosConnection.disconnect();
+        rrConnection.disconnect();
+        client_req_sock.reset();
+        client_out_sock.reset();
+
+        client_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
+        cosConnection = client_out_sock->messagesWritten.connect(
+            boost::bind(&Private::client_out_messagesWritten, this, boost::placeholders::_1));
+
+        client_out_sock->setHwm(OUT_HWM);
+        client_out_sock->setShutdownWaitTime(CLIENT_WAIT_TIME);
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(client_out_sock.get(), client_out_specs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        return true;
+    }
+
+    bool setupClientOutStream() {
+        rrConnection.disconnect();
+        cossConnection.disconnect();
+        client_req_sock.reset();
+        client_out_stream_valve.reset();
+        client_out_stream_sock.reset();
+
+        client_out_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        cossConnection = client_out_stream_sock->messagesWritten.connect(boost::bind(
+            &Private::client_out_stream_messagesWritten, this, boost::placeholders::_1));
+
+        client_out_stream_sock->setIdentity(instanceId);
+        client_out_stream_sock->setWriteQueueEnabled(false);
+        client_out_stream_sock->setHwm(DEFAULT_HWM);
+        client_out_stream_sock->setShutdownWaitTime(CLIENT_STREAM_WAIT_TIME);
+        client_out_stream_sock->setImmediateEnabled(true);
+
+        if (doProbe)
+            client_out_stream_sock->setProbeRouterEnabled(true);
 
-		client_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-
-		client_in_sock->setHwm(DEFAULT_HWM);
-		client_in_sock->setShutdownWaitTime(0);
-		client_in_sock->subscribe(instanceId + ' ');
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(client_in_sock.get(), client_in_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		client_in_valve = std::make_unique<ZmqValve>(client_in_sock.get());
-		clientConnection = client_in_valve->readyRead.connect(boost::bind(&Private::client_in_readyRead, this, boost::placeholders::_1));
-
-		client_in_valve->open();
-
-		return true;
-	}
-
-	bool setupClientReq()
-	{
-		cosConnection.disconnect();
-		cossConnection.disconnect();
-		client_out_sock.reset();
-		client_out_stream_sock.reset();
-		client_in_sock.reset();
-
-		client_req_sock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
-		rrConnection = client_req_sock->readyRead.connect(boost::bind(&Private::client_req_readyRead, this));
-
-		client_req_sock->setHwm(OUT_HWM);
-		client_req_sock->setShutdownWaitTime(CLIENT_WAIT_TIME);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(client_req_sock.get(), client_req_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		return true;
-	}
-
-	bool setupServerIn()
-	{
-		server_in_valve.reset();
-		server_in_sock.reset();
-
-		server_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
-
-		server_in_sock->setHwm(IN_HWM);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(server_in_sock.get(), server_in_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		server_in_valve = std::make_unique<ZmqValve>(server_in_sock.get());
-		serverConnection = server_in_valve->readyRead.connect(boost::bind(&Private::server_in_readyRead, this, boost::placeholders::_1));
-
-		server_in_valve->open();
-
-		return true;
-	}
-
-	bool setupServerInStream()
-	{
-		serverStreamConnection.disconnect();
-		server_in_stream_sock.reset();
-
-		server_in_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-
-		server_in_stream_sock->setIdentity(instanceId);
-		server_in_stream_sock->setHwm(DEFAULT_HWM);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(server_in_stream_sock.get(), server_in_stream_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		server_in_stream_valve = std::make_unique<ZmqValve>(server_in_stream_sock.get());
-		serverStreamConnection = server_in_stream_valve->readyRead.connect(boost::bind(&Private::server_in_stream_readyRead, this, boost::placeholders::_1));
-
-		server_in_stream_valve->open();
-
-		return true;
-	}
-
-	bool setupServerOut()
-	{
-		sosConnection.disconnect();
-		server_out_sock.reset();
-
-		server_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
-		sosConnection = server_out_sock->messagesWritten.connect(boost::bind(&Private::server_out_messagesWritten, this, boost::placeholders::_1));
-
-		server_out_sock->setWriteQueueEnabled(false);
-		server_out_sock->setHwm(DEFAULT_HWM);
-		server_out_sock->setShutdownWaitTime(SERVER_WAIT_TIME);
-
-		QString errorMessage;
-		if(!ZUtil::setupSocket(server_out_sock.get(), server_out_specs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
-
-		return true;
-	}
-
-	int smallestSessionRefreshBucket()
-	{
-		int best = -1;
-		int bestSize = 0;
-
-		for(int n = 0; n < ZHTTP_REFRESH_BUCKETS; ++n)
-		{
-			if(best == -1 || sessionRefreshBuckets[n].count() < bestSize)
-			{
-				best = n;
-				bestSize = sessionRefreshBuckets[n].count();
-			}
-		}
-
-		return best;
-	}
-
-	void tryRespondCancel(SessionType type, const QByteArray &id, const ZhttpRequestPacket &packet)
-	{
-		assert(!packet.from.isEmpty());
-
-		// If this was not an error packet, send cancel
-		if(packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel)
-		{
-			ZhttpResponsePacket out;
-			out.from = instanceId;
-			out.ids += ZhttpResponsePacket::Id(id);
-			out.type = ZhttpResponsePacket::Cancel;
-			write(type, out, packet.from.asQByteArray(), packet.routerResp);
-		}
-	}
-
-	void write(SessionType type, const ZhttpRequestPacket &packet)
-	{
-		assert(client_out_sock || client_req_sock);
-		const char *logprefix = logPrefixForType(type);
-
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
-
-		if(client_out_sock)
-		{
-			if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s client: OUT", logprefix);
-
-			client_out_sock->write(QList<QByteArray>() << buf);
-		}
-		else
-		{
-			if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s client req: OUT", logprefix);
-
-			client_req_sock->write(QList<QByteArray>() << QByteArray() << buf);
-		}
-	}
-
-	void write(SessionType type, const ZhttpRequestPacket &packet, const QByteArray &instanceAddress)
-	{
-		assert(client_out_stream_sock);
-		const char *logprefix = logPrefixForType(type);
-
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s client: OUT %s", logprefix, instanceAddress.data());
-
-		QList<QByteArray> msg;
-		msg += instanceAddress;
-		msg += QByteArray();
-		msg += buf;
-		client_out_stream_sock->write(msg);
-	}
-
-	void write(SessionType type, const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp)
-	{
-		assert(server_out_sock);
-		const char *logprefix = logPrefixForType(type);
-
-		Variant vpacket = packet.toVariant();
-
-		if(routerResp)
-		{
-			QByteArray buf = "T" + TnetString::fromVariant(vpacket);
-
-			if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s server: OUT (router) %s", logprefix, instanceAddress.data());
-
-			QList<QByteArray> msg;
-			msg += instanceAddress;
-			msg += QByteArray();
-			msg += buf;
-			server_in_stream_sock->write(msg);
-		}
-		else
-		{
-			QByteArray buf = instanceAddress + " T" + TnetString::fromVariant(vpacket);
-
-			if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s server: OUT %s", logprefix, instanceAddress.data());
-
-			server_out_sock->write(QList<QByteArray>() << buf);
-		}
-	}
-
-	void writeProbeAck(const CowByteArray &toAddress)
-	{
-		CowByteArrayList msg;
-		msg += toAddress;
-		msg += CowByteArray();
-		msg += "probe-ack";
-		server_in_stream_sock->write(msg);
-	}
-
-	static const char *logPrefixForType(SessionType type)
-	{
-		switch(type)
-		{
-			case HttpSession: return "zhttp";
-			case WebSocketSession: return "zws";
-			default: return "zhttp/zws";
-		}
-	}
-
-	void registerKeepAlive(void *p, SessionType type)
-	{
-		if(keepAliveRegistrations.contains(p))
-			return;
-
-		KeepAliveRegistration *r = new KeepAliveRegistration;
-		r->type = type;
-		if(type == HttpSession)
-			r->p.req = (ZhttpRequest *)p;
-		else // WebSocketSession
-			r->p.sock = (ZWebSocket *)p;
-
-		keepAliveRegistrations.insert(p, r);
-
-		r->refreshBucket = smallestSessionRefreshBucket();
-		sessionRefreshBuckets[r->refreshBucket] += r;
-
-		setupKeepAlive();
-	}
-
-	void unregisterKeepAlive(void *p)
-	{
-		KeepAliveRegistration *r = keepAliveRegistrations.value(p);
-		if(!r)
-			return;
-
-		sessionRefreshBuckets[r->refreshBucket].remove(r);
-		keepAliveRegistrations.remove(p);
-		delete r;
-
-		setupKeepAlive();
-	}
-
-	void setupKeepAlive()
-	{
-		if(!keepAliveRegistrations.isEmpty())
-		{
-			if(!refreshTimer->isActive())
-				refreshTimer->start(REFRESH_INTERVAL);
-		}
-		else
-			refreshTimer->stop();
-	}
-
-	void writeKeepAlive(SessionType type, const QList<ZhttpRequestPacket::Id> &ids, const QByteArray &zhttpAddress)
-	{
-		ZhttpRequestPacket zreq;
-		zreq.from = instanceId;
-		zreq.ids = ids;
-		zreq.type = ZhttpRequestPacket::KeepAlive;
-		write(type, zreq, zhttpAddress);
-	}
-
-	void writeKeepAlive(SessionType type, const QList<ZhttpResponsePacket::Id> &ids, const QByteArray &zhttpAddress, bool routerResp)
-	{
-		ZhttpResponsePacket zresp;
-		zresp.from = instanceId;
-		zresp.ids = ids;
-		zresp.type = ZhttpResponsePacket::KeepAlive;
-		write(type, zresp, zhttpAddress, routerResp);
-	}
-
-	void client_out_messagesWritten(int count)
-	{
-		Q_UNUSED(count);
-	}
-
-	void client_out_stream_messagesWritten(int count)
-	{
-		Q_UNUSED(count);
-	}
-
-	void server_out_messagesWritten(int count)
-	{
-		Q_UNUSED(count);
-	}
-
-	void client_req_readyRead()
-	{
-		std::weak_ptr<Private> self = q->d;
-
-		while(client_req_sock->canRead())
-		{
-			CowByteArrayList msg = client_req_sock->read();
-			if(msg.count() != 2)
-			{
-				log_warning("zhttp/zws client req: received message with parts != 2, skipping");
-				continue;
-			}
-
-			CowByteArray dataRaw = msg[1];
-			if(dataRaw.length() < 1 || dataRaw[0] != 'T')
-			{
-				log_warning("zhttp/zws client req: received message with invalid format (missing type), skipping");
-				continue;
-			}
-
-			Variant data = TnetString::toVariant(dataRaw.mid(1));
-			if(data.isNull())
-			{
-				log_warning("zhttp/zws client req: received message with invalid format (tnetstring parse failed), skipping");
-				continue;
-			}
-
-			if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "zhttp/zws client req: IN");
-
-			ZhttpResponsePacket p;
-			if(!p.fromVariant(data))
-			{
-				log_warning("zhttp/zws client req: received message with invalid format (parse failed), skipping");
-				continue;
-			}
-
-			if(p.ids.count() != 1)
-			{
-				log_warning("zhttp/zws client req: received message with multiple ids, skipping");
-				return;
-			}
-
-			const ZhttpResponsePacket::Id &id = p.ids.first();
-
-			ZhttpRequest *req = clientReqsByRid.value(ZhttpRequest::Rid(instanceId, id.id.asQByteArray()));
-			if(req)
-			{
-				req->handle(id.id.asQByteArray(), id.seq, p);
-				if(self.expired())
-					return;
-
-				continue;
-			}
-
-			log_debug("zhttp/zws client req: received message for unknown request id");
-
-			// NOTE: we don't respond with a cancel message in req mode
-		}
-	}
-
-	void processClientIn(const CowByteArray &receiver, const CowByteArray &msg)
-	{
-		if(msg.length() < 1 || msg[0] != 'T')
-		{
-			log_warning("zhttp/zws client: received message with invalid format (missing type), skipping");
-			return;
-		}
-
-		Variant data = TnetString::toVariant(msg.mid(1));
-		if(data.isNull())
-		{
-			log_warning("zhttp/zws client: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-		{
-			if(!receiver.isEmpty())
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "zhttp/zws client: IN %s", receiver.data());
-			else
-				LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "zhttp/zws client: IN");
-		}
-
-		ZhttpResponsePacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("zhttp/zws client: received message with invalid format (parse failed), skipping");
-			return;
-		}
-
-		std::weak_ptr<Private> self = q->d;
-
-		foreach(const ZhttpResponsePacket::Id &id, p.ids)
-		{
-			// Is this for a websocket?
-			ZWebSocket *sock = clientSocksByRid.value(ZWebSocket::Rid(instanceId, id.id.asQByteArray()));
-			if(sock)
-			{
-				sock->handle(id.id.asQByteArray(), id.seq, p);
-				if(self.expired())
-					return;
-
-				continue;
-			}
-
-			// Is this for an http request?
-			ZhttpRequest *req = clientReqsByRid.value(ZhttpRequest::Rid(instanceId, id.id.asQByteArray()));
-			if(req)
-			{
-				req->handle(id.id.asQByteArray(), id.seq, p);
-				if(self.expired())
-					return;
-
-				continue;
-			}
-
-			log_debug("zhttp/zws client: received message for unknown request id, skipping");
-		}
-	}
-
-	void client_out_stream_readyRead(const CowByteArrayList &msg)
-	{
-		if(msg.count() != 3)
-		{
-			log_warning("zhttp/zws client: received router message with parts != 3, skipping");
-			return;
-		}
-
-		if(msg[2] == "probe-ack")
-		{
-			q->probeAcked();
-			return;
-		}
-
-		processClientIn(CowByteArray(), msg[2]);
-	}
-
-	void client_in_readyRead(const CowByteArrayList &msg)
-	{
-		if(msg.count() != 1)
-		{
-			log_warning("zhttp/zws client: received pub message with parts != 1, skipping");
-			return;
-		}
-
-		int at = msg[0].indexOf(' ');
-		if(at == -1)
-		{
-			log_warning("zhttp/zws client: received pub message with invalid format, skipping");
-			return;
-		}
-
-		CowByteArray receiver = msg[0].mid(0, at);
-		CowByteArray dataRaw = msg[0].mid(at + 1);
-
-		processClientIn(receiver, dataRaw);
-	}
-
-	void server_in_readyRead(const CowByteArrayList &msg)
-	{
-		if(msg.count() != 1)
-		{
-			log_warning("zhttp/zws server: received message with parts != 1, skipping");
-			return;
-		}
-
-		if(msg[0].length() < 1 || msg[0][0] != 'T')
-		{
-			log_warning("zhttp/zws server: received message with invalid format (missing type), skipping");
-			return;
-		}
-
-		Variant data = TnetString::toVariant(msg[0].mid(1));
-		if(data.isNull())
-		{
-			log_warning("zhttp/zws server: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "zhttp/zws server: IN");
-
-		ZhttpRequestPacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("zhttp/zws server: received message with invalid format (parse failed), skipping");
-			return;
-		}
-
-		if(p.from.isEmpty())
-		{
-			log_warning("zhttp/zws server: received message without from address, skipping");
-			return;
-		}
-
-		if(p.ids.count() != 1)
-		{
-			log_warning("zhttp/zws server: received initial message with multiple ids, skipping");
-			return;
-		}
-
-		const ZhttpRequestPacket::Id &id = p.ids.first();
-
-		if(p.uri.scheme() == "wss" || p.uri.scheme() == "ws")
-		{
-			ZWebSocket::Rid rid(p.from.asQByteArray(), id.id.asQByteArray());
-
-			ZWebSocket *sock = serverSocksByRid.value(rid);
-			if(sock)
-			{
-				log_warning("zws server: received message for existing request id, canceling");
-				tryRespondCancel(WebSocketSession, id.id.asQByteArray(), p);
-				return;
-			}
-
-			sock = new ZWebSocket;
-			if(!sock->setupServer(q, id.id.asQByteArray(), id.seq, p))
-			{
-				delete sock;
-				return;
-			}
-
-			serverSocksByRid.insert(rid, sock);
-			serverPendingSocks += sock;
-
-			if(serverPendingReqs.count() + serverPendingSocks.count() >= PENDING_MAX)
-				server_in_valve->close();
-
-			q->socketReady();
-		}
-		else if(p.uri.scheme() == "https" || p.uri.scheme() == "http")
-		{
-			ZhttpRequest::Rid rid(p.from.asQByteArray(), id.id.asQByteArray());
-
-			ZhttpRequest *req = serverReqsByRid.value(rid);
-			if(req)
-			{
-				log_warning("zhttp server: received message for existing request id, canceling");
-				tryRespondCancel(HttpSession, id.id.asQByteArray(), p);
-				return;
-			}
-
-			req = new ZhttpRequest;
-			if(!req->setupServer(q, id.id.asQByteArray(), id.seq, p))
-			{
-				delete req;
-				return;
-			}
-
-			serverReqsByRid.insert(rid, req);
-			serverPendingReqs += req;
-
-			if(serverPendingReqs.count() + serverPendingSocks.count() >= PENDING_MAX)
-				server_in_valve->close();
-
-			q->requestReady();
-		}
-		else
-		{
-			log_debug("zhttp/zws server: rejecting unsupported scheme: %s", qPrintable(p.uri.scheme()));
-			tryRespondCancel(UnknownSession, id.id.asQByteArray(), p);
-			return;
-		}
-	}
-
-	void server_in_stream_readyRead(const CowByteArrayList &msg)
-	{
-		if(msg.count() < 2 || msg.count() > 3)
-		{
-			log_warning("zhttp/zws server: received message with parts != 2 or 3, skipping");
-			return;
-		}
-
-		if(msg.count() < 3)
-		{
-			// Reply to probe
-			writeProbeAck(msg[0]);
-			return;
-		}
-
-		if(msg[2].length() < 1 || msg[2][0] != 'T')
-		{
-			log_warning("zhttp/zws server: received message with invalid format (missing type), skipping");
-			return;
-		}
-
-		Variant data = TnetString::toVariant(msg[2].mid(1));
-		if(data.isNull())
-		{
-			log_warning("zhttp/zws server: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "zhttp/zws server: IN stream");
-
-		ZhttpRequestPacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("zhttp/zws server: received message with invalid format (parse failed), skipping");
-			return;
-		}
-
-		std::weak_ptr<Private> self = q->d;
-
-		foreach(const ZhttpRequestPacket::Id &id, p.ids)
-		{
-			// Is this for a websocket?
-			ZWebSocket *sock = serverSocksByRid.value(ZWebSocket::Rid(p.from.asQByteArray(), id.id.asQByteArray()));
-			if(sock)
-			{
-				sock->handle(id.id.asQByteArray(), id.seq, p);
-				if(self.expired())
-					return;
-
-				continue;
-			}
-
-			// Is this for an http request?
-			ZhttpRequest *req = serverReqsByRid.value(ZhttpRequest::Rid(p.from.asQByteArray(), id.id.asQByteArray()));
-			if(req)
-			{
-				req->handle(id.id.asQByteArray(), id.seq, p);
-				if(self.expired())
-					return;
-
-				continue;
-			}
-
-			log_debug("zhttp/zws server: received message for unknown request id, skipping");
-		}
-	}
-
-	void refresh_timeout()
-	{
-		QHash<QByteArray, QList<KeepAliveRegistration*> > clientSessionsBySender[2]; // Index corresponds to type
-		QHash<QByteArray, QList<KeepAliveRegistration*> > serverSessionsBySender[4]; // Index corresponds to type and response mode
-
-		// Process the current bucket
-		const QSet<KeepAliveRegistration*> &bucket = sessionRefreshBuckets[currentSessionRefreshBucket];
-		foreach(KeepAliveRegistration *r, bucket)
-		{
-			QPair<QByteArray, QByteArray> rid;
-			bool isServer;
-			if(r->type == HttpSession)
-			{
-				rid = r->p.req->rid();
-				isServer = r->p.req->isServer();
-			}
-			else // WebSocketSession
-			{
-				rid = r->p.sock->rid();
-				isServer = r->p.sock->isServer();
-			}
-
-			int groupIndex;
-			QByteArray sender;
-			bool routerResp = false;
-			if(isServer)
-			{
-				if(r->type == HttpSession)
-					routerResp = r->p.req->routerResp();
-				else // WebSocketSession
-					routerResp = r->p.sock->routerResp();
-
-				groupIndex = ((r->type - 1) * 2) + (routerResp ? 1 : 0);
-
-				sender = rid.first;
-			}
-			else
-			{
-				groupIndex = r->type - 1;
-
-				if(r->type == HttpSession)
-					sender = r->p.req->toAddress();
-				else // WebSocketSession
-					sender = r->p.sock->toAddress();
-			}
-
-			assert(!sender.isEmpty());
-
-			QHash<QByteArray, QList<KeepAliveRegistration*> > &sessionsBySender = (isServer ? serverSessionsBySender[groupIndex] : clientSessionsBySender[groupIndex]);
-
-			if(!sessionsBySender.contains(sender))
-				sessionsBySender.insert(sender, QList<KeepAliveRegistration*>());
-
-			QList<KeepAliveRegistration*> &sessions = sessionsBySender[sender];
-			sessions += r;
-
-			// If we're at max, send out now
-			if(sessions.count() >= ZHTTP_IDS_MAX)
-			{
-				if(isServer)
-				{
-					QList<ZhttpResponsePacket::Id> ids;
-					foreach(KeepAliveRegistration *i, sessions)
-					{
-						assert(i->type == r->type);
-						if(r->type == HttpSession)
-							ids += ZhttpResponsePacket::Id(i->p.req->rid().second, i->p.req->outSeqInc());
-						else // WebSocketSession
-							ids += ZhttpResponsePacket::Id(i->p.sock->rid().second, i->p.sock->outSeqInc());
-					}
-
-					writeKeepAlive(r->type, ids, sender, routerResp);
-				}
-				else
-				{
-					QList<ZhttpRequestPacket::Id> ids;
-					foreach(KeepAliveRegistration *i, sessions)
-					{
-						assert(i->type == r->type);
-						if(r->type == HttpSession)
-							ids += ZhttpRequestPacket::Id(i->p.req->rid().second, i->p.req->outSeqInc());
-						else // WebSocketSession
-							ids += ZhttpRequestPacket::Id(i->p.sock->rid().second, i->p.sock->outSeqInc());
-					}
-
-					writeKeepAlive(r->type, ids, sender);
-				}
-
-				sessions.clear();
-				sessionsBySender.remove(sender);
-			}
-		}
-
-		// Send last packets
-
-		for(int n = 0; n < 2; ++n)
-		{
-			SessionType type = (SessionType)(n + 1);
-
-			QHashIterator<QByteArray, QList<KeepAliveRegistration*> > sit(clientSessionsBySender[n]);
-			while(sit.hasNext())
-			{
-				sit.next();
-				const QByteArray &sender = sit.key();
-				const QList<KeepAliveRegistration*> &sessions = sit.value();
-
-				if(!sessions.isEmpty())
-				{
-					QList<ZhttpRequestPacket::Id> ids;
-					foreach(KeepAliveRegistration *i, sessions)
-					{
-						assert(i->type == type);
-						if(type == HttpSession)
-							ids += ZhttpRequestPacket::Id(i->p.req->rid().second, i->p.req->outSeqInc());
-						else // WebSocketSession
-							ids += ZhttpRequestPacket::Id(i->p.sock->rid().second, i->p.sock->outSeqInc());
-					}
-
-					writeKeepAlive(type, ids, sender);
-				}
-			}
-		}
-
-		for(int n = 0; n < 4; ++n)
-		{
-			SessionType type = (SessionType)((n / 2) + 1);
-			bool routerResp = n % 2 == 0 ? false : true;
-
-			QHashIterator<QByteArray, QList<KeepAliveRegistration*> > sit(serverSessionsBySender[n]);
-			while(sit.hasNext())
-			{
-				sit.next();
-				const QByteArray &sender = sit.key();
-				const QList<KeepAliveRegistration*> &sessions = sit.value();
-
-				if(!sessions.isEmpty())
-				{
-					QList<ZhttpResponsePacket::Id> ids;
-					foreach(KeepAliveRegistration *i, sessions)
-					{
-						assert(i->type == type);
-						if(type == HttpSession)
-							ids += ZhttpResponsePacket::Id(i->p.req->rid().second, i->p.req->outSeqInc());
-						else // WebSocketSession
-							ids += ZhttpResponsePacket::Id(i->p.sock->rid().second, i->p.sock->outSeqInc());
-					}
-
-					writeKeepAlive(type, ids, sender, routerResp);
-				}
-			}
-		}
-
-		++currentSessionRefreshBucket;
-		if(currentSessionRefreshBucket >= ZHTTP_REFRESH_BUCKETS)
-			currentSessionRefreshBucket = 0;
-	}
+        QString errorMessage;
+        if (!ZUtil::setupSocket(client_out_stream_sock.get(), client_out_stream_specs, doBind,
+                                ipcFileMode, &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        client_out_stream_valve = std::make_unique<ZmqValve>(client_out_stream_sock.get());
+        clientOutStreamConnection = client_out_stream_valve->readyRead.connect(
+            boost::bind(&Private::client_out_stream_readyRead, this, boost::placeholders::_1));
+
+        client_out_stream_valve->open();
+
+        return true;
+    }
+
+    bool setupClientIn() {
+        rrConnection.disconnect();
+        client_req_sock.reset();
+        client_in_valve.reset();
+        client_in_sock.reset();
+
+        client_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+
+        client_in_sock->setHwm(DEFAULT_HWM);
+        client_in_sock->setShutdownWaitTime(0);
+        client_in_sock->subscribe(instanceId + ' ');
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(client_in_sock.get(), client_in_specs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        client_in_valve = std::make_unique<ZmqValve>(client_in_sock.get());
+        clientConnection = client_in_valve->readyRead.connect(
+            boost::bind(&Private::client_in_readyRead, this, boost::placeholders::_1));
+
+        client_in_valve->open();
+
+        return true;
+    }
+
+    bool setupClientReq() {
+        cosConnection.disconnect();
+        cossConnection.disconnect();
+        client_out_sock.reset();
+        client_out_stream_sock.reset();
+        client_in_sock.reset();
+
+        client_req_sock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
+        rrConnection =
+            client_req_sock->readyRead.connect(boost::bind(&Private::client_req_readyRead, this));
+
+        client_req_sock->setHwm(OUT_HWM);
+        client_req_sock->setShutdownWaitTime(CLIENT_WAIT_TIME);
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(client_req_sock.get(), client_req_specs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        return true;
+    }
+
+    bool setupServerIn() {
+        server_in_valve.reset();
+        server_in_sock.reset();
+
+        server_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+
+        server_in_sock->setHwm(IN_HWM);
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(server_in_sock.get(), server_in_specs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        server_in_valve = std::make_unique<ZmqValve>(server_in_sock.get());
+        serverConnection = server_in_valve->readyRead.connect(
+            boost::bind(&Private::server_in_readyRead, this, boost::placeholders::_1));
+
+        server_in_valve->open();
+
+        return true;
+    }
+
+    bool setupServerInStream() {
+        serverStreamConnection.disconnect();
+        server_in_stream_sock.reset();
+
+        server_in_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+
+        server_in_stream_sock->setIdentity(instanceId);
+        server_in_stream_sock->setHwm(DEFAULT_HWM);
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(server_in_stream_sock.get(), server_in_stream_specs, doBind,
+                                ipcFileMode, &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        server_in_stream_valve = std::make_unique<ZmqValve>(server_in_stream_sock.get());
+        serverStreamConnection = server_in_stream_valve->readyRead.connect(
+            boost::bind(&Private::server_in_stream_readyRead, this, boost::placeholders::_1));
+
+        server_in_stream_valve->open();
+
+        return true;
+    }
+
+    bool setupServerOut() {
+        sosConnection.disconnect();
+        server_out_sock.reset();
+
+        server_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
+        sosConnection = server_out_sock->messagesWritten.connect(
+            boost::bind(&Private::server_out_messagesWritten, this, boost::placeholders::_1));
+
+        server_out_sock->setWriteQueueEnabled(false);
+        server_out_sock->setHwm(DEFAULT_HWM);
+        server_out_sock->setShutdownWaitTime(SERVER_WAIT_TIME);
+
+        QString errorMessage;
+        if (!ZUtil::setupSocket(server_out_sock.get(), server_out_specs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
+
+        return true;
+    }
+
+    int smallestSessionRefreshBucket() {
+        int best = -1;
+        int bestSize = 0;
+
+        for (int n = 0; n < ZHTTP_REFRESH_BUCKETS; ++n) {
+            if (best == -1 || sessionRefreshBuckets[n].count() < bestSize) {
+                best = n;
+                bestSize = sessionRefreshBuckets[n].count();
+            }
+        }
+
+        return best;
+    }
+
+    void tryRespondCancel(SessionType type, const QByteArray &id,
+                          const ZhttpRequestPacket &packet) {
+        assert(!packet.from.isEmpty());
+
+        // If this was not an error packet, send cancel
+        if (packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel) {
+            ZhttpResponsePacket out;
+            out.from = instanceId;
+            out.ids += ZhttpResponsePacket::Id(id);
+            out.type = ZhttpResponsePacket::Cancel;
+            write(type, out, packet.from.asQByteArray(), packet.routerResp);
+        }
+    }
+
+    void write(SessionType type, const ZhttpRequestPacket &packet) {
+        assert(client_out_sock || client_req_sock);
+        const char *logprefix = logPrefixForType(type);
+
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
+
+        if (client_out_sock) {
+            if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s client: OUT",
+                                               logprefix);
+
+            client_out_sock->write(QList<QByteArray>() << buf);
+        } else {
+            if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body",
+                                               "%s client req: OUT", logprefix);
+
+            client_req_sock->write(QList<QByteArray>() << QByteArray() << buf);
+        }
+    }
+
+    void write(SessionType type, const ZhttpRequestPacket &packet,
+               const QByteArray &instanceAddress) {
+        assert(client_out_stream_sock);
+        const char *logprefix = logPrefixForType(type);
+
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s client: OUT %s",
+                                           logprefix, instanceAddress.data());
+
+        QList<QByteArray> msg;
+        msg += instanceAddress;
+        msg += QByteArray();
+        msg += buf;
+        client_out_stream_sock->write(msg);
+    }
+
+    void write(SessionType type, const ZhttpResponsePacket &packet,
+               const QByteArray &instanceAddress, bool routerResp) {
+        assert(server_out_sock);
+        const char *logprefix = logPrefixForType(type);
+
+        Variant vpacket = packet.toVariant();
+
+        if (routerResp) {
+            QByteArray buf = "T" + TnetString::fromVariant(vpacket);
+
+            if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body",
+                                               "%s server: OUT (router) %s", logprefix,
+                                               instanceAddress.data());
+
+            QList<QByteArray> msg;
+            msg += instanceAddress;
+            msg += QByteArray();
+            msg += buf;
+            server_in_stream_sock->write(msg);
+        } else {
+            QByteArray buf = instanceAddress + " T" + TnetString::fromVariant(vpacket);
+
+            if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body",
+                                               "%s server: OUT %s", logprefix,
+                                               instanceAddress.data());
+
+            server_out_sock->write(QList<QByteArray>() << buf);
+        }
+    }
+
+    void writeProbeAck(const CowByteArray &toAddress) {
+        CowByteArrayList msg;
+        msg += toAddress;
+        msg += CowByteArray();
+        msg += "probe-ack";
+        server_in_stream_sock->write(msg);
+    }
+
+    static const char *logPrefixForType(SessionType type) {
+        switch (type) {
+        case HttpSession:
+            return "zhttp";
+        case WebSocketSession:
+            return "zws";
+        default:
+            return "zhttp/zws";
+        }
+    }
+
+    void registerKeepAlive(void *p, SessionType type) {
+        if (keepAliveRegistrations.contains(p))
+            return;
+
+        KeepAliveRegistration *r = new KeepAliveRegistration;
+        r->type = type;
+        if (type == HttpSession)
+            r->p.req = (ZhttpRequest *)p;
+        else // WebSocketSession
+            r->p.sock = (ZWebSocket *)p;
+
+        keepAliveRegistrations.insert(p, r);
+
+        r->refreshBucket = smallestSessionRefreshBucket();
+        sessionRefreshBuckets[r->refreshBucket] += r;
+
+        setupKeepAlive();
+    }
+
+    void unregisterKeepAlive(void *p) {
+        KeepAliveRegistration *r = keepAliveRegistrations.value(p);
+        if (!r)
+            return;
+
+        sessionRefreshBuckets[r->refreshBucket].remove(r);
+        keepAliveRegistrations.remove(p);
+        delete r;
+
+        setupKeepAlive();
+    }
+
+    void setupKeepAlive() {
+        if (!keepAliveRegistrations.isEmpty()) {
+            if (!refreshTimer->isActive())
+                refreshTimer->start(REFRESH_INTERVAL);
+        } else
+            refreshTimer->stop();
+    }
+
+    void writeKeepAlive(SessionType type, const QList<ZhttpRequestPacket::Id> &ids,
+                        const QByteArray &zhttpAddress) {
+        ZhttpRequestPacket zreq;
+        zreq.from = instanceId;
+        zreq.ids = ids;
+        zreq.type = ZhttpRequestPacket::KeepAlive;
+        write(type, zreq, zhttpAddress);
+    }
+
+    void writeKeepAlive(SessionType type, const QList<ZhttpResponsePacket::Id> &ids,
+                        const QByteArray &zhttpAddress, bool routerResp) {
+        ZhttpResponsePacket zresp;
+        zresp.from = instanceId;
+        zresp.ids = ids;
+        zresp.type = ZhttpResponsePacket::KeepAlive;
+        write(type, zresp, zhttpAddress, routerResp);
+    }
+
+    void client_out_messagesWritten(int count) { Q_UNUSED(count); }
+
+    void client_out_stream_messagesWritten(int count) { Q_UNUSED(count); }
+
+    void server_out_messagesWritten(int count) { Q_UNUSED(count); }
+
+    void client_req_readyRead() {
+        std::weak_ptr<Private> self = q->d;
+
+        while (client_req_sock->canRead()) {
+            CowByteArrayList msg = client_req_sock->read();
+            if (msg.count() != 2) {
+                log_warning("zhttp/zws client req: received message with parts != 2, skipping");
+                continue;
+            }
+
+            CowByteArray dataRaw = msg[1];
+            if (dataRaw.length() < 1 || dataRaw[0] != 'T') {
+                log_warning("zhttp/zws client req: received message with invalid "
+                            "format (missing type), skipping");
+                continue;
+            }
+
+            Variant data = TnetString::toVariant(dataRaw.mid(1));
+            if (data.isNull()) {
+                log_warning("zhttp/zws client req: received message with invalid "
+                            "format (tnetstring parse failed), skipping");
+                continue;
+            }
+
+            if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body",
+                                               "zhttp/zws client req: IN");
+
+            ZhttpResponsePacket p;
+            if (!p.fromVariant(data)) {
+                log_warning("zhttp/zws client req: received message with invalid "
+                            "format (parse failed), skipping");
+                continue;
+            }
+
+            if (p.ids.count() != 1) {
+                log_warning("zhttp/zws client req: received message with multiple ids, "
+                            "skipping");
+                return;
+            }
+
+            const ZhttpResponsePacket::Id &id = p.ids.first();
+
+            ZhttpRequest *req =
+                clientReqsByRid.value(ZhttpRequest::Rid(instanceId, id.id.asQByteArray()));
+            if (req) {
+                req->handle(id.id.asQByteArray(), id.seq, p);
+                if (self.expired())
+                    return;
+
+                continue;
+            }
+
+            log_debug("zhttp/zws client req: received message for unknown request id");
+
+            // NOTE: we don't respond with a cancel message in req mode
+        }
+    }
+
+    void processClientIn(const CowByteArray &receiver, const CowByteArray &msg) {
+        if (msg.length() < 1 || msg[0] != 'T') {
+            log_warning("zhttp/zws client: received message with invalid format "
+                        "(missing type), skipping");
+            return;
+        }
+
+        Variant data = TnetString::toVariant(msg.mid(1));
+        if (data.isNull()) {
+            log_warning("zhttp/zws client: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG) {
+            if (!receiver.isEmpty())
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body",
+                                               "zhttp/zws client: IN %s", receiver.data());
+            else
+                LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body",
+                                               "zhttp/zws client: IN");
+        }
+
+        ZhttpResponsePacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("zhttp/zws client: received message with invalid format "
+                        "(parse failed), skipping");
+            return;
+        }
+
+        std::weak_ptr<Private> self = q->d;
+
+        foreach (const ZhttpResponsePacket::Id &id, p.ids) {
+            // Is this for a websocket?
+            ZWebSocket *sock =
+                clientSocksByRid.value(ZWebSocket::Rid(instanceId, id.id.asQByteArray()));
+            if (sock) {
+                sock->handle(id.id.asQByteArray(), id.seq, p);
+                if (self.expired())
+                    return;
+
+                continue;
+            }
+
+            // Is this for an http request?
+            ZhttpRequest *req =
+                clientReqsByRid.value(ZhttpRequest::Rid(instanceId, id.id.asQByteArray()));
+            if (req) {
+                req->handle(id.id.asQByteArray(), id.seq, p);
+                if (self.expired())
+                    return;
+
+                continue;
+            }
+
+            log_debug("zhttp/zws client: received message for unknown request id, "
+                      "skipping");
+        }
+    }
+
+    void client_out_stream_readyRead(const CowByteArrayList &msg) {
+        if (msg.count() != 3) {
+            log_warning("zhttp/zws client: received router message with parts != 3, "
+                        "skipping");
+            return;
+        }
+
+        if (msg[2] == "probe-ack") {
+            q->probeAcked();
+            return;
+        }
+
+        processClientIn(CowByteArray(), msg[2]);
+    }
+
+    void client_in_readyRead(const CowByteArrayList &msg) {
+        if (msg.count() != 1) {
+            log_warning("zhttp/zws client: received pub message with parts != 1, skipping");
+            return;
+        }
+
+        int at = msg[0].indexOf(' ');
+        if (at == -1) {
+            log_warning("zhttp/zws client: received pub message with invalid format, "
+                        "skipping");
+            return;
+        }
+
+        CowByteArray receiver = msg[0].mid(0, at);
+        CowByteArray dataRaw = msg[0].mid(at + 1);
+
+        processClientIn(receiver, dataRaw);
+    }
+
+    void server_in_readyRead(const CowByteArrayList &msg) {
+        if (msg.count() != 1) {
+            log_warning("zhttp/zws server: received message with parts != 1, skipping");
+            return;
+        }
+
+        if (msg[0].length() < 1 || msg[0][0] != 'T') {
+            log_warning("zhttp/zws server: received message with invalid format "
+                        "(missing type), skipping");
+            return;
+        }
+
+        Variant data = TnetString::toVariant(msg[0].mid(1));
+        if (data.isNull()) {
+            log_warning("zhttp/zws server: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "zhttp/zws server: IN");
+
+        ZhttpRequestPacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("zhttp/zws server: received message with invalid format "
+                        "(parse failed), skipping");
+            return;
+        }
+
+        if (p.from.isEmpty()) {
+            log_warning("zhttp/zws server: received message without from address, skipping");
+            return;
+        }
+
+        if (p.ids.count() != 1) {
+            log_warning("zhttp/zws server: received initial message with multiple "
+                        "ids, skipping");
+            return;
+        }
+
+        const ZhttpRequestPacket::Id &id = p.ids.first();
+
+        if (p.uri.scheme() == "wss" || p.uri.scheme() == "ws") {
+            ZWebSocket::Rid rid(p.from.asQByteArray(), id.id.asQByteArray());
+
+            ZWebSocket *sock = serverSocksByRid.value(rid);
+            if (sock) {
+                log_warning("zws server: received message for existing request id, canceling");
+                tryRespondCancel(WebSocketSession, id.id.asQByteArray(), p);
+                return;
+            }
+
+            sock = new ZWebSocket;
+            if (!sock->setupServer(q, id.id.asQByteArray(), id.seq, p)) {
+                delete sock;
+                return;
+            }
+
+            serverSocksByRid.insert(rid, sock);
+            serverPendingSocks += sock;
+
+            if (serverPendingReqs.count() + serverPendingSocks.count() >= PENDING_MAX)
+                server_in_valve->close();
+
+            q->socketReady();
+        } else if (p.uri.scheme() == "https" || p.uri.scheme() == "http") {
+            ZhttpRequest::Rid rid(p.from.asQByteArray(), id.id.asQByteArray());
+
+            ZhttpRequest *req = serverReqsByRid.value(rid);
+            if (req) {
+                log_warning("zhttp server: received message for existing request id, "
+                            "canceling");
+                tryRespondCancel(HttpSession, id.id.asQByteArray(), p);
+                return;
+            }
+
+            req = new ZhttpRequest;
+            if (!req->setupServer(q, id.id.asQByteArray(), id.seq, p)) {
+                delete req;
+                return;
+            }
+
+            serverReqsByRid.insert(rid, req);
+            serverPendingReqs += req;
+
+            if (serverPendingReqs.count() + serverPendingSocks.count() >= PENDING_MAX)
+                server_in_valve->close();
+
+            q->requestReady();
+        } else {
+            log_debug("zhttp/zws server: rejecting unsupported scheme: %s",
+                      qPrintable(p.uri.scheme()));
+            tryRespondCancel(UnknownSession, id.id.asQByteArray(), p);
+            return;
+        }
+    }
+
+    void server_in_stream_readyRead(const CowByteArrayList &msg) {
+        if (msg.count() < 2 || msg.count() > 3) {
+            log_warning("zhttp/zws server: received message with parts != 2 or 3, skipping");
+            return;
+        }
+
+        if (msg.count() < 3) {
+            // Reply to probe
+            writeProbeAck(msg[0]);
+            return;
+        }
+
+        if (msg[2].length() < 1 || msg[2][0] != 'T') {
+            log_warning("zhttp/zws server: received message with invalid format "
+                        "(missing type), skipping");
+            return;
+        }
+
+        Variant data = TnetString::toVariant(msg[2].mid(1));
+        if (data.isNull()) {
+            log_warning("zhttp/zws server: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body",
+                                           "zhttp/zws server: IN stream");
+
+        ZhttpRequestPacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("zhttp/zws server: received message with invalid format "
+                        "(parse failed), skipping");
+            return;
+        }
+
+        std::weak_ptr<Private> self = q->d;
+
+        foreach (const ZhttpRequestPacket::Id &id, p.ids) {
+            // Is this for a websocket?
+            ZWebSocket *sock = serverSocksByRid.value(
+                ZWebSocket::Rid(p.from.asQByteArray(), id.id.asQByteArray()));
+            if (sock) {
+                sock->handle(id.id.asQByteArray(), id.seq, p);
+                if (self.expired())
+                    return;
+
+                continue;
+            }
+
+            // Is this for an http request?
+            ZhttpRequest *req = serverReqsByRid.value(
+                ZhttpRequest::Rid(p.from.asQByteArray(), id.id.asQByteArray()));
+            if (req) {
+                req->handle(id.id.asQByteArray(), id.seq, p);
+                if (self.expired())
+                    return;
+
+                continue;
+            }
+
+            log_debug("zhttp/zws server: received message for unknown request id, "
+                      "skipping");
+        }
+    }
+
+    void refresh_timeout() {
+        QHash<QByteArray, QList<KeepAliveRegistration *>>
+            clientSessionsBySender[2]; // Index corresponds to type
+        QHash<QByteArray, QList<KeepAliveRegistration *>>
+            serverSessionsBySender[4]; // Index corresponds to type and response
+                                       // mode
+
+        // Process the current bucket
+        const QSet<KeepAliveRegistration *> &bucket =
+            sessionRefreshBuckets[currentSessionRefreshBucket];
+        foreach (KeepAliveRegistration *r, bucket) {
+            QPair<QByteArray, QByteArray> rid;
+            bool isServer;
+            if (r->type == HttpSession) {
+                rid = r->p.req->rid();
+                isServer = r->p.req->isServer();
+            } else // WebSocketSession
+            {
+                rid = r->p.sock->rid();
+                isServer = r->p.sock->isServer();
+            }
+
+            int groupIndex;
+            QByteArray sender;
+            bool routerResp = false;
+            if (isServer) {
+                if (r->type == HttpSession)
+                    routerResp = r->p.req->routerResp();
+                else // WebSocketSession
+                    routerResp = r->p.sock->routerResp();
+
+                groupIndex = ((r->type - 1) * 2) + (routerResp ? 1 : 0);
+
+                sender = rid.first;
+            } else {
+                groupIndex = r->type - 1;
+
+                if (r->type == HttpSession)
+                    sender = r->p.req->toAddress();
+                else // WebSocketSession
+                    sender = r->p.sock->toAddress();
+            }
+
+            assert(!sender.isEmpty());
+
+            QHash<QByteArray, QList<KeepAliveRegistration *>> &sessionsBySender =
+                (isServer ? serverSessionsBySender[groupIndex]
+                          : clientSessionsBySender[groupIndex]);
+
+            if (!sessionsBySender.contains(sender))
+                sessionsBySender.insert(sender, QList<KeepAliveRegistration *>());
+
+            QList<KeepAliveRegistration *> &sessions = sessionsBySender[sender];
+            sessions += r;
+
+            // If we're at max, send out now
+            if (sessions.count() >= ZHTTP_IDS_MAX) {
+                if (isServer) {
+                    QList<ZhttpResponsePacket::Id> ids;
+                    foreach (KeepAliveRegistration *i, sessions) {
+                        assert(i->type == r->type);
+                        if (r->type == HttpSession)
+                            ids += ZhttpResponsePacket::Id(i->p.req->rid().second,
+                                                           i->p.req->outSeqInc());
+                        else // WebSocketSession
+                            ids += ZhttpResponsePacket::Id(i->p.sock->rid().second,
+                                                           i->p.sock->outSeqInc());
+                    }
+
+                    writeKeepAlive(r->type, ids, sender, routerResp);
+                } else {
+                    QList<ZhttpRequestPacket::Id> ids;
+                    foreach (KeepAliveRegistration *i, sessions) {
+                        assert(i->type == r->type);
+                        if (r->type == HttpSession)
+                            ids += ZhttpRequestPacket::Id(i->p.req->rid().second,
+                                                          i->p.req->outSeqInc());
+                        else // WebSocketSession
+                            ids += ZhttpRequestPacket::Id(i->p.sock->rid().second,
+                                                          i->p.sock->outSeqInc());
+                    }
+
+                    writeKeepAlive(r->type, ids, sender);
+                }
+
+                sessions.clear();
+                sessionsBySender.remove(sender);
+            }
+        }
+
+        // Send last packets
+
+        for (int n = 0; n < 2; ++n) {
+            SessionType type = (SessionType)(n + 1);
+
+            QHashIterator<QByteArray, QList<KeepAliveRegistration *>> sit(
+                clientSessionsBySender[n]);
+            while (sit.hasNext()) {
+                sit.next();
+                const QByteArray &sender = sit.key();
+                const QList<KeepAliveRegistration *> &sessions = sit.value();
+
+                if (!sessions.isEmpty()) {
+                    QList<ZhttpRequestPacket::Id> ids;
+                    foreach (KeepAliveRegistration *i, sessions) {
+                        assert(i->type == type);
+                        if (type == HttpSession)
+                            ids += ZhttpRequestPacket::Id(i->p.req->rid().second,
+                                                          i->p.req->outSeqInc());
+                        else // WebSocketSession
+                            ids += ZhttpRequestPacket::Id(i->p.sock->rid().second,
+                                                          i->p.sock->outSeqInc());
+                    }
+
+                    writeKeepAlive(type, ids, sender);
+                }
+            }
+        }
+
+        for (int n = 0; n < 4; ++n) {
+            SessionType type = (SessionType)((n / 2) + 1);
+            bool routerResp = n % 2 == 0 ? false : true;
+
+            QHashIterator<QByteArray, QList<KeepAliveRegistration *>> sit(
+                serverSessionsBySender[n]);
+            while (sit.hasNext()) {
+                sit.next();
+                const QByteArray &sender = sit.key();
+                const QList<KeepAliveRegistration *> &sessions = sit.value();
+
+                if (!sessions.isEmpty()) {
+                    QList<ZhttpResponsePacket::Id> ids;
+                    foreach (KeepAliveRegistration *i, sessions) {
+                        assert(i->type == type);
+                        if (type == HttpSession)
+                            ids += ZhttpResponsePacket::Id(i->p.req->rid().second,
+                                                           i->p.req->outSeqInc());
+                        else // WebSocketSession
+                            ids += ZhttpResponsePacket::Id(i->p.sock->rid().second,
+                                                           i->p.sock->outSeqInc());
+                    }
+
+                    writeKeepAlive(type, ids, sender, routerResp);
+                }
+            }
+        }
+
+        ++currentSessionRefreshBucket;
+        if (currentSessionRefreshBucket >= ZHTTP_REFRESH_BUCKETS)
+            currentSessionRefreshBucket = 0;
+    }
 };
 
-ZhttpManager::ZhttpManager()
-{
-	d = std::make_shared<Private>(this);
-}
+ZhttpManager::ZhttpManager() { d = std::make_shared<Private>(this); }
 
 ZhttpManager::~ZhttpManager() = default;
 
-int ZhttpManager::connectionCount() const
-{
-	int total = 0;
-	total += d->clientReqsByRid.count();
-	total += d->serverReqsByRid.count();
-	total += d->clientSocksByRid.count();
-	total += d->serverSocksByRid.count();
-	return total;
+int ZhttpManager::connectionCount() const {
+    int total = 0;
+    total += d->clientReqsByRid.count();
+    total += d->serverReqsByRid.count();
+    total += d->clientSocksByRid.count();
+    total += d->serverSocksByRid.count();
+    return total;
 }
 
-bool ZhttpManager::clientUsesReq() const
-{
-	return (!d->client_out_sock && d->client_req_sock);
+bool ZhttpManager::clientUsesReq() const { return (!d->client_out_sock && d->client_req_sock); }
+
+ZhttpRequest *ZhttpManager::serverRequestByRid(const ZhttpRequest::Rid &rid) const {
+    return d->serverReqsByRid.value(rid);
 }
 
-ZhttpRequest *ZhttpManager::serverRequestByRid(const ZhttpRequest::Rid &rid) const
-{
-	return d->serverReqsByRid.value(rid);
+QByteArray ZhttpManager::instanceId() const { return d->instanceId; }
+
+void ZhttpManager::setInstanceId(const QByteArray &id) { d->instanceId = id; }
+
+void ZhttpManager::setIpcFileMode(int mode) { d->ipcFileMode = mode; }
+
+void ZhttpManager::setBind(bool enable) { d->doBind = enable; }
+
+void ZhttpManager::setProbe(bool enable) { d->doProbe = enable; }
+
+bool ZhttpManager::setClientOutSpecs(const QStringList &specs) {
+    d->client_out_specs = specs;
+    return d->setupClientOut();
 }
 
-QByteArray ZhttpManager::instanceId() const
-{
-	return d->instanceId;
+bool ZhttpManager::setClientOutStreamSpecs(const QStringList &specs) {
+    d->client_out_stream_specs = specs;
+    return d->setupClientOutStream();
 }
 
-void ZhttpManager::setInstanceId(const QByteArray &id)
-{
-	d->instanceId = id;
+bool ZhttpManager::setClientInSpecs(const QStringList &specs) {
+    d->client_in_specs = specs;
+    return d->setupClientIn();
 }
 
-void ZhttpManager::setIpcFileMode(int mode)
-{
-	d->ipcFileMode = mode;
+bool ZhttpManager::setClientReqSpecs(const QStringList &specs) {
+    d->client_req_specs = specs;
+    return d->setupClientReq();
 }
 
-void ZhttpManager::setBind(bool enable)
-{
-	d->doBind = enable;
+bool ZhttpManager::setServerInSpecs(const QStringList &specs) {
+    d->server_in_specs = specs;
+    return d->setupServerIn();
 }
 
-void ZhttpManager::setProbe(bool enable)
-{
-	d->doProbe = enable;
+bool ZhttpManager::setServerInStreamSpecs(const QStringList &specs) {
+    d->server_in_stream_specs = specs;
+    return d->setupServerInStream();
 }
 
-bool ZhttpManager::setClientOutSpecs(const QStringList &specs)
-{
-	d->client_out_specs = specs;
-	return d->setupClientOut();
+bool ZhttpManager::setServerOutSpecs(const QStringList &specs) {
+    d->server_out_specs = specs;
+    return d->setupServerOut();
 }
 
-bool ZhttpManager::setClientOutStreamSpecs(const QStringList &specs)
-{
-	d->client_out_stream_specs = specs;
-	return d->setupClientOutStream();
+ZhttpRequest *ZhttpManager::createRequest() {
+    ZhttpRequest *req = new ZhttpRequest;
+    req->setupClient(this, d->client_req_sock ? true : false);
+    return req;
 }
 
-bool ZhttpManager::setClientInSpecs(const QStringList &specs)
-{
-	d->client_in_specs = specs;
-	return d->setupClientIn();
+ZhttpRequest *ZhttpManager::takeNextRequest() {
+    ZhttpRequest *req = 0;
+
+    while (!req) {
+        if (d->serverPendingReqs.isEmpty())
+            return 0;
+
+        req = d->serverPendingReqs.takeFirst();
+        if (!d->serverReqsByRid.contains(req->rid())) {
+            // This means the object was a zombie. Clean up and take next
+            delete req;
+            req = 0;
+            continue;
+        }
+
+        d->server_in_valve->open();
+    }
+
+    req->startServer();
+    return req;
 }
 
-bool ZhttpManager::setClientReqSpecs(const QStringList &specs)
-{
-	d->client_req_specs = specs;
-	return d->setupClientReq();
+ZWebSocket *ZhttpManager::createSocket() {
+    // Websockets not allowed in req mode
+    assert(!d->client_req_sock);
+
+    ZWebSocket *sock = new ZWebSocket;
+    sock->setupClient(this);
+    return sock;
 }
 
-bool ZhttpManager::setServerInSpecs(const QStringList &specs)
-{
-	d->server_in_specs = specs;
-	return d->setupServerIn();
+ZWebSocket *ZhttpManager::takeNextSocket() {
+    ZWebSocket *sock = 0;
+
+    while (!sock) {
+        if (d->serverPendingSocks.isEmpty())
+            return 0;
+
+        sock = d->serverPendingSocks.takeFirst();
+        if (!d->serverSocksByRid.contains(sock->rid())) {
+            // This means the object was a zombie. Clean up and take next
+            delete sock;
+            sock = 0;
+            continue;
+        }
+
+        d->server_in_valve->open();
+    }
+
+    sock->startServer();
+    return sock;
 }
 
-bool ZhttpManager::setServerInStreamSpecs(const QStringList &specs)
-{
-	d->server_in_stream_specs = specs;
-	return d->setupServerInStream();
+ZhttpRequest *ZhttpManager::createRequestFromState(const ZhttpRequest::ServerState &state) {
+    ZhttpRequest *req = new ZhttpRequest;
+    req->setupServer(this, state);
+    return req;
 }
 
-bool ZhttpManager::setServerOutSpecs(const QStringList &specs)
-{
-	d->server_out_specs = specs;
-	return d->setupServerOut();
+void ZhttpManager::link(ZhttpRequest *req) {
+    if (req->isServer())
+        d->serverReqsByRid.insert(req->rid(), req);
+    else
+        d->clientReqsByRid.insert(req->rid(), req);
 }
 
-ZhttpRequest *ZhttpManager::createRequest()
-{
-	ZhttpRequest *req = new ZhttpRequest;
-	req->setupClient(this, d->client_req_sock ? true : false);
-	return req;
+void ZhttpManager::unlink(ZhttpRequest *req) {
+    if (req->isServer())
+        d->serverReqsByRid.remove(req->rid());
+    else
+        d->clientReqsByRid.remove(req->rid());
 }
 
-ZhttpRequest *ZhttpManager::takeNextRequest()
-{
-	ZhttpRequest *req = 0;
-
-	while(!req)
-	{
-		if(d->serverPendingReqs.isEmpty())
-			return 0;
-
-		req = d->serverPendingReqs.takeFirst();
-		if(!d->serverReqsByRid.contains(req->rid()))
-		{
-			// This means the object was a zombie. Clean up and take next
-			delete req;
-			req = 0;
-			continue;
-		}
-
-		d->server_in_valve->open();
-	}
-
-	req->startServer();
-	return req;
+void ZhttpManager::link(ZWebSocket *sock) {
+    if (sock->isServer())
+        d->serverSocksByRid.insert(sock->rid(), sock);
+    else
+        d->clientSocksByRid.insert(sock->rid(), sock);
 }
 
-ZWebSocket *ZhttpManager::createSocket()
-{
-	// Websockets not allowed in req mode
-	assert(!d->client_req_sock);
-
-	ZWebSocket *sock = new ZWebSocket;
-	sock->setupClient(this);
-	return sock;
+void ZhttpManager::unlink(ZWebSocket *sock) {
+    if (sock->isServer())
+        d->serverSocksByRid.remove(sock->rid());
+    else
+        d->clientSocksByRid.remove(sock->rid());
 }
 
-ZWebSocket *ZhttpManager::takeNextSocket()
-{
-	ZWebSocket *sock = 0;
+bool ZhttpManager::canWriteImmediately() const {
+    assert(d->client_out_sock || d->client_req_sock);
 
-	while(!sock)
-	{
-		if(d->serverPendingSocks.isEmpty())
-			return 0;
-
-		sock = d->serverPendingSocks.takeFirst();
-		if(!d->serverSocksByRid.contains(sock->rid()))
-		{
-			// This means the object was a zombie. Clean up and take next
-			delete sock;
-			sock = 0;
-			continue;
-		}
-
-		d->server_in_valve->open();
-	}
-
-	sock->startServer();
-	return sock;
+    if (d->client_out_sock)
+        return d->client_out_sock->canWriteImmediately();
+    else
+        return d->client_req_sock->canWriteImmediately();
 }
 
-ZhttpRequest *ZhttpManager::createRequestFromState(const ZhttpRequest::ServerState &state)
-{
-	ZhttpRequest *req = new ZhttpRequest;
-	req->setupServer(this, state);
-	return req;
+void ZhttpManager::writeHttp(const ZhttpRequestPacket &packet) {
+    d->write(Private::HttpSession, packet);
 }
 
-void ZhttpManager::link(ZhttpRequest *req)
-{
-	if(req->isServer())
-		d->serverReqsByRid.insert(req->rid(), req);
-	else
-		d->clientReqsByRid.insert(req->rid(), req);
+void ZhttpManager::writeHttp(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress) {
+    d->write(Private::HttpSession, packet, instanceAddress);
 }
 
-void ZhttpManager::unlink(ZhttpRequest *req)
-{
-	if(req->isServer())
-		d->serverReqsByRid.remove(req->rid());
-	else
-		d->clientReqsByRid.remove(req->rid());
+void ZhttpManager::writeHttp(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress,
+                             bool routerResp) {
+    d->write(Private::HttpSession, packet, instanceAddress, routerResp);
 }
 
-void ZhttpManager::link(ZWebSocket *sock)
-{
-	if(sock->isServer())
-		d->serverSocksByRid.insert(sock->rid(), sock);
-	else
-		d->clientSocksByRid.insert(sock->rid(), sock);
+void ZhttpManager::writeWs(const ZhttpRequestPacket &packet) {
+    d->write(Private::WebSocketSession, packet);
 }
 
-void ZhttpManager::unlink(ZWebSocket *sock)
-{
-	if(sock->isServer())
-		d->serverSocksByRid.remove(sock->rid());
-	else
-		d->clientSocksByRid.remove(sock->rid());
+void ZhttpManager::writeWs(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress) {
+    d->write(Private::WebSocketSession, packet, instanceAddress);
 }
 
-bool ZhttpManager::canWriteImmediately() const
-{
-	assert(d->client_out_sock || d->client_req_sock);
-
-	if(d->client_out_sock)
-		return d->client_out_sock->canWriteImmediately();
-	else
-		return d->client_req_sock->canWriteImmediately();
+void ZhttpManager::writeWs(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress,
+                           bool routerResp) {
+    d->write(Private::WebSocketSession, packet, instanceAddress, routerResp);
 }
 
-void ZhttpManager::writeHttp(const ZhttpRequestPacket &packet)
-{
-	d->write(Private::HttpSession, packet);
+void ZhttpManager::registerKeepAlive(ZhttpRequest *req) {
+    d->registerKeepAlive(req, Private::HttpSession);
 }
 
-void ZhttpManager::writeHttp(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress)
-{
-	d->write(Private::HttpSession, packet, instanceAddress);
+void ZhttpManager::unregisterKeepAlive(ZhttpRequest *req) { d->unregisterKeepAlive(req); }
+
+void ZhttpManager::registerKeepAlive(ZWebSocket *sock) {
+    d->registerKeepAlive(sock, Private::WebSocketSession);
 }
 
-void ZhttpManager::writeHttp(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp)
-{
-	d->write(Private::HttpSession, packet, instanceAddress, routerResp);
+void ZhttpManager::unregisterKeepAlive(ZWebSocket *sock) { d->unregisterKeepAlive(sock); }
+
+int ZhttpManager::estimateRequestHeaderBytes(const QString &method, const Url &uri,
+                                             const HttpHeaders &headers) {
+    int total = method.toUtf8().length();
+
+    total += uri.path(Url::FullyEncoded).length();
+
+    if (uri.hasQuery())
+        total += uri.query(Url::FullyEncoded).length() + 1; // +1 for question mark
+
+    foreach (const HttpHeader &h, headers) {
+        total += h.first.length();
+        total += h.second.length();
+    }
+
+    return total;
 }
 
-void ZhttpManager::writeWs(const ZhttpRequestPacket &packet)
-{
-	d->write(Private::WebSocketSession, packet);
-}
+int ZhttpManager::estimateResponseHeaderBytes(int code, const QByteArray &reason,
+                                              const HttpHeaders &headers) {
+    int total = QString::number(code).length();
+    total += reason.length();
 
-void ZhttpManager::writeWs(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress)
-{
-	d->write(Private::WebSocketSession, packet, instanceAddress);
-}
+    foreach (const HttpHeader &h, headers) {
+        total += h.first.length();
+        total += h.second.length();
+    }
 
-void ZhttpManager::writeWs(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp)
-{
-	d->write(Private::WebSocketSession, packet, instanceAddress, routerResp);
-}
-
-void ZhttpManager::registerKeepAlive(ZhttpRequest *req)
-{
-	d->registerKeepAlive(req, Private::HttpSession);
-}
-
-void ZhttpManager::unregisterKeepAlive(ZhttpRequest *req)
-{
-	d->unregisterKeepAlive(req);
-}
-
-void ZhttpManager::registerKeepAlive(ZWebSocket *sock)
-{
-	d->registerKeepAlive(sock, Private::WebSocketSession);
-}
-
-void ZhttpManager::unregisterKeepAlive(ZWebSocket *sock)
-{
-	d->unregisterKeepAlive(sock);
-}
-
-int ZhttpManager::estimateRequestHeaderBytes(const QString &method, const Url &uri, const HttpHeaders &headers)
-{
-	int total = method.toUtf8().length();
-
-	total += uri.path(Url::FullyEncoded).length();
-
-	if(uri.hasQuery())
-		total += uri.query(Url::FullyEncoded).length() + 1; // +1 for question mark
-
-	foreach(const HttpHeader &h, headers)
-	{
-		total += h.first.length();
-		total += h.second.length();
-	}
-
-	return total;
-}
-
-int ZhttpManager::estimateResponseHeaderBytes(int code, const QByteArray &reason, const HttpHeaders &headers)
-{
-	int total = QString::number(code).length();
-	total += reason.length();
-
-	foreach(const HttpHeader &h, headers)
-	{
-		total += h.first.length();
-		total += h.second.length();
-	}
-
-	return total;
+    return total;
 }

--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -24,82 +24,85 @@
 #ifndef ZHTTPMANAGER_H
 #define ZHTTPMANAGER_H
 
+#include "url.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include <boost/signals2.hpp>
-#include "url.h"
 
 using Signal = boost::signals2::signal<void()>;
 
 class ZhttpRequestPacket;
 class ZhttpResponsePacket;
 
-class ZhttpManager
-{
+class ZhttpManager {
 public:
-	ZhttpManager();
-	~ZhttpManager();
+    ZhttpManager();
+    ~ZhttpManager();
 
-	int connectionCount() const;
-	bool clientUsesReq() const;
-	ZhttpRequest *serverRequestByRid(const ZhttpRequest::Rid &rid) const;
+    int connectionCount() const;
+    bool clientUsesReq() const;
+    ZhttpRequest *serverRequestByRid(const ZhttpRequest::Rid &rid) const;
 
-	QByteArray instanceId() const;
-	void setInstanceId(const QByteArray &id);
+    QByteArray instanceId() const;
+    void setInstanceId(const QByteArray &id);
 
-	void setIpcFileMode(int mode);
-	void setBind(bool enable);
-	void setProbe(bool enable);
+    void setIpcFileMode(int mode);
+    void setBind(bool enable);
+    void setProbe(bool enable);
 
-	bool setClientOutSpecs(const QStringList &specs);
-	bool setClientOutStreamSpecs(const QStringList &specs);
-	bool setClientInSpecs(const QStringList &specs);
+    bool setClientOutSpecs(const QStringList &specs);
+    bool setClientOutStreamSpecs(const QStringList &specs);
+    bool setClientInSpecs(const QStringList &specs);
 
-	bool setClientReqSpecs(const QStringList &specs);
+    bool setClientReqSpecs(const QStringList &specs);
 
-	bool setServerInSpecs(const QStringList &specs);
-	bool setServerInStreamSpecs(const QStringList &specs);
-	bool setServerOutSpecs(const QStringList &specs);
+    bool setServerInSpecs(const QStringList &specs);
+    bool setServerInStreamSpecs(const QStringList &specs);
+    bool setServerOutSpecs(const QStringList &specs);
 
-	ZhttpRequest *createRequest();
-	ZhttpRequest *takeNextRequest();
+    ZhttpRequest *createRequest();
+    ZhttpRequest *takeNextRequest();
 
-	ZWebSocket *createSocket();
-	ZWebSocket *takeNextSocket();
+    ZWebSocket *createSocket();
+    ZWebSocket *takeNextSocket();
 
-	// For server mode, jump directly to responding state
-	ZhttpRequest *createRequestFromState(const ZhttpRequest::ServerState &state);
+    // For server mode, jump directly to responding state
+    ZhttpRequest *createRequestFromState(const ZhttpRequest::ServerState &state);
 
-	static int estimateRequestHeaderBytes(const QString &method, const Url &uri, const HttpHeaders &headers);
-	static int estimateResponseHeaderBytes(int code, const QByteArray &reason, const HttpHeaders &headers);
+    static int estimateRequestHeaderBytes(const QString &method, const Url &uri,
+                                          const HttpHeaders &headers);
+    static int estimateResponseHeaderBytes(int code, const QByteArray &reason,
+                                           const HttpHeaders &headers);
 
-	Signal requestReady;
-	Signal socketReady;
-	Signal probeAcked;
+    Signal requestReady;
+    Signal socketReady;
+    Signal probeAcked;
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 
-	friend class ZhttpRequest;
-	friend class ZWebSocket;
-	void link(ZhttpRequest *req);
-	void unlink(ZhttpRequest *req);
-	void link(ZWebSocket *sock);
-	void unlink(ZWebSocket *sock);
-	bool canWriteImmediately() const;
-	void writeHttp(const ZhttpRequestPacket &packet);
-	void writeHttp(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress);
-	void writeHttp(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp);
-	void writeWs(const ZhttpRequestPacket &packet);
-	void writeWs(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress);
-	void writeWs(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress, bool routerResp);
+    friend class ZhttpRequest;
+    friend class ZWebSocket;
+    void link(ZhttpRequest *req);
+    void unlink(ZhttpRequest *req);
+    void link(ZWebSocket *sock);
+    void unlink(ZWebSocket *sock);
+    bool canWriteImmediately() const;
+    void writeHttp(const ZhttpRequestPacket &packet);
+    void writeHttp(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress);
+    void writeHttp(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress,
+                   bool routerResp);
+    void writeWs(const ZhttpRequestPacket &packet);
+    void writeWs(const ZhttpRequestPacket &packet, const QByteArray &instanceAddress);
+    void writeWs(const ZhttpResponsePacket &packet, const QByteArray &instanceAddress,
+                 bool routerResp);
 
-	void registerKeepAlive(ZhttpRequest *req);
-	void unregisterKeepAlive(ZhttpRequest *req);
-	void registerKeepAlive(ZWebSocket *sock);
-	void unregisterKeepAlive(ZWebSocket *sock);
+    void registerKeepAlive(ZhttpRequest *req);
+    void unregisterKeepAlive(ZhttpRequest *req);
+    void registerKeepAlive(ZWebSocket *sock);
+    void unregisterKeepAlive(ZWebSocket *sock);
 };
 
 #endif

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -23,1453 +23,1206 @@
 
 #include "zhttprequest.h"
 
-#include <assert.h>
-#include "zhttprequestpacket.h"
-#include "zhttpresponsepacket.h"
 #include "bufferlist.h"
+#include "defercall.h"
 #include "log.h"
 #include "timer.h"
-#include "variant.h"
-#include "defercall.h"
-#include "zhttpmanager.h"
 #include "uuidutil.h"
+#include "variant.h"
+#include "zhttpmanager.h"
+#include "zhttprequestpacket.h"
+#include "zhttpresponsepacket.h"
+#include <assert.h>
 
 #define IDEAL_CREDITS 200000
 #define SESSION_EXPIRE 60000
 #define KEEPALIVE_INTERVAL 45000
 #define REQ_BUF_MAX 1000000
 
-class ZhttpRequest::Private
-{
+class ZhttpRequest::Private {
 public:
-	enum State
-	{
-		Stopped,                 // Response finished, error, or not even started
-
-		ClientStarting,          // Prepared to send the first packet
-		ClientRequestStartWait,  // Sent the first packet of streamed input, waiting for ack
-		ClientRequesting,        // Sending the rest of streamed input
-		ClientRequestFinishWait, // Completed sending the request, waiting for ack
-		ClientReceiving,         // Completed sending the request, waiting on response
-
-		ServerStarting,          // Prepared to process the first packet
-		ServerReceiving,         // Receiving the rest of streamed input
-		ServerResponseWait,      // Waiting for the response to start
-		ServerResponseStarting,  // About to send the first packet
-		ServerResponding         // Sending the response
-	};
-
-	ZhttpRequest *q;
-	ZhttpManager *manager;
-	bool server;
-	State state;
-	ZhttpRequest::Rid rid;
-	bool doReq;
-	QByteArray toAddress;
-	QHostAddress peerAddress;
-	QString connectHost;
-	int connectPort;
-	bool ignorePolicies;
-	bool trustConnectHost;
-	bool ignoreTlsErrors;
-	int timeout;
-	QString clientCert;
-	QString clientKey;
-	bool sendBodyAfterAck;
-	Variant passthrough;
-	QString requestMethod;
-	Url requestUri;
-	HttpHeaders requestHeaders;
-	BufferList requestBodyBuf;
-	int inSeq;
-	int outSeq;
-	int outCredits;
-	bool bodyFinished; // User has finished providing input
-	int pendingInCredits;
-	bool haveRequestBody;
-	bool haveResponseValues;
-	int responseCode;
-	QByteArray responseReason;
-	HttpHeaders responseHeaders;
-	BufferList responseBodyBuf;
-	Variant userData;
-	bool pausing;
-	bool paused;
-	bool pendingUpdate;
-	bool needPause;
-	bool readableChanged;
-	bool writableChanged;
-	bool errored;
-	ErrorCondition errorCondition;
-	std::unique_ptr<Timer> expireTimer;
-	std::unique_ptr<Timer> keepAliveTimer;
-	std::unique_ptr<Timer> finishTimer;
-	bool multi;
-	bool routerResp;
-	bool quiet;
-	DeferCall deferCall;
-
-	Private(ZhttpRequest *_q) :
-		q(_q),
-		manager(0),
-		server(false),
-		state(Stopped),
-		doReq(false),
-		connectPort(-1),
-		ignorePolicies(false),
-		trustConnectHost(false),
-		ignoreTlsErrors(false),
-		timeout(0),
-		sendBodyAfterAck(false),
-		inSeq(0),
-		outSeq(0),
-		outCredits(0),
-		bodyFinished(false),
-		pendingInCredits(0),
-		haveRequestBody(false),
-		haveResponseValues(false),
-		pausing(false),
-		paused(false),
-		pendingUpdate(false),
-		needPause(false),
-		readableChanged(false),
-		writableChanged(false),
-		errored(false),
-		multi(false),
-		routerResp(false),
-		quiet(false)
-	{
-		expireTimer = std::make_unique<Timer>();
-		expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
-		expireTimer->setSingleShot(true);
-
-		keepAliveTimer = std::make_unique<Timer>();
-		keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
-	}
-
-	~Private()
-	{
-		if(manager && !paused && state != Stopped)
-			tryCancel();
-
-		cleanup();
-	}
-
-	void cleanup()
-	{
-		needPause = false;
-		readableChanged = false;
-		writableChanged = false;
-
-		expireTimer.reset();
-		keepAliveTimer.reset();
-		finishTimer.reset();
-
-		if(manager)
-		{
-			manager->unregisterKeepAlive(q);
-
-			manager->unlink(q);
-			manager = 0;
-		}
-	}
-
-	bool setupServer(int seq, const ZhttpRequestPacket &packet)
-	{
-		if(packet.type != ZhttpRequestPacket::Data)
-		{
-			log_warning("zhttp server: received request with invalid type, canceling");
-			tryRespondCancel(packet);
-			return false;
-		}
-
-		if(seq != -1 && seq != 0)
-		{
-			log_warning("zhttp server: error, received request with non-zero seq field");
-			writeError("bad-request");
-			state = Stopped;
-			return false;
-		}
-
-		if(!packet.stream)
-		{
-			log_warning("zhttp server: error, received request for non-stream response");
-			writeError("bad-request");
-			state = Stopped;
-			return false;
-		}
-
-		if(seq == -1 && packet.more)
-		{
-			log_warning("zhttp server: error, received stream request with no seq field");
-			writeError("bad-request");
-			state = Stopped;
-			return false;
-		}
-
-		inSeq = 1; // Next expected seq
-
-		if(packet.credits != -1)
-			outCredits = packet.credits;
-
-		requestMethod = packet.method.asQString();
-		requestUri = packet.uri;
-		requestHeaders = packet.headers;
-		requestBodyBuf += packet.body.asQByteArray();
-
-		passthrough = packet.passthrough;
-
-		userData = packet.userData;
-		peerAddress = packet.peerAddress;
-
-		if(packet.multi)
-			multi = true;
-
-		if(packet.routerResp)
-			routerResp = true;
-
-		if(!packet.more)
-			haveRequestBody = true;
-
-		return true;
-	}
-
-	void setupServer(const ZhttpRequest::ServerState &ss)
-	{
-		peerAddress = ss.peerAddress;
-		requestMethod = ss.requestMethod;
-		requestUri = ss.requestUri;
-		requestHeaders = ss.requestHeaders;
-		requestBodyBuf += ss.requestBody;
-		if(ss.inSeq >= 0)
-			inSeq = ss.inSeq;
-		if(ss.outSeq >= 0)
-			outSeq = ss.outSeq;
-		if(ss.outCredits >= 0)
-			outCredits = ss.outCredits;
-		routerResp = ss.routerResp;
-		userData = ss.userData;
-
-		if(ss.responseCode != -1)
-		{
-			responseCode = ss.responseCode;
-			state = ServerResponding;
-		}
-		else
-		{
-			state = ServerResponseWait;
-		}
-
-		refreshTimeout();
-		startKeepAlive();
-
-		// Send a keep-alive right away to accept after handoff
-		ZhttpResponsePacket p;
-		p.type = ZhttpResponsePacket::KeepAlive;
-		p.multi = true; // Request multi support
-		writePacket(p);
-	}
-
-	void startClient()
-	{
-		state = ClientStarting;
-
-		if(timeout > 0)
-		{
-			finishTimer = std::make_unique<Timer>();
-			finishTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
-			finishTimer->setSingleShot(true);
-			finishTimer->start(timeout);
-		}
-
-		refreshTimeout();
-		update();
-	}
-
-	void startServer()
-	{
-		state = ServerStarting;
-
-		startKeepAlive();
-		refreshTimeout();
-		update();
-	}
-
-	void pause()
-	{
-		assert(!pausing && !paused);
-		assert(!doReq);
-
-		stopKeepAlive();
-
-		pausing = true;
-		needPause = true;
-
-		update();
-	}
-
-	void resume()
-	{
-		assert(paused);
-		paused = false;
-
-		startKeepAlive();
-
-		ZhttpResponsePacket p;
-		p.type = ZhttpResponsePacket::KeepAlive;
-		writePacket(p);
-	}
-
-	void beginResponse()
-	{
-		assert(!pausing && !paused);
-		state = ServerResponseStarting;
-		update();
-	}
-
-	void startKeepAlive()
-	{
-		if(multi)
-		{
-			if(keepAliveTimer->isActive())
-			{
-				// Need to flush the current keepalive, since the
-				// manager registration may extend the timeout
-				keepAlive_timeout();
-
-				keepAliveTimer->stop();
-			}
-
-			manager->registerKeepAlive(q);
-		}
-		else
-		{
-			manager->unregisterKeepAlive(q);
-
-			if(!keepAliveTimer->isActive())
-				keepAliveTimer->start(KEEPALIVE_INTERVAL);
-		}
-	}
-
-	void stopKeepAlive()
-	{
-		if(keepAliveTimer->isActive())
-			keepAliveTimer->stop();
-
-		manager->unregisterKeepAlive(q);
-	}
-
-	void refreshTimeout()
-	{
-		expireTimer->start(SESSION_EXPIRE);
-	}
-
-	void update()
-	{
-		if(!pendingUpdate)
-		{
-			pendingUpdate = true;
-			deferCall.defer([&]() { doUpdate(); });
-		}
-	}
-
-	QByteArray readBody(int size)
-	{
-		if(server)
-		{
-			QByteArray out = requestBodyBuf.take(size);
-			if(out.isEmpty())
-				return out;
-
-			pendingInCredits += out.size();
-
-			if(!pausing && !paused)
-			{
-				ZhttpResponsePacket p;
-				p.type = ZhttpResponsePacket::Credit;
-				p.credits = pendingInCredits;
-				pendingInCredits = 0;
-				writePacket(p);
-			}
-
-			return out;
-		}
-		else
-		{
-			QByteArray out = responseBodyBuf.take(size);
-			if(out.isEmpty())
-				return out;
-
-			pendingInCredits += out.size();
-
-			if(state == ClientReceiving)
-				tryWrite(); // This should not emit signals in current state
-
-			return out;
-		}
-	}
-
-	void tryWrite()
-	{
-		std::weak_ptr<Private> self = q->d;
-
-		if(state == ClientRequesting)
-		{
-			// If all we have to send is EOF, we don't need credits for that
-			if(requestBodyBuf.isEmpty() && bodyFinished)
-			{
-				state = ClientReceiving;
-
-				ZhttpRequestPacket p;
-				p.type = ZhttpRequestPacket::Data;
-				writePacket(p);
-
-				q->bytesWritten(0);
-			}
-			else if(!requestBodyBuf.isEmpty() && outCredits > 0)
-			{
-				// If we have data to send, and the credits to do so, then send data.
-				// also send credits if we need to.
-
-				QByteArray buf = requestBodyBuf.take(outCredits);
-
-				outCredits -= buf.size();
-				writableChanged = true;
-
-				ZhttpRequestPacket p;
-				p.type = ZhttpRequestPacket::Data;
-				p.body = buf;
-				if(!requestBodyBuf.isEmpty() || !bodyFinished)
-					p.more = true;
-				if(pendingInCredits > 0)
-				{
-					p.credits = pendingInCredits;
-					pendingInCredits = 0;
-				}
-
-				if(!p.more)
-					state = ClientReceiving;
-
-				writePacket(p);
-
-				q->bytesWritten(buf.size());
-			}
-		}
-		else if(state == ClientReceiving)
-		{
-			if(pendingInCredits > 0)
-			{
-				// If we have no data to send but we need to send credits, do at least that
-				ZhttpRequestPacket p;
-				p.type = ZhttpRequestPacket::Credit;
-				p.credits = pendingInCredits;
-				pendingInCredits = 0;
-
-				writePacket(p);
-			}
-		}
-		else if(state == ServerResponding)
-		{
-			if((!responseBodyBuf.isEmpty() && outCredits > 0) || (responseBodyBuf.isEmpty() && bodyFinished))
-			{
-				ZhttpResponsePacket packet;
-				packet.type = ZhttpResponsePacket::Data;
-				packet.body = responseBodyBuf.take(outCredits);
-
-				outCredits -= packet.body.size();
-				if(!packet.body.isEmpty())
-					writableChanged = true;
-
-				packet.more = (!responseBodyBuf.isEmpty() || !bodyFinished);
-
-				writePacket(packet);
-
-				if(!packet.more)
-				{
-					state = Stopped;
-					cleanup();
-				}
-
-				q->bytesWritten(packet.body.size());
-			}
-		}
-
-		if(self.expired())
-			return;
-
-		trySendPause();
-	}
-
-	void trySendPause()
-	{
-		if(needPause && (state == ServerResponseWait || state == ServerResponding) && responseBodyBuf.isEmpty())
-		{
-			needPause = false;
-
-			ZhttpResponsePacket p;
-			p.type = ZhttpResponsePacket::HandoffStart;
-			writePacket(p);
-		}
-	}
-
-	void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet)
-	{
-		if(paused)
-			return;
-
-		if(packet.type == ZhttpRequestPacket::Error)
-		{
-			errored = true;
-			errorCondition = convertError(packet.condition.asQByteArray());
-
-			log_debug("zhttp server: error id=%s cond=%s", id.data(), packet.condition.data());
-
-			state = Stopped;
-			cleanup();
-			q->error();
-			return;
-		}
-		else if(packet.type == ZhttpRequestPacket::Cancel)
-		{
-			log_debug("zhttp server: received cancel id=%s", id.data());
-
-			errored = true;
-			errorCondition = ErrorGeneric;
-			state = Stopped;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(seq != -1)
-		{
-			if(seq != inSeq)
-			{
-				log_warning("zhttp server: error id=%s received message out of sequence (expected %d, got %d), canceling", id.data(), inSeq, seq);
-
-				// If this was not an error packet, send cancel
-				if(packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel)
-				{
-					ZhttpResponsePacket p;
-					p.type = ZhttpResponsePacket::Cancel;
-					writePacket(p);
-				}
-
-				state = Stopped;
-				errored = true;
-				errorCondition = ErrorGeneric;
-				cleanup();
-				q->error();
-				return;
-			}
-
-			++inSeq;
-		}
-
-		if(!multi && packet.multi)
-		{
-			// Switch on multi support
-			multi = true;
-
-			if(!pausing)
-			{
-				// Re-setup keep alive
-				startKeepAlive();
-			}
-		}
-
-		refreshTimeout();
-
-		if(packet.type == ZhttpRequestPacket::Data)
-		{
-			requestBodyBuf += packet.body.asQByteArray();
-
-			bool done = haveRequestBody;
-
-			if(!packet.more)
-			{
-				haveRequestBody = true;
-				state = ServerResponseWait;
-			}
-
-			if(packet.credits > 0)
-			{
-				outCredits += packet.credits;
-				writableChanged = true;
-			}
-
-			if(!packet.body.isEmpty() || (!done && haveRequestBody))
-				readableChanged = true;
-
-			if(readableChanged || writableChanged)
-				update();
-		}
-		else if(packet.type == ZhttpRequestPacket::Credit)
-		{
-			if(packet.credits > 0)
-			{
-				outCredits += packet.credits;
-				writableChanged = true;
-				update();
-			}
-		}
-		else if(packet.type == ZhttpRequestPacket::KeepAlive)
-		{
-			// Nothing to do
-		}
-		else if(packet.type == ZhttpRequestPacket::HandoffProceed)
-		{
-			if(pausing)
-			{
-				pausing = false;
-				paused = true;
-				q->paused();
-			}
-		}
-		else
-		{
-			log_debug("zhttp server: unsupported packet type id=%s type=%d", id.data(), (int)packet.type);
-		}
-	}
-
-	void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet)
-	{
-		if(state == ClientRequestStartWait)
-		{
-			if(packet.from.isEmpty())
-			{
-				state = Stopped;
-				errored = true;
-				errorCondition = ErrorGeneric;
-				cleanup();
-				log_warning("zhttp client: error id=%s initial ack for streamed input request did not contain from field", id.data());
-				q->error();
-				return;
-			}
-
-			toAddress = packet.from.asQByteArray();
-
-			state = ClientRequesting;
-
-			startKeepAlive();
-		}
-		else if(state == ClientRequestFinishWait)
-		{
-			toAddress = packet.from.asQByteArray();
-
-			state = ClientReceiving;
-
-			if(!doReq)
-				startKeepAlive();
-		}
-
-		if(packet.type == ZhttpResponsePacket::Error)
-		{
-			errored = true;
-			errorCondition = convertError(packet.condition.asQByteArray());
-
-			log_debug("zhttp client: error id=%s cond=%s", id.data(), packet.condition.data());
-
-			state = Stopped;
-			cleanup();
-			q->error();
-			return;
-		}
-		else if(packet.type == ZhttpResponsePacket::Cancel)
-		{
-			log_debug("zhttp client: received cancel id=%s", id.data());
-
-			errored = true;
-			errorCondition = ErrorGeneric;
-			state = Stopped;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		// If non-req mode, check sequencing
-		if(!doReq && seq != inSeq)
-		{
-			log_warning("zhttp client: error id=%s received message out of sequence (expected %d, got %d), canceling", id.data(), inSeq, seq);
-
-			// If this was not an error packet, send cancel
-			if(packet.type != ZhttpResponsePacket::Error && packet.type != ZhttpResponsePacket::Cancel)
-			{
-				ZhttpRequestPacket p;
-				p.type = ZhttpRequestPacket::Cancel;
-				writePacket(p);
-			}
-
-			state = Stopped;
-			errored = true;
-			errorCondition = ErrorGeneric;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		++inSeq;
-
-		if(!multi && packet.multi)
-		{
-			// Switch on multi support
-			multi = true;
-			startKeepAlive(); // Re-setup keep alive
-		}
-
-		refreshTimeout();
-
-		if(doReq && (packet.type != ZhttpResponsePacket::Data || packet.more))
-		{
-			log_warning("zhttp/zws client req: received invalid req response");
-
-			state = Stopped;
-			errored = true;
-			errorCondition = ErrorGeneric;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(packet.type == ZhttpResponsePacket::Data)
-		{
-			bool needToSendHeaders = false;
-
-			if(!haveResponseValues)
-			{
-				haveResponseValues = true;
-
-				responseCode = packet.code;
-				responseReason = packet.reason.asQByteArray();
-				responseHeaders = packet.headers;
-
-				needToSendHeaders = true;
-			}
-
-			if(doReq)
-			{
-				if(responseBodyBuf.size() + packet.body.size() > REQ_BUF_MAX)
-					log_warning("zhttp client req: id=%s server response too large", id.data());
-			}
-			else
-			{
-				if(responseBodyBuf.size() + packet.body.size() > IDEAL_CREDITS)
-					log_warning("zhttp client: id=%s server is sending too fast", id.data());
-			}
-
-			responseBodyBuf += packet.body.asQByteArray();
-
-			if(packet.more)
-			{
-				if(!doReq && packet.credits > 0)
-				{
-					outCredits += packet.credits;
-					writableChanged = true;
-				}
-
-				if(needToSendHeaders || !packet.body.isEmpty())
-					readableChanged = true;
-
-				if(readableChanged || writableChanged)
-					update();
-			}
-			else
-			{
-				// Always emit readyRead here even if body is empty, for EOF
-				state = Stopped;
-				cleanup();
-				q->readyRead();
-			}
-		}
-		else if(packet.type == ZhttpResponsePacket::Credit)
-		{
-			if(packet.credits > 0)
-			{
-				outCredits += packet.credits;
-				writableChanged = true;
-				update();
-			}
-		}
-		else if(packet.type == ZhttpResponsePacket::KeepAlive)
-		{
-			// Nothing to do
-		}
-		else
-		{
-			log_debug("zhttp client: unsupported packet type id=%s type=%d", id.data(), (int)packet.type);
-		}
-	}
-
-	void writeBody(const QByteArray &body)
-	{
-		assert(!bodyFinished);
-		assert(!pausing && !paused);
-
-		if(server)
-			responseBodyBuf += body;
-		else
-			requestBodyBuf += body;
-
-		update();
-	}
-
-	void endBody()
-	{
-		assert(!bodyFinished);
-		assert(!pausing && !paused);
-
-		bodyFinished = true;
-		update();
-	}
-
-	void writePacket(const ZhttpRequestPacket &packet)
-	{
-		assert(manager);
-
-		ZhttpRequestPacket out = packet;
-		out.from = rid.first;
-
-		if(doReq)
-		{
-			out.ids += ZhttpRequestPacket::Id(rid.second);
-
-			manager->writeHttp(out);
-		}
-		else
-		{
-			bool first = (outSeq == 0);
-
-			out.ids += ZhttpRequestPacket::Id(rid.second, outSeq++);
-
-			if(first)
-			{
-				manager->writeHttp(out);
-			}
-			else
-			{
-				assert(!toAddress.isEmpty());
-				manager->writeHttp(out, toAddress);
-			}
-		}
-	}
-
-	void writePacket(const ZhttpResponsePacket &packet)
-	{
-		assert(manager);
-
-		ZhttpResponsePacket out = packet;
-		out.from = manager->instanceId();
-		out.ids += ZhttpResponsePacket::Id(rid.second, outSeq++);
-		out.userData = userData;
-		
-		manager->writeHttp(out, rid.first, routerResp);
-	}
-
-	void writeCancel()
-	{
-		ZhttpResponsePacket out;
-		out.type = ZhttpResponsePacket::Cancel;
-		writePacket(out);
-	}
-
-	void writeError(const QByteArray &condition)
-	{
-		ZhttpResponsePacket out;
-		out.type = ZhttpResponsePacket::Error;
-		out.condition = condition;
-		writePacket(out);
-	}
-
-	void tryCancel()
-	{
-		if(state == ClientRequesting || state == ClientReceiving)
-		{
-			state = Stopped;
-
-			if(!doReq)
-			{
-				ZhttpRequestPacket p;
-				p.type = ZhttpRequestPacket::Cancel;
-				writePacket(p);
-			}
-		}
-		else if(server)
-		{
-			state = Stopped;
-
-			ZhttpResponsePacket p;
-			p.type = ZhttpResponsePacket::Cancel;
-			writePacket(p);
-		}
-	}
-
-	void tryRespondCancel(const ZhttpRequestPacket &packet)
-	{
-		// If this was not an error packet, send cancel
-		if(packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel)
-			writeCancel();
-	}
-
-	static ErrorCondition convertError(const QByteArray &cond)
-	{
-		// Zhttp conditions:
-		//  remote-connection-failed
-		//  connection-timeout
-		//  tls-error
-		//  bad-request
-		//  policy-violation
-		//  max-size-exceeded
-		//  session-timeout
-
-		if(cond == "policy-violation")
-			return ErrorPolicy;
-		else if(cond == "remote-connection-failed")
-			return ErrorConnect;
-		else if(cond == "tls-error")
-			return ErrorTls;
-		else if(cond == "length-required")
-			return ErrorLengthRequired;
-		else if(cond == "connection-timeout")
-			return ErrorConnectTimeout;
-		else if(cond == "disconnected")
-			return ErrorDisconnected;
-		else // Lump the rest as generic
-			return ErrorGeneric;
-	}
-
-	void doUpdate()
-	{
-		pendingUpdate = false;
-
-		if(state == ClientStarting)
-		{
-			if(doReq)
-			{
-				if(requestBodyBuf.size() > REQ_BUF_MAX)
-				{
-					state = Stopped;
-					errored = true;
-					errorCondition = ErrorRequestTooLarge;
-					cleanup();
-					q->error();
-					return;
-				}
-
-				// For req mode, wait until request is fully supplied then send in one packet
-				if(bodyFinished)
-				{
-					ZhttpRequestPacket p;
-					p.type = ZhttpRequestPacket::Data;
-					p.method = requestMethod;
-					p.uri = requestUri;
-					p.headers = requestHeaders;
-					p.body = requestBodyBuf.take();
-					p.maxSize = REQ_BUF_MAX;
-					p.connectHost = connectHost;
-					p.connectPort = connectPort;
-					if(ignorePolicies)
-						p.ignorePolicies = true;
-					if(trustConnectHost)
-						p.trustConnectHost = true;
-					if(ignoreTlsErrors)
-						p.ignoreTlsErrors = true;
-					p.clientCert = clientCert;
-					p.clientKey = clientKey;
-					if(passthrough.isValid())
-						p.passthrough = passthrough;
-					if(quiet)
-						p.quiet = true;
-					writePacket(p);
-
-					state = ClientRequestFinishWait;
-
-					q->bytesWritten(p.body.size());
-				}
-			}
-			else
-			{
-				// NOTE: not quite sure why we do this. Maybe to avoid a
-				// zhttp PUSH/SUB race?
-				if(!manager->canWriteImmediately())
-				{
-					state = Stopped;
-					errored = true;
-					errorCondition = ErrorUnavailable;
-					cleanup();
-					q->error();
-					return;
-				}
-
-				ZhttpRequestPacket p;
-				p.type = ZhttpRequestPacket::Data;
-				p.method = requestMethod;
-				p.uri = requestUri;
-				p.headers = requestHeaders;
-
-				if(!sendBodyAfterAck)
-				{
-					// Even though we don't have credits yet, we can act
-					// like we do on the first packet. We'll still cap
-					// our potential size though.
-					p.body = requestBodyBuf.take(IDEAL_CREDITS);
-				}
-
-				if(!requestBodyBuf.isEmpty() || !bodyFinished)
-					p.more = true;
-				p.stream = true;
-				p.routerResp = true;
-				p.connectHost = connectHost;
-				p.connectPort = connectPort;
-				if(ignorePolicies)
-					p.ignorePolicies = true;
-				if(trustConnectHost)
-					p.trustConnectHost = true;
-				if(ignoreTlsErrors)
-					p.ignoreTlsErrors = true;
-				p.clientCert = clientCert;
-				p.clientKey = clientKey;
-				if(passthrough.isValid())
-					p.passthrough = passthrough;
-				if(quiet)
-					p.quiet = true;
-				p.credits = IDEAL_CREDITS;
-				p.multi = true;
-				writePacket(p);
-
-				if(p.more)
-					state = ClientRequestStartWait;
-				else
-					state = ClientRequestFinishWait;
-
-				if(!p.body.isEmpty())
-					q->bytesWritten(p.body.size());
-				else if(!p.more)
-					q->bytesWritten(0);
-			}
-		}
-		else if(state == ClientRequesting)
-		{
-			std::weak_ptr<Private> self = q->d;
-			tryWrite();
-			if(self.expired())
-				return;
-
-			if(writableChanged)
-			{
-				writableChanged = false;
-				q->writeBytesChanged();
-			}
-		}
-		else if(state == ClientReceiving)
-		{
-			if(readableChanged)
-			{
-				readableChanged = false;
-				q->readyRead();
-			}
-		}
-		else if(state == ServerStarting)
-		{
-			if(haveRequestBody)
-			{
-				state = ServerResponseWait;
-
-				// Send ack
-				ZhttpResponsePacket p;
-				p.type = ZhttpResponsePacket::KeepAlive;
-				if(multi)
-					p.multi = true;
-				writePacket(p);
-			}
-			else
-			{
-				state = ServerReceiving;
-
-				// Send credits ack
-				ZhttpResponsePacket p;
-				p.type = ZhttpResponsePacket::Credit;
-				p.credits = IDEAL_CREDITS - responseBodyBuf.size();
-				if(multi)
-					p.multi = true;
-				writePacket(p);
-			}
-
-			q->readyRead();
-		}
-		else if(state == ServerReceiving)
-		{
-			if(readableChanged)
-			{
-				readableChanged = false;
-				q->readyRead();
-			}
-		}
-		else if(state == ServerResponseWait)
-		{
-			trySendPause();
-
-			if(readableChanged)
-			{
-				readableChanged = false;
-				q->readyRead();
-			}
-		}
-		else if(state == ServerResponseStarting)
-		{
-			state = ServerResponding;
-
-			ZhttpResponsePacket packet;
-			packet.type = ZhttpResponsePacket::Data;
-			packet.code = responseCode;
-			packet.reason = responseReason;
-			packet.headers = responseHeaders;
-			packet.body = responseBodyBuf.take(outCredits);
-			outCredits -= packet.body.size();
-			packet.more = (!responseBodyBuf.isEmpty() || !bodyFinished);
-
-			writePacket(packet);
-
-			if(!packet.more)
-			{
-				state = Stopped;
-				cleanup();
-			}
-
-			std::weak_ptr<Private> self = q->d;
-
-			if(!packet.body.isEmpty())
-				q->bytesWritten(packet.body.size());
-			else if(!packet.more)
-				q->bytesWritten(0);
-
-			if(self.expired())
-				return;
-
-			trySendPause();
-		}
-		else if(state == ServerResponding)
-		{
-			std::weak_ptr<Private> self = q->d;
-			tryWrite();
-			if(self.expired())
-				return;
-
-			if(writableChanged)
-			{
-				writableChanged = false;
-				q->writeBytesChanged();
-			}
-		}
-	}
-
-	void expire_timeout()
-	{
-		state = Stopped;
-		errored = true;
-		errorCondition = ErrorTimeout;
-		cleanup();
-		q->error();
-	}
-
-	void keepAlive_timeout()
-	{
-		if(server)
-		{
-			ZhttpResponsePacket p;
-			p.type = ZhttpResponsePacket::KeepAlive;
-			writePacket(p);
-		}
-		else
-		{
-			ZhttpRequestPacket p;
-			p.type = ZhttpRequestPacket::KeepAlive;
-			writePacket(p);
-		}
-	}
+    enum State {
+        Stopped, // Response finished, error, or not even started
+
+        ClientStarting,          // Prepared to send the first packet
+        ClientRequestStartWait,  // Sent the first packet of streamed input, waiting
+                                 // for ack
+        ClientRequesting,        // Sending the rest of streamed input
+        ClientRequestFinishWait, // Completed sending the request, waiting for ack
+        ClientReceiving,         // Completed sending the request, waiting on response
+
+        ServerStarting,         // Prepared to process the first packet
+        ServerReceiving,        // Receiving the rest of streamed input
+        ServerResponseWait,     // Waiting for the response to start
+        ServerResponseStarting, // About to send the first packet
+        ServerResponding        // Sending the response
+    };
+
+    ZhttpRequest *q;
+    ZhttpManager *manager;
+    bool server;
+    State state;
+    ZhttpRequest::Rid rid;
+    bool doReq;
+    QByteArray toAddress;
+    QHostAddress peerAddress;
+    QString connectHost;
+    int connectPort;
+    bool ignorePolicies;
+    bool trustConnectHost;
+    bool ignoreTlsErrors;
+    int timeout;
+    QString clientCert;
+    QString clientKey;
+    bool sendBodyAfterAck;
+    Variant passthrough;
+    QString requestMethod;
+    Url requestUri;
+    HttpHeaders requestHeaders;
+    BufferList requestBodyBuf;
+    int inSeq;
+    int outSeq;
+    int outCredits;
+    bool bodyFinished; // User has finished providing input
+    int pendingInCredits;
+    bool haveRequestBody;
+    bool haveResponseValues;
+    int responseCode;
+    QByteArray responseReason;
+    HttpHeaders responseHeaders;
+    BufferList responseBodyBuf;
+    Variant userData;
+    bool pausing;
+    bool paused;
+    bool pendingUpdate;
+    bool needPause;
+    bool readableChanged;
+    bool writableChanged;
+    bool errored;
+    ErrorCondition errorCondition;
+    std::unique_ptr<Timer> expireTimer;
+    std::unique_ptr<Timer> keepAliveTimer;
+    std::unique_ptr<Timer> finishTimer;
+    bool multi;
+    bool routerResp;
+    bool quiet;
+    DeferCall deferCall;
+
+    Private(ZhttpRequest *_q)
+        : q(_q),
+          manager(0),
+          server(false),
+          state(Stopped),
+          doReq(false),
+          connectPort(-1),
+          ignorePolicies(false),
+          trustConnectHost(false),
+          ignoreTlsErrors(false),
+          timeout(0),
+          sendBodyAfterAck(false),
+          inSeq(0),
+          outSeq(0),
+          outCredits(0),
+          bodyFinished(false),
+          pendingInCredits(0),
+          haveRequestBody(false),
+          haveResponseValues(false),
+          pausing(false),
+          paused(false),
+          pendingUpdate(false),
+          needPause(false),
+          readableChanged(false),
+          writableChanged(false),
+          errored(false),
+          multi(false),
+          routerResp(false),
+          quiet(false) {
+        expireTimer = std::make_unique<Timer>();
+        expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
+        expireTimer->setSingleShot(true);
+
+        keepAliveTimer = std::make_unique<Timer>();
+        keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
+    }
+
+    ~Private() {
+        if (manager && !paused && state != Stopped)
+            tryCancel();
+
+        cleanup();
+    }
+
+    void cleanup() {
+        needPause = false;
+        readableChanged = false;
+        writableChanged = false;
+
+        expireTimer.reset();
+        keepAliveTimer.reset();
+        finishTimer.reset();
+
+        if (manager) {
+            manager->unregisterKeepAlive(q);
+
+            manager->unlink(q);
+            manager = 0;
+        }
+    }
+
+    bool setupServer(int seq, const ZhttpRequestPacket &packet) {
+        if (packet.type != ZhttpRequestPacket::Data) {
+            log_warning("zhttp server: received request with invalid type, canceling");
+            tryRespondCancel(packet);
+            return false;
+        }
+
+        if (seq != -1 && seq != 0) {
+            log_warning("zhttp server: error, received request with non-zero seq field");
+            writeError("bad-request");
+            state = Stopped;
+            return false;
+        }
+
+        if (!packet.stream) {
+            log_warning("zhttp server: error, received request for non-stream response");
+            writeError("bad-request");
+            state = Stopped;
+            return false;
+        }
+
+        if (seq == -1 && packet.more) {
+            log_warning("zhttp server: error, received stream request with no seq field");
+            writeError("bad-request");
+            state = Stopped;
+            return false;
+        }
+
+        inSeq = 1; // Next expected seq
+
+        if (packet.credits != -1)
+            outCredits = packet.credits;
+
+        requestMethod = packet.method.asQString();
+        requestUri = packet.uri;
+        requestHeaders = packet.headers;
+        requestBodyBuf += packet.body.asQByteArray();
+
+        passthrough = packet.passthrough;
+
+        userData = packet.userData;
+        peerAddress = packet.peerAddress;
+
+        if (packet.multi)
+            multi = true;
+
+        if (packet.routerResp)
+            routerResp = true;
+
+        if (!packet.more)
+            haveRequestBody = true;
+
+        return true;
+    }
+
+    void setupServer(const ZhttpRequest::ServerState &ss) {
+        peerAddress = ss.peerAddress;
+        requestMethod = ss.requestMethod;
+        requestUri = ss.requestUri;
+        requestHeaders = ss.requestHeaders;
+        requestBodyBuf += ss.requestBody;
+        if (ss.inSeq >= 0)
+            inSeq = ss.inSeq;
+        if (ss.outSeq >= 0)
+            outSeq = ss.outSeq;
+        if (ss.outCredits >= 0)
+            outCredits = ss.outCredits;
+        routerResp = ss.routerResp;
+        userData = ss.userData;
+
+        if (ss.responseCode != -1) {
+            responseCode = ss.responseCode;
+            state = ServerResponding;
+        } else {
+            state = ServerResponseWait;
+        }
+
+        refreshTimeout();
+        startKeepAlive();
+
+        // Send a keep-alive right away to accept after handoff
+        ZhttpResponsePacket p;
+        p.type = ZhttpResponsePacket::KeepAlive;
+        p.multi = true; // Request multi support
+        writePacket(p);
+    }
+
+    void startClient() {
+        state = ClientStarting;
+
+        if (timeout > 0) {
+            finishTimer = std::make_unique<Timer>();
+            finishTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
+            finishTimer->setSingleShot(true);
+            finishTimer->start(timeout);
+        }
+
+        refreshTimeout();
+        update();
+    }
+
+    void startServer() {
+        state = ServerStarting;
+
+        startKeepAlive();
+        refreshTimeout();
+        update();
+    }
+
+    void pause() {
+        assert(!pausing && !paused);
+        assert(!doReq);
+
+        stopKeepAlive();
+
+        pausing = true;
+        needPause = true;
+
+        update();
+    }
+
+    void resume() {
+        assert(paused);
+        paused = false;
+
+        startKeepAlive();
+
+        ZhttpResponsePacket p;
+        p.type = ZhttpResponsePacket::KeepAlive;
+        writePacket(p);
+    }
+
+    void beginResponse() {
+        assert(!pausing && !paused);
+        state = ServerResponseStarting;
+        update();
+    }
+
+    void startKeepAlive() {
+        if (multi) {
+            if (keepAliveTimer->isActive()) {
+                // Need to flush the current keepalive, since the
+                // manager registration may extend the timeout
+                keepAlive_timeout();
+
+                keepAliveTimer->stop();
+            }
+
+            manager->registerKeepAlive(q);
+        } else {
+            manager->unregisterKeepAlive(q);
+
+            if (!keepAliveTimer->isActive())
+                keepAliveTimer->start(KEEPALIVE_INTERVAL);
+        }
+    }
+
+    void stopKeepAlive() {
+        if (keepAliveTimer->isActive())
+            keepAliveTimer->stop();
+
+        manager->unregisterKeepAlive(q);
+    }
+
+    void refreshTimeout() { expireTimer->start(SESSION_EXPIRE); }
+
+    void update() {
+        if (!pendingUpdate) {
+            pendingUpdate = true;
+            deferCall.defer([&]() { doUpdate(); });
+        }
+    }
+
+    QByteArray readBody(int size) {
+        if (server) {
+            QByteArray out = requestBodyBuf.take(size);
+            if (out.isEmpty())
+                return out;
+
+            pendingInCredits += out.size();
+
+            if (!pausing && !paused) {
+                ZhttpResponsePacket p;
+                p.type = ZhttpResponsePacket::Credit;
+                p.credits = pendingInCredits;
+                pendingInCredits = 0;
+                writePacket(p);
+            }
+
+            return out;
+        } else {
+            QByteArray out = responseBodyBuf.take(size);
+            if (out.isEmpty())
+                return out;
+
+            pendingInCredits += out.size();
+
+            if (state == ClientReceiving)
+                tryWrite(); // This should not emit signals in current state
+
+            return out;
+        }
+    }
+
+    void tryWrite() {
+        std::weak_ptr<Private> self = q->d;
+
+        if (state == ClientRequesting) {
+            // If all we have to send is EOF, we don't need credits for that
+            if (requestBodyBuf.isEmpty() && bodyFinished) {
+                state = ClientReceiving;
+
+                ZhttpRequestPacket p;
+                p.type = ZhttpRequestPacket::Data;
+                writePacket(p);
+
+                q->bytesWritten(0);
+            } else if (!requestBodyBuf.isEmpty() && outCredits > 0) {
+                // If we have data to send, and the credits to do so, then send data.
+                // also send credits if we need to.
+
+                QByteArray buf = requestBodyBuf.take(outCredits);
+
+                outCredits -= buf.size();
+                writableChanged = true;
+
+                ZhttpRequestPacket p;
+                p.type = ZhttpRequestPacket::Data;
+                p.body = buf;
+                if (!requestBodyBuf.isEmpty() || !bodyFinished)
+                    p.more = true;
+                if (pendingInCredits > 0) {
+                    p.credits = pendingInCredits;
+                    pendingInCredits = 0;
+                }
+
+                if (!p.more)
+                    state = ClientReceiving;
+
+                writePacket(p);
+
+                q->bytesWritten(buf.size());
+            }
+        } else if (state == ClientReceiving) {
+            if (pendingInCredits > 0) {
+                // If we have no data to send but we need to send credits, do at least
+                // that
+                ZhttpRequestPacket p;
+                p.type = ZhttpRequestPacket::Credit;
+                p.credits = pendingInCredits;
+                pendingInCredits = 0;
+
+                writePacket(p);
+            }
+        } else if (state == ServerResponding) {
+            if ((!responseBodyBuf.isEmpty() && outCredits > 0) ||
+                (responseBodyBuf.isEmpty() && bodyFinished)) {
+                ZhttpResponsePacket packet;
+                packet.type = ZhttpResponsePacket::Data;
+                packet.body = responseBodyBuf.take(outCredits);
+
+                outCredits -= packet.body.size();
+                if (!packet.body.isEmpty())
+                    writableChanged = true;
+
+                packet.more = (!responseBodyBuf.isEmpty() || !bodyFinished);
+
+                writePacket(packet);
+
+                if (!packet.more) {
+                    state = Stopped;
+                    cleanup();
+                }
+
+                q->bytesWritten(packet.body.size());
+            }
+        }
+
+        if (self.expired())
+            return;
+
+        trySendPause();
+    }
+
+    void trySendPause() {
+        if (needPause && (state == ServerResponseWait || state == ServerResponding) &&
+            responseBodyBuf.isEmpty()) {
+            needPause = false;
+
+            ZhttpResponsePacket p;
+            p.type = ZhttpResponsePacket::HandoffStart;
+            writePacket(p);
+        }
+    }
+
+    void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet) {
+        if (paused)
+            return;
+
+        if (packet.type == ZhttpRequestPacket::Error) {
+            errored = true;
+            errorCondition = convertError(packet.condition.asQByteArray());
+
+            log_debug("zhttp server: error id=%s cond=%s", id.data(), packet.condition.data());
+
+            state = Stopped;
+            cleanup();
+            q->error();
+            return;
+        } else if (packet.type == ZhttpRequestPacket::Cancel) {
+            log_debug("zhttp server: received cancel id=%s", id.data());
+
+            errored = true;
+            errorCondition = ErrorGeneric;
+            state = Stopped;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (seq != -1) {
+            if (seq != inSeq) {
+                log_warning("zhttp server: error id=%s received message out of "
+                            "sequence (expected %d, got %d), canceling",
+                            id.data(), inSeq, seq);
+
+                // If this was not an error packet, send cancel
+                if (packet.type != ZhttpRequestPacket::Error &&
+                    packet.type != ZhttpRequestPacket::Cancel) {
+                    ZhttpResponsePacket p;
+                    p.type = ZhttpResponsePacket::Cancel;
+                    writePacket(p);
+                }
+
+                state = Stopped;
+                errored = true;
+                errorCondition = ErrorGeneric;
+                cleanup();
+                q->error();
+                return;
+            }
+
+            ++inSeq;
+        }
+
+        if (!multi && packet.multi) {
+            // Switch on multi support
+            multi = true;
+
+            if (!pausing) {
+                // Re-setup keep alive
+                startKeepAlive();
+            }
+        }
+
+        refreshTimeout();
+
+        if (packet.type == ZhttpRequestPacket::Data) {
+            requestBodyBuf += packet.body.asQByteArray();
+
+            bool done = haveRequestBody;
+
+            if (!packet.more) {
+                haveRequestBody = true;
+                state = ServerResponseWait;
+            }
+
+            if (packet.credits > 0) {
+                outCredits += packet.credits;
+                writableChanged = true;
+            }
+
+            if (!packet.body.isEmpty() || (!done && haveRequestBody))
+                readableChanged = true;
+
+            if (readableChanged || writableChanged)
+                update();
+        } else if (packet.type == ZhttpRequestPacket::Credit) {
+            if (packet.credits > 0) {
+                outCredits += packet.credits;
+                writableChanged = true;
+                update();
+            }
+        } else if (packet.type == ZhttpRequestPacket::KeepAlive) {
+            // Nothing to do
+        } else if (packet.type == ZhttpRequestPacket::HandoffProceed) {
+            if (pausing) {
+                pausing = false;
+                paused = true;
+                q->paused();
+            }
+        } else {
+            log_debug("zhttp server: unsupported packet type id=%s type=%d", id.data(),
+                      (int)packet.type);
+        }
+    }
+
+    void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet) {
+        if (state == ClientRequestStartWait) {
+            if (packet.from.isEmpty()) {
+                state = Stopped;
+                errored = true;
+                errorCondition = ErrorGeneric;
+                cleanup();
+                log_warning("zhttp client: error id=%s initial ack for streamed input "
+                            "request did not contain from field",
+                            id.data());
+                q->error();
+                return;
+            }
+
+            toAddress = packet.from.asQByteArray();
+
+            state = ClientRequesting;
+
+            startKeepAlive();
+        } else if (state == ClientRequestFinishWait) {
+            toAddress = packet.from.asQByteArray();
+
+            state = ClientReceiving;
+
+            if (!doReq)
+                startKeepAlive();
+        }
+
+        if (packet.type == ZhttpResponsePacket::Error) {
+            errored = true;
+            errorCondition = convertError(packet.condition.asQByteArray());
+
+            log_debug("zhttp client: error id=%s cond=%s", id.data(), packet.condition.data());
+
+            state = Stopped;
+            cleanup();
+            q->error();
+            return;
+        } else if (packet.type == ZhttpResponsePacket::Cancel) {
+            log_debug("zhttp client: received cancel id=%s", id.data());
+
+            errored = true;
+            errorCondition = ErrorGeneric;
+            state = Stopped;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        // If non-req mode, check sequencing
+        if (!doReq && seq != inSeq) {
+            log_warning("zhttp client: error id=%s received message out of sequence "
+                        "(expected %d, got %d), canceling",
+                        id.data(), inSeq, seq);
+
+            // If this was not an error packet, send cancel
+            if (packet.type != ZhttpResponsePacket::Error &&
+                packet.type != ZhttpResponsePacket::Cancel) {
+                ZhttpRequestPacket p;
+                p.type = ZhttpRequestPacket::Cancel;
+                writePacket(p);
+            }
+
+            state = Stopped;
+            errored = true;
+            errorCondition = ErrorGeneric;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        ++inSeq;
+
+        if (!multi && packet.multi) {
+            // Switch on multi support
+            multi = true;
+            startKeepAlive(); // Re-setup keep alive
+        }
+
+        refreshTimeout();
+
+        if (doReq && (packet.type != ZhttpResponsePacket::Data || packet.more)) {
+            log_warning("zhttp/zws client req: received invalid req response");
+
+            state = Stopped;
+            errored = true;
+            errorCondition = ErrorGeneric;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (packet.type == ZhttpResponsePacket::Data) {
+            bool needToSendHeaders = false;
+
+            if (!haveResponseValues) {
+                haveResponseValues = true;
+
+                responseCode = packet.code;
+                responseReason = packet.reason.asQByteArray();
+                responseHeaders = packet.headers;
+
+                needToSendHeaders = true;
+            }
+
+            if (doReq) {
+                if (responseBodyBuf.size() + packet.body.size() > REQ_BUF_MAX)
+                    log_warning("zhttp client req: id=%s server response too large", id.data());
+            } else {
+                if (responseBodyBuf.size() + packet.body.size() > IDEAL_CREDITS)
+                    log_warning("zhttp client: id=%s server is sending too fast", id.data());
+            }
+
+            responseBodyBuf += packet.body.asQByteArray();
+
+            if (packet.more) {
+                if (!doReq && packet.credits > 0) {
+                    outCredits += packet.credits;
+                    writableChanged = true;
+                }
+
+                if (needToSendHeaders || !packet.body.isEmpty())
+                    readableChanged = true;
+
+                if (readableChanged || writableChanged)
+                    update();
+            } else {
+                // Always emit readyRead here even if body is empty, for EOF
+                state = Stopped;
+                cleanup();
+                q->readyRead();
+            }
+        } else if (packet.type == ZhttpResponsePacket::Credit) {
+            if (packet.credits > 0) {
+                outCredits += packet.credits;
+                writableChanged = true;
+                update();
+            }
+        } else if (packet.type == ZhttpResponsePacket::KeepAlive) {
+            // Nothing to do
+        } else {
+            log_debug("zhttp client: unsupported packet type id=%s type=%d", id.data(),
+                      (int)packet.type);
+        }
+    }
+
+    void writeBody(const QByteArray &body) {
+        assert(!bodyFinished);
+        assert(!pausing && !paused);
+
+        if (server)
+            responseBodyBuf += body;
+        else
+            requestBodyBuf += body;
+
+        update();
+    }
+
+    void endBody() {
+        assert(!bodyFinished);
+        assert(!pausing && !paused);
+
+        bodyFinished = true;
+        update();
+    }
+
+    void writePacket(const ZhttpRequestPacket &packet) {
+        assert(manager);
+
+        ZhttpRequestPacket out = packet;
+        out.from = rid.first;
+
+        if (doReq) {
+            out.ids += ZhttpRequestPacket::Id(rid.second);
+
+            manager->writeHttp(out);
+        } else {
+            bool first = (outSeq == 0);
+
+            out.ids += ZhttpRequestPacket::Id(rid.second, outSeq++);
+
+            if (first) {
+                manager->writeHttp(out);
+            } else {
+                assert(!toAddress.isEmpty());
+                manager->writeHttp(out, toAddress);
+            }
+        }
+    }
+
+    void writePacket(const ZhttpResponsePacket &packet) {
+        assert(manager);
+
+        ZhttpResponsePacket out = packet;
+        out.from = manager->instanceId();
+        out.ids += ZhttpResponsePacket::Id(rid.second, outSeq++);
+        out.userData = userData;
+
+        manager->writeHttp(out, rid.first, routerResp);
+    }
+
+    void writeCancel() {
+        ZhttpResponsePacket out;
+        out.type = ZhttpResponsePacket::Cancel;
+        writePacket(out);
+    }
+
+    void writeError(const QByteArray &condition) {
+        ZhttpResponsePacket out;
+        out.type = ZhttpResponsePacket::Error;
+        out.condition = condition;
+        writePacket(out);
+    }
+
+    void tryCancel() {
+        if (state == ClientRequesting || state == ClientReceiving) {
+            state = Stopped;
+
+            if (!doReq) {
+                ZhttpRequestPacket p;
+                p.type = ZhttpRequestPacket::Cancel;
+                writePacket(p);
+            }
+        } else if (server) {
+            state = Stopped;
+
+            ZhttpResponsePacket p;
+            p.type = ZhttpResponsePacket::Cancel;
+            writePacket(p);
+        }
+    }
+
+    void tryRespondCancel(const ZhttpRequestPacket &packet) {
+        // If this was not an error packet, send cancel
+        if (packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel)
+            writeCancel();
+    }
+
+    static ErrorCondition convertError(const QByteArray &cond) {
+        // Zhttp conditions:
+        //  remote-connection-failed
+        //  connection-timeout
+        //  tls-error
+        //  bad-request
+        //  policy-violation
+        //  max-size-exceeded
+        //  session-timeout
+
+        if (cond == "policy-violation")
+            return ErrorPolicy;
+        else if (cond == "remote-connection-failed")
+            return ErrorConnect;
+        else if (cond == "tls-error")
+            return ErrorTls;
+        else if (cond == "length-required")
+            return ErrorLengthRequired;
+        else if (cond == "connection-timeout")
+            return ErrorConnectTimeout;
+        else if (cond == "disconnected")
+            return ErrorDisconnected;
+        else // Lump the rest as generic
+            return ErrorGeneric;
+    }
+
+    void doUpdate() {
+        pendingUpdate = false;
+
+        if (state == ClientStarting) {
+            if (doReq) {
+                if (requestBodyBuf.size() > REQ_BUF_MAX) {
+                    state = Stopped;
+                    errored = true;
+                    errorCondition = ErrorRequestTooLarge;
+                    cleanup();
+                    q->error();
+                    return;
+                }
+
+                // For req mode, wait until request is fully supplied then send in one
+                // packet
+                if (bodyFinished) {
+                    ZhttpRequestPacket p;
+                    p.type = ZhttpRequestPacket::Data;
+                    p.method = requestMethod;
+                    p.uri = requestUri;
+                    p.headers = requestHeaders;
+                    p.body = requestBodyBuf.take();
+                    p.maxSize = REQ_BUF_MAX;
+                    p.connectHost = connectHost;
+                    p.connectPort = connectPort;
+                    if (ignorePolicies)
+                        p.ignorePolicies = true;
+                    if (trustConnectHost)
+                        p.trustConnectHost = true;
+                    if (ignoreTlsErrors)
+                        p.ignoreTlsErrors = true;
+                    p.clientCert = clientCert;
+                    p.clientKey = clientKey;
+                    if (passthrough.isValid())
+                        p.passthrough = passthrough;
+                    if (quiet)
+                        p.quiet = true;
+                    writePacket(p);
+
+                    state = ClientRequestFinishWait;
+
+                    q->bytesWritten(p.body.size());
+                }
+            } else {
+                // NOTE: not quite sure why we do this. Maybe to avoid a
+                // zhttp PUSH/SUB race?
+                if (!manager->canWriteImmediately()) {
+                    state = Stopped;
+                    errored = true;
+                    errorCondition = ErrorUnavailable;
+                    cleanup();
+                    q->error();
+                    return;
+                }
+
+                ZhttpRequestPacket p;
+                p.type = ZhttpRequestPacket::Data;
+                p.method = requestMethod;
+                p.uri = requestUri;
+                p.headers = requestHeaders;
+
+                if (!sendBodyAfterAck) {
+                    // Even though we don't have credits yet, we can act
+                    // like we do on the first packet. We'll still cap
+                    // our potential size though.
+                    p.body = requestBodyBuf.take(IDEAL_CREDITS);
+                }
+
+                if (!requestBodyBuf.isEmpty() || !bodyFinished)
+                    p.more = true;
+                p.stream = true;
+                p.routerResp = true;
+                p.connectHost = connectHost;
+                p.connectPort = connectPort;
+                if (ignorePolicies)
+                    p.ignorePolicies = true;
+                if (trustConnectHost)
+                    p.trustConnectHost = true;
+                if (ignoreTlsErrors)
+                    p.ignoreTlsErrors = true;
+                p.clientCert = clientCert;
+                p.clientKey = clientKey;
+                if (passthrough.isValid())
+                    p.passthrough = passthrough;
+                if (quiet)
+                    p.quiet = true;
+                p.credits = IDEAL_CREDITS;
+                p.multi = true;
+                writePacket(p);
+
+                if (p.more)
+                    state = ClientRequestStartWait;
+                else
+                    state = ClientRequestFinishWait;
+
+                if (!p.body.isEmpty())
+                    q->bytesWritten(p.body.size());
+                else if (!p.more)
+                    q->bytesWritten(0);
+            }
+        } else if (state == ClientRequesting) {
+            std::weak_ptr<Private> self = q->d;
+            tryWrite();
+            if (self.expired())
+                return;
+
+            if (writableChanged) {
+                writableChanged = false;
+                q->writeBytesChanged();
+            }
+        } else if (state == ClientReceiving) {
+            if (readableChanged) {
+                readableChanged = false;
+                q->readyRead();
+            }
+        } else if (state == ServerStarting) {
+            if (haveRequestBody) {
+                state = ServerResponseWait;
+
+                // Send ack
+                ZhttpResponsePacket p;
+                p.type = ZhttpResponsePacket::KeepAlive;
+                if (multi)
+                    p.multi = true;
+                writePacket(p);
+            } else {
+                state = ServerReceiving;
+
+                // Send credits ack
+                ZhttpResponsePacket p;
+                p.type = ZhttpResponsePacket::Credit;
+                p.credits = IDEAL_CREDITS - responseBodyBuf.size();
+                if (multi)
+                    p.multi = true;
+                writePacket(p);
+            }
+
+            q->readyRead();
+        } else if (state == ServerReceiving) {
+            if (readableChanged) {
+                readableChanged = false;
+                q->readyRead();
+            }
+        } else if (state == ServerResponseWait) {
+            trySendPause();
+
+            if (readableChanged) {
+                readableChanged = false;
+                q->readyRead();
+            }
+        } else if (state == ServerResponseStarting) {
+            state = ServerResponding;
+
+            ZhttpResponsePacket packet;
+            packet.type = ZhttpResponsePacket::Data;
+            packet.code = responseCode;
+            packet.reason = responseReason;
+            packet.headers = responseHeaders;
+            packet.body = responseBodyBuf.take(outCredits);
+            outCredits -= packet.body.size();
+            packet.more = (!responseBodyBuf.isEmpty() || !bodyFinished);
+
+            writePacket(packet);
+
+            if (!packet.more) {
+                state = Stopped;
+                cleanup();
+            }
+
+            std::weak_ptr<Private> self = q->d;
+
+            if (!packet.body.isEmpty())
+                q->bytesWritten(packet.body.size());
+            else if (!packet.more)
+                q->bytesWritten(0);
+
+            if (self.expired())
+                return;
+
+            trySendPause();
+        } else if (state == ServerResponding) {
+            std::weak_ptr<Private> self = q->d;
+            tryWrite();
+            if (self.expired())
+                return;
+
+            if (writableChanged) {
+                writableChanged = false;
+                q->writeBytesChanged();
+            }
+        }
+    }
+
+    void expire_timeout() {
+        state = Stopped;
+        errored = true;
+        errorCondition = ErrorTimeout;
+        cleanup();
+        q->error();
+    }
+
+    void keepAlive_timeout() {
+        if (server) {
+            ZhttpResponsePacket p;
+            p.type = ZhttpResponsePacket::KeepAlive;
+            writePacket(p);
+        } else {
+            ZhttpRequestPacket p;
+            p.type = ZhttpRequestPacket::KeepAlive;
+            writePacket(p);
+        }
+    }
 };
 
-ZhttpRequest::ZhttpRequest()
-{
-	d = std::make_shared<Private>(this);
-}
+ZhttpRequest::ZhttpRequest() { d = std::make_shared<Private>(this); }
 
 ZhttpRequest::~ZhttpRequest() = default;
 
-ZhttpRequest::Rid ZhttpRequest::rid() const
-{
-	return d->rid;
+ZhttpRequest::Rid ZhttpRequest::rid() const { return d->rid; }
+
+Variant ZhttpRequest::passthroughData() const { return d->passthrough; }
+
+QHostAddress ZhttpRequest::peerAddress() const { return d->peerAddress; }
+
+void ZhttpRequest::setConnectHost(const QString &host) { d->connectHost = host; }
+
+void ZhttpRequest::setConnectPort(int port) { d->connectPort = port; }
+
+void ZhttpRequest::setIgnorePolicies(bool on) { d->ignorePolicies = on; }
+
+void ZhttpRequest::setTrustConnectHost(bool on) { d->trustConnectHost = on; }
+
+void ZhttpRequest::setIgnoreTlsErrors(bool on) { d->ignoreTlsErrors = on; }
+
+void ZhttpRequest::setTimeout(int msecs) { d->timeout = msecs; }
+
+void ZhttpRequest::setClientCert(const QString &cert, const QString &key) {
+    d->clientCert = cert;
+    d->clientKey = key;
 }
 
-Variant ZhttpRequest::passthroughData() const
-{
-	return d->passthrough;
+void ZhttpRequest::setIsTls(bool on) { d->requestUri.setScheme(on ? "https" : "http"); }
+
+void ZhttpRequest::setSendBodyAfterAcknowledgement(bool on) { d->sendBodyAfterAck = on; }
+
+void ZhttpRequest::setPassthroughData(const Variant &data) { d->passthrough = data; }
+
+void ZhttpRequest::setQuiet(bool on) { d->quiet = on; }
+
+void ZhttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers) {
+    assert(!d->server);
+
+    d->requestMethod = method;
+    d->requestUri = uri;
+    d->requestHeaders = headers;
+    d->startClient();
 }
 
-QHostAddress ZhttpRequest::peerAddress() const
-{
-	return d->peerAddress;
+void ZhttpRequest::beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) {
+    assert(d->server);
+    assert(d->state == Private::ServerReceiving || d->state == Private::ServerResponseWait);
+
+    d->responseCode = code;
+    d->responseReason = reason;
+    d->responseHeaders = headers;
+    d->beginResponse();
 }
 
-void ZhttpRequest::setConnectHost(const QString &host)
-{
-	d->connectHost = host;
+void ZhttpRequest::writeBody(const QByteArray &body) { d->writeBody(body); }
+
+void ZhttpRequest::endBody() { d->endBody(); }
+
+void ZhttpRequest::pause() {
+    assert(d->server);
+    d->pause();
 }
 
-void ZhttpRequest::setConnectPort(int port)
-{
-	d->connectPort = port;
+void ZhttpRequest::resume() {
+    assert(d->server);
+    d->resume();
 }
 
-void ZhttpRequest::setIgnorePolicies(bool on)
-{
-	d->ignorePolicies = on;
+ZhttpRequest::ServerState ZhttpRequest::serverState() const {
+    ServerState ss;
+    ss.peerAddress = d->peerAddress;
+    ss.requestMethod = d->requestMethod;
+    ss.requestUri = d->requestUri;
+    ss.requestHeaders = d->requestHeaders;
+    if (d->state == Private::ServerResponding)
+        ss.responseCode = d->responseCode;
+    ss.inSeq = d->inSeq;
+    ss.outSeq = d->outSeq;
+    ss.outCredits = d->outCredits;
+    ss.routerResp = d->routerResp;
+    ss.userData = d->userData;
+    return ss;
 }
 
-void ZhttpRequest::setTrustConnectHost(bool on)
-{
-	d->trustConnectHost = on;
+int ZhttpRequest::bytesAvailable() const {
+    if (d->server)
+        return d->requestBodyBuf.size();
+    else
+        return d->responseBodyBuf.size();
 }
 
-void ZhttpRequest::setIgnoreTlsErrors(bool on)
-{
-	d->ignoreTlsErrors = on;
+int ZhttpRequest::writeBytesAvailable() const {
+    if (d->server && d->responseBodyBuf.size() < d->outCredits)
+        return d->outCredits - d->responseBodyBuf.size();
+    else if (!d->server && d->requestBodyBuf.size() < d->outCredits)
+        return d->outCredits - d->requestBodyBuf.size();
+    else
+        return 0;
 }
 
-void ZhttpRequest::setTimeout(int msecs)
-{
-	d->timeout = msecs;
+bool ZhttpRequest::isFinished() const { return d->state == Private::Stopped; }
+
+bool ZhttpRequest::isInputFinished() const {
+    if (d->server)
+        return (d->state == Private::Stopped || d->state == Private::ServerResponseWait ||
+                d->state == Private::ServerResponseStarting ||
+                d->state == Private::ServerResponding);
+    else
+        return (d->state == Private::Stopped);
 }
 
-void ZhttpRequest::setClientCert(const QString &cert, const QString &key)
-{
-	d->clientCert = cert;
-	d->clientKey = key;
+bool ZhttpRequest::isOutputFinished() const {
+    if (d->server)
+        return (d->state == Private::Stopped);
+    else
+        return (d->state == Private::Stopped || d->state == Private::ClientRequestFinishWait ||
+                d->state == Private::ClientReceiving);
 }
 
-void ZhttpRequest::setIsTls(bool on)
-{
-	d->requestUri.setScheme(on ? "https" : "http");
+bool ZhttpRequest::isErrored() const { return d->errored; }
+
+HttpRequest::ErrorCondition ZhttpRequest::errorCondition() const { return d->errorCondition; }
+
+QString ZhttpRequest::requestMethod() const { return d->requestMethod; }
+
+Url ZhttpRequest::requestUri() const { return d->requestUri; }
+
+HttpHeaders ZhttpRequest::requestHeaders() const { return d->requestHeaders; }
+
+int ZhttpRequest::responseCode() const { return d->responseCode; }
+
+QByteArray ZhttpRequest::responseReason() const { return d->responseReason; }
+
+HttpHeaders ZhttpRequest::responseHeaders() const { return d->responseHeaders; }
+
+QByteArray ZhttpRequest::readBody(int size) { return d->readBody(size); }
+
+void ZhttpRequest::setupClient(ZhttpManager *manager, bool req) {
+    d->manager = manager;
+    d->rid = Rid(manager->instanceId(), UuidUtil::createUuid());
+    d->doReq = req;
+    d->manager->link(this);
 }
 
-void ZhttpRequest::setSendBodyAfterAcknowledgement(bool on)
-{
-	d->sendBodyAfterAck = on;
+bool ZhttpRequest::setupServer(ZhttpManager *manager, const QByteArray &id, int seq,
+                               const ZhttpRequestPacket &packet) {
+    d->manager = manager;
+    d->server = true;
+    d->rid = Rid(packet.from.asQByteArray(), id);
+    return d->setupServer(seq, packet);
 }
 
-void ZhttpRequest::setPassthroughData(const Variant &data)
-{
-	d->passthrough = data;
+void ZhttpRequest::setupServer(ZhttpManager *manager, const ZhttpRequest::ServerState &state) {
+    d->manager = manager;
+    d->server = true;
+    d->rid = state.rid;
+    d->manager->link(this);
+    d->setupServer(state);
 }
 
-void ZhttpRequest::setQuiet(bool on)
-{
-	d->quiet = on;
+void ZhttpRequest::startServer() { d->startServer(); }
+
+bool ZhttpRequest::isServer() const { return d->server; }
+
+QByteArray ZhttpRequest::toAddress() const { return d->toAddress; }
+
+bool ZhttpRequest::routerResp() const { return d->routerResp; }
+
+int ZhttpRequest::outSeqInc() { return d->outSeq++; }
+
+void ZhttpRequest::handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet) {
+    assert(d->manager);
+
+    d->handle(id, seq, packet);
 }
 
-void ZhttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers)
-{
-	assert(!d->server);
+void ZhttpRequest::handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet) {
+    assert(d->manager);
 
-	d->requestMethod = method;
-	d->requestUri = uri;
-	d->requestHeaders = headers;
-	d->startClient();
-}
-
-void ZhttpRequest::beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers)
-{
-	assert(d->server);
-	assert(d->state == Private::ServerReceiving || d->state == Private::ServerResponseWait);
-
-	d->responseCode = code;
-	d->responseReason = reason;
-	d->responseHeaders = headers;
-	d->beginResponse();
-}
-
-void ZhttpRequest::writeBody(const QByteArray &body)
-{
-	d->writeBody(body);
-}
-
-void ZhttpRequest::endBody()
-{
-	d->endBody();
-}
-
-void ZhttpRequest::pause()
-{
-	assert(d->server);
-	d->pause();
-}
-
-void ZhttpRequest::resume()
-{
-	assert(d->server);
-	d->resume();
-}
-
-ZhttpRequest::ServerState ZhttpRequest::serverState() const
-{
-	ServerState ss;
-	ss.peerAddress = d->peerAddress;
-	ss.requestMethod = d->requestMethod;
-	ss.requestUri = d->requestUri;
-	ss.requestHeaders = d->requestHeaders;
-	if(d->state == Private::ServerResponding)
-		ss.responseCode = d->responseCode;
-	ss.inSeq = d->inSeq;
-	ss.outSeq = d->outSeq;
-	ss.outCredits = d->outCredits;
-	ss.routerResp = d->routerResp;
-	ss.userData = d->userData;
-	return ss;
-}
-
-int ZhttpRequest::bytesAvailable() const
-{
-	if(d->server)
-		return d->requestBodyBuf.size();
-	else
-		return d->responseBodyBuf.size();
-}
-
-int ZhttpRequest::writeBytesAvailable() const
-{
-	if(d->server && d->responseBodyBuf.size() < d->outCredits)
-		return d->outCredits - d->responseBodyBuf.size();
-	else if(!d->server && d->requestBodyBuf.size() < d->outCredits)
-		return d->outCredits - d->requestBodyBuf.size();
-	else
-		return 0;
-}
-
-bool ZhttpRequest::isFinished() const
-{
-	return d->state == Private::Stopped;
-}
-
-bool ZhttpRequest::isInputFinished() const
-{
-	if(d->server)
-		return (d->state == Private::Stopped || d->state == Private::ServerResponseWait || d->state == Private::ServerResponseStarting || d->state == Private::ServerResponding);
-	else
-		return (d->state == Private::Stopped);
-}
-
-bool ZhttpRequest::isOutputFinished() const
-{
-	if(d->server)
-		return (d->state == Private::Stopped);
-	else
-		return (d->state == Private::Stopped || d->state == Private::ClientRequestFinishWait || d->state == Private::ClientReceiving);
-}
-
-bool ZhttpRequest::isErrored() const
-{
-	return d->errored;
-}
-
-HttpRequest::ErrorCondition ZhttpRequest::errorCondition() const
-{
-	return d->errorCondition;
-}
-
-QString ZhttpRequest::requestMethod() const
-{
-	return d->requestMethod;
-}
-
-Url ZhttpRequest::requestUri() const
-{
-	return d->requestUri;
-}
-
-HttpHeaders ZhttpRequest::requestHeaders() const
-{
-	return d->requestHeaders;
-}
-
-int ZhttpRequest::responseCode() const
-{
-	return d->responseCode;
-}
-
-QByteArray ZhttpRequest::responseReason() const
-{
-	return d->responseReason;
-}
-
-HttpHeaders ZhttpRequest::responseHeaders() const
-{
-	return d->responseHeaders;
-}
-
-QByteArray ZhttpRequest::readBody(int size)
-{
-	return d->readBody(size);
-}
-
-void ZhttpRequest::setupClient(ZhttpManager *manager, bool req)
-{
-	d->manager = manager;
-	d->rid = Rid(manager->instanceId(), UuidUtil::createUuid());
-	d->doReq = req;
-	d->manager->link(this);
-}
-
-bool ZhttpRequest::setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet)
-{
-	d->manager = manager;
-	d->server = true;
-	d->rid = Rid(packet.from.asQByteArray(), id);
-	return d->setupServer(seq, packet);
-}
-
-void ZhttpRequest::setupServer(ZhttpManager *manager, const ZhttpRequest::ServerState &state)
-{
-	d->manager = manager;
-	d->server = true;
-	d->rid = state.rid;
-	d->manager->link(this);
-	d->setupServer(state);
-}
-
-void ZhttpRequest::startServer()
-{
-	d->startServer();
-}
-
-bool ZhttpRequest::isServer() const
-{
-	return d->server;
-}
-
-QByteArray ZhttpRequest::toAddress() const
-{
-	return d->toAddress;
-}
-
-bool ZhttpRequest::routerResp() const
-{
-	return d->routerResp;
-}
-
-int ZhttpRequest::outSeqInc()
-{
-	return d->outSeq++;
-}
-
-void ZhttpRequest::handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet)
-{
-	assert(d->manager);
-
-	d->handle(id, seq, packet);
-}
-
-void ZhttpRequest::handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet)
-{
-	assert(d->manager);
-
-	d->handle(id, seq, packet);
+    d->handle(id, seq, packet);
 }

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -24,10 +24,10 @@
 #ifndef ZHTTPREQUEST_H
 #define ZHTTPREQUEST_H
 
-#include "variant.h"
 #include "httprequest.h"
-#include <boost/signals2.hpp>
 #include "url.h"
+#include "variant.h"
+#include <boost/signals2.hpp>
 
 #define TIMERS_PER_ZHTTPREQUEST 3
 
@@ -37,106 +37,99 @@ class ZhttpRequestPacket;
 class ZhttpResponsePacket;
 class ZhttpManager;
 
-class ZhttpRequest : public HttpRequest
-{
+class ZhttpRequest : public HttpRequest {
 public:
-	// Pair of sender + request id
-	typedef QPair<QByteArray, QByteArray> Rid;
+    // Pair of sender + request id
+    typedef QPair<QByteArray, QByteArray> Rid;
 
-	class ServerState
-	{
-	public:
-		Rid rid;
-		QHostAddress peerAddress;
-		QString requestMethod;
-		Url requestUri;
-		HttpHeaders requestHeaders;
-		QByteArray requestBody;
-		int responseCode;
-		int inSeq;
-		int outSeq;
-		int outCredits;
-		bool routerResp;
-		Variant userData;
+    class ServerState {
+    public:
+        Rid rid;
+        QHostAddress peerAddress;
+        QString requestMethod;
+        Url requestUri;
+        HttpHeaders requestHeaders;
+        QByteArray requestBody;
+        int responseCode;
+        int inSeq;
+        int outSeq;
+        int outCredits;
+        bool routerResp;
+        Variant userData;
 
-		ServerState() :
-			responseCode(-1),
-			inSeq(-1),
-			outSeq(-1),
-			outCredits(-1),
-			routerResp(false)
-		{
-		}
-	};
+        ServerState()
+            : responseCode(-1), inSeq(-1), outSeq(-1), outCredits(-1), routerResp(false) {}
+    };
 
-	~ZhttpRequest();
+    ~ZhttpRequest();
 
-	Rid rid() const;
-	Variant passthroughData() const;
-	void setIsTls(bool on); // Updates scheme
-	void setSendBodyAfterAcknowledgement(bool on); // Only works in push/sub mode
-	void setPassthroughData(const Variant &data);
-	void setQuiet(bool on);
+    Rid rid() const;
+    Variant passthroughData() const;
+    void setIsTls(bool on);                        // Updates scheme
+    void setSendBodyAfterAcknowledgement(bool on); // Only works in push/sub mode
+    void setPassthroughData(const Variant &data);
+    void setQuiet(bool on);
 
-	// For server requests only
-	void pause();
-	void resume();
-	ServerState serverState() const;
+    // For server requests only
+    void pause();
+    void resume();
+    ServerState serverState() const;
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QHostAddress peerAddress() const;
+    virtual QHostAddress peerAddress() const;
 
-	virtual void setConnectHost(const QString &host);
-	virtual void setConnectPort(int port);
-	virtual void setIgnorePolicies(bool on);
-	virtual void setTrustConnectHost(bool on);
-	virtual void setIgnoreTlsErrors(bool on);
-	virtual void setTimeout(int msecs);
-	virtual void setClientCert(const QString &cert, const QString &key);
+    virtual void setConnectHost(const QString &host);
+    virtual void setConnectPort(int port);
+    virtual void setIgnorePolicies(bool on);
+    virtual void setTrustConnectHost(bool on);
+    virtual void setIgnoreTlsErrors(bool on);
+    virtual void setTimeout(int msecs);
+    virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
-	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
+    virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
+    virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
 
-	virtual void writeBody(const QByteArray &body);
+    virtual void writeBody(const QByteArray &body);
 
-	virtual void endBody();
+    virtual void endBody();
 
-	virtual int bytesAvailable() const;
-	virtual int writeBytesAvailable() const;
-	virtual bool isFinished() const;
-	virtual bool isInputFinished() const;
-	virtual bool isOutputFinished() const;
-	virtual bool isErrored() const;
-	virtual ErrorCondition errorCondition() const;
+    virtual int bytesAvailable() const;
+    virtual int writeBytesAvailable() const;
+    virtual bool isFinished() const;
+    virtual bool isInputFinished() const;
+    virtual bool isOutputFinished() const;
+    virtual bool isErrored() const;
+    virtual ErrorCondition errorCondition() const;
 
-	virtual QString requestMethod() const;
-	virtual Url requestUri() const;
-	virtual HttpHeaders requestHeaders() const;
+    virtual QString requestMethod() const;
+    virtual Url requestUri() const;
+    virtual HttpHeaders requestHeaders() const;
 
-	virtual int responseCode() const;
-	virtual QByteArray responseReason() const;
-	virtual HttpHeaders responseHeaders() const;
+    virtual int responseCode() const;
+    virtual QByteArray responseReason() const;
+    virtual HttpHeaders responseHeaders() const;
 
-	virtual QByteArray readBody(int size = -1);
+    virtual QByteArray readBody(int size = -1);
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 
-	friend class ZhttpManager;
-	ZhttpRequest();
-	void setupClient(ZhttpManager *manager, bool req);
-	bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
-	void setupServer(ZhttpManager *manager, const ServerState &state);
-	void startServer();
-	bool isServer() const;
-	QByteArray toAddress() const;
-	bool routerResp() const;
-	int outSeqInc();
-	void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
-	void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet);
+    friend class ZhttpManager;
+    ZhttpRequest();
+    void setupClient(ZhttpManager *manager, bool req);
+    bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq,
+                     const ZhttpRequestPacket &packet);
+    void setupServer(ZhttpManager *manager, const ServerState &state);
+    void startServer();
+    bool isServer() const;
+    QByteArray toAddress() const;
+    bool routerResp() const;
+    int outSeqInc();
+    void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
+    void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet);
 };
 
 #endif

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -21,506 +21,476 @@
 
 #include "zhttprequestpacket.h"
 
-#include <stdio.h>
 #include "qtcompat.h"
-#include "variant.h"
 #include "tnetstring.h"
+#include "variant.h"
+#include <stdio.h>
 
-Variant ZhttpRequestPacket::toVariant() const
-{
-	VariantHash obj;
+Variant ZhttpRequestPacket::toVariant() const {
+    VariantHash obj;
 
-	if(!from.isEmpty())
-		obj["from"] = from.asQByteArray();
+    if (!from.isEmpty())
+        obj["from"] = from.asQByteArray();
 
-	if(!ids.isEmpty())
-	{
-		if(ids.count() == 1)
-		{
-			const Id &id = ids.first();
-			if(!id.id.isEmpty())
-				obj["id"] = id.id.asQByteArray();
-			if(id.seq != -1)
-				obj["seq"] = id.seq;
-		}
-		else
-		{
-			VariantList vl;
-			foreach(const Id &id, ids)
-			{
-				VariantHash vh;
-				if(!id.id.isEmpty())
-					vh["id"] = id.id.asQByteArray();
-				if(id.seq != -1)
-					vh["seq"] = id.seq;
-				vl += vh;
-			}
-			obj["id"] = vl;
-		}
-	}
+    if (!ids.isEmpty()) {
+        if (ids.count() == 1) {
+            const Id &id = ids.first();
+            if (!id.id.isEmpty())
+                obj["id"] = id.id.asQByteArray();
+            if (id.seq != -1)
+                obj["seq"] = id.seq;
+        } else {
+            VariantList vl;
+            foreach (const Id &id, ids) {
+                VariantHash vh;
+                if (!id.id.isEmpty())
+                    vh["id"] = id.id.asQByteArray();
+                if (id.seq != -1)
+                    vh["seq"] = id.seq;
+                vl += vh;
+            }
+            obj["id"] = vl;
+        }
+    }
 
-	QByteArray typeStr;
-	switch(type)
-	{
-		case Error:          typeStr = "error"; break;
-		case Credit:         typeStr = "credit"; break;
-		case KeepAlive:      typeStr = "keep-alive"; break;
-		case Cancel:         typeStr = "cancel"; break;
-		case HandoffStart:   typeStr = "handoff-start"; break;
-		case HandoffProceed: typeStr = "handoff-proceed"; break;
-		case Close:          typeStr = "close"; break;
-		case Ping:           typeStr = "ping"; break;
-		case Pong:           typeStr = "pong"; break;
-		default: break;
-	}
+    QByteArray typeStr;
+    switch (type) {
+    case Error:
+        typeStr = "error";
+        break;
+    case Credit:
+        typeStr = "credit";
+        break;
+    case KeepAlive:
+        typeStr = "keep-alive";
+        break;
+    case Cancel:
+        typeStr = "cancel";
+        break;
+    case HandoffStart:
+        typeStr = "handoff-start";
+        break;
+    case HandoffProceed:
+        typeStr = "handoff-proceed";
+        break;
+    case Close:
+        typeStr = "close";
+        break;
+    case Ping:
+        typeStr = "ping";
+        break;
+    case Pong:
+        typeStr = "pong";
+        break;
+    default:
+        break;
+    }
 
-	if(!typeStr.isEmpty())
-		obj["type"] = typeStr;
+    if (!typeStr.isEmpty())
+        obj["type"] = typeStr;
 
-	if(type == Error && !condition.isEmpty())
-		obj["condition"] = condition.asQByteArray();
+    if (type == Error && !condition.isEmpty())
+        obj["condition"] = condition.asQByteArray();
 
-	if(credits != -1)
-		obj["credits"] = credits;
+    if (credits != -1)
+        obj["credits"] = credits;
 
-	if(more)
-		obj["more"] = true;
+    if (more)
+        obj["more"] = true;
 
-	if(stream)
-		obj["stream"] = true;
+    if (stream)
+        obj["stream"] = true;
 
-	if(routerResp)
-		obj["router-resp"] = true;
+    if (routerResp)
+        obj["router-resp"] = true;
 
-	if(maxSize != -1)
-		obj["max-size"] = maxSize;
+    if (maxSize != -1)
+        obj["max-size"] = maxSize;
 
-	if(timeout != -1)
-		obj["timeout"] = timeout;
+    if (timeout != -1)
+        obj["timeout"] = timeout;
 
-	if(!method.isEmpty())
-		obj["method"] = method.toUtf8().asQByteArray();
+    if (!method.isEmpty())
+        obj["method"] = method.toUtf8().asQByteArray();
 
-	if(!uri.isEmpty())
-		obj["uri"] = uri.toEncoded();
+    if (!uri.isEmpty())
+        obj["uri"] = uri.toEncoded();
 
-	if(!headers.isEmpty())
-	{
-		VariantList vheaders;
-		foreach(const HttpHeader &h, headers)
-		{
-			VariantList vheader;
-			vheader += h.first.asQByteArray();
-			vheader += h.second.asQByteArray();
-			vheaders += Variant(vheader);
-		}
+    if (!headers.isEmpty()) {
+        VariantList vheaders;
+        foreach (const HttpHeader &h, headers) {
+            VariantList vheader;
+            vheader += h.first.asQByteArray();
+            vheader += h.second.asQByteArray();
+            vheaders += Variant(vheader);
+        }
 
-		obj["headers"] = vheaders;
-	}
+        obj["headers"] = vheaders;
+    }
 
-	if(!body.isNull())
-		obj["body"] = body.asQByteArray();
+    if (!body.isNull())
+        obj["body"] = body.asQByteArray();
 
-	if(!contentType.isEmpty())
-		obj["content-type"] = contentType.asQByteArray();
+    if (!contentType.isEmpty())
+        obj["content-type"] = contentType.asQByteArray();
 
-	if(code != -1)
-		obj["code"] = code;
+    if (code != -1)
+        obj["code"] = code;
 
-	if(userData.isValid())
-		obj["user-data"] = userData;
+    if (userData.isValid())
+        obj["user-data"] = userData;
 
-	if(!peerAddress.isNull())
-		obj["peer-address"] = peerAddress.toString().toUtf8();
+    if (!peerAddress.isNull())
+        obj["peer-address"] = peerAddress.toString().toUtf8();
 
-	if(peerPort != -1)
-		obj["peer-port"] = QByteArray::number(peerPort);
+    if (peerPort != -1)
+        obj["peer-port"] = QByteArray::number(peerPort);
 
-	if(!connectHost.isEmpty())
-		obj["connect-host"] = connectHost.toUtf8().asQByteArray();
+    if (!connectHost.isEmpty())
+        obj["connect-host"] = connectHost.toUtf8().asQByteArray();
 
-	if(connectPort != -1)
-		obj["connect-port"] = connectPort;
+    if (connectPort != -1)
+        obj["connect-port"] = connectPort;
 
-	if(ignorePolicies)
-		obj["ignore-policies"] = true;
+    if (ignorePolicies)
+        obj["ignore-policies"] = true;
 
-	if(trustConnectHost)
-		obj["trust-connect-host"] = true;
+    if (trustConnectHost)
+        obj["trust-connect-host"] = true;
 
-	if(ignoreTlsErrors)
-		obj["ignore-tls-errors"] = true;
+    if (ignoreTlsErrors)
+        obj["ignore-tls-errors"] = true;
 
-	if(!clientCert.isEmpty())
-		obj["client-cert"] = clientCert.toUtf8().asQByteArray();
+    if (!clientCert.isEmpty())
+        obj["client-cert"] = clientCert.toUtf8().asQByteArray();
 
-	if(!clientKey.isEmpty())
-		obj["client-key"] = clientKey.toUtf8().asQByteArray();
+    if (!clientKey.isEmpty())
+        obj["client-key"] = clientKey.toUtf8().asQByteArray();
 
-	if(followRedirects)
-		obj["follow-redirects"] = true;
+    if (followRedirects)
+        obj["follow-redirects"] = true;
 
-	if(passthrough.isValid())
-		obj["passthrough"] = passthrough;
+    if (passthrough.isValid())
+        obj["passthrough"] = passthrough;
 
-	if(multi || quiet)
-	{
-		VariantHash ext;
+    if (multi || quiet) {
+        VariantHash ext;
 
-		if(multi)
-			ext["multi"] = true;
+        if (multi)
+            ext["multi"] = true;
 
-		if(quiet)
-			ext["quiet"] = true;
+        if (quiet)
+            ext["quiet"] = true;
 
-		obj["ext"] = ext;
-	}
+        obj["ext"] = ext;
+    }
 
-	return obj;
+    return obj;
 }
 
-bool ZhttpRequestPacket::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
-
-	VariantHash obj = in.toHash();
-
-	from.clear();
-	if(obj.contains("from"))
-	{
-		if(typeId(obj["from"]) != VariantType::ByteArray)
-			return false;
-
-		from = obj["from"].toByteArray();
-	}
-
-	ids.clear();
-	if(obj.contains("id"))
-	{
-		if(typeId(obj["id"]) == VariantType::ByteArray)
-		{
-			Id id;
-			id.id = obj["id"].toByteArray();
-			ids += id;
-		}
-		else if(typeId(obj["id"]) == VariantType::List)
-		{
-			VariantList vl = obj["id"].toList();
-			for(const Variant &v : vl)
-			{
-				if(typeId(v) != VariantType::Hash)
-					return false;
-
-				Id id;
-
-				VariantHash vh = v.toHash();
-
-				if(vh.contains("id"))
-				{
-					if(typeId(vh["id"]) != VariantType::ByteArray)
-						return false;
-
-					id.id = vh["id"].toByteArray();
-				}
-
-				if(vh.contains("seq"))
-				{
-					if(!canConvert(vh["seq"], VariantType::Int))
-						return false;
-
-					id.seq = vh["seq"].toInt();
-				}
-
-				ids += id;
-			}
-		}
-		else
-			return false;
-	}
-
-	if(obj.contains("seq"))
-	{
-		if(!canConvert(obj["seq"], VariantType::Int))
-			return false;
-
-		if(ids.isEmpty())
-			ids += Id();
-
-		ids.first().seq = obj["seq"].toInt();
-	}
-
-	type = Data;
-	if(obj.contains("type"))
-	{
-		if(typeId(obj["type"]) != VariantType::ByteArray)
-			return false;
-
-		QByteArray typeStr = obj["type"].toByteArray();
-
-		if(typeStr == "error")
-			type = Error;
-		else if(typeStr == "credit")
-			type = Credit;
-		else if(typeStr == "keep-alive")
-			type = KeepAlive;
-		else if(typeStr == "cancel")
-			type = Cancel;
-		else if(typeStr == "handoff-start")
-			type = HandoffStart;
-		else if(typeStr == "handoff-proceed")
-			type = HandoffProceed;
-		else if(typeStr == "close")
-			type = Close;
-		else if(typeStr == "ping")
-			type = Ping;
-		else if(typeStr == "pong")
-			type = Pong;
-		else
-			return false;
-	}
-
-	if(type == Error)
-	{
-		condition.clear();
-		if(obj.contains("condition"))
-		{
-			if(typeId(obj["condition"]) != VariantType::ByteArray)
-				return false;
-
-			condition = obj["condition"].toByteArray();
-		}
-	}
-
-	credits = -1;
-	if(obj.contains("credits"))
-	{
-		if(!canConvert(obj["credits"], VariantType::Int))
-			return false;
-
-		credits = obj["credits"].toInt();
-	}
-
-	more = false;
-	if(obj.contains("more"))
-	{
-		if(typeId(obj["more"]) != VariantType::Bool)
-			return false;
-
-		more = obj["more"].toBool();
-	}
-
-	stream = false;
-	if(obj.contains("stream"))
-	{
-		if(typeId(obj["stream"]) != VariantType::Bool)
-			return false;
-
-		stream = obj["stream"].toBool();
-	}
-
-	routerResp = false;
-	if(obj.contains("router-resp"))
-	{
-		if(typeId(obj["router-resp"]) != VariantType::Bool)
-			return false;
-
-		routerResp = obj["router-resp"].toBool();
-	}
-
-	maxSize = -1;
-	if(obj.contains("max-size"))
-	{
-		if(!canConvert(obj["max-size"], VariantType::Int))
-			return false;
-
-		maxSize = obj["max-size"].toInt();
-	}
-
-	timeout = -1;
-	if(obj.contains("timeout"))
-	{
-		if(!canConvert(obj["timeout"], VariantType::Int))
-			return false;
-
-		timeout = obj["timeout"].toInt();
-	}
-
-	method.clear();
-	if(obj.contains("method"))
-	{
-		if(typeId(obj["method"]) != VariantType::ByteArray)
-			return false;
-
-		method = QString::fromLatin1(obj["method"].toByteArray());
-	}
-
-	uri.clear();
-	if(obj.contains("uri"))
-	{
-		if(typeId(obj["uri"]) != VariantType::ByteArray)
-			return false;
-
-		uri = Url::fromEncoded(obj["uri"].toByteArray(), Url::StrictMode);
-	}
-
-	headers.clear();
-	if(obj.contains("headers"))
-	{
-		if(typeId(obj["headers"]) != VariantType::List)
-			return false;
-
-		for(const Variant &i : obj["headers"].toList())
-		{
-			VariantList list = i.toList();
-			if(list.count() != 2)
-				return false;
-
-			if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
-				return false;
-
-			headers += HttpHeader(list[0].toByteArray(), list[1].toByteArray());
-		}
-	}
-
-	body.clear();
-	if(obj.contains("body"))
-	{
-		if(typeId(obj["body"]) != VariantType::ByteArray)
-			return false;
-
-		body = obj["body"].toByteArray();
-	}
-
-	contentType.clear();
-	if(obj.contains("content-type"))
-	{
-		if(typeId(obj["content-type"]) != VariantType::ByteArray)
-			return false;
-
-		contentType = obj["content-type"].toByteArray();
-	}
-
-	code = -1;
-	if(obj.contains("code"))
-	{
-		if(!canConvert(obj["code"], VariantType::Int))
-			return false;
-
-		code = obj["code"].toInt();
-	}
-
-	userData = obj.value("user-data");
-
-	peerAddress = QHostAddress();
-	if(obj.contains("peer-address"))
-	{
-		if(typeId(obj["peer-address"]) != VariantType::ByteArray)
-			return false;
-
-		peerAddress = QHostAddress(QString::fromUtf8(obj["peer-address"].toByteArray()));
-	}
-
-	peerPort = -1;
-	if(obj.contains("peer-port"))
-	{
-		if(!canConvert(obj["peer-port"], VariantType::Int))
-			return false;
-
-		peerPort = obj["peer-port"].toInt();
-	}
-
-	connectHost.clear();
-	if(obj.contains("connect-host"))
-	{
-		if(typeId(obj["connect-host"]) != VariantType::ByteArray)
-			return false;
-
-		connectHost = QString::fromUtf8(obj["connect-host"].toByteArray());
-	}
-
-	connectPort = -1;
-	if(obj.contains("connect-port"))
-	{
-		if(!canConvert(obj["connect-port"], VariantType::Int))
-			return false;
-
-		connectPort = obj["connect-port"].toInt();
-	}
-
-	ignorePolicies = false;
-	if(obj.contains("ignore-policies"))
-	{
-		if(typeId(obj["ignore-policies"]) != VariantType::Bool)
-			return false;
-
-		ignorePolicies = obj["ignore-policies"].toBool();
-	}
-
-	trustConnectHost = false;
-	if(obj.contains("trust-connect-host"))
-	{
-		if(typeId(obj["trust-connect-host"]) != VariantType::Bool)
-			return false;
-
-		trustConnectHost = obj["trust-connect-host"].toBool();
-	}
-
-	ignoreTlsErrors = false;
-	if(obj.contains("ignore-tls-errors"))
-	{
-		if(typeId(obj["ignore-tls-errors"]) != VariantType::Bool)
-			return false;
-
-		ignoreTlsErrors = obj["ignore-tls-errors"].toBool();
-	}
-
-	clientCert.clear();
-	if(obj.contains("client-cert"))
-	{
-		if(typeId(obj["client-cert"]) != VariantType::ByteArray)
-			return false;
-
-		clientCert = QString::fromUtf8(obj["client-cert"].toByteArray());
-	}
-
-	clientKey.clear();
-	if(obj.contains("client-key"))
-	{
-		if(typeId(obj["client-key"]) != VariantType::ByteArray)
-			return false;
-
-		clientKey = QString::fromUtf8(obj["client-key"].toByteArray());
-	}
-
-	followRedirects = false;
-	if(obj.contains("follow-redirects"))
-	{
-		if(typeId(obj["follow-redirects"]) != VariantType::Bool)
-			return false;
-
-		followRedirects = obj["follow-redirects"].toBool();
-	}
-
-	passthrough = obj.value("passthrough");
-
-	multi = false;
-	if(obj.contains("ext"))
-	{
-		if(typeId(obj["ext"]) != VariantType::Hash)
-			return false;
-
-		VariantHash ext = obj["ext"].toHash();
-		if(ext.contains("multi") && typeId(ext["multi"]) == VariantType::Bool)
-		{
-			multi = ext["multi"].toBool();
-		}
-
-		if(ext.contains("quiet") && typeId(ext["quiet"]) == VariantType::Bool)
-		{
-			quiet = ext["quiet"].toBool();
-		}
-	}
-
-	return true;
+bool ZhttpRequestPacket::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
+
+    VariantHash obj = in.toHash();
+
+    from.clear();
+    if (obj.contains("from")) {
+        if (typeId(obj["from"]) != VariantType::ByteArray)
+            return false;
+
+        from = obj["from"].toByteArray();
+    }
+
+    ids.clear();
+    if (obj.contains("id")) {
+        if (typeId(obj["id"]) == VariantType::ByteArray) {
+            Id id;
+            id.id = obj["id"].toByteArray();
+            ids += id;
+        } else if (typeId(obj["id"]) == VariantType::List) {
+            VariantList vl = obj["id"].toList();
+            for (const Variant &v : vl) {
+                if (typeId(v) != VariantType::Hash)
+                    return false;
+
+                Id id;
+
+                VariantHash vh = v.toHash();
+
+                if (vh.contains("id")) {
+                    if (typeId(vh["id"]) != VariantType::ByteArray)
+                        return false;
+
+                    id.id = vh["id"].toByteArray();
+                }
+
+                if (vh.contains("seq")) {
+                    if (!canConvert(vh["seq"], VariantType::Int))
+                        return false;
+
+                    id.seq = vh["seq"].toInt();
+                }
+
+                ids += id;
+            }
+        } else
+            return false;
+    }
+
+    if (obj.contains("seq")) {
+        if (!canConvert(obj["seq"], VariantType::Int))
+            return false;
+
+        if (ids.isEmpty())
+            ids += Id();
+
+        ids.first().seq = obj["seq"].toInt();
+    }
+
+    type = Data;
+    if (obj.contains("type")) {
+        if (typeId(obj["type"]) != VariantType::ByteArray)
+            return false;
+
+        QByteArray typeStr = obj["type"].toByteArray();
+
+        if (typeStr == "error")
+            type = Error;
+        else if (typeStr == "credit")
+            type = Credit;
+        else if (typeStr == "keep-alive")
+            type = KeepAlive;
+        else if (typeStr == "cancel")
+            type = Cancel;
+        else if (typeStr == "handoff-start")
+            type = HandoffStart;
+        else if (typeStr == "handoff-proceed")
+            type = HandoffProceed;
+        else if (typeStr == "close")
+            type = Close;
+        else if (typeStr == "ping")
+            type = Ping;
+        else if (typeStr == "pong")
+            type = Pong;
+        else
+            return false;
+    }
+
+    if (type == Error) {
+        condition.clear();
+        if (obj.contains("condition")) {
+            if (typeId(obj["condition"]) != VariantType::ByteArray)
+                return false;
+
+            condition = obj["condition"].toByteArray();
+        }
+    }
+
+    credits = -1;
+    if (obj.contains("credits")) {
+        if (!canConvert(obj["credits"], VariantType::Int))
+            return false;
+
+        credits = obj["credits"].toInt();
+    }
+
+    more = false;
+    if (obj.contains("more")) {
+        if (typeId(obj["more"]) != VariantType::Bool)
+            return false;
+
+        more = obj["more"].toBool();
+    }
+
+    stream = false;
+    if (obj.contains("stream")) {
+        if (typeId(obj["stream"]) != VariantType::Bool)
+            return false;
+
+        stream = obj["stream"].toBool();
+    }
+
+    routerResp = false;
+    if (obj.contains("router-resp")) {
+        if (typeId(obj["router-resp"]) != VariantType::Bool)
+            return false;
+
+        routerResp = obj["router-resp"].toBool();
+    }
+
+    maxSize = -1;
+    if (obj.contains("max-size")) {
+        if (!canConvert(obj["max-size"], VariantType::Int))
+            return false;
+
+        maxSize = obj["max-size"].toInt();
+    }
+
+    timeout = -1;
+    if (obj.contains("timeout")) {
+        if (!canConvert(obj["timeout"], VariantType::Int))
+            return false;
+
+        timeout = obj["timeout"].toInt();
+    }
+
+    method.clear();
+    if (obj.contains("method")) {
+        if (typeId(obj["method"]) != VariantType::ByteArray)
+            return false;
+
+        method = QString::fromLatin1(obj["method"].toByteArray());
+    }
+
+    uri.clear();
+    if (obj.contains("uri")) {
+        if (typeId(obj["uri"]) != VariantType::ByteArray)
+            return false;
+
+        uri = Url::fromEncoded(obj["uri"].toByteArray(), Url::StrictMode);
+    }
+
+    headers.clear();
+    if (obj.contains("headers")) {
+        if (typeId(obj["headers"]) != VariantType::List)
+            return false;
+
+        for (const Variant &i : obj["headers"].toList()) {
+            VariantList list = i.toList();
+            if (list.count() != 2)
+                return false;
+
+            if (typeId(list[0]) != VariantType::ByteArray ||
+                typeId(list[1]) != VariantType::ByteArray)
+                return false;
+
+            headers += HttpHeader(list[0].toByteArray(), list[1].toByteArray());
+        }
+    }
+
+    body.clear();
+    if (obj.contains("body")) {
+        if (typeId(obj["body"]) != VariantType::ByteArray)
+            return false;
+
+        body = obj["body"].toByteArray();
+    }
+
+    contentType.clear();
+    if (obj.contains("content-type")) {
+        if (typeId(obj["content-type"]) != VariantType::ByteArray)
+            return false;
+
+        contentType = obj["content-type"].toByteArray();
+    }
+
+    code = -1;
+    if (obj.contains("code")) {
+        if (!canConvert(obj["code"], VariantType::Int))
+            return false;
+
+        code = obj["code"].toInt();
+    }
+
+    userData = obj.value("user-data");
+
+    peerAddress = QHostAddress();
+    if (obj.contains("peer-address")) {
+        if (typeId(obj["peer-address"]) != VariantType::ByteArray)
+            return false;
+
+        peerAddress = QHostAddress(QString::fromUtf8(obj["peer-address"].toByteArray()));
+    }
+
+    peerPort = -1;
+    if (obj.contains("peer-port")) {
+        if (!canConvert(obj["peer-port"], VariantType::Int))
+            return false;
+
+        peerPort = obj["peer-port"].toInt();
+    }
+
+    connectHost.clear();
+    if (obj.contains("connect-host")) {
+        if (typeId(obj["connect-host"]) != VariantType::ByteArray)
+            return false;
+
+        connectHost = QString::fromUtf8(obj["connect-host"].toByteArray());
+    }
+
+    connectPort = -1;
+    if (obj.contains("connect-port")) {
+        if (!canConvert(obj["connect-port"], VariantType::Int))
+            return false;
+
+        connectPort = obj["connect-port"].toInt();
+    }
+
+    ignorePolicies = false;
+    if (obj.contains("ignore-policies")) {
+        if (typeId(obj["ignore-policies"]) != VariantType::Bool)
+            return false;
+
+        ignorePolicies = obj["ignore-policies"].toBool();
+    }
+
+    trustConnectHost = false;
+    if (obj.contains("trust-connect-host")) {
+        if (typeId(obj["trust-connect-host"]) != VariantType::Bool)
+            return false;
+
+        trustConnectHost = obj["trust-connect-host"].toBool();
+    }
+
+    ignoreTlsErrors = false;
+    if (obj.contains("ignore-tls-errors")) {
+        if (typeId(obj["ignore-tls-errors"]) != VariantType::Bool)
+            return false;
+
+        ignoreTlsErrors = obj["ignore-tls-errors"].toBool();
+    }
+
+    clientCert.clear();
+    if (obj.contains("client-cert")) {
+        if (typeId(obj["client-cert"]) != VariantType::ByteArray)
+            return false;
+
+        clientCert = QString::fromUtf8(obj["client-cert"].toByteArray());
+    }
+
+    clientKey.clear();
+    if (obj.contains("client-key")) {
+        if (typeId(obj["client-key"]) != VariantType::ByteArray)
+            return false;
+
+        clientKey = QString::fromUtf8(obj["client-key"].toByteArray());
+    }
+
+    followRedirects = false;
+    if (obj.contains("follow-redirects")) {
+        if (typeId(obj["follow-redirects"]) != VariantType::Bool)
+            return false;
+
+        followRedirects = obj["follow-redirects"].toBool();
+    }
+
+    passthrough = obj.value("passthrough");
+
+    multi = false;
+    if (obj.contains("ext")) {
+        if (typeId(obj["ext"]) != VariantType::Hash)
+            return false;
+
+        VariantHash ext = obj["ext"].toHash();
+        if (ext.contains("multi") && typeId(ext["multi"]) == VariantType::Bool) {
+            multi = ext["multi"].toBool();
+        }
+
+        if (ext.contains("quiet") && typeId(ext["quiet"]) == VariantType::Bool) {
+            quiet = ext["quiet"].toBool();
+        }
+    }
+
+    return true;
 }

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -22,108 +22,96 @@
 #ifndef ZHTTPREQUESTPACKET_H
 #define ZHTTPREQUESTPACKET_H
 
-#include "url.h"
-#include <QHostAddress>
-#include "cowstring.h"
 #include "cowbytearray.h"
+#include "cowstring.h"
 #include "httpheaders.h"
+#include "url.h"
 #include "variant.h"
+#include <QHostAddress>
 
-class ZhttpRequestPacket
-{
+class ZhttpRequestPacket {
 public:
-	class Id
-	{
-	public:
-		CowByteArray id;
-		int seq;
+    class Id {
+    public:
+        CowByteArray id;
+        int seq;
 
-		Id() :
-			seq(-1)
-		{
-		}
+        Id() : seq(-1) {}
 
-		Id(const CowByteArray &_id, int _seq = -1) :
-			id(_id),
-			seq(_seq)
-		{
-		}
-	};
+        Id(const CowByteArray &_id, int _seq = -1) : id(_id), seq(_seq) {}
+    };
 
-	enum Type
-	{
-		Data,
-		Error,
-		Credit,
-		KeepAlive,
-		Cancel,
-		HandoffStart,
-		HandoffProceed,
-		Close, // WebSocket
-		Ping, // WebSocket
-		Pong // WebSocket
-	};
+    enum Type {
+        Data,
+        Error,
+        Credit,
+        KeepAlive,
+        Cancel,
+        HandoffStart,
+        HandoffProceed,
+        Close, // WebSocket
+        Ping,  // WebSocket
+        Pong   // WebSocket
+    };
 
-	CowByteArray from;
-	QList<Id> ids;
+    CowByteArray from;
+    QList<Id> ids;
 
-	Type type;
-	CowByteArray condition;
+    Type type;
+    CowByteArray condition;
 
-	int credits;
-	bool more;
-	bool stream;
-	bool routerResp;
-	int maxSize;
-	int timeout;
+    int credits;
+    bool more;
+    bool stream;
+    bool routerResp;
+    int maxSize;
+    int timeout;
 
-	CowString method;
-	Url uri;
-	HttpHeaders headers;
-	CowByteArray body;
+    CowString method;
+    Url uri;
+    HttpHeaders headers;
+    CowByteArray body;
 
-	CowByteArray contentType; // WebSocket
-	int code; // WebSocket
+    CowByteArray contentType; // WebSocket
+    int code;                 // WebSocket
 
-	Variant userData;
+    Variant userData;
 
-	QHostAddress peerAddress;
-	int peerPort;
+    QHostAddress peerAddress;
+    int peerPort;
 
-	CowString connectHost;
-	int connectPort;
-	bool ignorePolicies;
-	bool trustConnectHost;
-	bool ignoreTlsErrors;
-	CowString clientCert;
-	CowString clientKey;
-	bool followRedirects;
-	Variant passthrough; // If valid, may contain pushpin-specific passthrough info
-	bool multi;
-	bool quiet;
+    CowString connectHost;
+    int connectPort;
+    bool ignorePolicies;
+    bool trustConnectHost;
+    bool ignoreTlsErrors;
+    CowString clientCert;
+    CowString clientKey;
+    bool followRedirects;
+    Variant passthrough; // If valid, may contain pushpin-specific passthrough info
+    bool multi;
+    bool quiet;
 
-	ZhttpRequestPacket() :
-		type((Type)-1),
-		credits(-1),
-		more(false),
-		stream(false),
-		routerResp(false),
-		maxSize(-1),
-		timeout(-1),
-		code(-1),
-		peerPort(-1),
-		connectPort(-1),
-		ignorePolicies(false),
-		trustConnectHost(false),
-		ignoreTlsErrors(false),
-		followRedirects(false),
-		multi(false),
-		quiet(false)
-	{
-	}
+    ZhttpRequestPacket()
+        : type((Type)-1),
+          credits(-1),
+          more(false),
+          stream(false),
+          routerResp(false),
+          maxSize(-1),
+          timeout(-1),
+          code(-1),
+          peerPort(-1),
+          connectPort(-1),
+          ignorePolicies(false),
+          trustConnectHost(false),
+          ignoreTlsErrors(false),
+          followRedirects(false),
+          multi(false),
+          quiet(false) {}
 
-	Variant toVariant() const;
-	bool fromVariant(const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/zhttpresponsepacket.cpp
+++ b/src/core/zhttpresponsepacket.cpp
@@ -24,304 +24,289 @@
 #include "qtcompat.h"
 #include "variant.h"
 
-Variant ZhttpResponsePacket::toVariant() const
-{
-	VariantHash obj;
+Variant ZhttpResponsePacket::toVariant() const {
+    VariantHash obj;
 
-	if(!from.isEmpty())
-		obj["from"] = from.asQByteArray();
+    if (!from.isEmpty())
+        obj["from"] = from.asQByteArray();
 
-	if(!ids.isEmpty())
-	{
-		if(ids.count() == 1)
-		{
-			const Id &id = ids.first();
-			if(!id.id.isEmpty())
-				obj["id"] = id.id.asQByteArray();
-			if(id.seq != -1)
-				obj["seq"] = id.seq;
-		}
-		else
-		{
-			VariantList vl;
-			foreach(const Id &id, ids)
-			{
-				VariantHash vh;
-				if(!id.id.isEmpty())
-					vh["id"] = id.id.asQByteArray();
-				if(id.seq != -1)
-					vh["seq"] = id.seq;
-				vl += vh;
-			}
-			obj["id"] = vl;
-		}
-	}
+    if (!ids.isEmpty()) {
+        if (ids.count() == 1) {
+            const Id &id = ids.first();
+            if (!id.id.isEmpty())
+                obj["id"] = id.id.asQByteArray();
+            if (id.seq != -1)
+                obj["seq"] = id.seq;
+        } else {
+            VariantList vl;
+            foreach (const Id &id, ids) {
+                VariantHash vh;
+                if (!id.id.isEmpty())
+                    vh["id"] = id.id.asQByteArray();
+                if (id.seq != -1)
+                    vh["seq"] = id.seq;
+                vl += vh;
+            }
+            obj["id"] = vl;
+        }
+    }
 
-	QByteArray typeStr;
-	switch(type)
-	{
-		case Error:          typeStr = "error"; break;
-		case Credit:         typeStr = "credit"; break;
-		case KeepAlive:      typeStr = "keep-alive"; break;
-		case Cancel:         typeStr = "cancel"; break;
-		case HandoffStart:   typeStr = "handoff-start"; break;
-		case HandoffProceed: typeStr = "handoff-proceed"; break;
-		case Close:          typeStr = "close"; break;
-		case Ping:           typeStr = "ping"; break;
-		case Pong:           typeStr = "pong"; break;
-		default: break;
-	}
+    QByteArray typeStr;
+    switch (type) {
+    case Error:
+        typeStr = "error";
+        break;
+    case Credit:
+        typeStr = "credit";
+        break;
+    case KeepAlive:
+        typeStr = "keep-alive";
+        break;
+    case Cancel:
+        typeStr = "cancel";
+        break;
+    case HandoffStart:
+        typeStr = "handoff-start";
+        break;
+    case HandoffProceed:
+        typeStr = "handoff-proceed";
+        break;
+    case Close:
+        typeStr = "close";
+        break;
+    case Ping:
+        typeStr = "ping";
+        break;
+    case Pong:
+        typeStr = "pong";
+        break;
+    default:
+        break;
+    }
 
-	if(!typeStr.isEmpty())
-		obj["type"] = typeStr;
+    if (!typeStr.isEmpty())
+        obj["type"] = typeStr;
 
-	if(type == Error && !condition.isEmpty())
-		obj["condition"] = condition.asQByteArray();
+    if (type == Error && !condition.isEmpty())
+        obj["condition"] = condition.asQByteArray();
 
-	if(credits != -1)
-		obj["credits"] = credits;
+    if (credits != -1)
+        obj["credits"] = credits;
 
-	if(more)
-		obj["more"] = true;
+    if (more)
+        obj["more"] = true;
 
-	if(code != -1)
-	{
-		obj["code"] = code;
+    if (code != -1) {
+        obj["code"] = code;
 
-		if(type == Data || (type == Error && condition == "rejected"))
-		{
-			obj["reason"] = reason.asQByteArray();
-			VariantList vheaders;
-			foreach(const HttpHeader &h, headers)
-			{
-				VariantList vheader;
-				vheader += h.first.asQByteArray();
-				vheader += h.second.asQByteArray();
-				vheaders += Variant(vheader);
-			}
-			obj["headers"] = vheaders;
-		}
-	}
+        if (type == Data || (type == Error && condition == "rejected")) {
+            obj["reason"] = reason.asQByteArray();
+            VariantList vheaders;
+            foreach (const HttpHeader &h, headers) {
+                VariantList vheader;
+                vheader += h.first.asQByteArray();
+                vheader += h.second.asQByteArray();
+                vheaders += Variant(vheader);
+            }
+            obj["headers"] = vheaders;
+        }
+    }
 
-	if(!body.isNull())
-		obj["body"] = body.asQByteArray();
+    if (!body.isNull())
+        obj["body"] = body.asQByteArray();
 
-	if(!contentType.isEmpty())
-		obj["content-type"] = contentType.asQByteArray();
+    if (!contentType.isEmpty())
+        obj["content-type"] = contentType.asQByteArray();
 
-	if(userData.isValid())
-		obj["user-data"] = userData;
+    if (userData.isValid())
+        obj["user-data"] = userData;
 
-	if(multi)
-	{
-		VariantHash ext;
-		ext["multi"] = true;
-		obj["ext"] = ext;
-	}
+    if (multi) {
+        VariantHash ext;
+        ext["multi"] = true;
+        obj["ext"] = ext;
+    }
 
-	return obj;
+    return obj;
 }
 
-bool ZhttpResponsePacket::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return false;
+bool ZhttpResponsePacket::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return false;
 
-	VariantHash obj = in.toHash();
+    VariantHash obj = in.toHash();
 
-	from.clear();
-	if(obj.contains("from"))
-	{
-		if(typeId(obj["from"]) != VariantType::ByteArray)
-			return false;
+    from.clear();
+    if (obj.contains("from")) {
+        if (typeId(obj["from"]) != VariantType::ByteArray)
+            return false;
 
-		from = obj["from"].toByteArray();
-	}
+        from = obj["from"].toByteArray();
+    }
 
-	ids.clear();
-	if(obj.contains("id"))
-	{
-		if(typeId(obj["id"]) == VariantType::ByteArray)
-		{
-			Id id;
-			id.id = obj["id"].toByteArray();
-			ids += id;
-		}
-		else if(typeId(obj["id"]) == VariantType::List)
-		{
-			VariantList vl = obj["id"].toList();
-			for(const Variant &v : vl)
-			{
-				if(typeId(v) != VariantType::Hash)
-					return false;
+    ids.clear();
+    if (obj.contains("id")) {
+        if (typeId(obj["id"]) == VariantType::ByteArray) {
+            Id id;
+            id.id = obj["id"].toByteArray();
+            ids += id;
+        } else if (typeId(obj["id"]) == VariantType::List) {
+            VariantList vl = obj["id"].toList();
+            for (const Variant &v : vl) {
+                if (typeId(v) != VariantType::Hash)
+                    return false;
 
-				Id id;
+                Id id;
 
-				VariantHash vh = v.toHash();
+                VariantHash vh = v.toHash();
 
-				if(vh.contains("id"))
-				{
-					if(typeId(vh["id"]) != VariantType::ByteArray)
-						return false;
+                if (vh.contains("id")) {
+                    if (typeId(vh["id"]) != VariantType::ByteArray)
+                        return false;
 
-					id.id = vh["id"].toByteArray();
-				}
+                    id.id = vh["id"].toByteArray();
+                }
 
-				if(vh.contains("seq"))
-				{
-					if(!canConvert(vh["seq"], VariantType::Int))
-						return false;
+                if (vh.contains("seq")) {
+                    if (!canConvert(vh["seq"], VariantType::Int))
+                        return false;
 
-					id.seq = vh["seq"].toInt();
-				}
+                    id.seq = vh["seq"].toInt();
+                }
 
-				ids += id;
-			}
-		}
-		else
-			return false;
-	}
+                ids += id;
+            }
+        } else
+            return false;
+    }
 
-	if(obj.contains("seq"))
-	{
-		if(!canConvert(obj["seq"], VariantType::Int))
-			return false;
+    if (obj.contains("seq")) {
+        if (!canConvert(obj["seq"], VariantType::Int))
+            return false;
 
-		if(ids.isEmpty())
-			ids += Id();
+        if (ids.isEmpty())
+            ids += Id();
 
-		ids.first().seq = obj["seq"].toInt();
-	}
+        ids.first().seq = obj["seq"].toInt();
+    }
 
-	type = Data;
-	if(obj.contains("type"))
-	{
-		if(typeId(obj["type"]) != VariantType::ByteArray)
-			return false;
+    type = Data;
+    if (obj.contains("type")) {
+        if (typeId(obj["type"]) != VariantType::ByteArray)
+            return false;
 
-		QByteArray typeStr = obj["type"].toByteArray();
+        QByteArray typeStr = obj["type"].toByteArray();
 
-		if(typeStr == "error")
-			type = Error;
-		else if(typeStr == "credit")
-			type = Credit;
-		else if(typeStr == "keep-alive")
-			type = KeepAlive;
-		else if(typeStr == "cancel")
-			type = Cancel;
-		else if(typeStr == "handoff-start")
-			type = HandoffStart;
-		else if(typeStr == "handoff-proceed")
-			type = HandoffProceed;
-		else if(typeStr == "close")
-			type = Close;
-		else if(typeStr == "ping")
-			type = Ping;
-		else if(typeStr == "pong")
-			type = Pong;
-		else
-			return false;
-	}
+        if (typeStr == "error")
+            type = Error;
+        else if (typeStr == "credit")
+            type = Credit;
+        else if (typeStr == "keep-alive")
+            type = KeepAlive;
+        else if (typeStr == "cancel")
+            type = Cancel;
+        else if (typeStr == "handoff-start")
+            type = HandoffStart;
+        else if (typeStr == "handoff-proceed")
+            type = HandoffProceed;
+        else if (typeStr == "close")
+            type = Close;
+        else if (typeStr == "ping")
+            type = Ping;
+        else if (typeStr == "pong")
+            type = Pong;
+        else
+            return false;
+    }
 
-	if(type == Error)
-	{
-		condition.clear();
-		if(obj.contains("condition"))
-		{
-			if(typeId(obj["condition"]) != VariantType::ByteArray)
-				return false;
+    if (type == Error) {
+        condition.clear();
+        if (obj.contains("condition")) {
+            if (typeId(obj["condition"]) != VariantType::ByteArray)
+                return false;
 
-			condition = obj["condition"].toByteArray();
-		}
-	}
+            condition = obj["condition"].toByteArray();
+        }
+    }
 
-	credits = -1;
-	if(obj.contains("credits"))
-	{
-		if(!canConvert(obj["credits"], VariantType::Int))
-			return false;
+    credits = -1;
+    if (obj.contains("credits")) {
+        if (!canConvert(obj["credits"], VariantType::Int))
+            return false;
 
-		credits = obj["credits"].toInt();
-	}
+        credits = obj["credits"].toInt();
+    }
 
-	more = false;
-	if(obj.contains("more"))
-	{
-		if(typeId(obj["more"]) != VariantType::Bool)
-			return false;
+    more = false;
+    if (obj.contains("more")) {
+        if (typeId(obj["more"]) != VariantType::Bool)
+            return false;
 
-		more = obj["more"].toBool();
-	}
+        more = obj["more"].toBool();
+    }
 
-	code = -1;
-	if(obj.contains("code"))
-	{
-		if(!canConvert(obj["code"], VariantType::Int))
-			return false;
+    code = -1;
+    if (obj.contains("code")) {
+        if (!canConvert(obj["code"], VariantType::Int))
+            return false;
 
-		code = obj["code"].toInt();
-	}
+        code = obj["code"].toInt();
+    }
 
-	reason.clear();
-	if(obj.contains("reason"))
-	{
-		if(typeId(obj["reason"]) != VariantType::ByteArray)
-			return false;
+    reason.clear();
+    if (obj.contains("reason")) {
+        if (typeId(obj["reason"]) != VariantType::ByteArray)
+            return false;
 
-		reason = obj["reason"].toByteArray();
-	}
+        reason = obj["reason"].toByteArray();
+    }
 
-	headers.clear();
-	if(obj.contains("headers"))
-	{
-		if(typeId(obj["headers"]) != VariantType::List)
-			return false;
+    headers.clear();
+    if (obj.contains("headers")) {
+        if (typeId(obj["headers"]) != VariantType::List)
+            return false;
 
-		for(const Variant &i : obj["headers"].toList())
-		{
-			VariantList list = i.toList();
-			if(list.count() != 2)
-				return false;
+        for (const Variant &i : obj["headers"].toList()) {
+            VariantList list = i.toList();
+            if (list.count() != 2)
+                return false;
 
-			if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
-				return false;
+            if (typeId(list[0]) != VariantType::ByteArray ||
+                typeId(list[1]) != VariantType::ByteArray)
+                return false;
 
-			headers += HttpHeader(list[0].toByteArray(), list[1].toByteArray());
-		}
-	}
+            headers += HttpHeader(list[0].toByteArray(), list[1].toByteArray());
+        }
+    }
 
-	body.clear();
-	if(obj.contains("body"))
-	{
-		if(typeId(obj["body"]) != VariantType::ByteArray)
-			return false;
+    body.clear();
+    if (obj.contains("body")) {
+        if (typeId(obj["body"]) != VariantType::ByteArray)
+            return false;
 
-		body = obj["body"].toByteArray();
-	}
+        body = obj["body"].toByteArray();
+    }
 
-	contentType.clear();
-	if(obj.contains("content-type"))
-	{
-		if(typeId(obj["content-type"]) != VariantType::ByteArray)
-			return false;
+    contentType.clear();
+    if (obj.contains("content-type")) {
+        if (typeId(obj["content-type"]) != VariantType::ByteArray)
+            return false;
 
-		contentType = obj["content-type"].toByteArray();
-	}
+        contentType = obj["content-type"].toByteArray();
+    }
 
-	userData = obj["user-data"];
+    userData = obj["user-data"];
 
-	multi = false;
-	if(obj.contains("ext"))
-	{
-		if(typeId(obj["ext"]) != VariantType::Hash)
-			return false;
+    multi = false;
+    if (obj.contains("ext")) {
+        if (typeId(obj["ext"]) != VariantType::Hash)
+            return false;
 
-		VariantHash ext = obj["ext"].toHash();
-		if(ext.contains("multi") && typeId(ext["multi"]) == VariantType::Bool)
-		{
-			multi = ext["multi"].toBool();
-		}
-	}
+        VariantHash ext = obj["ext"].toHash();
+        if (ext.contains("multi") && typeId(ext["multi"]) == VariantType::Bool) {
+            multi = ext["multi"].toBool();
+        }
+    }
 
-	return true;
+    return true;
 }

--- a/src/core/zhttpresponsepacket.h
+++ b/src/core/zhttpresponsepacket.h
@@ -22,77 +22,60 @@
 #ifndef ZHTTPRESPONSEPACKET_H
 #define ZHTTPRESPONSEPACKET_H
 
-#include "variant.h"
-#include "cowstring.h"
 #include "cowbytearray.h"
+#include "cowstring.h"
 #include "httpheaders.h"
+#include "variant.h"
 
-class ZhttpResponsePacket
-{
+class ZhttpResponsePacket {
 public:
-	class Id
-	{
-	public:
-		CowByteArray id;
-		int seq;
+    class Id {
+    public:
+        CowByteArray id;
+        int seq;
 
-		Id() :
-			seq(-1)
-		{
-		}
+        Id() : seq(-1) {}
 
-		Id(const CowByteArray &_id, int _seq = -1) :
-			id(_id),
-			seq(_seq)
-		{
-		}
-	};
+        Id(const CowByteArray &_id, int _seq = -1) : id(_id), seq(_seq) {}
+    };
 
-	enum Type
-	{
-		Data,
-		Error,
-		Credit,
-		KeepAlive,
-		Cancel,
-		HandoffStart,
-		HandoffProceed,
-		Close, // WebSocket
-		Ping, // WebSocket
-		Pong // WebSocket
-	};
+    enum Type {
+        Data,
+        Error,
+        Credit,
+        KeepAlive,
+        Cancel,
+        HandoffStart,
+        HandoffProceed,
+        Close, // WebSocket
+        Ping,  // WebSocket
+        Pong   // WebSocket
+    };
 
-	CowByteArray from;
-	QList<Id> ids;
+    CowByteArray from;
+    QList<Id> ids;
 
-	Type type;
-	CowByteArray condition;
+    Type type;
+    CowByteArray condition;
 
-	int credits;
-	bool more;
+    int credits;
+    bool more;
 
-	int code;
-	CowByteArray reason;
-	HttpHeaders headers;
-	CowByteArray body;
+    int code;
+    CowByteArray reason;
+    HttpHeaders headers;
+    CowByteArray body;
 
-	CowByteArray contentType; // WebSocket
+    CowByteArray contentType; // WebSocket
 
-	Variant userData;
+    Variant userData;
 
-	bool multi;
+    bool multi;
 
-	ZhttpResponsePacket() :
-		type((Type)-1),
-		credits(-1),
-		more(false),
-		code(-1),
-		multi(false)
-	{
-	}
+    ZhttpResponsePacket() : type((Type)-1), credits(-1), more(false), code(-1), multi(false) {}
 
-	Variant toVariant() const;
-	bool fromVariant(const Variant &in);
+    Variant toVariant() const;
+    bool fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/core/zmqcontext.cpp
+++ b/src/core/zmqcontext.cpp
@@ -23,16 +23,12 @@
 
 #include "zmqcontext.h"
 
-#include <assert.h>
 #include "rust/bindings.h"
+#include <assert.h>
 
-ZmqContext::ZmqContext(int ioThreads)
-{
-	context_ = ffi::wzmq_init(ioThreads);
-	assert(context_);
+ZmqContext::ZmqContext(int ioThreads) {
+    context_ = ffi::wzmq_init(ioThreads);
+    assert(context_);
 }
 
-ZmqContext::~ZmqContext()
-{
-	ffi::wzmq_term(context_);
-}
+ZmqContext::~ZmqContext() { ffi::wzmq_term(context_); }

--- a/src/core/zmqcontext.h
+++ b/src/core/zmqcontext.h
@@ -24,17 +24,16 @@
 #ifndef ZMQCONTEXT_H
 #define ZMQCONTEXT_H
 
-class ZmqContext
-{
+class ZmqContext {
 public:
-	ZmqContext(int ioThreads = 1);
-	~ZmqContext();
+    ZmqContext(int ioThreads = 1);
+    ~ZmqContext();
 
-	// The zmq context
-	void *context() { return context_; }
+    // The zmq context
+    void *context() { return context_; }
 
 private:
-	void *context_;
+    void *context_;
 };
 
 #endif

--- a/src/core/zmqreprouter.cpp
+++ b/src/core/zmqreprouter.cpp
@@ -24,69 +24,40 @@
 #include "zmqreprouter.h"
 
 #include "cowstring.h"
-#include "zmqsocket.h"
 #include "zmqreqmessage.h"
+#include "zmqsocket.h"
 
-class ZmqRepRouter::Private
-{
+class ZmqRepRouter::Private {
 public:
-	ZmqRepRouter *q;
-	std::unique_ptr<ZmqSocket> sock;
-	Connection mWConnection;
-	Connection rrConnection;
+    ZmqRepRouter *q;
+    std::unique_ptr<ZmqSocket> sock;
+    Connection mWConnection;
+    Connection rrConnection;
 
-	Private(ZmqRepRouter *_q) :
-		q(_q)
-	{
-		sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		rrConnection = sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this));
-		mWConnection = sock->messagesWritten.connect(boost::bind(&Private::sock_messagesWritten, this,  boost::placeholders::_1));
-	}
+    Private(ZmqRepRouter *_q) : q(_q) {
+        sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        rrConnection = sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this));
+        mWConnection = sock->messagesWritten.connect(
+            boost::bind(&Private::sock_messagesWritten, this, boost::placeholders::_1));
+    }
 
-	void sock_messagesWritten(int count)
-	{
-		q->messagesWritten(count);
-	}
+    void sock_messagesWritten(int count) { q->messagesWritten(count); }
 
-	void sock_readyRead()
-	{
-		q->readyRead();
-	}
+    void sock_readyRead() { q->readyRead(); }
 };
 
-ZmqRepRouter::ZmqRepRouter()
-{
-	d = std::make_unique<Private>(this);
-}
+ZmqRepRouter::ZmqRepRouter() { d = std::make_unique<Private>(this); }
 
 ZmqRepRouter::~ZmqRepRouter() = default;
 
-void ZmqRepRouter::setShutdownWaitTime(int msecs)
-{
-	d->sock->setShutdownWaitTime(msecs);
-}
+void ZmqRepRouter::setShutdownWaitTime(int msecs) { d->sock->setShutdownWaitTime(msecs); }
 
-void ZmqRepRouter::connectToAddress(const CowString &addr)
-{
-	d->sock->connectToAddress(addr);
-}
+void ZmqRepRouter::connectToAddress(const CowString &addr) { d->sock->connectToAddress(addr); }
 
-bool ZmqRepRouter::bind(const CowString &addr)
-{
-	return d->sock->bind(addr);
-}
+bool ZmqRepRouter::bind(const CowString &addr) { return d->sock->bind(addr); }
 
-bool ZmqRepRouter::canRead() const
-{
-	return d->sock->canRead();
-}
+bool ZmqRepRouter::canRead() const { return d->sock->canRead(); }
 
-ZmqReqMessage ZmqRepRouter::read()
-{
-	return ZmqReqMessage(d->sock->read());
-}
+ZmqReqMessage ZmqRepRouter::read() { return ZmqReqMessage(d->sock->read()); }
 
-void ZmqRepRouter::write(const ZmqReqMessage &message)
-{
-	d->sock->write(message.toRawMessage());
-}
+void ZmqRepRouter::write(const ZmqReqMessage &message) { d->sock->write(message.toRawMessage()); }

--- a/src/core/zmqreprouter.h
+++ b/src/core/zmqreprouter.h
@@ -34,32 +34,31 @@ using Connection = boost::signals2::scoped_connection;
 
 class ZmqReqMessage;
 
-class ZmqRepRouter
-{
+class ZmqRepRouter {
 public:
-	ZmqRepRouter();
-	~ZmqRepRouter();
+    ZmqRepRouter();
+    ~ZmqRepRouter();
 
-	void setShutdownWaitTime(int msecs);
+    void setShutdownWaitTime(int msecs);
 
-	void connectToAddress(const CowString &addr);
-	bool bind(const CowString &addr);
+    void connectToAddress(const CowString &addr);
+    bool bind(const CowString &addr);
 
-	bool canRead() const;
+    bool canRead() const;
 
-	ZmqReqMessage read();
-	void write(const ZmqReqMessage &message);
+    ZmqReqMessage read();
+    void write(const ZmqReqMessage &message);
 
-	Signal readyRead;
-	SignalInt messagesWritten;
+    Signal readyRead;
+    SignalInt messagesWritten;
 
 private:
-	ZmqRepRouter(const ZmqRepRouter &) = delete;
-	ZmqRepRouter &operator=(const ZmqRepRouter &) = delete;
+    ZmqRepRouter(const ZmqRepRouter &) = delete;
+    ZmqRepRouter &operator=(const ZmqRepRouter &) = delete;
 
-	class Private;
-	friend class Private;
-	std::unique_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::unique_ptr<Private> d;
 };
 
 #endif

--- a/src/core/zmqreqmessage.h
+++ b/src/core/zmqreqmessage.h
@@ -26,59 +26,48 @@
 
 #include "cowbytearray.h"
 
-class ZmqReqMessage
-{
+class ZmqReqMessage {
 public:
-	ZmqReqMessage()
-	{
-	}
+    ZmqReqMessage() {}
 
-	ZmqReqMessage(const CowByteArrayList &headers, const CowByteArrayList &content) :
-		headers_(headers),
-		content_(content)
-	{
-	}
+    ZmqReqMessage(const CowByteArrayList &headers, const CowByteArrayList &content)
+        : headers_(headers), content_(content) {}
 
-	ZmqReqMessage(const CowByteArrayList &rawMessage)
-	{
-		bool collectHeaders = true;
-		for(CowByteArrayConstRef part : std::as_const(rawMessage))
-		{
-			if(part.isEmpty())
-			{
-				collectHeaders = false;
-				continue;
-			}
+    ZmqReqMessage(const CowByteArrayList &rawMessage) {
+        bool collectHeaders = true;
+        for (CowByteArrayConstRef part : std::as_const(rawMessage)) {
+            if (part.isEmpty()) {
+                collectHeaders = false;
+                continue;
+            }
 
-			if(collectHeaders)
-				headers_ += part;
-			else
-				content_ += part;
-		}
-	}
+            if (collectHeaders)
+                headers_ += part;
+            else
+                content_ += part;
+        }
+    }
 
-	bool isNull() const { return headers_.isEmpty() && content_.isEmpty(); }
+    bool isNull() const { return headers_.isEmpty() && content_.isEmpty(); }
 
-	CowByteArrayList headers() const { return headers_; }
-	CowByteArrayList content() const { return content_; }
+    CowByteArrayList headers() const { return headers_; }
+    CowByteArrayList content() const { return content_; }
 
-	ZmqReqMessage createReply(const CowByteArrayList &content)
-	{
-		return ZmqReqMessage(headers_, content);
-	}
+    ZmqReqMessage createReply(const CowByteArrayList &content) {
+        return ZmqReqMessage(headers_, content);
+    }
 
-	CowByteArrayList toRawMessage() const
-	{
-		CowByteArrayList out;
-		out += headers_;
-		out += CowByteArray();
-		out += content_;
-		return out;
-	}
+    CowByteArrayList toRawMessage() const {
+        CowByteArrayList out;
+        out += headers_;
+        out += CowByteArray();
+        out += content_;
+        return out;
+    }
 
 private:
-	CowByteArrayList headers_;
-	CowByteArrayList content_;
+    CowByteArrayList headers_;
+    CowByteArrayList content_;
 };
 
 #endif

--- a/src/core/zmqsocket.cpp
+++ b/src/core/zmqsocket.cpp
@@ -24,640 +24,533 @@
 
 #include "zmqsocket.h"
 
+#include "cowstring.h"
+#include "rust/bindings.h"
+#include "socketnotifier.h"
+#include "timer.h"
+#include "zmqcontext.h"
 #include <assert.h>
+#include <boost/signals2.hpp>
 #include <list>
 #include <mutex>
-#include <boost/signals2.hpp>
-#include "rust/bindings.h"
-#include "cowstring.h"
-#include "zmqcontext.h"
-#include "timer.h"
-#include "socketnotifier.h"
 
 using Connection = boost::signals2::scoped_connection;
 
-static int get_fd(void *sock)
-{
-	int fd;
-	size_t opt_len = sizeof(fd);
-	int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_FD, &fd, &opt_len);
-	assert(ret == 0);
-	return fd;
+static int get_fd(void *sock) {
+    int fd;
+    size_t opt_len = sizeof(fd);
+    int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_FD, &fd, &opt_len);
+    assert(ret == 0);
+    return fd;
 }
 
-static void set_subscribe(void *sock, const char *data, int size)
-{
-	size_t opt_len = size;
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_SUBSCRIBE, data, opt_len);
-	assert(ret == 0);
+static void set_subscribe(void *sock, const char *data, int size) {
+    size_t opt_len = size;
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_SUBSCRIBE, data, opt_len);
+    assert(ret == 0);
 }
 
-static void set_unsubscribe(void *sock, const char *data, int size)
-{
-	size_t opt_len = size;
-	ffi::wzmq_setsockopt(sock, ffi::WZMQ_UNSUBSCRIBE, data, opt_len);
-	// Note: we ignore errors, such as unsubscribing a nonexisting filter
+static void set_unsubscribe(void *sock, const char *data, int size) {
+    size_t opt_len = size;
+    ffi::wzmq_setsockopt(sock, ffi::WZMQ_UNSUBSCRIBE, data, opt_len);
+    // Note: we ignore errors, such as unsubscribing a nonexisting filter
 }
 
-static void set_linger(void *sock, int value)
-{
-	size_t opt_len = sizeof(value);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_LINGER, &value, opt_len);
-	assert(ret == 0);
+static void set_linger(void *sock, int value) {
+    size_t opt_len = sizeof(value);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_LINGER, &value, opt_len);
+    assert(ret == 0);
 }
 
-static int get_identity(void *sock, char *data, int size)
-{
-	size_t opt_len = size;
-	int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_IDENTITY, data, &opt_len);
-	assert(ret == 0);
-	return (int)opt_len;
+static int get_identity(void *sock, char *data, int size) {
+    size_t opt_len = size;
+    int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_IDENTITY, data, &opt_len);
+    assert(ret == 0);
+    return (int)opt_len;
 }
 
-static void set_identity(void *sock, const char *data, int size)
-{
-	size_t opt_len = size;
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_IDENTITY, data, opt_len);
-	assert(ret == 0);
+static void set_identity(void *sock, const char *data, int size) {
+    size_t opt_len = size;
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_IDENTITY, data, opt_len);
+    assert(ret == 0);
 }
 
-static void set_immediate(void *sock, bool on)
-{
-	int v = on ? 1 : 0;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_IMMEDIATE, &v, opt_len);
-	assert(ret == 0);
+static void set_immediate(void *sock, bool on) {
+    int v = on ? 1 : 0;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_IMMEDIATE, &v, opt_len);
+    assert(ret == 0);
 }
 
-static void set_router_mandatory(void *sock, bool on)
-{
-	int v = on ? 1 : 0;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_ROUTER_MANDATORY, &v, opt_len);
-	assert(ret == 0);
+static void set_router_mandatory(void *sock, bool on) {
+    int v = on ? 1 : 0;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_ROUTER_MANDATORY, &v, opt_len);
+    assert(ret == 0);
 }
 
-static void set_probe_router(void *sock, bool on)
-{
-	int v = on ? 1 : 0;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_PROBE_ROUTER, &v, opt_len);
-	assert(ret == 0);
+static void set_probe_router(void *sock, bool on) {
+    int v = on ? 1 : 0;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_PROBE_ROUTER, &v, opt_len);
+    assert(ret == 0);
 }
 
-static bool get_rcvmore(void *sock)
-{
-	int more;
-	size_t opt_len = sizeof(more);
-	int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_RCVMORE, &more, &opt_len);
-	assert(ret == 0);
-	return more ? true : false;
+static bool get_rcvmore(void *sock) {
+    int more;
+    size_t opt_len = sizeof(more);
+    int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_RCVMORE, &more, &opt_len);
+    assert(ret == 0);
+    return more ? true : false;
 }
 
-static int get_events(void *sock)
-{
-	while(true)
-	{
-		int events;
-		size_t opt_len = sizeof(events);
+static int get_events(void *sock) {
+    while (true) {
+        int events;
+        size_t opt_len = sizeof(events);
 
-		int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_EVENTS, &events, &opt_len);
-		if(ret == 0)
-		{
-			return (int)events;
-		}
+        int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_EVENTS, &events, &opt_len);
+        if (ret == 0) {
+            return (int)events;
+        }
 
-		assert(errno == EINTR);
-	}
+        assert(errno == EINTR);
+    }
 }
 
-static int get_sndhwm(void *sock)
-{
-	int hwm;
-	size_t opt_len = sizeof(hwm);
-	int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_SNDHWM, &hwm, &opt_len);
-	assert(ret == 0);
-	return (int)hwm;
+static int get_sndhwm(void *sock) {
+    int hwm;
+    size_t opt_len = sizeof(hwm);
+    int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_SNDHWM, &hwm, &opt_len);
+    assert(ret == 0);
+    return (int)hwm;
 }
 
-static void set_sndhwm(void *sock, int value)
-{
-	int v = value;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_SNDHWM, &v, opt_len);
-	assert(ret == 0);
+static void set_sndhwm(void *sock, int value) {
+    int v = value;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_SNDHWM, &v, opt_len);
+    assert(ret == 0);
 }
 
-static int get_rcvhwm(void *sock)
-{
-	int hwm;
-	size_t opt_len = sizeof(hwm);
-	int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_RCVHWM, &hwm, &opt_len);
-	assert(ret == 0);
-	return (int)hwm;
+static int get_rcvhwm(void *sock) {
+    int hwm;
+    size_t opt_len = sizeof(hwm);
+    int ret = ffi::wzmq_getsockopt(sock, ffi::WZMQ_RCVHWM, &hwm, &opt_len);
+    assert(ret == 0);
+    return (int)hwm;
 }
 
-static void set_rcvhwm(void *sock, int value)
-{
-	int v = value;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_RCVHWM, &v, opt_len);
-	assert(ret == 0);
+static void set_rcvhwm(void *sock, int value) {
+    int v = value;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_RCVHWM, &v, opt_len);
+    assert(ret == 0);
 }
 
-static int get_hwm(void *sock)
-{
-	return get_sndhwm(sock);
+static int get_hwm(void *sock) { return get_sndhwm(sock); }
+
+static void set_hwm(void *sock, int value) {
+    set_sndhwm(sock, value);
+    set_rcvhwm(sock, value);
 }
 
-static void set_hwm(void *sock, int value)
-{
-	set_sndhwm(sock, value);
-	set_rcvhwm(sock, value);
+static void set_tcp_keepalive(void *sock, int value) {
+    int v = value;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE, &v, opt_len);
+    assert(ret == 0);
 }
 
-static void set_tcp_keepalive(void *sock, int value)
-{
-	int v = value;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE, &v, opt_len);
-	assert(ret == 0);
+static void set_tcp_keepalive_idle(void *sock, int value) {
+    int v = value;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE_IDLE, &v, opt_len);
+    assert(ret == 0);
 }
 
-static void set_tcp_keepalive_idle(void *sock, int value)
-{
-	int v = value;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE_IDLE, &v, opt_len);
-	assert(ret == 0);
+static void set_tcp_keepalive_cnt(void *sock, int value) {
+    int v = value;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE_CNT, &v, opt_len);
+    assert(ret == 0);
 }
 
-static void set_tcp_keepalive_cnt(void *sock, int value)
-{
-	int v = value;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE_CNT, &v, opt_len);
-	assert(ret == 0);
+static void set_tcp_keepalive_intvl(void *sock, int value) {
+    int v = value;
+    size_t opt_len = sizeof(v);
+    int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE_INTVL, &v, opt_len);
+    assert(ret == 0);
 }
 
-static void set_tcp_keepalive_intvl(void *sock, int value)
-{
-	int v = value;
-	size_t opt_len = sizeof(v);
-	int ret = ffi::wzmq_setsockopt(sock, ffi::WZMQ_TCP_KEEPALIVE_INTVL, &v, opt_len);
-	assert(ret == 0);
+static std::mutex &g_mutex() {
+    static std::mutex m;
+    return m;
 }
 
-static std::mutex &g_mutex()
-{
-	static std::mutex m;
-	return m;
-}
-
-class Global
-{
+class Global {
 public:
-	ZmqContext context;
-	int refs;
+    ZmqContext context;
+    int refs;
 
-	Global() :
-		refs(0)
-	{
-	}
+    Global() : refs(0) {}
 };
 
 static Global *global = nullptr;
 
-static ZmqContext *addGlobalContextRef()
-{
-	std::lock_guard<std::mutex> guard(g_mutex());
+static ZmqContext *addGlobalContextRef() {
+    std::lock_guard<std::mutex> guard(g_mutex());
 
-	if(!global)
-		global = new Global;
+    if (!global)
+        global = new Global;
 
-	++(global->refs);
-	return &(global->context);
+    ++(global->refs);
+    return &(global->context);
 }
 
-static void removeGlobalContextRef()
-{
-	std::lock_guard<std::mutex> guard(g_mutex());
+static void removeGlobalContextRef() {
+    std::lock_guard<std::mutex> guard(g_mutex());
 
-	assert(global);
-	assert(global->refs > 0);
+    assert(global);
+    assert(global->refs > 0);
 
-	--(global->refs);
-	if(global->refs == 0)
-	{
-		delete global;
-		global = nullptr;
-	}
+    --(global->refs);
+    if (global->refs == 0) {
+        delete global;
+        global = nullptr;
+    }
 }
 
-class ZmqSocket::Private
-{
+class ZmqSocket::Private {
 public:
-	ZmqSocket *q;
-	bool usingGlobalContext;
-	ZmqContext *context;
-	void *sock;
-	std::unique_ptr<SocketNotifier> sn_read;
-	bool canWrite, canRead;
-	std::list<CowByteArrayList> pendingWrites;
-	int pendingWritten;
-	std::unique_ptr<Timer> updateTimer;
-	Connection updateTimerConnection;
-	bool pendingUpdate;
-	int shutdownWaitTime;
-	bool writeQueueEnabled;
+    ZmqSocket *q;
+    bool usingGlobalContext;
+    ZmqContext *context;
+    void *sock;
+    std::unique_ptr<SocketNotifier> sn_read;
+    bool canWrite, canRead;
+    std::list<CowByteArrayList> pendingWrites;
+    int pendingWritten;
+    std::unique_ptr<Timer> updateTimer;
+    Connection updateTimerConnection;
+    bool pendingUpdate;
+    int shutdownWaitTime;
+    bool writeQueueEnabled;
 
-	Private(ZmqSocket *_q, ZmqSocket::Type type, ZmqContext *_context) :
-		q(_q),
-		canWrite(false),
-		canRead(false),
-		pendingWritten(0),
-		pendingUpdate(false),
-		shutdownWaitTime(-1),
-		writeQueueEnabled(true)
-	{
-		if(_context)
-		{
-			usingGlobalContext = false;
-			context = _context;
-		}
-		else
-		{
-			usingGlobalContext = true;
-			context = addGlobalContextRef();
-		}
+    Private(ZmqSocket *_q, ZmqSocket::Type type, ZmqContext *_context)
+        : q(_q),
+          canWrite(false),
+          canRead(false),
+          pendingWritten(0),
+          pendingUpdate(false),
+          shutdownWaitTime(-1),
+          writeQueueEnabled(true) {
+        if (_context) {
+            usingGlobalContext = false;
+            context = _context;
+        } else {
+            usingGlobalContext = true;
+            context = addGlobalContextRef();
+        }
 
-		int ztype = 0;
-		switch(type)
-		{
-			case ZmqSocket::Pair: ztype = ffi::WZMQ_PAIR; break;
-			case ZmqSocket::Dealer: ztype = ffi::WZMQ_DEALER; break;
-			case ZmqSocket::Router: ztype = ffi::WZMQ_ROUTER; break;
-			case ZmqSocket::Req: ztype = ffi::WZMQ_REQ; break;
-			case ZmqSocket::Rep: ztype = ffi::WZMQ_REP; break;
-			case ZmqSocket::Push: ztype = ffi::WZMQ_PUSH; break;
-			case ZmqSocket::Pull: ztype = ffi::WZMQ_PULL; break;
-			case ZmqSocket::Pub: ztype = ffi::WZMQ_PUB; break;
-			case ZmqSocket::Sub: ztype = ffi::WZMQ_SUB; break;
-			default:
-				assert(0);
-		}
+        int ztype = 0;
+        switch (type) {
+        case ZmqSocket::Pair:
+            ztype = ffi::WZMQ_PAIR;
+            break;
+        case ZmqSocket::Dealer:
+            ztype = ffi::WZMQ_DEALER;
+            break;
+        case ZmqSocket::Router:
+            ztype = ffi::WZMQ_ROUTER;
+            break;
+        case ZmqSocket::Req:
+            ztype = ffi::WZMQ_REQ;
+            break;
+        case ZmqSocket::Rep:
+            ztype = ffi::WZMQ_REP;
+            break;
+        case ZmqSocket::Push:
+            ztype = ffi::WZMQ_PUSH;
+            break;
+        case ZmqSocket::Pull:
+            ztype = ffi::WZMQ_PULL;
+            break;
+        case ZmqSocket::Pub:
+            ztype = ffi::WZMQ_PUB;
+            break;
+        case ZmqSocket::Sub:
+            ztype = ffi::WZMQ_SUB;
+            break;
+        default:
+            assert(0);
+        }
 
-		sock = ffi::wzmq_socket(context->context(), ztype);
-		assert(sock != NULL);
+        sock = ffi::wzmq_socket(context->context(), ztype);
+        assert(sock != NULL);
 
-		sn_read = std::make_unique<SocketNotifier>(get_fd(sock), SocketNotifier::Read);
-		sn_read->activated.connect(boost::bind(&Private::sn_read_activated, this));
-		sn_read->setReadEnabled(true);
+        sn_read = std::make_unique<SocketNotifier>(get_fd(sock), SocketNotifier::Read);
+        sn_read->activated.connect(boost::bind(&Private::sn_read_activated, this));
+        sn_read->setReadEnabled(true);
 
-		updateTimer = std::make_unique<Timer>();
-		updateTimerConnection = updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));
-		updateTimer->setSingleShot(true);
+        updateTimer = std::make_unique<Timer>();
+        updateTimerConnection =
+            updateTimer->timeout.connect(boost::bind(&Private::update_timeout, this));
+        updateTimer->setSingleShot(true);
 
-		// Socket notifier starts out ready. Attempt to read events
-		if(processEvents())
-		{
-			// If there are events, queue them for processing
-			update();
-		}
-	}
+        // Socket notifier starts out ready. Attempt to read events
+        if (processEvents()) {
+            // If there are events, queue them for processing
+            update();
+        }
+    }
 
-	~Private()
-	{
-		sn_read.reset();
+    ~Private() {
+        sn_read.reset();
 
-		set_linger(sock, shutdownWaitTime);
-		ffi::wzmq_close(sock);
+        set_linger(sock, shutdownWaitTime);
+        ffi::wzmq_close(sock);
 
-		if(usingGlobalContext)
-			removeGlobalContextRef();
-	}
+        if (usingGlobalContext)
+            removeGlobalContextRef();
+    }
 
-	void update()
-	{
-		if(!pendingUpdate)
-		{
-			pendingUpdate = true;
-			updateTimer->start();
-		}
-	}
+    void update() {
+        if (!pendingUpdate) {
+            pendingUpdate = true;
+            updateTimer->start();
+        }
+    }
 
-	CowByteArrayList read()
-	{
-		if(canRead)
-		{
-			CowByteArrayList out;
+    CowByteArrayList read() {
+        if (canRead) {
+            CowByteArrayList out;
 
-			bool ok = true;
+            bool ok = true;
 
-			do
-			{
-				ffi::wzmq_msg_t msg;
+            do {
+                ffi::wzmq_msg_t msg;
 
-				int ret = ffi::wzmq_msg_init(&msg);
-				assert(ret == 0);
+                int ret = ffi::wzmq_msg_init(&msg);
+                assert(ret == 0);
 
-				ret = ffi::wzmq_msg_recv(&msg, sock, ffi::WZMQ_DONTWAIT);
+                ret = ffi::wzmq_msg_recv(&msg, sock, ffi::WZMQ_DONTWAIT);
 
-				if(ret < 0)
-				{
-					ret = ffi::wzmq_msg_close(&msg);
-					assert(ret == 0);
+                if (ret < 0) {
+                    ret = ffi::wzmq_msg_close(&msg);
+                    assert(ret == 0);
 
-					ok = false;
-					break;
-				}
+                    ok = false;
+                    break;
+                }
 
-				CowByteArray buf((const char *)ffi::wzmq_msg_data(&msg), ffi::wzmq_msg_size(&msg));
+                CowByteArray buf((const char *)ffi::wzmq_msg_data(&msg), ffi::wzmq_msg_size(&msg));
 
-				ret = ffi::wzmq_msg_close(&msg);
-				assert(ret == 0);
+                ret = ffi::wzmq_msg_close(&msg);
+                assert(ret == 0);
 
-				out += buf;
-			} while(get_rcvmore(sock));
+                out += buf;
+            } while (get_rcvmore(sock));
 
-			processEvents();
+            processEvents();
 
-			if((canWrite && !pendingWrites.empty()) || canRead)
-				update();
+            if ((canWrite && !pendingWrites.empty()) || canRead)
+                update();
 
-			if(ok)
-				return out;
-			else
-				return CowByteArrayList();
-		}
-		else
-			return CowByteArrayList();
-	}
+            if (ok)
+                return out;
+            else
+                return CowByteArrayList();
+        } else
+            return CowByteArrayList();
+    }
 
-	void write(const CowByteArrayList &message)
-	{
-		assert(!message.isEmpty());
+    void write(const CowByteArrayList &message) {
+        assert(!message.isEmpty());
 
-		if(writeQueueEnabled)
-		{
-			pendingWrites.push_back(message);
+        if (writeQueueEnabled) {
+            pendingWrites.push_back(message);
 
-			if(canWrite)
-				update();
-		}
-		else
-		{
-			if(zmqWrite(message))
-			{
-				++pendingWritten;
-			}
+            if (canWrite)
+                update();
+        } else {
+            if (zmqWrite(message)) {
+                ++pendingWritten;
+            }
 
-			processEvents();
+            processEvents();
 
-			if(pendingWritten > 0 || canRead)
-				update();
-		}
-	}
+            if (pendingWritten > 0 || canRead)
+                update();
+        }
+    }
 
-	// Return true if flags changed
-	bool processEvents()
-	{
-		int flags = get_events(sock);
+    // Return true if flags changed
+    bool processEvents() {
+        int flags = get_events(sock);
 
-		sn_read->clearReadiness(SocketNotifier::Read);
+        sn_read->clearReadiness(SocketNotifier::Read);
 
-		bool canWriteOld = canWrite;
-		bool canReadOld = canRead;
+        bool canWriteOld = canWrite;
+        bool canReadOld = canRead;
 
-		canWrite = (flags & ffi::WZMQ_POLLOUT);
-		canRead = (flags & ffi::WZMQ_POLLIN);
+        canWrite = (flags & ffi::WZMQ_POLLOUT);
+        canRead = (flags & ffi::WZMQ_POLLIN);
 
-		return (canWrite != canWriteOld || canRead != canReadOld);
-	}
+        return (canWrite != canWriteOld || canRead != canReadOld);
+    }
 
-	bool zmqWrite(const CowByteArrayList &message)
-	{
-		for(int n = 0; n < message.count(); ++n)
-		{
-			CowByteArrayConstRef buf = message[n];
+    bool zmqWrite(const CowByteArrayList &message) {
+        for (int n = 0; n < message.count(); ++n) {
+            CowByteArrayConstRef buf = message[n];
 
-			ffi::wzmq_msg_t msg;
+            ffi::wzmq_msg_t msg;
 
-			int ret = ffi::wzmq_msg_init_size(&msg, buf.size());
-			assert(ret == 0);
+            int ret = ffi::wzmq_msg_init_size(&msg, buf.size());
+            assert(ret == 0);
 
-			memcpy(ffi::wzmq_msg_data(&msg), buf.data(), buf.size());
+            memcpy(ffi::wzmq_msg_data(&msg), buf.data(), buf.size());
 
-			ret = ffi::wzmq_msg_send(&msg, sock, ffi::WZMQ_DONTWAIT | (n + 1 < message.count() ? ffi::WZMQ_SNDMORE : 0));
+            ret = ffi::wzmq_msg_send(
+                &msg, sock, ffi::WZMQ_DONTWAIT | (n + 1 < message.count() ? ffi::WZMQ_SNDMORE : 0));
 
-			if(ret < 0)
-			{
-				ret = ffi::wzmq_msg_close(&msg);
-				assert(ret == 0);
+            if (ret < 0) {
+                ret = ffi::wzmq_msg_close(&msg);
+                assert(ret == 0);
 
-				return false;
-			}
+                return false;
+            }
 
-			ret = ffi::wzmq_msg_close(&msg);
-			assert(ret == 0);
-		}
+            ret = ffi::wzmq_msg_close(&msg);
+            assert(ret == 0);
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	void tryWrite()
-	{
-		while(canWrite && !pendingWrites.empty())
-		{
-			// Whether this write succeeds or not, we assume we
-			// can't write afterwards
-			canWrite = false;
+    void tryWrite() {
+        while (canWrite && !pendingWrites.empty()) {
+            // Whether this write succeeds or not, we assume we
+            // can't write afterwards
+            canWrite = false;
 
-			if(zmqWrite(pendingWrites.front()))
-			{
-				pendingWrites.pop_front();
-				++pendingWritten;
-			}
+            if (zmqWrite(pendingWrites.front())) {
+                pendingWrites.pop_front();
+                ++pendingWritten;
+            }
 
-			processEvents();
-		}
-	}
+            processEvents();
+        }
+    }
 
-	void doUpdate()
-	{
-		tryWrite();
+    void doUpdate() {
+        tryWrite();
 
-		if(canRead)
-		{
-			std::weak_ptr<Private> self = q->d;
-			q->readyRead();
-			if(self.expired())
-				return;
-		}
+        if (canRead) {
+            std::weak_ptr<Private> self = q->d;
+            q->readyRead();
+            if (self.expired())
+                return;
+        }
 
-		if(pendingWritten > 0)
-		{
-			int count = pendingWritten;
-			pendingWritten = 0;
+        if (pendingWritten > 0) {
+            int count = pendingWritten;
+            pendingWritten = 0;
 
-			q->messagesWritten(count);
-		}
-	}
+            q->messagesWritten(count);
+        }
+    }
 
-	void update_timeout()
-	{
-		pendingUpdate = false;
+    void update_timeout() {
+        pendingUpdate = false;
 
-		doUpdate();
-	}
+        doUpdate();
+    }
 
-	void sn_read_activated()
-	{
-		if(!processEvents())
-			return;
+    void sn_read_activated() {
+        if (!processEvents())
+            return;
 
-		if(pendingUpdate)
-		{
-			pendingUpdate = false;
-			updateTimer->stop();
-		}
+        if (pendingUpdate) {
+            pendingUpdate = false;
+            updateTimer->stop();
+        }
 
-		doUpdate();
-	}
+        doUpdate();
+    }
 };
 
-ZmqSocket::ZmqSocket(Type type)
-{
-	d = std::make_shared<Private>(this, type, nullptr);
-}
+ZmqSocket::ZmqSocket(Type type) { d = std::make_shared<Private>(this, type, nullptr); }
 
-ZmqSocket::ZmqSocket(Type type, ZmqContext *context)
-{
-	d = std::make_shared<Private>(this, type, context);
+ZmqSocket::ZmqSocket(Type type, ZmqContext *context) {
+    d = std::make_shared<Private>(this, type, context);
 }
 
 ZmqSocket::~ZmqSocket() = default;
 
-void ZmqSocket::setShutdownWaitTime(int msecs)
-{
-	d->shutdownWaitTime = msecs;
+void ZmqSocket::setShutdownWaitTime(int msecs) { d->shutdownWaitTime = msecs; }
+
+void ZmqSocket::setWriteQueueEnabled(bool enable) { d->writeQueueEnabled = enable; }
+
+void ZmqSocket::subscribe(const CowByteArray &filter) {
+    set_subscribe(d->sock, filter.data(), filter.size());
 }
 
-void ZmqSocket::setWriteQueueEnabled(bool enable)
-{
-	d->writeQueueEnabled = enable;
+void ZmqSocket::unsubscribe(const CowByteArray &filter) {
+    set_unsubscribe(d->sock, filter.data(), filter.size());
 }
 
-void ZmqSocket::subscribe(const CowByteArray &filter)
-{
-	set_subscribe(d->sock, filter.data(), filter.size());
+CowByteArray ZmqSocket::identity() const {
+    CowByteArray buf(255, 0);
+    buf.resize(get_identity(d->sock, buf.data(), buf.size()));
+    return buf;
 }
 
-void ZmqSocket::unsubscribe(const CowByteArray &filter)
-{
-	set_unsubscribe(d->sock, filter.data(), filter.size());
+void ZmqSocket::setIdentity(const CowByteArray &id) { set_identity(d->sock, id.data(), id.size()); }
+
+int ZmqSocket::hwm() const { return get_hwm(d->sock); }
+
+void ZmqSocket::setHwm(int hwm) { set_hwm(d->sock, hwm); }
+
+int ZmqSocket::sendHwm() const { return get_sndhwm(d->sock); }
+
+int ZmqSocket::receiveHwm() const { return get_rcvhwm(d->sock); }
+
+void ZmqSocket::setSendHwm(int hwm) { set_sndhwm(d->sock, hwm); }
+
+void ZmqSocket::setReceiveHwm(int hwm) { set_rcvhwm(d->sock, hwm); }
+
+void ZmqSocket::setImmediateEnabled(bool on) { set_immediate(d->sock, on); }
+
+void ZmqSocket::setRouterMandatoryEnabled(bool on) { set_router_mandatory(d->sock, on); }
+
+void ZmqSocket::setProbeRouterEnabled(bool on) { set_probe_router(d->sock, on); }
+
+void ZmqSocket::setTcpKeepAliveEnabled(bool on) { set_tcp_keepalive(d->sock, on ? 1 : 0); }
+
+void ZmqSocket::setTcpKeepAliveParameters(int idle, int count, int interval) {
+    set_tcp_keepalive_idle(d->sock, idle);
+    set_tcp_keepalive_cnt(d->sock, count);
+    set_tcp_keepalive_intvl(d->sock, interval);
 }
 
-CowByteArray ZmqSocket::identity() const
-{
-	CowByteArray buf(255, 0);
-	buf.resize(get_identity(d->sock, buf.data(), buf.size()));
-	return buf;
+void ZmqSocket::connectToAddress(const CowString &addr) {
+    int ret = ffi::wzmq_connect(d->sock, addr.toUtf8().data());
+    assert(ret == 0);
 }
 
-void ZmqSocket::setIdentity(const CowByteArray &id)
-{
-	set_identity(d->sock, id.data(), id.size());
+bool ZmqSocket::bind(const CowString &addr) {
+    int ret = ffi::wzmq_bind(d->sock, addr.toUtf8().data());
+    if (ret != 0)
+        return false;
+
+    return true;
 }
 
-int ZmqSocket::hwm() const
-{
-	return get_hwm(d->sock);
-}
+bool ZmqSocket::canRead() const { return d->canRead; }
 
-void ZmqSocket::setHwm(int hwm)
-{
-	set_hwm(d->sock, hwm);
-}
+bool ZmqSocket::canWriteImmediately() const { return d->canWrite; }
 
-int ZmqSocket::sendHwm() const
-{
-	return get_sndhwm(d->sock);
-}
+CowByteArrayList ZmqSocket::read() { return d->read(); }
 
-int ZmqSocket::receiveHwm() const
-{
-	return get_rcvhwm(d->sock);
-}
-
-void ZmqSocket::setSendHwm(int hwm)
-{
-	set_sndhwm(d->sock, hwm);
-}
-
-void ZmqSocket::setReceiveHwm(int hwm)
-{
-	set_rcvhwm(d->sock, hwm);
-}
-
-void ZmqSocket::setImmediateEnabled(bool on)
-{
-	set_immediate(d->sock, on);
-}
-
-void ZmqSocket::setRouterMandatoryEnabled(bool on)
-{
-	set_router_mandatory(d->sock, on);
-}
-
-void ZmqSocket::setProbeRouterEnabled(bool on)
-{
-	set_probe_router(d->sock, on);
-}
-
-void ZmqSocket::setTcpKeepAliveEnabled(bool on)
-{
-	set_tcp_keepalive(d->sock, on ? 1 : 0);
-}
-
-void ZmqSocket::setTcpKeepAliveParameters(int idle, int count, int interval)
-{
-	set_tcp_keepalive_idle(d->sock, idle);
-	set_tcp_keepalive_cnt(d->sock, count);
-	set_tcp_keepalive_intvl(d->sock, interval);
-}
-
-void ZmqSocket::connectToAddress(const CowString &addr)
-{
-	int ret = ffi::wzmq_connect(d->sock, addr.toUtf8().data());
-	assert(ret == 0);
-}
-
-bool ZmqSocket::bind(const CowString &addr)
-{
-	int ret = ffi::wzmq_bind(d->sock, addr.toUtf8().data());
-	if(ret != 0)
-		return false;
-
-	return true;
-}
-
-bool ZmqSocket::canRead() const
-{
-	return d->canRead;
-}
-
-bool ZmqSocket::canWriteImmediately() const
-{
-	return d->canWrite;
-}
-
-CowByteArrayList ZmqSocket::read()
-{
-	return d->read();
-}
-
-void ZmqSocket::write(const CowByteArrayList &message)
-{
-	d->write(message);
-}
+void ZmqSocket::write(const CowByteArrayList &message) { d->write(message); }

--- a/src/core/zmqsocket.h
+++ b/src/core/zmqsocket.h
@@ -25,8 +25,8 @@
 #ifndef ZMQSOCKET_H
 #define ZMQSOCKET_H
 
-#include <boost/signals2.hpp>
 #include "cowbytearray.h"
+#include <boost/signals2.hpp>
 
 class CowString;
 
@@ -36,84 +36,72 @@ using Connection = boost::signals2::scoped_connection;
 
 class ZmqContext;
 
-class ZmqSocket
-{
+class ZmqSocket {
 public:
-	enum Type
-	{
-		Pair,
-		Dealer,
-		Router,
-		Req,
-		Rep,
-		Push,
-		Pull,
-		Pub,
-		Sub
-	};
+    enum Type { Pair, Dealer, Router, Req, Rep, Push, Pull, Pub, Sub };
 
-	ZmqSocket(Type type);
-	ZmqSocket(Type type, ZmqContext *context);
-	~ZmqSocket();
+    ZmqSocket(Type type);
+    ZmqSocket(Type type, ZmqContext *context);
+    ~ZmqSocket();
 
-	// 0 means drop queue and don't block, -1 means infinite (default = -1)
-	void setShutdownWaitTime(int msecs);
+    // 0 means drop queue and don't block, -1 means infinite (default = -1)
+    void setShutdownWaitTime(int msecs);
 
-	// If enabled, messages are queued internally until the socket is able
-	// to accept them. The messagesWritten signal is emitted once writes
-	// have succeeded. Otherwise, messages are passed directly to
-	// zmq_send and dropped if they can't be written. Default enabled.
-	// disabling the queue is good for socket types where the HWM has a
-	// drop policy. Enabling the queue is good when the HWM has a
-	// blocking policy.
-	void setWriteQueueEnabled(bool enable);
+    // If enabled, messages are queued internally until the socket is able
+    // to accept them. The messagesWritten signal is emitted once writes
+    // have succeeded. Otherwise, messages are passed directly to
+    // zmq_send and dropped if they can't be written. Default enabled.
+    // disabling the queue is good for socket types where the HWM has a
+    // drop policy. Enabling the queue is good when the HWM has a
+    // blocking policy.
+    void setWriteQueueEnabled(bool enable);
 
-	void subscribe(const CowByteArray &filter);
-	void unsubscribe(const CowByteArray &filter);
+    void subscribe(const CowByteArray &filter);
+    void unsubscribe(const CowByteArray &filter);
 
-	CowByteArray identity() const;
-	void setIdentity(const CowByteArray &id);
+    CowByteArray identity() const;
+    void setIdentity(const CowByteArray &id);
 
-	// deprecated, zmq 2.x
-	int hwm() const;
-	void setHwm(int hwm);
+    // deprecated, zmq 2.x
+    int hwm() const;
+    void setHwm(int hwm);
 
-	int sendHwm() const;
-	int receiveHwm() const;
-	void setSendHwm(int hwm);
-	void setReceiveHwm(int hwm);
+    int sendHwm() const;
+    int receiveHwm() const;
+    void setSendHwm(int hwm);
+    void setReceiveHwm(int hwm);
 
-	void setImmediateEnabled(bool on);
-	void setRouterMandatoryEnabled(bool on);
-	void setProbeRouterEnabled(bool on);
+    void setImmediateEnabled(bool on);
+    void setRouterMandatoryEnabled(bool on);
+    void setProbeRouterEnabled(bool on);
 
-	void setTcpKeepAliveEnabled(bool on);
-	void setTcpKeepAliveParameters(int idle = -1, int count = -1, int interval = -1);
+    void setTcpKeepAliveEnabled(bool on);
+    void setTcpKeepAliveParameters(int idle = -1, int count = -1, int interval = -1);
 
-	void connectToAddress(const CowString &addr);
-	bool bind(const CowString &addr);
+    void connectToAddress(const CowString &addr);
+    bool bind(const CowString &addr);
 
-	bool canRead() const;
+    bool canRead() const;
 
-	// Returns true if this object believes the next write to zmq will
-	// succeed immediately. Note that it starts out false until the
-	// value is discovered. Also note that the write could still end up
-	// needing to be queued, if the conditions change in between.
-	bool canWriteImmediately() const;
+    // Returns true if this object believes the next write to zmq will
+    // succeed immediately. Note that it starts out false until the
+    // value is discovered. Also note that the write could still end up
+    // needing to be queued, if the conditions change in between.
+    bool canWriteImmediately() const;
 
-	CowByteArrayList read();
-	void write(const CowByteArrayList &message);
+    CowByteArrayList read();
+    void write(const CowByteArrayList &message);
 
-	Signal readyRead;
-	SignalInt messagesWritten;
+    Signal readyRead;
+    SignalInt messagesWritten;
 
 private:
-	ZmqSocket(const ZmqSocket &) = delete;
-	ZmqSocket &operator=(const ZmqSocket &) = delete;
+    ZmqSocket(const ZmqSocket &) = delete;
+    ZmqSocket &operator=(const ZmqSocket &) = delete;
 
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/core/zmqvalve.cpp
+++ b/src/core/zmqvalve.cpp
@@ -24,114 +24,87 @@
 
 #include "zmqvalve.h"
 
-#include "zmqsocket.h"
 #include "defercall.h"
+#include "zmqsocket.h"
 
-class ZmqValve::Private
-{
+class ZmqValve::Private {
 public:
-	ZmqValve *q;
-	ZmqSocket *sock;
-	bool isOpen;
-	bool pendingRead;
-	int maxReadsPerEvent;
-	boost::signals2::scoped_connection rrConnection;
-	DeferCall deferCall;
+    ZmqValve *q;
+    ZmqSocket *sock;
+    bool isOpen;
+    bool pendingRead;
+    int maxReadsPerEvent;
+    boost::signals2::scoped_connection rrConnection;
+    DeferCall deferCall;
 
-	Private(ZmqValve *_q) :
-		q(_q),
-		sock(0),
-		isOpen(false),
-		pendingRead(false),
-		maxReadsPerEvent(100)
-	{
-	}
+    Private(ZmqValve *_q)
+        : q(_q), sock(0), isOpen(false), pendingRead(false), maxReadsPerEvent(100) {}
 
-	void setup(ZmqSocket *_sock)
-	{
-		sock = _sock;
-		rrConnection = sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this));
-	}
+    void setup(ZmqSocket *_sock) {
+        sock = _sock;
+        rrConnection = sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this));
+    }
 
-	void queueRead()
-	{
-		if(pendingRead)
-			return;
+    void queueRead() {
+        if (pendingRead)
+            return;
 
-		pendingRead = true;
-		deferCall.defer([=] { queuedRead(); });
-	}
+        pendingRead = true;
+        deferCall.defer([=] { queuedRead(); });
+    }
 
-	void tryRead()
-	{
-		std::weak_ptr<Private> self = q->d;
+    void tryRead() {
+        std::weak_ptr<Private> self = q->d;
 
-		int count = 0;
-		while(isOpen && sock->canRead())
-		{
-			if(count >= maxReadsPerEvent)
-			{
-				queueRead();
-				return;
-			}
+        int count = 0;
+        while (isOpen && sock->canRead()) {
+            if (count >= maxReadsPerEvent) {
+                queueRead();
+                return;
+            }
 
-			CowByteArrayList msg = sock->read();
+            CowByteArrayList msg = sock->read();
 
-			if(!msg.isEmpty())
-			{
-				q->readyRead(msg);
-				if(self.expired())
-					return;
-			}
+            if (!msg.isEmpty()) {
+                q->readyRead(msg);
+                if (self.expired())
+                    return;
+            }
 
-			++count;
-		}
-	}
+            ++count;
+        }
+    }
 
-	void sock_readyRead()
-	{
-		if(pendingRead)
-			return;
+    void sock_readyRead() {
+        if (pendingRead)
+            return;
 
-		tryRead();
-	}
+        tryRead();
+    }
 
-	void queuedRead()
-	{
-		pendingRead = false;
-		tryRead();
-	}
+    void queuedRead() {
+        pendingRead = false;
+        tryRead();
+    }
 };
 
-ZmqValve::ZmqValve(ZmqSocket *sock)
-{
-	d = std::make_shared<Private>(this);
-	d->setup(sock);
+ZmqValve::ZmqValve(ZmqSocket *sock) {
+    d = std::make_shared<Private>(this);
+    d->setup(sock);
 }
 
 ZmqValve::~ZmqValve() = default;
 
-bool ZmqValve::isOpen() const
-{
-	return d->isOpen;
+bool ZmqValve::isOpen() const { return d->isOpen; }
+
+void ZmqValve::setMaxReadsPerEvent(int max) { d->maxReadsPerEvent = max; }
+
+void ZmqValve::open() {
+    if (!d->isOpen) {
+        d->isOpen = true;
+        if (!d->pendingRead && d->sock->canRead())
+            d->queueRead();
+    }
 }
 
-void ZmqValve::setMaxReadsPerEvent(int max)
-{
-	d->maxReadsPerEvent = max;
-}
-
-void ZmqValve::open()
-{
-	if(!d->isOpen)
-	{
-		d->isOpen = true;
-		if(!d->pendingRead && d->sock->canRead())
-			d->queueRead();
-	}
-}
-
-void ZmqValve::close()
-{
-	d->isOpen = false;
-}
+void ZmqValve::close() { d->isOpen = false; }

--- a/src/core/zmqvalve.h
+++ b/src/core/zmqvalve.h
@@ -25,33 +25,32 @@
 #ifndef ZMQVALVE_H
 #define ZMQVALVE_H
 
-#include <boost/signals2.hpp>
 #include "cowbytearray.h"
+#include <boost/signals2.hpp>
 
-using SignalList = boost::signals2::signal<void(const CowByteArrayList&)>;
+using SignalList = boost::signals2::signal<void(const CowByteArrayList &)>;
 using Connection = boost::signals2::scoped_connection;
 
 class ZmqSocket;
 
-class ZmqValve
-{
+class ZmqValve {
 public:
-	ZmqValve(ZmqSocket *sock);
-	~ZmqValve();
+    ZmqValve(ZmqSocket *sock);
+    ~ZmqValve();
 
-	bool isOpen() const;
+    bool isOpen() const;
 
-	void setMaxReadsPerEvent(int max);
+    void setMaxReadsPerEvent(int max);
 
-	void open();
-	void close();
+    void open();
+    void close();
 
-	SignalList readyRead;
+    SignalList readyRead;
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/core/zrpcmanager.cpp
+++ b/src/core/zrpcmanager.cpp
@@ -23,19 +23,19 @@
 
 #include "zrpcmanager.h"
 
-#include <assert.h>
-#include <QStringList>
-#include <QFile>
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "zmqreqmessage.h"
 #include "log.h"
-#include "tnetstring.h"
-#include "variant.h"
 #include "packet/zrpcrequestpacket.h"
 #include "packet/zrpcresponsepacket.h"
+#include "tnetstring.h"
+#include "variant.h"
+#include "zmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
 #include "zrpcrequest.h"
 #include "zutil.h"
+#include <QFile>
+#include <QStringList>
+#include <assert.h>
 
 #define OUT_HWM 100
 #define IN_HWM 100
@@ -45,295 +45,241 @@
 
 #define PENDING_MAX 100
 
-class ZrpcManager::Private
-{
+class ZrpcManager::Private {
 public:
-	class PendingItem
-	{
-	public:
-		QList<QByteArray> headers;
-		ZrpcRequestPacket packet;
-	};
+    class PendingItem {
+    public:
+        QList<QByteArray> headers;
+        ZrpcRequestPacket packet;
+    };
 
-	ZrpcManager *q;
-	QByteArray instanceId;
-	int ipcFileMode;
-	bool doBind;
-	int timeout;
-	QStringList clientSpecs;
-	QStringList serverSpecs;
-	std::unique_ptr<ZmqSocket> clientSock;
-	std::unique_ptr<ZmqSocket> serverSock;
-	std::unique_ptr<ZmqValve> clientValve;
-	std::unique_ptr<ZmqValve> serverValve;
-	QHash<QByteArray, ZrpcRequest*> clientReqsById;
-	QList<PendingItem> pending;
-	Connection clientValveConnection;
-	Connection serverValveConnection;
+    ZrpcManager *q;
+    QByteArray instanceId;
+    int ipcFileMode;
+    bool doBind;
+    int timeout;
+    QStringList clientSpecs;
+    QStringList serverSpecs;
+    std::unique_ptr<ZmqSocket> clientSock;
+    std::unique_ptr<ZmqSocket> serverSock;
+    std::unique_ptr<ZmqValve> clientValve;
+    std::unique_ptr<ZmqValve> serverValve;
+    QHash<QByteArray, ZrpcRequest *> clientReqsById;
+    QList<PendingItem> pending;
+    Connection clientValveConnection;
+    Connection serverValveConnection;
 
-	Private(ZrpcManager *_q) :
-		q(_q),
-		ipcFileMode(-1),
-		doBind(false),
-		timeout(-1)
-	{
-	}
+    Private(ZrpcManager *_q) : q(_q), ipcFileMode(-1), doBind(false), timeout(-1) {}
 
-	~Private()
-	{
-		assert(clientReqsById.isEmpty());
-	}
+    ~Private() { assert(clientReqsById.isEmpty()); }
 
-	bool setupClient()
-	{
-		clientValveConnection.disconnect();
-		clientValve.reset();
-		clientSock.reset();
+    bool setupClient() {
+        clientValveConnection.disconnect();
+        clientValve.reset();
+        clientSock.reset();
 
-		clientSock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
+        clientSock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
 
-		clientSock->setSendHwm(OUT_HWM);
-		clientSock->setShutdownWaitTime(REQ_WAIT_TIME);
+        clientSock->setSendHwm(OUT_HWM);
+        clientSock->setShutdownWaitTime(REQ_WAIT_TIME);
 
-		QString errorMessage;
-		if(!ZUtil::setupSocket(clientSock.get(), clientSpecs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
+        QString errorMessage;
+        if (!ZUtil::setupSocket(clientSock.get(), clientSpecs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
 
-		clientValve = std::make_unique<ZmqValve>(clientSock.get());
-		clientValveConnection = clientValve->readyRead.connect(boost::bind(&Private::client_readyRead, this, boost::placeholders::_1));
+        clientValve = std::make_unique<ZmqValve>(clientSock.get());
+        clientValveConnection = clientValve->readyRead.connect(
+            boost::bind(&Private::client_readyRead, this, boost::placeholders::_1));
 
-		clientValve->open();
+        clientValve->open();
 
-		return true;
-	}
+        return true;
+    }
 
-	bool setupServer()
-	{
-		serverValveConnection.disconnect();
-		serverValve.reset();
-		serverSock.reset();
+    bool setupServer() {
+        serverValveConnection.disconnect();
+        serverValve.reset();
+        serverSock.reset();
 
-		serverSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        serverSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 
-		serverSock->setReceiveHwm(IN_HWM);
-		serverSock->setShutdownWaitTime(REP_WAIT_TIME);
+        serverSock->setReceiveHwm(IN_HWM);
+        serverSock->setShutdownWaitTime(REP_WAIT_TIME);
 
-		QString errorMessage;
-		if(!ZUtil::setupSocket(serverSock.get(), serverSpecs, doBind, ipcFileMode, &errorMessage))
-		{
-			log_error("%s", qPrintable(errorMessage));
-			return false;
-		}
+        QString errorMessage;
+        if (!ZUtil::setupSocket(serverSock.get(), serverSpecs, doBind, ipcFileMode,
+                                &errorMessage)) {
+            log_error("%s", qPrintable(errorMessage));
+            return false;
+        }
 
-		serverValve = std::make_unique<ZmqValve>(serverSock.get());
-		serverValveConnection = serverValve->readyRead.connect(boost::bind(&Private::server_readyRead, this, boost::placeholders::_1));
+        serverValve = std::make_unique<ZmqValve>(serverSock.get());
+        serverValveConnection = serverValve->readyRead.connect(
+            boost::bind(&Private::server_readyRead, this, boost::placeholders::_1));
 
-		serverValve->open();
+        serverValve->open();
 
-		return true;
-	}
+        return true;
+    }
 
-	void write(const ZrpcRequestPacket &packet)
-	{
-		assert(clientSock);
+    void write(const ZrpcRequestPacket &packet) {
+        assert(clientSock);
 
-		ZrpcRequestPacket p = packet;
-		p.from = instanceId;
+        ZrpcRequestPacket p = packet;
+        p.from = instanceId;
 
-		Variant vpacket = p.toVariant();
-		QByteArray buf = TnetString::fromVariant(vpacket);
+        Variant vpacket = p.toVariant();
+        QByteArray buf = TnetString::fromVariant(vpacket);
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("zrpc client: OUT %s", qPrintable(TnetString::variantToString(vpacket, -1)));
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("zrpc client: OUT %s", qPrintable(TnetString::variantToString(vpacket, -1)));
 
-		clientSock->write(QList<QByteArray>() << QByteArray() << buf);
-	}
+        clientSock->write(QList<QByteArray>() << QByteArray() << buf);
+    }
 
-	void write(const QList<QByteArray> &headers, const ZrpcResponsePacket &packet)
-	{
-		assert(serverSock);
+    void write(const QList<QByteArray> &headers, const ZrpcResponsePacket &packet) {
+        assert(serverSock);
 
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = TnetString::fromVariant(vpacket);
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = TnetString::fromVariant(vpacket);
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("zrpc server: OUT %s", qPrintable(TnetString::variantToString(vpacket, -1)));
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("zrpc server: OUT %s", qPrintable(TnetString::variantToString(vpacket, -1)));
 
-		QList<QByteArray> message;
-		message += headers;
-		message += QByteArray();
-		message += buf;
-		serverSock->write(message);
-	}
+        QList<QByteArray> message;
+        message += headers;
+        message += QByteArray();
+        message += buf;
+        serverSock->write(message);
+    }
 
-	void client_readyRead(const CowByteArrayList &message)
-	{
-		if(message.count() != 2)
-		{
-			log_warning("zrpc client: received message with parts != 2, skipping");
-			return;
-		}
+    void client_readyRead(const CowByteArrayList &message) {
+        if (message.count() != 2) {
+            log_warning("zrpc client: received message with parts != 2, skipping");
+            return;
+        }
 
-		if(!message[0].isEmpty())
-		{
-			log_warning("zrpc client: received message with first part non-empty, skipping");
-			return;
-		}
+        if (!message[0].isEmpty()) {
+            log_warning("zrpc client: received message with first part non-empty, skipping");
+            return;
+        }
 
-		Variant data = TnetString::toVariant(message[1]);
-		if(data.isNull())
-		{
-			log_warning("zrpc client: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
+        Variant data = TnetString::toVariant(message[1]);
+        if (data.isNull()) {
+            log_warning("zrpc client: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("zrpc client: IN %s", qPrintable(TnetString::variantToString(data, -1)));
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("zrpc client: IN %s", qPrintable(TnetString::variantToString(data, -1)));
 
-		ZrpcResponsePacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("zrpc client: received message with invalid format (parse failed), skipping");
-			return;
-		}
+        ZrpcResponsePacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("zrpc client: received message with invalid format (parse "
+                        "failed), skipping");
+            return;
+        }
 
-		ZrpcRequest *req = clientReqsById.value(p.id);
-		if(!req)
-		{
-			log_debug("zrpc client: received message for unknown request id, skipping");
-			return;
-		}
+        ZrpcRequest *req = clientReqsById.value(p.id);
+        if (!req) {
+            log_debug("zrpc client: received message for unknown request id, skipping");
+            return;
+        }
 
-		req->handle(p);
-	}
+        req->handle(p);
+    }
 
-	void server_readyRead(const CowByteArrayList &message)
-	{
-		ZmqReqMessage req(message);
+    void server_readyRead(const CowByteArrayList &message) {
+        ZmqReqMessage req(message);
 
-		if(req.content().count() != 1)
-		{
-			log_warning("zrpc server: received message with parts != 1, skipping");
-			return;
-		}
+        if (req.content().count() != 1) {
+            log_warning("zrpc server: received message with parts != 1, skipping");
+            return;
+        }
 
-		Variant data = TnetString::toVariant(req.content()[0]);
-		if(data.isNull())
-		{
-			log_warning("zrpc server: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
+        Variant data = TnetString::toVariant(req.content()[0]);
+        if (data.isNull()) {
+            log_warning("zrpc server: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("zrpc server: IN %s", qPrintable(TnetString::variantToString(data, -1)));
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("zrpc server: IN %s", qPrintable(TnetString::variantToString(data, -1)));
 
-		ZrpcRequestPacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("zrpc server: received message with invalid format (parse failed), skipping");
-			return;
-		}
+        ZrpcRequestPacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("zrpc server: received message with invalid format (parse "
+                        "failed), skipping");
+            return;
+        }
 
-		PendingItem i;
-		i.headers = req.headers().asQByteArrayList();
-		i.packet = p;
-		pending += i;
+        PendingItem i;
+        i.headers = req.headers().asQByteArrayList();
+        i.packet = p;
+        pending += i;
 
-		if(pending.count() >= PENDING_MAX)
-			serverValve->close();
+        if (pending.count() >= PENDING_MAX)
+            serverValve->close();
 
-		q->requestReady();
-	}
+        q->requestReady();
+    }
 };
 
-ZrpcManager::ZrpcManager()
-{
-	d = new Private(this);
+ZrpcManager::ZrpcManager() { d = new Private(this); }
+
+ZrpcManager::~ZrpcManager() { delete d; }
+
+int ZrpcManager::timeout() const { return d->timeout; }
+
+void ZrpcManager::setInstanceId(const QByteArray &instanceId) { d->instanceId = instanceId; }
+
+void ZrpcManager::setIpcFileMode(int mode) { d->ipcFileMode = mode; }
+
+void ZrpcManager::setBind(bool enable) { d->doBind = enable; }
+
+void ZrpcManager::setTimeout(int ms) { d->timeout = ms; }
+
+bool ZrpcManager::setClientSpecs(const QStringList &specs) {
+    d->clientSpecs = specs;
+    return d->setupClient();
 }
 
-ZrpcManager::~ZrpcManager()
-{
-	delete d;
+bool ZrpcManager::setServerSpecs(const QStringList &specs) {
+    d->serverSpecs = specs;
+    return d->setupServer();
 }
 
-int ZrpcManager::timeout() const
-{
-	return d->timeout;
+ZrpcRequest *ZrpcManager::takeNext() {
+    if (d->pending.isEmpty())
+        return 0;
+
+    Private::PendingItem i = d->pending.takeFirst();
+    ZrpcRequest *req = new ZrpcRequest;
+    req->setupServer(this);
+    req->handle(i.headers, i.packet);
+
+    d->serverValve->open();
+
+    return req;
 }
 
-void ZrpcManager::setInstanceId(const QByteArray &instanceId)
-{
-	d->instanceId = instanceId;
+bool ZrpcManager::canWriteImmediately() const {
+    assert(d->clientSock);
+
+    return d->clientSock->canWriteImmediately();
 }
 
-void ZrpcManager::setIpcFileMode(int mode)
-{
-	d->ipcFileMode = mode;
-}
+void ZrpcManager::link(ZrpcRequest *req) { d->clientReqsById.insert(req->id(), req); }
 
-void ZrpcManager::setBind(bool enable)
-{
-	d->doBind = enable;
-}
+void ZrpcManager::unlink(ZrpcRequest *req) { d->clientReqsById.remove(req->id()); }
 
-void ZrpcManager::setTimeout(int ms)
-{
-	d->timeout = ms;
-}
+void ZrpcManager::write(const ZrpcRequestPacket &packet) { d->write(packet); }
 
-bool ZrpcManager::setClientSpecs(const QStringList &specs)
-{
-	d->clientSpecs = specs;
-	return d->setupClient();
-}
-
-bool ZrpcManager::setServerSpecs(const QStringList &specs)
-{
-	d->serverSpecs = specs;
-	return d->setupServer();
-}
-
-ZrpcRequest *ZrpcManager::takeNext()
-{
-	if(d->pending.isEmpty())
-		return 0;
-
-	Private::PendingItem i = d->pending.takeFirst();
-	ZrpcRequest *req = new ZrpcRequest;
-	req->setupServer(this);
-	req->handle(i.headers, i.packet);
-
-	d->serverValve->open();
-
-	return req;
-}
-
-bool ZrpcManager::canWriteImmediately() const
-{
-	assert(d->clientSock);
-
-	return d->clientSock->canWriteImmediately();
-}
-
-void ZrpcManager::link(ZrpcRequest *req)
-{
-	d->clientReqsById.insert(req->id(), req);
-}
-
-void ZrpcManager::unlink(ZrpcRequest *req)
-{
-	d->clientReqsById.remove(req->id());
-}
-
-void ZrpcManager::write(const ZrpcRequestPacket &packet)
-{
-	d->write(packet);
-}
-
-void ZrpcManager::write(const QList<QByteArray> &headers, const ZrpcResponsePacket &packet)
-{
-	d->write(headers, packet);
+void ZrpcManager::write(const QList<QByteArray> &headers, const ZrpcResponsePacket &packet) {
+    d->write(headers, packet);
 }

--- a/src/core/zrpcmanager.h
+++ b/src/core/zrpcmanager.h
@@ -35,38 +35,37 @@ class ZrpcResponsePacket;
 class ZrpcRequest;
 
 /// Manages RPC communication over ZeroMQ between Pushpin processes
-class ZrpcManager
-{
+class ZrpcManager {
 public:
-	ZrpcManager();
-	~ZrpcManager();
+    ZrpcManager();
+    ~ZrpcManager();
 
-	int timeout() const;
+    int timeout() const;
 
-	void setInstanceId(const QByteArray &instanceId);
-	void setIpcFileMode(int mode);
-	void setBind(bool enable);
-	void setTimeout(int ms);
-	void setUnavailableOnTimeout(bool enable);
+    void setInstanceId(const QByteArray &instanceId);
+    void setIpcFileMode(int mode);
+    void setBind(bool enable);
+    void setTimeout(int ms);
+    void setUnavailableOnTimeout(bool enable);
 
-	bool setClientSpecs(const QStringList &specs);
-	bool setServerSpecs(const QStringList &specs);
+    bool setClientSpecs(const QStringList &specs);
+    bool setServerSpecs(const QStringList &specs);
 
-	ZrpcRequest *takeNext();
+    ZrpcRequest *takeNext();
 
-	bool canWriteImmediately() const;
-	void write(const ZrpcRequestPacket &packet);
+    bool canWriteImmediately() const;
+    void write(const ZrpcRequestPacket &packet);
 
-	Signal requestReady;
+    Signal requestReady;
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 
-	friend class ZrpcRequest;
-	void link(ZrpcRequest *req);
-	void unlink(ZrpcRequest *req);
-	void write(const QList<QByteArray> &headers, const ZrpcResponsePacket &packet);
+    friend class ZrpcRequest;
+    void link(ZrpcRequest *req);
+    void unlink(ZrpcRequest *req);
+    void write(const QList<QByteArray> &headers, const ZrpcResponsePacket &packet);
 };
 
 #endif

--- a/src/core/zrpcrequest.cpp
+++ b/src/core/zrpcrequest.cpp
@@ -23,270 +23,203 @@
 
 #include "zrpcrequest.h"
 
-#include <assert.h>
-#include <boost/signals2.hpp>
+#include "defercall.h"
+#include "log.h"
 #include "packet/zrpcrequestpacket.h"
 #include "packet/zrpcresponsepacket.h"
+#include "timer.h"
+#include "uuidutil.h"
 #include "variant.h"
 #include "zrpcmanager.h"
-#include "uuidutil.h"
-#include "log.h"
-#include "timer.h"
-#include "defercall.h"
+#include <assert.h>
+#include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
 
-class ZrpcRequest::Private
-{
+class ZrpcRequest::Private {
 public:
-	ZrpcRequest *q;
-	ZrpcManager *manager;
-	QList<QByteArray> reqHeaders;
-	QByteArray from;
-	QByteArray id;
-	QString method;
-	VariantHash args;
-	bool success;
-	Variant result;
-	ErrorCondition condition;
-	QByteArray conditionString;
-	std::unique_ptr<Timer> timer;
-	Connection timerConnection;
-	DeferCall deferCall;
+    ZrpcRequest *q;
+    ZrpcManager *manager;
+    QList<QByteArray> reqHeaders;
+    QByteArray from;
+    QByteArray id;
+    QString method;
+    VariantHash args;
+    bool success;
+    Variant result;
+    ErrorCondition condition;
+    QByteArray conditionString;
+    std::unique_ptr<Timer> timer;
+    Connection timerConnection;
+    DeferCall deferCall;
 
-	Private(ZrpcRequest *_q) :
-		q(_q),
-		manager(0),
-		success(false),
-		condition(ErrorGeneric)
-	{
-	}
+    Private(ZrpcRequest *_q) : q(_q), manager(0), success(false), condition(ErrorGeneric) {}
 
-	~Private()
-	{
-		cleanup();
-	}
+    ~Private() { cleanup(); }
 
-	void cleanup()
-	{
-		if(timer)
-		{
-			timerConnection.disconnect();
-			timer.reset();
-		}
+    void cleanup() {
+        if (timer) {
+            timerConnection.disconnect();
+            timer.reset();
+        }
 
-		if(manager)
-		{
-			manager->unlink(q);
-			manager = 0;
-		}
-	}
+        if (manager) {
+            manager->unlink(q);
+            manager = 0;
+        }
+    }
 
-	void respond(const Variant &value)
-	{
-		ZrpcResponsePacket p;
-		p.id = id;
-		p.success = true;
-		p.value = value;
-		manager->write(reqHeaders, p);
-	}
+    void respond(const Variant &value) {
+        ZrpcResponsePacket p;
+        p.id = id;
+        p.success = true;
+        p.value = value;
+        manager->write(reqHeaders, p);
+    }
 
-	void respondError(const QByteArray &condition, const Variant &value)
-	{
-		ZrpcResponsePacket p;
-		p.id = id;
-		p.success = false;
-		p.condition = condition;
-		p.value = value;
-		manager->write(reqHeaders, p);
-	}
+    void respondError(const QByteArray &condition, const Variant &value) {
+        ZrpcResponsePacket p;
+        p.id = id;
+        p.success = false;
+        p.condition = condition;
+        p.value = value;
+        manager->write(reqHeaders, p);
+    }
 
-	void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet)
-	{
-		reqHeaders = headers;
-		from = packet.from;
-		id = packet.id;
-		method = packet.method;
-		args = packet.args;
-	}
+    void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet) {
+        reqHeaders = headers;
+        from = packet.from;
+        id = packet.id;
+        method = packet.method;
+        args = packet.args;
+    }
 
-	void handle(const ZrpcResponsePacket &packet)
-	{
-		cleanup();
+    void handle(const ZrpcResponsePacket &packet) {
+        cleanup();
 
-		success = packet.success;
-		if(success)
-		{
-			result = packet.value;
-			q->onSuccess();
-		}
-		else
-		{
-			if(packet.condition == "bad-format")
-				condition = ErrorFormat;
-			else
-				condition = ErrorGeneric;
+        success = packet.success;
+        if (success) {
+            result = packet.value;
+            q->onSuccess();
+        } else {
+            if (packet.condition == "bad-format")
+                condition = ErrorFormat;
+            else
+                condition = ErrorGeneric;
 
-			conditionString = packet.condition;
+            conditionString = packet.condition;
 
-			result = packet.value;
-			q->onError();
-		}
+            result = packet.value;
+            q->onError();
+        }
 
-		q->finished();
-	}
+        q->finished();
+    }
 
-	void doStart()
-	{
-		if(!manager->canWriteImmediately())
-		{
-			success = false;
-			condition = ErrorUnavailable;
-			conditionString = "service-unavailable";
-			cleanup();
-			q->finished();
-			return;
-		}
+    void doStart() {
+        if (!manager->canWriteImmediately()) {
+            success = false;
+            condition = ErrorUnavailable;
+            conditionString = "service-unavailable";
+            cleanup();
+            q->finished();
+            return;
+        }
 
-		ZrpcRequestPacket p;
-		p.id = id;
-		p.method = method;
-		p.args = args;
+        ZrpcRequestPacket p;
+        p.id = id;
+        p.method = method;
+        p.args = args;
 
-		if(manager->timeout() >= 0)
-		{
-			timer = std::make_unique<Timer>();
-			timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
-			timer->setSingleShot(true);
-			timer->start(manager->timeout());
-		}
+        if (manager->timeout() >= 0) {
+            timer = std::make_unique<Timer>();
+            timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
+            timer->setSingleShot(true);
+            timer->start(manager->timeout());
+        }
 
-		manager->write(p);
-	}
+        manager->write(p);
+    }
 
-	void timer_timeout()
-	{
-		success = false;
-		condition = ErrorTimeout;
-		conditionString = "timeout";
-		cleanup();
-		q->finished();
-	}
+    void timer_timeout() {
+        success = false;
+        condition = ErrorTimeout;
+        conditionString = "timeout";
+        cleanup();
+        q->finished();
+    }
 };
 
-ZrpcRequest::ZrpcRequest()
-{
-	d = new Private(this);
+ZrpcRequest::ZrpcRequest() { d = new Private(this); }
+
+ZrpcRequest::ZrpcRequest(ZrpcManager *manager) {
+    d = new Private(this);
+    setupClient(manager);
 }
 
-ZrpcRequest::ZrpcRequest(ZrpcManager *manager)
-{
-	d = new Private(this);
-	setupClient(manager);
+ZrpcRequest::~ZrpcRequest() {
+    destroyed();
+    delete d;
 }
 
-ZrpcRequest::~ZrpcRequest()
-{
-	destroyed();
-	delete d;
+QByteArray ZrpcRequest::from() const { return d->from; }
+
+QByteArray ZrpcRequest::id() const { return d->id; }
+
+QString ZrpcRequest::method() const { return d->method; }
+
+VariantHash ZrpcRequest::args() const { return d->args; }
+
+bool ZrpcRequest::success() const { return d->success; }
+
+Variant ZrpcRequest::result() const { return d->result; }
+
+ZrpcRequest::ErrorCondition ZrpcRequest::errorCondition() const { return d->condition; }
+
+QByteArray ZrpcRequest::errorConditionString() const { return d->conditionString; }
+
+void ZrpcRequest::start(const QString &method, const VariantHash &args) {
+    d->method = method;
+    d->args = args;
+    d->deferCall.defer([=] { d->doStart(); });
 }
 
-QByteArray ZrpcRequest::from() const
-{
-	return d->from;
+void ZrpcRequest::respond(const Variant &result) { d->respond(result); }
+
+void ZrpcRequest::respondError(const QByteArray &condition, const Variant &result) {
+    d->respondError(condition, result);
 }
 
-QByteArray ZrpcRequest::id() const
-{
-	return d->id;
+void ZrpcRequest::setError(ErrorCondition condition, const Variant &result) {
+    d->success = false;
+    d->condition = condition;
+    d->result = result;
 }
 
-QString ZrpcRequest::method() const
-{
-	return d->method;
+void ZrpcRequest::onSuccess() {
+    // By default, do nothing
 }
 
-VariantHash ZrpcRequest::args() const
-{
-	return d->args;
+void ZrpcRequest::onError() {
+    // By default, do nothing
 }
 
-bool ZrpcRequest::success() const
-{
-	return d->success;
+void ZrpcRequest::setupClient(ZrpcManager *manager) {
+    d->id = UuidUtil::createUuid();
+    d->manager = manager;
+    d->manager->link(this);
 }
 
-Variant ZrpcRequest::result() const
-{
-	return d->result;
+void ZrpcRequest::setupServer(ZrpcManager *manager) { d->manager = manager; }
+
+void ZrpcRequest::handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet) {
+    assert(d->manager);
+
+    d->handle(headers, packet);
 }
 
-ZrpcRequest::ErrorCondition ZrpcRequest::errorCondition() const
-{
-	return d->condition;
-}
+void ZrpcRequest::handle(const ZrpcResponsePacket &packet) {
+    assert(d->manager);
 
-QByteArray ZrpcRequest::errorConditionString() const
-{
-	return d->conditionString;
-}
-
-void ZrpcRequest::start(const QString &method, const VariantHash &args)
-{
-	d->method = method;
-	d->args = args;
-	d->deferCall.defer([=] { d->doStart(); });
-}
-
-void ZrpcRequest::respond(const Variant &result)
-{
-	d->respond(result);
-}
-
-void ZrpcRequest::respondError(const QByteArray &condition, const Variant &result)
-{
-	d->respondError(condition, result);
-}
-
-void ZrpcRequest::setError(ErrorCondition condition, const Variant &result)
-{
-	d->success = false;
-	d->condition = condition;
-	d->result = result;
-}
-
-void ZrpcRequest::onSuccess()
-{
-	// By default, do nothing
-}
-
-void ZrpcRequest::onError()
-{
-	// By default, do nothing
-}
-
-void ZrpcRequest::setupClient(ZrpcManager *manager)
-{
-	d->id = UuidUtil::createUuid();
-	d->manager = manager;
-	d->manager->link(this);
-}
-
-void ZrpcRequest::setupServer(ZrpcManager *manager)
-{
-	d->manager = manager;
-}
-
-void ZrpcRequest::handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet)
-{
-	assert(d->manager);
-
-	d->handle(headers, packet);
-}
-
-void ZrpcRequest::handle(const ZrpcResponsePacket &packet)
-{
-	assert(d->manager);
-
-	d->handle(packet);
+    d->handle(packet);
 }

--- a/src/core/zrpcrequest.h
+++ b/src/core/zrpcrequest.h
@@ -33,52 +33,45 @@ class ZrpcRequestPacket;
 class ZrpcResponsePacket;
 class ZrpcManager;
 
-class ZrpcRequest
-{
+class ZrpcRequest {
 public:
-	enum ErrorCondition
-	{
-		ErrorGeneric,
-		ErrorFormat,
-		ErrorUnavailable,
-		ErrorTimeout
-	};
+    enum ErrorCondition { ErrorGeneric, ErrorFormat, ErrorUnavailable, ErrorTimeout };
 
-	ZrpcRequest(ZrpcManager *manager);
-	virtual ~ZrpcRequest();
+    ZrpcRequest(ZrpcManager *manager);
+    virtual ~ZrpcRequest();
 
-	QByteArray from() const;
-	QByteArray id() const;
-	QString method() const;
-	VariantHash args() const;
-	bool success() const;
-	Variant result() const;
-	ErrorCondition errorCondition() const;
-	QByteArray errorConditionString() const;
+    QByteArray from() const;
+    QByteArray id() const;
+    QString method() const;
+    VariantHash args() const;
+    bool success() const;
+    Variant result() const;
+    ErrorCondition errorCondition() const;
+    QByteArray errorConditionString() const;
 
-	void start(const QString &method, const VariantHash &args = VariantHash());
-	void respond(const Variant &result = Variant());
-	void respondError(const QByteArray &condition, const Variant &result = Variant());
+    void start(const QString &method, const VariantHash &args = VariantHash());
+    void respond(const Variant &result = Variant());
+    void respondError(const QByteArray &condition, const Variant &result = Variant());
 
-	void setError(ErrorCondition condition, const Variant &result = Variant());
+    void setError(ErrorCondition condition, const Variant &result = Variant());
 
-	Signal finished;
-	Signal destroyed;
+    Signal finished;
+    Signal destroyed;
 
 protected:
-	virtual void onSuccess();
-	virtual void onError();
+    virtual void onSuccess();
+    virtual void onError();
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 
-	friend class ZrpcManager;
-	ZrpcRequest();
-	void setupClient(ZrpcManager *manager);
-	void setupServer(ZrpcManager *manager);
-	void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet);
-	void handle(const ZrpcResponsePacket &packet);
+    friend class ZrpcManager;
+    ZrpcRequest();
+    void setupClient(ZrpcManager *manager);
+    void setupServer(ZrpcManager *manager);
+    void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet);
+    void handle(const ZrpcResponsePacket &packet);
 };
 
 #endif

--- a/src/core/zutil.cpp
+++ b/src/core/zutil.cpp
@@ -22,78 +22,71 @@
 
 #include "zutil.h"
 
-#include <QFile>
-#include "zmqsocket.h"
 #include "cowstring.h"
+#include "zmqsocket.h"
+#include <QFile>
 
 namespace ZUtil {
 
-bool bindSpec(ZmqSocket *sock, const QString &spec, int ipcFileMode, QString *errorMessage)
-{
-	if(!sock->bind(spec))
-	{
-		if(errorMessage)
-			*errorMessage = QString("unable to bind to %1").arg(spec);
-		return false;
-	}
+bool bindSpec(ZmqSocket *sock, const QString &spec, int ipcFileMode, QString *errorMessage) {
+    if (!sock->bind(spec)) {
+        if (errorMessage)
+            *errorMessage = QString("unable to bind to %1").arg(spec);
+        return false;
+    }
 
-	if(spec.startsWith("ipc://") && ipcFileMode != -1)
-	{
-		QFile::Permissions perms;
-		if(ipcFileMode & 0400)
-			perms |= QFile::ReadUser;
-		if(ipcFileMode & 0200)
-			perms |= QFile::WriteUser;
-		if(ipcFileMode & 0100)
-			perms |= QFile::ExeUser;
-		if(ipcFileMode & 0040)
-			perms |= QFile::ReadGroup;
-		if(ipcFileMode & 0020)
-			perms |= QFile::WriteGroup;
-		if(ipcFileMode & 0010)
-			perms |= QFile::ExeGroup;
-		if(ipcFileMode & 0004)
-			perms |= QFile::ReadOther;
-		if(ipcFileMode & 0002)
-			perms |= QFile::WriteOther;
-		if(ipcFileMode & 0001)
-			perms |= QFile::ExeOther;
-		if(!QFile::setPermissions(spec.mid(6), perms))
-		{
-			if(errorMessage)
-				*errorMessage = QString("unable to set permissions on %1").arg(spec);
-			return false;
-		}
-	}
+    if (spec.startsWith("ipc://") && ipcFileMode != -1) {
+        QFile::Permissions perms;
+        if (ipcFileMode & 0400)
+            perms |= QFile::ReadUser;
+        if (ipcFileMode & 0200)
+            perms |= QFile::WriteUser;
+        if (ipcFileMode & 0100)
+            perms |= QFile::ExeUser;
+        if (ipcFileMode & 0040)
+            perms |= QFile::ReadGroup;
+        if (ipcFileMode & 0020)
+            perms |= QFile::WriteGroup;
+        if (ipcFileMode & 0010)
+            perms |= QFile::ExeGroup;
+        if (ipcFileMode & 0004)
+            perms |= QFile::ReadOther;
+        if (ipcFileMode & 0002)
+            perms |= QFile::WriteOther;
+        if (ipcFileMode & 0001)
+            perms |= QFile::ExeOther;
+        if (!QFile::setPermissions(spec.mid(6), perms)) {
+            if (errorMessage)
+                *errorMessage = QString("unable to set permissions on %1").arg(spec);
+            return false;
+        }
+    }
 
-	if(errorMessage)
-		*errorMessage = QString();
+    if (errorMessage)
+        *errorMessage = QString();
 
-	return true;
+    return true;
 }
 
-bool setupSocket(ZmqSocket *sock, const QStringList &specs, bool bind, int ipcFileMode, QString *errorMessage)
-{
-	if(bind)
-	{
-		if(!bindSpec(sock, specs[0], ipcFileMode, errorMessage))
-			return false;
-	}
-	else
-	{
-		foreach(const QString &spec, specs)
-			sock->connectToAddress(spec);
-	}
+bool setupSocket(ZmqSocket *sock, const QStringList &specs, bool bind, int ipcFileMode,
+                 QString *errorMessage) {
+    if (bind) {
+        if (!bindSpec(sock, specs[0], ipcFileMode, errorMessage))
+            return false;
+    } else {
+        foreach (const QString &spec, specs)
+            sock->connectToAddress(spec);
+    }
 
-	if(errorMessage)
-		*errorMessage = QString();
+    if (errorMessage)
+        *errorMessage = QString();
 
-	return true;
+    return true;
 }
 
-bool setupSocket(ZmqSocket *sock, const QString &spec, bool bind, int ipcFileMode, QString *errorMessage)
-{
-	return setupSocket(sock, QStringList() << spec, bind, ipcFileMode, errorMessage);
+bool setupSocket(ZmqSocket *sock, const QString &spec, bool bind, int ipcFileMode,
+                 QString *errorMessage) {
+    return setupSocket(sock, QStringList() << spec, bind, ipcFileMode, errorMessage);
 }
 
-}
+} // namespace ZUtil

--- a/src/core/zutil.h
+++ b/src/core/zutil.h
@@ -32,10 +32,12 @@ namespace ZUtil {
 
 bool bindSpec(ZmqSocket *sock, const QString &spec, int ipcFileMode, QString *errorMessage = 0);
 
-bool setupSocket(ZmqSocket *sock, const QStringList &specs, bool bind, int ipcFileMode, QString *errorMessage = 0);
+bool setupSocket(ZmqSocket *sock, const QStringList &specs, bool bind, int ipcFileMode,
+                 QString *errorMessage = 0);
 
-bool setupSocket(ZmqSocket *sock, const QString &spec, bool bind, int ipcFileMode, QString *errorMessage = 0);
+bool setupSocket(ZmqSocket *sock, const QString &spec, bool bind, int ipcFileMode,
+                 QString *errorMessage = 0);
 
-}
+} // namespace ZUtil
 
 #endif

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -23,1295 +23,1049 @@
 
 #include "zwebsocket.h"
 
-#include <assert.h>
-#include "zhttprequestpacket.h"
-#include "zhttpresponsepacket.h"
+#include "defercall.h"
 #include "log.h"
 #include "timer.h"
-#include "variant.h"
-#include "defercall.h"
-#include "zhttpmanager.h"
 #include "uuidutil.h"
+#include "variant.h"
+#include "zhttpmanager.h"
+#include "zhttprequestpacket.h"
+#include "zhttpresponsepacket.h"
+#include <assert.h>
 
 #define IDEAL_CREDITS 200000
 #define SESSION_EXPIRE 60000
 #define KEEPALIVE_INTERVAL 45000
 
-class ZWebSocket::Private
-{
+class ZWebSocket::Private {
 public:
-	enum InternalState
-	{
-		Idle,
-		AboutToConnect,
-		Connecting,
-		Connected,
-		ConnectedPeerClosed,
-		ClosedPeerConnected
-	};
-
-	ZWebSocket *q;
-	ZhttpManager *manager;
-	bool server;
-	InternalState state;
-	ZWebSocket::Rid rid;
-	QByteArray toAddress;
-	QHostAddress peerAddress;
-	QString connectHost;
-	int connectPort;
-	bool ignorePolicies;
-	bool trustConnectHost;
-	bool ignoreTlsErrors;
-	QString clientCert;
-	QString clientKey;
-	Url requestUri;
-	HttpHeaders requestHeaders;
-	int inSeq;
-	int outSeq;
-	int outCredits;
-	int pendingInCredits;
-	int responseCode;
-	QByteArray responseReason;
-	HttpHeaders responseHeaders;
-	QByteArray responseBody; // For rejections only
-	bool inClosed;
-	bool outClosed;
-	int closeCode;
-	QString closeReason;
-	int peerCloseCode;
-	QString peerCloseReason;
-	Variant userData;
-	bool pendingUpdate;
-	bool readableChanged;
-	bool writableChanged;
-	ErrorCondition errorCondition;
-	std::unique_ptr<Timer> expireTimer;
-	std::unique_ptr<Timer> keepAliveTimer;
-	QList<Frame> inFrames;
-	QList<Frame> outFrames;
-	int inSize;
-	int outSize;
-	int inContentType;
-	int outContentType;
-	bool multi;
-	bool routerResp;
-	DeferCall deferCall;
-
-	Private(ZWebSocket *_q) :
-		q(_q),
-		manager(0),
-		server(false),
-		state(Idle),
-		connectPort(-1),
-		ignorePolicies(false),
-		trustConnectHost(false),
-		ignoreTlsErrors(false),
-		inSeq(0),
-		outSeq(0),
-		outCredits(0),
-		pendingInCredits(0),
-		responseCode(-1),
-		inClosed(false),
-		outClosed(false),
-		closeCode(-1),
-		peerCloseCode(-1),
-		pendingUpdate(false),
-		readableChanged(false),
-		writableChanged(false),
-		inSize(0),
-		outSize(0),
-		inContentType(-1),
-		outContentType((int)Frame::Text),
-		multi(false),
-		routerResp(false)
-	{
-		expireTimer = std::make_unique<Timer>();
-		expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
-		expireTimer->setSingleShot(true);
-
-		keepAliveTimer = std::make_unique<Timer>();
-		keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
-	}
-
-	~Private()
-	{
-		if(manager && state != Idle)
-			tryCancel();
-
-		cleanup();
-	}
-
-	void cleanup()
-	{
-		readableChanged = false;
-		writableChanged = false;
-
-		expireTimer.reset();
-		keepAliveTimer.reset();
-
-		if(manager)
-		{
-			manager->unregisterKeepAlive(q);
-
-			manager->unlink(q);
-			manager = 0;
-		}
-	}
-
-	bool setupServer(int seq, const ZhttpRequestPacket &packet)
-	{
-		if(packet.type != ZhttpRequestPacket::Data)
-		{
-			log_warning("zws server: received request with invalid type, canceling");
-			tryRespondCancel(packet);
-			return false;
-		}
-
-		if(seq != 0)
-		{
-			log_warning("zws server: error, received request with non-zero seq field");
-			writeError("bad-request");
-			state = Idle;
-			return false;
-		}
-
-		inSeq = 1; // Next expected seq
-
-		if(packet.credits != -1)
-			outCredits = packet.credits;
-
-		requestUri = packet.uri;
-		requestHeaders = packet.headers;
-
-		userData = packet.userData;
-		peerAddress = packet.peerAddress;
-
-		if(packet.multi)
-			multi = true;
-
-		if(packet.routerResp)
-			routerResp = true;
-
-		return true;
-	}
-
-	void startClient()
-	{
-		state = AboutToConnect;
-
-		refreshTimeout();
-		update();
-	}
-
-	void startServer()
-	{
-		state = Connecting;
-
-		startKeepAlive();
-		refreshTimeout();
-		update();
-	}
-
-	void startKeepAlive()
-	{
-		if(multi)
-		{
-			if(keepAliveTimer->isActive())
-			{
-				// Need to flush the current keepalive, since the
-				// manager registration may extend the timeout
-				keepAlive_timeout();
-
-				keepAliveTimer->stop();
-			}
-
-			manager->registerKeepAlive(q);
-		}
-		else
-		{
-			manager->unregisterKeepAlive(q);
-
-			if(!keepAliveTimer->isActive())
-				keepAliveTimer->start(KEEPALIVE_INTERVAL);
-		}
-	}
-
-	void stopKeepAlive()
-	{
-		if(keepAliveTimer->isActive())
-			keepAliveTimer->stop();
-
-		manager->unregisterKeepAlive(q);
-	}
-
-	void refreshTimeout()
-	{
-		expireTimer->start(SESSION_EXPIRE);
-	}
-
-	void update()
-	{
-		if(!pendingUpdate)
-		{
-			pendingUpdate = true;
-			deferCall.defer([=] { doUpdate(); });
-		}
-	}
-
-	void respond()
-	{
-		state = Connected;
-
-		ZhttpResponsePacket out;
-		out.type = ZhttpResponsePacket::Data;
-		out.code = responseCode;
-		out.reason = responseReason;
-		out.headers = responseHeaders;
-		out.credits = IDEAL_CREDITS;
-		if(multi)
-			out.multi = true;
-		writePacket(out);
-	}
-
-	void reject()
-	{
-		ZhttpResponsePacket out;
-		out.type = ZhttpResponsePacket::Error;
-		out.condition = "rejected";
-		out.code = responseCode;
-		out.reason = responseReason;
-		out.headers = responseHeaders;
-		out.body = responseBody;
-		writePacket(out);
-
-		state = Idle;
-		cleanup();
-		deferCall.defer([=] { doClosed(); });
-	}
-
-	Frame readFrame()
-	{
-		Frame f = inFrames.takeFirst();
-		inSize -= f.data.size();
-		pendingInCredits += f.data.size();
-		update();
-		return f;
-	}
-
-	void writeFrame(const Frame &frame)
-	{
-		if(state != Connected && state != ConnectedPeerClosed)
-			return;
-
-		outFrames += frame;
-		outSize += frame.data.size();
-		update();
-	}
-
-	void close(int code, const QString &reason)
-	{
-		if((state != Connected && state != ConnectedPeerClosed) || outClosed)
-			return;
-
-		outClosed = true;
-		closeCode = code;
-		closeReason = reason;
-
-		if(outFrames.isEmpty())
-		{
-			writeClose(code, reason);
-
-			if(state == ConnectedPeerClosed)
-			{
-				// If peer was already closed, then we're done!
-				state = Idle;
-				cleanup();
-				deferCall.defer([=] { doClosed(); });
-			}
-			else
-			{
-				// If peer was not closed, then we wait around
-				state = ClosedPeerConnected;
-			}
-		}
-	}
-
-	void tryWrite()
-	{
-		std::weak_ptr<Private> self = q->d;
-
-		if(state == Connected || state == ConnectedPeerClosed)
-		{
-			int written = 0;
-			int contentBytesWritten = 0;
-
-			while(!outFrames.isEmpty())
-			{
-				Frame &nextFrame = outFrames.first();
-				int contentSize = 0;
-
-				if((nextFrame.type == Frame::Ping || nextFrame.type == Frame::Pong) && outCredits >= nextFrame.data.size())
-				{
-					contentSize = nextFrame.data.size();
-				}
-				else if((nextFrame.type == Frame::Text || nextFrame.type == Frame::Binary || nextFrame.type == Frame::Continuation) && (nextFrame.data.isEmpty() || outCredits > 0))
-				{
-					contentSize = qMin(nextFrame.data.size(), outCredits);
-				}
-				else
-				{
-					break;
-				}
-
-				// If we have data to send, and the credits to do so, then send data.
-				// also send credits if we need to.
-
-				Frame f = nextFrame;
-				bool outFrameDone = false;
-
-				if(contentSize >= nextFrame.data.size())
-				{
-					outFrames.removeFirst();
-					outFrameDone = true;
-				}
-				else
-				{
-					f.data = f.data.mid(0, contentSize);
-					f.more = true;
-
-					nextFrame.type = Frame::Continuation;
-					nextFrame.data = nextFrame.data.mid(contentSize);
-				}
-
-				outSize -= f.data.size();
-				outCredits -= f.data.size();
-
-				int credits = -1;
-				if(state != ConnectedPeerClosed && pendingInCredits > 0)
-				{
-					credits = pendingInCredits;
-					pendingInCredits = 0;
-				}
-
-				writeFrameInternal(f, credits);
-
-				if(outFrameDone)
-					++written;
-
-				contentBytesWritten += f.data.size();
-			}
-
-			if(written > 0 || contentBytesWritten > 0)
-			{
-				q->framesWritten(written, contentBytesWritten);
-				if(self.expired())
-					return;
-			}
-
-			if(outFrames.isEmpty() && outClosed)
-			{
-				writeClose(closeCode, closeReason);
-
-				if(state == ConnectedPeerClosed)
-				{
-					// If peer was already closed, then we're done!
-					state = Idle;
-					cleanup();
-					q->closed();
-					return;
-				}
-				else
-				{
-					// If peer was not closed, then we wait around
-					state = ClosedPeerConnected;
-				}
-			}
-		}
-
-		// If we didn't send credits in a data packet, then do them now
-		if(state != ConnectedPeerClosed && pendingInCredits > 0)
-		{
-			int credits = pendingInCredits;
-			pendingInCredits = 0;
-
-			writeCredits(credits);
-		}
-	}
-
-	void handleIncomingDataPacket(const QByteArray &contentType, const QByteArray &data, bool more)
-	{
-		Frame::Type ftype;
-		if(inContentType != -1)
-		{
-			ftype = Frame::Continuation;
-		}
-		else
-		{
-			if(contentType == "binary")
-				ftype = Frame::Binary;
-			else
-				ftype = Frame::Text;
-
-			inContentType = (int)ftype;
-		}
-
-		inFrames += Frame(ftype, !data.isNull() ? data : QByteArray(""), more);
-		inSize += data.size();
-
-		if(!more)
-			inContentType = -1;
-	}
-
-	void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet)
-	{
-		if(packet.type == ZhttpRequestPacket::Error)
-		{
-			errorCondition = convertError(packet.condition.asQByteArray());
-
-			log_debug("zws server: error id=%s cond=%s", id.data(), packet.condition.data());
-
-			state = Idle;
-			cleanup();
-			q->error();
-			return;
-		}
-		else if(packet.type == ZhttpRequestPacket::Cancel)
-		{
-			log_debug("zws server: received cancel id=%s", id.data());
-
-			errorCondition = ErrorGeneric;
-			state = Idle;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(seq != inSeq)
-		{
-			log_warning("zws server: error id=%s received message out of sequence, canceling", id.data());
-
-			tryRespondCancel(packet);
-
-			state = Idle;
-			errorCondition = ErrorGeneric;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		++inSeq;
-
-		if(!multi && packet.multi)
-		{
-			// Switch on multi support
-			multi = true;
-			startKeepAlive(); // Re-setup keep alive
-		}
-
-		refreshTimeout();
-
-		if(packet.type == ZhttpRequestPacket::Data || packet.type == ZhttpRequestPacket::Ping || packet.type == ZhttpRequestPacket::Pong)
-		{
-			if(inSize + packet.body.size() > IDEAL_CREDITS)
-				log_warning("zws client: id=%s server is sending too fast", id.data());
-
-			if(packet.type == ZhttpRequestPacket::Data)
-			{
-				handleIncomingDataPacket(packet.contentType.asQByteArray(), packet.body.asQByteArray(), packet.more);
-			}
-			else if(packet.type == ZhttpRequestPacket::Ping)
-			{
-				inFrames += Frame(Frame::Ping, packet.body.asQByteArray(), false);
-				inSize += packet.body.size();
-			}
-			else if(packet.type == ZhttpRequestPacket::Pong)
-			{
-				inFrames += Frame(Frame::Pong, packet.body.asQByteArray(), false);
-				inSize += packet.body.size();
-			}
-
-			if(packet.credits > 0)
-			{
-				outCredits += packet.credits;
-				writableChanged = true;
-			}
-
-			readableChanged = true;
-			update();
-		}
-		else if(packet.type == ZhttpRequestPacket::Close)
-		{
-			handlePeerClose(packet.code, QString::fromUtf8(packet.body.asQByteArray()));
-		}
-		else if(packet.type == ZhttpRequestPacket::Credit)
-		{
-			if(packet.credits > 0)
-			{
-				outCredits += packet.credits;
-				writableChanged = true;
-				update();
-			}
-		}
-		else if(packet.type == ZhttpRequestPacket::KeepAlive)
-		{
-			// Nothing to do
-		}
-		else
-		{
-			log_debug("zws server: unsupported packet type id=%s type=%d", id.data(), (int)packet.type);
-		}
-	}
-
-	void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet)
-	{
-		if(packet.type == ZhttpResponsePacket::Error)
-		{
-			errorCondition = convertError(packet.condition.asQByteArray());
-
-			log_debug("zws client: error id=%s cond=%s", id.data(), packet.condition.data());
-
-			responseCode = packet.code;
-			responseReason = packet.reason.asQByteArray();
-			responseHeaders = packet.headers;
-			responseBody = packet.body.asQByteArray();
-
-			state = Idle;
-			cleanup();
-			q->error();
-			return;
-		}
-		else if(packet.type == ZhttpResponsePacket::Cancel)
-		{
-			log_debug("zws client: received cancel id=%s", id.data());
-
-			errorCondition = ErrorGeneric;
-			state = Idle;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(!packet.from.isEmpty())
-			toAddress = packet.from.asQByteArray();
-
-		if(seq != inSeq)
-		{
-			log_warning("zws client: error id=%s received message out of sequence, canceling", id.data());
-
-			tryRespondCancel(packet);
-
-			state = Idle;
-			errorCondition = ErrorGeneric;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(!toAddress.isEmpty())
-			startKeepAlive(); // Only starts if wasn't started already
-
-		++inSeq;
-
-		if(!multi && packet.multi)
-		{
-			// Switch on multi support
-			multi = true;
-			startKeepAlive(); // Re-setup keep alive
-		}
-
-		refreshTimeout();
-
-		if(state == Connecting)
-		{
-			if(packet.type != ZhttpResponsePacket::Data && packet.type != ZhttpResponsePacket::Credit && packet.type != ZhttpResponsePacket::KeepAlive)
-			{
-				state = Idle;
-				errorCondition = ErrorGeneric;
-				cleanup();
-				log_warning("zws client: error id=%s initial response wrong type", id.data());
-				q->error();
-				return;
-			}
-
-			if(packet.from.isEmpty())
-			{
-				state = Idle;
-				errorCondition = ErrorGeneric;
-				cleanup();
-				log_warning("zws client: error id=%s initial ack did not contain from field", id.data());
-				q->error();
-				return;
-			}
-		}
-
-		if(packet.type == ZhttpResponsePacket::Data || packet.type == ZhttpResponsePacket::Ping || packet.type == ZhttpResponsePacket::Pong)
-		{
-			if(state == Connecting)
-			{
-				// This is assured earlier
-				assert(packet.type == ZhttpResponsePacket::Data);
-
-				responseCode = packet.code;
-				responseReason = packet.reason.asQByteArray();
-				responseHeaders = packet.headers;
-
-				if(packet.credits > 0)
-					outCredits += packet.credits;
-
-				state = Connected;
-				update();
-				q->connected();
-			}
-			else
-			{
-				if(inSize + packet.body.size() > IDEAL_CREDITS)
-					log_warning("zws client: id=%s server is sending too fast", id.data());
-
-				if(packet.type == ZhttpResponsePacket::Data)
-				{
-					handleIncomingDataPacket(packet.contentType.asQByteArray(), packet.body.asQByteArray(), packet.more);
-				}
-				else if(packet.type == ZhttpResponsePacket::Ping)
-				{
-					inFrames += Frame(Frame::Ping, packet.body.asQByteArray(), false);
-					inSize += packet.body.size();
-				}
-				else if(packet.type == ZhttpResponsePacket::Pong)
-				{
-					inFrames += Frame(Frame::Pong, packet.body.asQByteArray(), false);
-					inSize += packet.body.size();
-				}
-
-				if(packet.credits > 0)
-				{
-					outCredits += packet.credits;
-					writableChanged = true;
-				}
-
-				readableChanged = true;
-				update();
-			}
-		}
-		else if(packet.type == ZhttpResponsePacket::Close)
-		{
-			handlePeerClose(packet.code, QString::fromUtf8(packet.body.asQByteArray()));
-		}
-		else if(packet.type == ZhttpResponsePacket::Credit)
-		{
-			if(packet.credits > 0)
-			{
-				outCredits += packet.credits;
-				writableChanged = true;
-				update();
-			}
-		}
-		else if(packet.type == ZhttpResponsePacket::KeepAlive)
-		{
-			// Nothing to do
-		}
-		else
-		{
-			log_debug("zws client: unsupported packet type id=%s type=%d", id.data(), (int)packet.type);
-		}
-	}
-
-	void handlePeerClose(int code, const QString &reason)
-	{
-		if((state == Connected || state == ClosedPeerConnected) && !inClosed)
-		{
-			inClosed = true;
-			peerCloseCode = code;
-			peerCloseReason = reason;
-
-			if(inFrames.isEmpty())
-			{
-				if(state == ClosedPeerConnected)
-				{
-					state = Idle;
-					cleanup();
-					q->closed();
-				}
-				else
-				{
-					state = ConnectedPeerClosed;
-					q->peerClosed();
-				}
-			}
-		}
-	}
-
-	void writePacket(const ZhttpRequestPacket &packet)
-	{
-		assert(manager);
-
-		bool first = (outSeq == 0);
-
-		ZhttpRequestPacket out = packet;
-		out.from = rid.first;
-		out.ids += ZhttpRequestPacket::Id(rid.second, outSeq++);
-
-		if(first)
-		{
-			manager->writeWs(out);
-		}
-		else
-		{
-			assert(!toAddress.isEmpty());
-			manager->writeWs(out, toAddress);
-		}
-	}
-
-	void writePacket(const ZhttpResponsePacket &packet)
-	{
-		assert(manager);
-
-		ZhttpResponsePacket out = packet;
-		out.from = manager->instanceId();
-		out.ids += ZhttpResponsePacket::Id(rid.second, outSeq++);
-		out.userData = userData;
-
-		manager->writeWs(out, rid.first, routerResp);
-	}
-
-	void writeFrameInternal(const Frame &frame, int credits = -1)
-	{
-		// For content frames, set the type
-		QByteArray contentType;
-		if(frame.type == Frame::Binary || frame.type == Frame::Text || frame.type == Frame::Continuation)
-		{
-			Frame::Type ftype = (Frame::Type)-1;
-			if(frame.type == Frame::Binary || frame.type == Frame::Text)
-			{
-				ftype = frame.type;
-				outContentType = (int)frame.type;
-			}
-			else if(frame.type == Frame::Continuation)
-			{
-				ftype = (Frame::Type)outContentType;
-			}
-
-			if(ftype != (Frame::Type)-1)
-			{
-				if(ftype == Frame::Binary)
-					contentType = "binary";
-				else // Text
-					contentType = "text";
-			}
-		}
-
-		if(server)
-		{
-			ZhttpResponsePacket p;
-
-			if(frame.type == Frame::Ping)
-			{
-				p.type = ZhttpResponsePacket::Ping;
-			}
-			else if(frame.type == Frame::Pong)
-			{
-				p.type = ZhttpResponsePacket::Pong;
-			}
-			else
-			{
-				p.type = ZhttpResponsePacket::Data;
-				p.contentType = contentType;
-			}
-
-			p.body = frame.data;
-			p.more = frame.more;
-			p.credits = credits;
-			writePacket(p);
-		}
-		else
-		{
-			ZhttpRequestPacket p;
-
-			if(frame.type == Frame::Ping)
-			{
-				p.type = ZhttpRequestPacket::Ping;
-			}
-			else if(frame.type == Frame::Pong)
-			{
-				p.type = ZhttpRequestPacket::Pong;
-			}
-			else
-			{
-				p.type = ZhttpRequestPacket::Data;
-				p.contentType = contentType;
-			}
-
-			p.body = frame.data;
-			p.more = frame.more;
-			p.credits = credits;
-			writePacket(p);
-		}
-	}
-
-	void writeCredits(int credits)
-	{
-		if(server)
-		{
-			ZhttpResponsePacket p;
-			p.type = ZhttpResponsePacket::Credit;
-			p.credits = credits;
-			writePacket(p);
-		}
-		else
-		{
-			ZhttpRequestPacket p;
-			p.type = ZhttpRequestPacket::Credit;
-			p.credits = credits;
-			writePacket(p);
-		}
-	}
-
-	void writeClose(int code = -1, const QString &reason = QString())
-	{
-		if(server)
-		{
-			ZhttpResponsePacket out;
-			out.type = ZhttpResponsePacket::Close;
-			out.code = code;
-			if(!reason.isEmpty())
-				out.body = reason.toUtf8();
-			writePacket(out);
-		}
-		else
-		{
-			ZhttpRequestPacket out;
-			out.type = ZhttpRequestPacket::Close;
-			out.code = code;
-			if(!reason.isEmpty())
-				out.body = reason.toUtf8();
-			writePacket(out);
-		}
-	}
-
-	void writeCancel()
-	{
-		if(server)
-		{
-			ZhttpResponsePacket out;
-			out.type = ZhttpResponsePacket::Cancel;
-			writePacket(out);
-		}
-		else
-		{
-			ZhttpRequestPacket out;
-			out.type = ZhttpRequestPacket::Cancel;
-			writePacket(out);
-		}
-	}
-
-	void writeError(const QByteArray &condition)
-	{
-		ZhttpResponsePacket out;
-		out.type = ZhttpResponsePacket::Error;
-		out.condition = condition;
-		writePacket(out);
-	}
-
-	void tryCancel()
-	{
-		if(state != Idle)
-		{
-			state = Idle;
-
-			// Can't send cancel in client mode without address
-			if(!server && toAddress.isEmpty())
-				return;
-
-			writeCancel();
-		}
-	}
-
-	void tryRespondCancel(const ZhttpRequestPacket &packet)
-	{
-		// If this was not an error packet, send cancel
-		if(packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel)
-			writeCancel();
-	}
-
-	void tryRespondCancel(const ZhttpResponsePacket &packet)
-	{
-		// If this was not an error packet, send cancel
-		if(packet.type != ZhttpResponsePacket::Error && packet.type != ZhttpResponsePacket::Cancel && !toAddress.isEmpty())
-			writeCancel();
-	}
-
-	static ErrorCondition convertError(const QByteArray &cond)
-	{
-		// Zws conditions:
-		//  remote-connection-failed
-		//  connection-timeout
-		//  tls-error
-		//  bad-request
-		//  policy-violation
-		//  max-size-exceeded
-		//  session-timeout
-		//  rejected
-
-		if(cond == "policy-violation")
-			return ErrorPolicy;
-		else if(cond == "remote-connection-failed")
-			return ErrorConnect;
-		else if(cond == "tls-error")
-			return ErrorTls;
-		else if(cond == "connection-timeout")
-			return ErrorConnectTimeout;
-		else if(cond == "rejected")
-			return ErrorRejected;
-		else // Lump the rest as generic
-			return ErrorGeneric;
-	}
-
-	void doClosed()
-	{
-		q->closed();
-	}
-
-	void doUpdate()
-	{
-		pendingUpdate = false;
-
-		if(state == Connected || state == ClosedPeerConnected)
-		{
-			if(inFrames.isEmpty() && inClosed)
-			{
-				if(state == ClosedPeerConnected)
-				{
-					state = Idle;
-					cleanup();
-					q->closed();
-					return;
-				}
-				else
-				{
-					std::weak_ptr<Private> self = q->d;
-					state = ConnectedPeerClosed;
-					q->peerClosed();
-					if(self.expired())
-						return;
-				}
-			}
-			else
-			{
-				if(readableChanged)
-				{
-					readableChanged = false;
-
-					std::weak_ptr<Private> self = q->d;
-					q->readyRead();
-					if(self.expired())
-						return;
-				}
-			}
-		}
-
-		if(state == AboutToConnect)
-		{
-			if(!manager->canWriteImmediately())
-			{
-				state = Idle;
-				errorCondition = ErrorUnavailable;
-				cleanup();
-				q->error();
-				return;
-			}
-
-			state = Connecting;
-
-			ZhttpRequestPacket p;
-			p.type = ZhttpRequestPacket::Data;
-			p.uri = requestUri;
-			p.headers = requestHeaders;
-			p.routerResp = true;
-			p.connectHost = connectHost;
-			p.connectPort = connectPort;
-			if(ignorePolicies)
-				p.ignorePolicies = true;
-			if(trustConnectHost)
-				p.trustConnectHost = true;
-			if(ignoreTlsErrors)
-				p.ignoreTlsErrors = true;
-			p.clientCert = clientCert;
-			p.clientKey = clientKey;
-			p.credits = IDEAL_CREDITS;
-			p.multi = true;
-			writePacket(p);
-		}
-		else if(state == Connected || state == ConnectedPeerClosed)
-		{
-			std::weak_ptr<Private> self = q->d;
-			tryWrite();
-			if(self.expired())
-				return;
-
-			if(writableChanged)
-			{
-				writableChanged = false;
-
-				q->writeBytesChanged();
-			}
-		}
-	}
-
-	void expire_timeout()
-	{
-		state = Idle;
-		errorCondition = ErrorTimeout;
-		cleanup();
-		q->error();
-	}
-
-	void keepAlive_timeout()
-	{
-		if(server)
-		{
-			ZhttpResponsePacket p;
-			p.type = ZhttpResponsePacket::KeepAlive;
-			writePacket(p);
-		}
-		else
-		{
-			ZhttpRequestPacket p;
-			p.type = ZhttpRequestPacket::KeepAlive;
-			writePacket(p);
-		}
-	}
+    enum InternalState {
+        Idle,
+        AboutToConnect,
+        Connecting,
+        Connected,
+        ConnectedPeerClosed,
+        ClosedPeerConnected
+    };
+
+    ZWebSocket *q;
+    ZhttpManager *manager;
+    bool server;
+    InternalState state;
+    ZWebSocket::Rid rid;
+    QByteArray toAddress;
+    QHostAddress peerAddress;
+    QString connectHost;
+    int connectPort;
+    bool ignorePolicies;
+    bool trustConnectHost;
+    bool ignoreTlsErrors;
+    QString clientCert;
+    QString clientKey;
+    Url requestUri;
+    HttpHeaders requestHeaders;
+    int inSeq;
+    int outSeq;
+    int outCredits;
+    int pendingInCredits;
+    int responseCode;
+    QByteArray responseReason;
+    HttpHeaders responseHeaders;
+    QByteArray responseBody; // For rejections only
+    bool inClosed;
+    bool outClosed;
+    int closeCode;
+    QString closeReason;
+    int peerCloseCode;
+    QString peerCloseReason;
+    Variant userData;
+    bool pendingUpdate;
+    bool readableChanged;
+    bool writableChanged;
+    ErrorCondition errorCondition;
+    std::unique_ptr<Timer> expireTimer;
+    std::unique_ptr<Timer> keepAliveTimer;
+    QList<Frame> inFrames;
+    QList<Frame> outFrames;
+    int inSize;
+    int outSize;
+    int inContentType;
+    int outContentType;
+    bool multi;
+    bool routerResp;
+    DeferCall deferCall;
+
+    Private(ZWebSocket *_q)
+        : q(_q),
+          manager(0),
+          server(false),
+          state(Idle),
+          connectPort(-1),
+          ignorePolicies(false),
+          trustConnectHost(false),
+          ignoreTlsErrors(false),
+          inSeq(0),
+          outSeq(0),
+          outCredits(0),
+          pendingInCredits(0),
+          responseCode(-1),
+          inClosed(false),
+          outClosed(false),
+          closeCode(-1),
+          peerCloseCode(-1),
+          pendingUpdate(false),
+          readableChanged(false),
+          writableChanged(false),
+          inSize(0),
+          outSize(0),
+          inContentType(-1),
+          outContentType((int)Frame::Text),
+          multi(false),
+          routerResp(false) {
+        expireTimer = std::make_unique<Timer>();
+        expireTimer->timeout.connect(boost::bind(&Private::expire_timeout, this));
+        expireTimer->setSingleShot(true);
+
+        keepAliveTimer = std::make_unique<Timer>();
+        keepAliveTimer->timeout.connect(boost::bind(&Private::keepAlive_timeout, this));
+    }
+
+    ~Private() {
+        if (manager && state != Idle)
+            tryCancel();
+
+        cleanup();
+    }
+
+    void cleanup() {
+        readableChanged = false;
+        writableChanged = false;
+
+        expireTimer.reset();
+        keepAliveTimer.reset();
+
+        if (manager) {
+            manager->unregisterKeepAlive(q);
+
+            manager->unlink(q);
+            manager = 0;
+        }
+    }
+
+    bool setupServer(int seq, const ZhttpRequestPacket &packet) {
+        if (packet.type != ZhttpRequestPacket::Data) {
+            log_warning("zws server: received request with invalid type, canceling");
+            tryRespondCancel(packet);
+            return false;
+        }
+
+        if (seq != 0) {
+            log_warning("zws server: error, received request with non-zero seq field");
+            writeError("bad-request");
+            state = Idle;
+            return false;
+        }
+
+        inSeq = 1; // Next expected seq
+
+        if (packet.credits != -1)
+            outCredits = packet.credits;
+
+        requestUri = packet.uri;
+        requestHeaders = packet.headers;
+
+        userData = packet.userData;
+        peerAddress = packet.peerAddress;
+
+        if (packet.multi)
+            multi = true;
+
+        if (packet.routerResp)
+            routerResp = true;
+
+        return true;
+    }
+
+    void startClient() {
+        state = AboutToConnect;
+
+        refreshTimeout();
+        update();
+    }
+
+    void startServer() {
+        state = Connecting;
+
+        startKeepAlive();
+        refreshTimeout();
+        update();
+    }
+
+    void startKeepAlive() {
+        if (multi) {
+            if (keepAliveTimer->isActive()) {
+                // Need to flush the current keepalive, since the
+                // manager registration may extend the timeout
+                keepAlive_timeout();
+
+                keepAliveTimer->stop();
+            }
+
+            manager->registerKeepAlive(q);
+        } else {
+            manager->unregisterKeepAlive(q);
+
+            if (!keepAliveTimer->isActive())
+                keepAliveTimer->start(KEEPALIVE_INTERVAL);
+        }
+    }
+
+    void stopKeepAlive() {
+        if (keepAliveTimer->isActive())
+            keepAliveTimer->stop();
+
+        manager->unregisterKeepAlive(q);
+    }
+
+    void refreshTimeout() { expireTimer->start(SESSION_EXPIRE); }
+
+    void update() {
+        if (!pendingUpdate) {
+            pendingUpdate = true;
+            deferCall.defer([=] { doUpdate(); });
+        }
+    }
+
+    void respond() {
+        state = Connected;
+
+        ZhttpResponsePacket out;
+        out.type = ZhttpResponsePacket::Data;
+        out.code = responseCode;
+        out.reason = responseReason;
+        out.headers = responseHeaders;
+        out.credits = IDEAL_CREDITS;
+        if (multi)
+            out.multi = true;
+        writePacket(out);
+    }
+
+    void reject() {
+        ZhttpResponsePacket out;
+        out.type = ZhttpResponsePacket::Error;
+        out.condition = "rejected";
+        out.code = responseCode;
+        out.reason = responseReason;
+        out.headers = responseHeaders;
+        out.body = responseBody;
+        writePacket(out);
+
+        state = Idle;
+        cleanup();
+        deferCall.defer([=] { doClosed(); });
+    }
+
+    Frame readFrame() {
+        Frame f = inFrames.takeFirst();
+        inSize -= f.data.size();
+        pendingInCredits += f.data.size();
+        update();
+        return f;
+    }
+
+    void writeFrame(const Frame &frame) {
+        if (state != Connected && state != ConnectedPeerClosed)
+            return;
+
+        outFrames += frame;
+        outSize += frame.data.size();
+        update();
+    }
+
+    void close(int code, const QString &reason) {
+        if ((state != Connected && state != ConnectedPeerClosed) || outClosed)
+            return;
+
+        outClosed = true;
+        closeCode = code;
+        closeReason = reason;
+
+        if (outFrames.isEmpty()) {
+            writeClose(code, reason);
+
+            if (state == ConnectedPeerClosed) {
+                // If peer was already closed, then we're done!
+                state = Idle;
+                cleanup();
+                deferCall.defer([=] { doClosed(); });
+            } else {
+                // If peer was not closed, then we wait around
+                state = ClosedPeerConnected;
+            }
+        }
+    }
+
+    void tryWrite() {
+        std::weak_ptr<Private> self = q->d;
+
+        if (state == Connected || state == ConnectedPeerClosed) {
+            int written = 0;
+            int contentBytesWritten = 0;
+
+            while (!outFrames.isEmpty()) {
+                Frame &nextFrame = outFrames.first();
+                int contentSize = 0;
+
+                if ((nextFrame.type == Frame::Ping || nextFrame.type == Frame::Pong) &&
+                    outCredits >= nextFrame.data.size()) {
+                    contentSize = nextFrame.data.size();
+                } else if ((nextFrame.type == Frame::Text || nextFrame.type == Frame::Binary ||
+                            nextFrame.type == Frame::Continuation) &&
+                           (nextFrame.data.isEmpty() || outCredits > 0)) {
+                    contentSize = qMin(nextFrame.data.size(), outCredits);
+                } else {
+                    break;
+                }
+
+                // If we have data to send, and the credits to do so, then send data.
+                // also send credits if we need to.
+
+                Frame f = nextFrame;
+                bool outFrameDone = false;
+
+                if (contentSize >= nextFrame.data.size()) {
+                    outFrames.removeFirst();
+                    outFrameDone = true;
+                } else {
+                    f.data = f.data.mid(0, contentSize);
+                    f.more = true;
+
+                    nextFrame.type = Frame::Continuation;
+                    nextFrame.data = nextFrame.data.mid(contentSize);
+                }
+
+                outSize -= f.data.size();
+                outCredits -= f.data.size();
+
+                int credits = -1;
+                if (state != ConnectedPeerClosed && pendingInCredits > 0) {
+                    credits = pendingInCredits;
+                    pendingInCredits = 0;
+                }
+
+                writeFrameInternal(f, credits);
+
+                if (outFrameDone)
+                    ++written;
+
+                contentBytesWritten += f.data.size();
+            }
+
+            if (written > 0 || contentBytesWritten > 0) {
+                q->framesWritten(written, contentBytesWritten);
+                if (self.expired())
+                    return;
+            }
+
+            if (outFrames.isEmpty() && outClosed) {
+                writeClose(closeCode, closeReason);
+
+                if (state == ConnectedPeerClosed) {
+                    // If peer was already closed, then we're done!
+                    state = Idle;
+                    cleanup();
+                    q->closed();
+                    return;
+                } else {
+                    // If peer was not closed, then we wait around
+                    state = ClosedPeerConnected;
+                }
+            }
+        }
+
+        // If we didn't send credits in a data packet, then do them now
+        if (state != ConnectedPeerClosed && pendingInCredits > 0) {
+            int credits = pendingInCredits;
+            pendingInCredits = 0;
+
+            writeCredits(credits);
+        }
+    }
+
+    void handleIncomingDataPacket(const QByteArray &contentType, const QByteArray &data,
+                                  bool more) {
+        Frame::Type ftype;
+        if (inContentType != -1) {
+            ftype = Frame::Continuation;
+        } else {
+            if (contentType == "binary")
+                ftype = Frame::Binary;
+            else
+                ftype = Frame::Text;
+
+            inContentType = (int)ftype;
+        }
+
+        inFrames += Frame(ftype, !data.isNull() ? data : QByteArray(""), more);
+        inSize += data.size();
+
+        if (!more)
+            inContentType = -1;
+    }
+
+    void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet) {
+        if (packet.type == ZhttpRequestPacket::Error) {
+            errorCondition = convertError(packet.condition.asQByteArray());
+
+            log_debug("zws server: error id=%s cond=%s", id.data(), packet.condition.data());
+
+            state = Idle;
+            cleanup();
+            q->error();
+            return;
+        } else if (packet.type == ZhttpRequestPacket::Cancel) {
+            log_debug("zws server: received cancel id=%s", id.data());
+
+            errorCondition = ErrorGeneric;
+            state = Idle;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (seq != inSeq) {
+            log_warning("zws server: error id=%s received message out of sequence, canceling",
+                        id.data());
+
+            tryRespondCancel(packet);
+
+            state = Idle;
+            errorCondition = ErrorGeneric;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        ++inSeq;
+
+        if (!multi && packet.multi) {
+            // Switch on multi support
+            multi = true;
+            startKeepAlive(); // Re-setup keep alive
+        }
+
+        refreshTimeout();
+
+        if (packet.type == ZhttpRequestPacket::Data || packet.type == ZhttpRequestPacket::Ping ||
+            packet.type == ZhttpRequestPacket::Pong) {
+            if (inSize + packet.body.size() > IDEAL_CREDITS)
+                log_warning("zws client: id=%s server is sending too fast", id.data());
+
+            if (packet.type == ZhttpRequestPacket::Data) {
+                handleIncomingDataPacket(packet.contentType.asQByteArray(),
+                                         packet.body.asQByteArray(), packet.more);
+            } else if (packet.type == ZhttpRequestPacket::Ping) {
+                inFrames += Frame(Frame::Ping, packet.body.asQByteArray(), false);
+                inSize += packet.body.size();
+            } else if (packet.type == ZhttpRequestPacket::Pong) {
+                inFrames += Frame(Frame::Pong, packet.body.asQByteArray(), false);
+                inSize += packet.body.size();
+            }
+
+            if (packet.credits > 0) {
+                outCredits += packet.credits;
+                writableChanged = true;
+            }
+
+            readableChanged = true;
+            update();
+        } else if (packet.type == ZhttpRequestPacket::Close) {
+            handlePeerClose(packet.code, QString::fromUtf8(packet.body.asQByteArray()));
+        } else if (packet.type == ZhttpRequestPacket::Credit) {
+            if (packet.credits > 0) {
+                outCredits += packet.credits;
+                writableChanged = true;
+                update();
+            }
+        } else if (packet.type == ZhttpRequestPacket::KeepAlive) {
+            // Nothing to do
+        } else {
+            log_debug("zws server: unsupported packet type id=%s type=%d", id.data(),
+                      (int)packet.type);
+        }
+    }
+
+    void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet) {
+        if (packet.type == ZhttpResponsePacket::Error) {
+            errorCondition = convertError(packet.condition.asQByteArray());
+
+            log_debug("zws client: error id=%s cond=%s", id.data(), packet.condition.data());
+
+            responseCode = packet.code;
+            responseReason = packet.reason.asQByteArray();
+            responseHeaders = packet.headers;
+            responseBody = packet.body.asQByteArray();
+
+            state = Idle;
+            cleanup();
+            q->error();
+            return;
+        } else if (packet.type == ZhttpResponsePacket::Cancel) {
+            log_debug("zws client: received cancel id=%s", id.data());
+
+            errorCondition = ErrorGeneric;
+            state = Idle;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (!packet.from.isEmpty())
+            toAddress = packet.from.asQByteArray();
+
+        if (seq != inSeq) {
+            log_warning("zws client: error id=%s received message out of sequence, canceling",
+                        id.data());
+
+            tryRespondCancel(packet);
+
+            state = Idle;
+            errorCondition = ErrorGeneric;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (!toAddress.isEmpty())
+            startKeepAlive(); // Only starts if wasn't started already
+
+        ++inSeq;
+
+        if (!multi && packet.multi) {
+            // Switch on multi support
+            multi = true;
+            startKeepAlive(); // Re-setup keep alive
+        }
+
+        refreshTimeout();
+
+        if (state == Connecting) {
+            if (packet.type != ZhttpResponsePacket::Data &&
+                packet.type != ZhttpResponsePacket::Credit &&
+                packet.type != ZhttpResponsePacket::KeepAlive) {
+                state = Idle;
+                errorCondition = ErrorGeneric;
+                cleanup();
+                log_warning("zws client: error id=%s initial response wrong type", id.data());
+                q->error();
+                return;
+            }
+
+            if (packet.from.isEmpty()) {
+                state = Idle;
+                errorCondition = ErrorGeneric;
+                cleanup();
+                log_warning("zws client: error id=%s initial ack did not contain from field",
+                            id.data());
+                q->error();
+                return;
+            }
+        }
+
+        if (packet.type == ZhttpResponsePacket::Data || packet.type == ZhttpResponsePacket::Ping ||
+            packet.type == ZhttpResponsePacket::Pong) {
+            if (state == Connecting) {
+                // This is assured earlier
+                assert(packet.type == ZhttpResponsePacket::Data);
+
+                responseCode = packet.code;
+                responseReason = packet.reason.asQByteArray();
+                responseHeaders = packet.headers;
+
+                if (packet.credits > 0)
+                    outCredits += packet.credits;
+
+                state = Connected;
+                update();
+                q->connected();
+            } else {
+                if (inSize + packet.body.size() > IDEAL_CREDITS)
+                    log_warning("zws client: id=%s server is sending too fast", id.data());
+
+                if (packet.type == ZhttpResponsePacket::Data) {
+                    handleIncomingDataPacket(packet.contentType.asQByteArray(),
+                                             packet.body.asQByteArray(), packet.more);
+                } else if (packet.type == ZhttpResponsePacket::Ping) {
+                    inFrames += Frame(Frame::Ping, packet.body.asQByteArray(), false);
+                    inSize += packet.body.size();
+                } else if (packet.type == ZhttpResponsePacket::Pong) {
+                    inFrames += Frame(Frame::Pong, packet.body.asQByteArray(), false);
+                    inSize += packet.body.size();
+                }
+
+                if (packet.credits > 0) {
+                    outCredits += packet.credits;
+                    writableChanged = true;
+                }
+
+                readableChanged = true;
+                update();
+            }
+        } else if (packet.type == ZhttpResponsePacket::Close) {
+            handlePeerClose(packet.code, QString::fromUtf8(packet.body.asQByteArray()));
+        } else if (packet.type == ZhttpResponsePacket::Credit) {
+            if (packet.credits > 0) {
+                outCredits += packet.credits;
+                writableChanged = true;
+                update();
+            }
+        } else if (packet.type == ZhttpResponsePacket::KeepAlive) {
+            // Nothing to do
+        } else {
+            log_debug("zws client: unsupported packet type id=%s type=%d", id.data(),
+                      (int)packet.type);
+        }
+    }
+
+    void handlePeerClose(int code, const QString &reason) {
+        if ((state == Connected || state == ClosedPeerConnected) && !inClosed) {
+            inClosed = true;
+            peerCloseCode = code;
+            peerCloseReason = reason;
+
+            if (inFrames.isEmpty()) {
+                if (state == ClosedPeerConnected) {
+                    state = Idle;
+                    cleanup();
+                    q->closed();
+                } else {
+                    state = ConnectedPeerClosed;
+                    q->peerClosed();
+                }
+            }
+        }
+    }
+
+    void writePacket(const ZhttpRequestPacket &packet) {
+        assert(manager);
+
+        bool first = (outSeq == 0);
+
+        ZhttpRequestPacket out = packet;
+        out.from = rid.first;
+        out.ids += ZhttpRequestPacket::Id(rid.second, outSeq++);
+
+        if (first) {
+            manager->writeWs(out);
+        } else {
+            assert(!toAddress.isEmpty());
+            manager->writeWs(out, toAddress);
+        }
+    }
+
+    void writePacket(const ZhttpResponsePacket &packet) {
+        assert(manager);
+
+        ZhttpResponsePacket out = packet;
+        out.from = manager->instanceId();
+        out.ids += ZhttpResponsePacket::Id(rid.second, outSeq++);
+        out.userData = userData;
+
+        manager->writeWs(out, rid.first, routerResp);
+    }
+
+    void writeFrameInternal(const Frame &frame, int credits = -1) {
+        // For content frames, set the type
+        QByteArray contentType;
+        if (frame.type == Frame::Binary || frame.type == Frame::Text ||
+            frame.type == Frame::Continuation) {
+            Frame::Type ftype = (Frame::Type)-1;
+            if (frame.type == Frame::Binary || frame.type == Frame::Text) {
+                ftype = frame.type;
+                outContentType = (int)frame.type;
+            } else if (frame.type == Frame::Continuation) {
+                ftype = (Frame::Type)outContentType;
+            }
+
+            if (ftype != (Frame::Type)-1) {
+                if (ftype == Frame::Binary)
+                    contentType = "binary";
+                else // Text
+                    contentType = "text";
+            }
+        }
+
+        if (server) {
+            ZhttpResponsePacket p;
+
+            if (frame.type == Frame::Ping) {
+                p.type = ZhttpResponsePacket::Ping;
+            } else if (frame.type == Frame::Pong) {
+                p.type = ZhttpResponsePacket::Pong;
+            } else {
+                p.type = ZhttpResponsePacket::Data;
+                p.contentType = contentType;
+            }
+
+            p.body = frame.data;
+            p.more = frame.more;
+            p.credits = credits;
+            writePacket(p);
+        } else {
+            ZhttpRequestPacket p;
+
+            if (frame.type == Frame::Ping) {
+                p.type = ZhttpRequestPacket::Ping;
+            } else if (frame.type == Frame::Pong) {
+                p.type = ZhttpRequestPacket::Pong;
+            } else {
+                p.type = ZhttpRequestPacket::Data;
+                p.contentType = contentType;
+            }
+
+            p.body = frame.data;
+            p.more = frame.more;
+            p.credits = credits;
+            writePacket(p);
+        }
+    }
+
+    void writeCredits(int credits) {
+        if (server) {
+            ZhttpResponsePacket p;
+            p.type = ZhttpResponsePacket::Credit;
+            p.credits = credits;
+            writePacket(p);
+        } else {
+            ZhttpRequestPacket p;
+            p.type = ZhttpRequestPacket::Credit;
+            p.credits = credits;
+            writePacket(p);
+        }
+    }
+
+    void writeClose(int code = -1, const QString &reason = QString()) {
+        if (server) {
+            ZhttpResponsePacket out;
+            out.type = ZhttpResponsePacket::Close;
+            out.code = code;
+            if (!reason.isEmpty())
+                out.body = reason.toUtf8();
+            writePacket(out);
+        } else {
+            ZhttpRequestPacket out;
+            out.type = ZhttpRequestPacket::Close;
+            out.code = code;
+            if (!reason.isEmpty())
+                out.body = reason.toUtf8();
+            writePacket(out);
+        }
+    }
+
+    void writeCancel() {
+        if (server) {
+            ZhttpResponsePacket out;
+            out.type = ZhttpResponsePacket::Cancel;
+            writePacket(out);
+        } else {
+            ZhttpRequestPacket out;
+            out.type = ZhttpRequestPacket::Cancel;
+            writePacket(out);
+        }
+    }
+
+    void writeError(const QByteArray &condition) {
+        ZhttpResponsePacket out;
+        out.type = ZhttpResponsePacket::Error;
+        out.condition = condition;
+        writePacket(out);
+    }
+
+    void tryCancel() {
+        if (state != Idle) {
+            state = Idle;
+
+            // Can't send cancel in client mode without address
+            if (!server && toAddress.isEmpty())
+                return;
+
+            writeCancel();
+        }
+    }
+
+    void tryRespondCancel(const ZhttpRequestPacket &packet) {
+        // If this was not an error packet, send cancel
+        if (packet.type != ZhttpRequestPacket::Error && packet.type != ZhttpRequestPacket::Cancel)
+            writeCancel();
+    }
+
+    void tryRespondCancel(const ZhttpResponsePacket &packet) {
+        // If this was not an error packet, send cancel
+        if (packet.type != ZhttpResponsePacket::Error &&
+            packet.type != ZhttpResponsePacket::Cancel && !toAddress.isEmpty())
+            writeCancel();
+    }
+
+    static ErrorCondition convertError(const QByteArray &cond) {
+        // Zws conditions:
+        //  remote-connection-failed
+        //  connection-timeout
+        //  tls-error
+        //  bad-request
+        //  policy-violation
+        //  max-size-exceeded
+        //  session-timeout
+        //  rejected
+
+        if (cond == "policy-violation")
+            return ErrorPolicy;
+        else if (cond == "remote-connection-failed")
+            return ErrorConnect;
+        else if (cond == "tls-error")
+            return ErrorTls;
+        else if (cond == "connection-timeout")
+            return ErrorConnectTimeout;
+        else if (cond == "rejected")
+            return ErrorRejected;
+        else // Lump the rest as generic
+            return ErrorGeneric;
+    }
+
+    void doClosed() { q->closed(); }
+
+    void doUpdate() {
+        pendingUpdate = false;
+
+        if (state == Connected || state == ClosedPeerConnected) {
+            if (inFrames.isEmpty() && inClosed) {
+                if (state == ClosedPeerConnected) {
+                    state = Idle;
+                    cleanup();
+                    q->closed();
+                    return;
+                } else {
+                    std::weak_ptr<Private> self = q->d;
+                    state = ConnectedPeerClosed;
+                    q->peerClosed();
+                    if (self.expired())
+                        return;
+                }
+            } else {
+                if (readableChanged) {
+                    readableChanged = false;
+
+                    std::weak_ptr<Private> self = q->d;
+                    q->readyRead();
+                    if (self.expired())
+                        return;
+                }
+            }
+        }
+
+        if (state == AboutToConnect) {
+            if (!manager->canWriteImmediately()) {
+                state = Idle;
+                errorCondition = ErrorUnavailable;
+                cleanup();
+                q->error();
+                return;
+            }
+
+            state = Connecting;
+
+            ZhttpRequestPacket p;
+            p.type = ZhttpRequestPacket::Data;
+            p.uri = requestUri;
+            p.headers = requestHeaders;
+            p.routerResp = true;
+            p.connectHost = connectHost;
+            p.connectPort = connectPort;
+            if (ignorePolicies)
+                p.ignorePolicies = true;
+            if (trustConnectHost)
+                p.trustConnectHost = true;
+            if (ignoreTlsErrors)
+                p.ignoreTlsErrors = true;
+            p.clientCert = clientCert;
+            p.clientKey = clientKey;
+            p.credits = IDEAL_CREDITS;
+            p.multi = true;
+            writePacket(p);
+        } else if (state == Connected || state == ConnectedPeerClosed) {
+            std::weak_ptr<Private> self = q->d;
+            tryWrite();
+            if (self.expired())
+                return;
+
+            if (writableChanged) {
+                writableChanged = false;
+
+                q->writeBytesChanged();
+            }
+        }
+    }
+
+    void expire_timeout() {
+        state = Idle;
+        errorCondition = ErrorTimeout;
+        cleanup();
+        q->error();
+    }
+
+    void keepAlive_timeout() {
+        if (server) {
+            ZhttpResponsePacket p;
+            p.type = ZhttpResponsePacket::KeepAlive;
+            writePacket(p);
+        } else {
+            ZhttpRequestPacket p;
+            p.type = ZhttpRequestPacket::KeepAlive;
+            writePacket(p);
+        }
+    }
 };
 
-ZWebSocket::ZWebSocket()
-{
-	d = std::make_shared<Private>(this);
-}
+ZWebSocket::ZWebSocket() { d = std::make_shared<Private>(this); }
 
 ZWebSocket::~ZWebSocket() = default;
 
-ZWebSocket::Rid ZWebSocket::rid() const
-{
-	return d->rid;
+ZWebSocket::Rid ZWebSocket::rid() const { return d->rid; }
+
+QHostAddress ZWebSocket::peerAddress() const { return d->peerAddress; }
+
+void ZWebSocket::setConnectHost(const QString &host) { d->connectHost = host; }
+
+void ZWebSocket::setConnectPort(int port) { d->connectPort = port; }
+
+void ZWebSocket::setIgnorePolicies(bool on) { d->ignorePolicies = on; }
+
+void ZWebSocket::setTrustConnectHost(bool on) { d->trustConnectHost = on; }
+
+void ZWebSocket::setIgnoreTlsErrors(bool on) { d->ignoreTlsErrors = on; }
+
+void ZWebSocket::setIsTls(bool on) { d->requestUri.setScheme(on ? "wss" : "ws"); }
+
+void ZWebSocket::setClientCert(const QString &cert, const QString &key) {
+    d->clientCert = cert;
+    d->clientKey = key;
 }
 
-QHostAddress ZWebSocket::peerAddress() const
-{
-	return d->peerAddress;
+void ZWebSocket::start(const Url &uri, const HttpHeaders &headers) {
+    assert(!d->server);
+
+    d->requestUri = uri;
+    d->requestHeaders = headers;
+    d->startClient();
 }
 
-void ZWebSocket::setConnectHost(const QString &host)
-{
-	d->connectHost = host;
+void ZWebSocket::respondSuccess(const QByteArray &reason, const HttpHeaders &headers) {
+    assert(d->server);
+    assert(d->state == Private::Connecting);
+
+    d->responseCode = 101;
+    d->responseReason = reason;
+    d->responseHeaders = headers;
+    d->respond();
 }
 
-void ZWebSocket::setConnectPort(int port)
-{
-	d->connectPort = port;
+void ZWebSocket::respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                              const QByteArray &body) {
+    assert(d->server);
+    assert(d->state == Private::Connecting);
+
+    d->responseCode = code;
+    d->responseReason = reason;
+    d->responseHeaders = headers;
+    d->responseBody = body;
+    d->reject();
 }
 
-void ZWebSocket::setIgnorePolicies(bool on)
-{
-	d->ignorePolicies = on;
+WebSocket::State ZWebSocket::state() const {
+    switch (d->state) {
+    case Private::Idle:
+        return Idle;
+    case Private::AboutToConnect:
+    case Private::Connecting:
+        if (d->outClosed)
+            return Closing;
+        else
+            return Connecting;
+    case Private::Connected:
+    case Private::ConnectedPeerClosed:
+    case Private::ClosedPeerConnected:
+    default:
+        if (d->outClosed)
+            return Closing;
+        else
+            return Connected;
+    }
 }
 
-void ZWebSocket::setTrustConnectHost(bool on)
-{
-	d->trustConnectHost = on;
+Url ZWebSocket::requestUri() const { return d->requestUri; }
+
+HttpHeaders ZWebSocket::requestHeaders() const { return d->requestHeaders; }
+
+int ZWebSocket::responseCode() const { return d->responseCode; }
+
+QByteArray ZWebSocket::responseReason() const { return d->responseReason; }
+
+HttpHeaders ZWebSocket::responseHeaders() const { return d->responseHeaders; }
+
+QByteArray ZWebSocket::responseBody() const { return d->responseBody; }
+
+int ZWebSocket::framesAvailable() const { return d->inFrames.count(); }
+
+int ZWebSocket::writeBytesAvailable() const {
+    if (d->outSize < d->outCredits)
+        return d->outCredits - d->outSize;
+    else
+        return 0;
 }
 
-void ZWebSocket::setIgnoreTlsErrors(bool on)
-{
-	d->ignoreTlsErrors = on;
+int ZWebSocket::peerCloseCode() const { return d->peerCloseCode; }
+
+QString ZWebSocket::peerCloseReason() const { return d->peerCloseReason; }
+
+WebSocket::ErrorCondition ZWebSocket::errorCondition() const { return d->errorCondition; }
+
+void ZWebSocket::writeFrame(const Frame &frame) { d->writeFrame(frame); }
+
+WebSocket::Frame ZWebSocket::readFrame() { return d->readFrame(); }
+
+void ZWebSocket::close(int code, const QString &reason) { d->close(code, reason); }
+
+void ZWebSocket::setupClient(ZhttpManager *manager) {
+    d->manager = manager;
+    d->rid = Rid(manager->instanceId(), UuidUtil::createUuid());
+    d->manager->link(this);
 }
 
-void ZWebSocket::setIsTls(bool on)
-{
-	d->requestUri.setScheme(on ? "wss" : "ws");
+bool ZWebSocket::setupServer(ZhttpManager *manager, const QByteArray &id, int seq,
+                             const ZhttpRequestPacket &packet) {
+    d->manager = manager;
+    d->server = true;
+    d->rid = Rid(packet.from.asQByteArray(), id);
+    return d->setupServer(seq, packet);
 }
 
-void ZWebSocket::setClientCert(const QString &cert, const QString &key)
-{
-	d->clientCert = cert;
-	d->clientKey = key;
+void ZWebSocket::startServer() { d->startServer(); }
+
+bool ZWebSocket::isServer() const { return d->server; }
+
+QByteArray ZWebSocket::toAddress() const { return d->toAddress; }
+
+bool ZWebSocket::routerResp() const { return d->routerResp; }
+
+int ZWebSocket::outSeqInc() { return d->outSeq++; }
+
+void ZWebSocket::handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet) {
+    assert(d->manager);
+
+    d->handle(id, seq, packet);
 }
 
-void ZWebSocket::start(const Url &uri, const HttpHeaders &headers)
-{
-	assert(!d->server);
+void ZWebSocket::handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet) {
+    assert(d->manager);
 
-	d->requestUri = uri;
-	d->requestHeaders = headers;
-	d->startClient();
-}
-
-void ZWebSocket::respondSuccess(const QByteArray &reason, const HttpHeaders &headers)
-{
-	assert(d->server);
-	assert(d->state == Private::Connecting);
-
-	d->responseCode = 101;
-	d->responseReason = reason;
-	d->responseHeaders = headers;
-	d->respond();
-}
-
-void ZWebSocket::respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	assert(d->server);
-	assert(d->state == Private::Connecting);
-
-	d->responseCode = code;
-	d->responseReason = reason;
-	d->responseHeaders = headers;
-	d->responseBody = body;
-	d->reject();
-}
-
-WebSocket::State ZWebSocket::state() const
-{
-	switch(d->state)
-	{
-		case Private::Idle:
-			return Idle;
-		case Private::AboutToConnect:
-		case Private::Connecting:
-			if(d->outClosed)
-				return Closing;
-			else
-				return Connecting;
-		case Private::Connected:
-		case Private::ConnectedPeerClosed:
-		case Private::ClosedPeerConnected:
-		default:
-			if(d->outClosed)
-				return Closing;
-			else
-				return Connected;
-	}
-}
-
-Url ZWebSocket::requestUri() const
-{
-	return d->requestUri;
-}
-
-HttpHeaders ZWebSocket::requestHeaders() const
-{
-	return d->requestHeaders;
-}
-
-int ZWebSocket::responseCode() const
-{
-	return d->responseCode;
-}
-
-QByteArray ZWebSocket::responseReason() const
-{
-	return d->responseReason;
-}
-
-HttpHeaders ZWebSocket::responseHeaders() const
-{
-	return d->responseHeaders;
-}
-
-QByteArray ZWebSocket::responseBody() const
-{
-	return d->responseBody;
-}
-
-int ZWebSocket::framesAvailable() const
-{
-	return d->inFrames.count();
-}
-
-int ZWebSocket::writeBytesAvailable() const
-{
-	if(d->outSize < d->outCredits)
-		return d->outCredits - d->outSize;
-	else
-		return 0;
-}
-
-int ZWebSocket::peerCloseCode() const
-{
-	return d->peerCloseCode;
-}
-
-QString ZWebSocket::peerCloseReason() const
-{
-	return d->peerCloseReason;
-}
-
-WebSocket::ErrorCondition ZWebSocket::errorCondition() const
-{
-	return d->errorCondition;
-}
-
-void ZWebSocket::writeFrame(const Frame &frame)
-{
-	d->writeFrame(frame);
-}
-
-WebSocket::Frame ZWebSocket::readFrame()
-{
-	return d->readFrame();
-}
-
-void ZWebSocket::close(int code, const QString &reason)
-{
-	d->close(code, reason);
-}
-
-void ZWebSocket::setupClient(ZhttpManager *manager)
-{
-	d->manager = manager;
-	d->rid = Rid(manager->instanceId(), UuidUtil::createUuid());
-	d->manager->link(this);
-}
-
-bool ZWebSocket::setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet)
-{
-	d->manager = manager;
-	d->server = true;
-	d->rid = Rid(packet.from.asQByteArray(), id);
-	return d->setupServer(seq, packet);
-}
-
-void ZWebSocket::startServer()
-{
-	d->startServer();
-}
-
-bool ZWebSocket::isServer() const
-{
-	return d->server;
-}
-
-QByteArray ZWebSocket::toAddress() const
-{
-	return d->toAddress;
-}
-
-bool ZWebSocket::routerResp() const
-{
-	return d->routerResp;
-}
-
-int ZWebSocket::outSeqInc()
-{
-	return d->outSeq++;
-}
-
-void ZWebSocket::handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet)
-{
-	assert(d->manager);
-
-	d->handle(id, seq, packet);
-}
-
-void ZWebSocket::handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet)
-{
-	assert(d->manager);
-
-	d->handle(id, seq, packet);
+    d->handle(id, seq, packet);
 }

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -24,9 +24,9 @@
 #ifndef ZWEBSOCKET_H
 #define ZWEBSOCKET_H
 
+#include "url.h"
 #include "websocket.h"
 #include <boost/signals2.hpp>
-#include "url.h"
 
 using Connection = boost::signals2::scoped_connection;
 
@@ -34,66 +34,67 @@ class ZhttpRequestPacket;
 class ZhttpResponsePacket;
 class ZhttpManager;
 
-class ZWebSocket : public WebSocket
-{
+class ZWebSocket : public WebSocket {
 public:
-	// Pair of sender + request id
-	typedef QPair<QByteArray, QByteArray> Rid;
+    // Pair of sender + request id
+    typedef QPair<QByteArray, QByteArray> Rid;
 
-	~ZWebSocket();
+    ~ZWebSocket();
 
-	Rid rid() const;
-	void setIsTls(bool on);
+    Rid rid() const;
+    void setIsTls(bool on);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QHostAddress peerAddress() const;
+    virtual QHostAddress peerAddress() const;
 
-	virtual void setConnectHost(const QString &host);
-	virtual void setConnectPort(int port);
-	virtual void setIgnorePolicies(bool on);
-	virtual void setTrustConnectHost(bool on);
-	virtual void setIgnoreTlsErrors(bool on);
-	virtual void setClientCert(const QString &cert, const QString &key);
+    virtual void setConnectHost(const QString &host);
+    virtual void setConnectPort(int port);
+    virtual void setIgnorePolicies(bool on);
+    virtual void setTrustConnectHost(bool on);
+    virtual void setIgnoreTlsErrors(bool on);
+    virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const Url &uri, const HttpHeaders &headers);
 
-	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
-	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
+    virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
+    virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                              const QByteArray &body);
 
-	virtual State state() const;
-	virtual Url requestUri() const;
-	virtual HttpHeaders requestHeaders() const;
-	virtual int responseCode() const;
-	virtual QByteArray responseReason() const;
-	virtual HttpHeaders responseHeaders() const;
-	virtual QByteArray responseBody() const;
-	virtual int framesAvailable() const;
-	virtual int writeBytesAvailable() const;
-	virtual int peerCloseCode() const;
-	virtual QString peerCloseReason() const;
-	virtual ErrorCondition errorCondition() const;
+    virtual State state() const;
+    virtual Url requestUri() const;
+    virtual HttpHeaders requestHeaders() const;
+    virtual int responseCode() const;
+    virtual QByteArray responseReason() const;
+    virtual HttpHeaders responseHeaders() const;
+    virtual QByteArray responseBody() const;
+    virtual int framesAvailable() const;
+    virtual int writeBytesAvailable() const;
+    virtual int peerCloseCode() const;
+    virtual QString peerCloseReason() const;
+    virtual ErrorCondition errorCondition() const;
 
-	virtual void writeFrame(const Frame &frame);
-	virtual Frame readFrame();
-	virtual void close(int code = -1, const QString &reason = QString());
+    virtual void writeFrame(const Frame &frame);
+    virtual Frame readFrame();
+    virtual void close(int code = -1, const QString &reason = QString());
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 
-	friend class ZhttpManager;
-	ZWebSocket();
-	void setupClient(ZhttpManager *manager);
-	bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
-	void startServer();
-	bool isServer() const;
-	QByteArray toAddress() const;
-	bool routerResp() const;
-	int outSeqInc();
-	void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
-	void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet);
+    friend class ZhttpManager;
+    ZWebSocket();
+    void setupClient(ZhttpManager *manager);
+    bool setupServer(ZhttpManager *manager, const QByteArray &id, int seq,
+                     const ZhttpRequestPacket &packet);
+    void startServer();
+    bool isServer() const;
+    QByteArray toAddress() const;
+    bool routerResp() const;
+    int outSeqInc();
+    void handle(const QByteArray &id, int seq, const ZhttpRequestPacket &packet);
+    void handle(const QByteArray &id, int seq, const ZhttpResponsePacket &packet);
 };
 
 #endif

--- a/src/handler/cidset.h
+++ b/src/handler/cidset.h
@@ -23,9 +23,9 @@
 #ifndef CIDSET_H
 #define CIDSET_H
 
+#include <QMetaType>
 #include <QSet>
 #include <QString>
-#include <QMetaType>
 
 typedef QSet<QString> CidSet;
 Q_DECLARE_METATYPE(CidSet);

--- a/src/handler/clientsession.h
+++ b/src/handler/clientsession.h
@@ -23,10 +23,9 @@
 #ifndef CLIENTSESSION_H
 #define CLIENTSESSION_H
 
-class ClientSession
-{
+class ClientSession {
 public:
-	virtual ~ClientSession() = default;
+    virtual ~ClientSession() = default;
 };
 
 #endif

--- a/src/handler/conncheckworker.cpp
+++ b/src/handler/conncheckworker.cpp
@@ -23,85 +23,76 @@
 
 #include "conncheckworker.h"
 
-#include "qtcompat.h"
-#include "zrpcrequest.h"
 #include "controlrequest.h"
+#include "qtcompat.h"
 #include "statsmanager.h"
 #include "variant.h"
+#include "zrpcrequest.h"
 
-ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats) :
-	req_(req)
-{
-	VariantHash args = req_->args();
+ConnCheckWorker::ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient,
+                                 StatsManager *stats)
+    : req_(req) {
+    VariantHash args = req_->args();
 
-	if(!args.contains("ids") || typeId(args["ids"]) != VariantType::List)
-	{
-		respondError("bad-request");
-		return;
-	}
+    if (!args.contains("ids") || typeId(args["ids"]) != VariantType::List) {
+        respondError("bad-request");
+        return;
+    }
 
-	VariantList vids = args["ids"].toList();
+    VariantList vids = args["ids"].toList();
 
-	for(const Variant &vid : vids)
-	{
-		if(typeId(vid) != VariantType::ByteArray)
-		{
-			respondError("bad-request");
-			return;
-		}
+    for (const Variant &vid : vids) {
+        if (typeId(vid) != VariantType::ByteArray) {
+            respondError("bad-request");
+            return;
+        }
 
-		cids_ += QString::fromUtf8(vid.toByteArray());
-	}
+        cids_ += QString::fromUtf8(vid.toByteArray());
+    }
 
-	for(const QString &cid : cids_)
-	{
-		if(!stats->checkConnection(cid.toUtf8()))
-			missing_ += cid;
-	}
+    for (const QString &cid : cids_) {
+        if (!stats->checkConnection(cid.toUtf8()))
+            missing_ += cid;
+    }
 
-	if(!missing_.isEmpty())
-	{
-		// Ask the proxy about any cids we don't know about
-		connCheck_ = std::unique_ptr<Deferred>(ControlRequest::connCheck(proxyControlClient, missing_));
-		finishedConnection_ = connCheck_->finished.connect(boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
-		return;
-	}
+    if (!missing_.isEmpty()) {
+        // Ask the proxy about any cids we don't know about
+        connCheck_ =
+            std::unique_ptr<Deferred>(ControlRequest::connCheck(proxyControlClient, missing_));
+        finishedConnection_ = connCheck_->finished.connect(
+            boost::bind(&ConnCheckWorker::proxyConnCheck_finished, this, boost::placeholders::_1));
+        return;
+    }
 
-	doFinish();
+    doFinish();
 }
 
-void ConnCheckWorker::respondError(const QByteArray &condition)
-{
-	req_->respondError(condition);
-	setFinished(true);
+void ConnCheckWorker::respondError(const QByteArray &condition) {
+    req_->respondError(condition);
+    setFinished(true);
 }
 
-void ConnCheckWorker::doFinish()
-{
-	foreach(const QString &cid, missing_)
-		cids_.remove(cid);
+void ConnCheckWorker::doFinish() {
+    foreach (const QString &cid, missing_)
+        cids_.remove(cid);
 
-	VariantList result;
-	for(const QString &cid : cids_)
-		result += cid.toUtf8();
+    VariantList result;
+    for (const QString &cid : cids_)
+        result += cid.toUtf8();
 
-	req_->respond(result);
-	setFinished(true);
+    req_->respond(result);
+    setFinished(true);
 }
 
-void ConnCheckWorker::proxyConnCheck_finished(const DeferredResult &result)
-{
-	if(result.success)
-	{
-		CidSet found = result.value.value<CidSet>();
+void ConnCheckWorker::proxyConnCheck_finished(const DeferredResult &result) {
+    if (result.success) {
+        CidSet found = result.value.value<CidSet>();
 
-		foreach(const QString &cid, found)
-			missing_.remove(cid);
+        foreach (const QString &cid, found)
+            missing_.remove(cid);
 
-		doFinish();
-	}
-	else
-	{
-		respondError("proxy-request-failed");
-	}
+        doFinish();
+    } else {
+        respondError("proxy-request-failed");
+    }
 }

--- a/src/handler/conncheckworker.h
+++ b/src/handler/conncheckworker.h
@@ -24,34 +24,33 @@
 #ifndef CONNCHECKWORKER_H
 #define CONNCHECKWORKER_H
 
+#include "cidset.h"
+#include "deferred.h"
+#include "zrpcrequest.h"
 #include <QByteArray>
 #include <boost/signals2.hpp>
-#include "zrpcrequest.h"
-#include "deferred.h"
-#include "cidset.h"
 
 using Connection = boost::signals2::scoped_connection;
 
 class ZrpcManager;
 class StatsManager;
 
-class ConnCheckWorker : public Deferred
-{
+class ConnCheckWorker : public Deferred {
 public:
-	ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats);
+    ConnCheckWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, StatsManager *stats);
 
 private:
-	std::unique_ptr<ZrpcRequest> req_;
-	CidSet cids_;
-	CidSet missing_;
-	std::unique_ptr<Deferred> connCheck_;
-	Connection finishedConnection_;
+    std::unique_ptr<ZrpcRequest> req_;
+    CidSet cids_;
+    CidSet missing_;
+    std::unique_ptr<Deferred> connCheck_;
+    Connection finishedConnection_;
 
-	void respondError(const QByteArray &condition);
-	void doFinish();
+    void respondError(const QByteArray &condition);
+    void doFinish();
 
 private:
-	void proxyConnCheck_finished(const DeferredResult &result);
+    void proxyConnCheck_finished(const DeferredResult &result);
 };
 
 #endif

--- a/src/handler/controlrequest.cpp
+++ b/src/handler/controlrequest.cpp
@@ -23,103 +23,89 @@
 
 #include "controlrequest.h"
 
+#include "deferred.h"
 #include "packet/statspacket.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include "deferred.h"
 #include "zrpcrequest.h"
 
 namespace ControlRequest {
 
-class ConnCheck : public Deferred
-{
+class ConnCheck : public Deferred {
 public:
-	ConnCheck(ZrpcManager *controlClient, const CidSet &cids)
-	{
-		req = std::make_unique<ZrpcRequest>(controlClient);
-		finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this));
+    ConnCheck(ZrpcManager *controlClient, const CidSet &cids) {
+        req = std::make_unique<ZrpcRequest>(controlClient);
+        finishedConnection = req->finished.connect(boost::bind(&ConnCheck::req_finished, this));
 
-		VariantList vcids;
-		for(const QString &cid : cids)
-			vcids += cid.toUtf8();
+        VariantList vcids;
+        for (const QString &cid : cids)
+            vcids += cid.toUtf8();
 
-		VariantHash args;
-		args["ids"] = vcids;
-		req->start("conncheck", args);
-	}
+        VariantHash args;
+        args["ids"] = vcids;
+        req->start("conncheck", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-		{
-			Variant vresult = req->result();
-			if(typeId(vresult) != VariantType::List)
-			{
-				setFinished(false);
-				return;
-			}
+    void req_finished() {
+        if (req->success()) {
+            Variant vresult = req->result();
+            if (typeId(vresult) != VariantType::List) {
+                setFinished(false);
+                return;
+            }
 
-			VariantList result = vresult.toList();
+            VariantList result = vresult.toList();
 
-			CidSet out;
-			for(const Variant &vcid : result)
-			{
-				if(typeId(vcid) != VariantType::ByteArray)
-				{
-					setFinished(false);
-					return;
-				}
+            CidSet out;
+            for (const Variant &vcid : result) {
+                if (typeId(vcid) != VariantType::ByteArray) {
+                    setFinished(false);
+                    return;
+                }
 
-				out += QString::fromUtf8(vcid.toByteArray());
-			}
+                out += QString::fromUtf8(vcid.toByteArray());
+            }
 
-			setFinished(true, Variant::fromValue<CidSet>(out));
-		}
-		else
-		{
-			setFinished(false, req->errorCondition());
-		}
-	}
+            setFinished(true, Variant::fromValue<CidSet>(out));
+        } else {
+            setFinished(false, req->errorCondition());
+        }
+    }
 };
 
-class Refresh : public Deferred
-{
+class Refresh : public Deferred {
 public:
-	Refresh(ZrpcManager *controlClient, const QByteArray &cid)
-	{
-		req = std::make_unique<ZrpcRequest>(controlClient);
-		finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this));
+    Refresh(ZrpcManager *controlClient, const QByteArray &cid) {
+        req = std::make_unique<ZrpcRequest>(controlClient);
+        finishedConnection = req->finished.connect(boost::bind(&Refresh::req_finished, this));
 
-		VariantHash args;
-		args["cid"] = cid;
-		req->start("refresh", args);
-	}
+        VariantHash args;
+        args["cid"] = cid;
+        req->start("refresh", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-			setFinished(true);
-		else
-			setFinished(false, req->errorConditionString());
-	}
+    void req_finished() {
+        if (req->success())
+            setFinished(true);
+        else
+            setFinished(false, req->errorConditionString());
+    }
 };
 
-Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids)
-{
-	return new ConnCheck(controlClient, cids);
+Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids) {
+    return new ConnCheck(controlClient, cids);
 }
 
-Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid)
-{
-	return new Refresh(controlClient, cid);
+Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid) {
+    return new Refresh(controlClient, cid);
 }
 
-}
+} // namespace ControlRequest

--- a/src/handler/controlrequest.h
+++ b/src/handler/controlrequest.h
@@ -24,8 +24,8 @@
 #ifndef CONTROLREQUEST_H
 #define CONTROLREQUEST_H
 
-#include <boost/signals2.hpp>
 #include "cidset.h"
+#include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
 
@@ -39,6 +39,6 @@ Deferred *connCheck(ZrpcManager *controlClient, const CidSet &cids);
 Deferred *refresh(ZrpcManager *controlClient, const QByteArray &cid);
 Deferred *report(ZrpcManager *controlClient, const StatsPacket &packet);
 
-}
+} // namespace ControlRequest
 
 #endif

--- a/src/handler/deferred.cpp
+++ b/src/handler/deferred.cpp
@@ -25,24 +25,15 @@
 
 #include "variant.h"
 
-Deferred::Deferred()
-{
-	qRegisterMetaType<DeferredResult>();
+Deferred::Deferred() { qRegisterMetaType<DeferredResult>(); }
+
+Deferred::~Deferred() {}
+
+void Deferred::setFinished(bool ok, const Variant &value) {
+    result_.success = ok;
+    result_.value = value;
+
+    deferCall_.defer([=] { doFinish(); });
 }
 
-Deferred::~Deferred()
-{
-}
-
-void Deferred::setFinished(bool ok, const Variant &value)
-{
-	result_.success = ok;
-	result_.value = value;
-
-	deferCall_.defer([=] { doFinish(); });
-}
-
-void Deferred::doFinish()
-{
-	finished(result_);
-}
+void Deferred::doFinish() { finished(result_); }

--- a/src/handler/deferred.h
+++ b/src/handler/deferred.h
@@ -24,47 +24,39 @@
 #ifndef DEFERRED_H
 #define DEFERRED_H
 
+#include "defercall.h"
 #include "variant.h"
 #include <boost/signals2.hpp>
-#include "defercall.h"
 
-class DeferredResult
-{
+class DeferredResult {
 public:
-	bool success;
-	Variant value;
+    bool success;
+    Variant value;
 
-	DeferredResult() :
-		success(false)
-	{
-	}
+    DeferredResult() : success(false) {}
 
-	DeferredResult(bool _success, const Variant &_value = Variant()) :
-		success(_success),
-		value(_value)
-	{
-	}
+    DeferredResult(bool _success, const Variant &_value = Variant())
+        : success(_success), value(_value) {}
 };
 
 Q_DECLARE_METATYPE(DeferredResult)
 
-class Deferred
-{
+class Deferred {
 public:
-	virtual ~Deferred();
+    virtual ~Deferred();
 
-	boost::signals2::signal<void(const DeferredResult&)> finished;
+    boost::signals2::signal<void(const DeferredResult &)> finished;
 
 protected:
-	Deferred();
+    Deferred();
 
-	void setFinished(bool ok, const Variant &value = Variant());
+    void setFinished(bool ok, const Variant &value = Variant());
 
 private:
-	DeferredResult result_;
-	DeferCall deferCall_;
+    DeferredResult result_;
+    DeferCall deferCall_;
 
-	void doFinish();
+    void doFinish();
 };
 
 #endif

--- a/src/handler/detectrule.h
+++ b/src/handler/detectrule.h
@@ -26,13 +26,12 @@
 #include <QByteArray>
 #include <QString>
 
-class DetectRule
-{
+class DetectRule {
 public:
-	QString domain;
-	QByteArray pathPrefix;
-	QString sidPtr;
-	QString jsonParam;
+    QString domain;
+    QByteArray pathPrefix;
+    QString sidPtr;
+    QString jsonParam;
 };
 
 typedef QList<DetectRule> DetectRuleList;

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -23,788 +23,669 @@
 
 #include "filter.h"
 
-#include <QJsonDocument>
-#include <QJsonObject>
-#include "log.h"
-#include "variant.h"
 #include "format.h"
 #include "idformat.h"
+#include "log.h"
+#include "variant.h"
 #include "zhttpmanager.h"
 #include "zhttprequest.h"
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #define REQUEST_TIMEOUT_SECS 10
 
 namespace {
 
-class SkipSelfFilter : public Filter, public Filter::MessageFilter
-{
+class SkipSelfFilter : public Filter, public Filter::MessageFilter {
 public:
-	SkipSelfFilter() :
-		Filter("skip-self")
-	{
-	}
+    SkipSelfFilter() : Filter("skip-self") {}
 
-	virtual void start(const Filter::Context &context, const QByteArray &content)
-	{
-		setContext(context);
+    virtual void start(const Filter::Context &context, const QByteArray &content) {
+        setContext(context);
 
-		Result r;
-		r.sendAction = sendAction();
-		r.content = content;
-		finished(r);
-	}
+        Result r;
+        r.sendAction = sendAction();
+        r.content = content;
+        finished(r);
+    }
 
-	virtual SendAction sendAction() const
-	{
-		QString user = context().subscriptionMeta.value("user");
-		QString sender = context().publishMeta.value("sender");
-		if(!user.isEmpty() && !sender.isEmpty() && sender == user)
-			return Drop;
+    virtual SendAction sendAction() const {
+        QString user = context().subscriptionMeta.value("user");
+        QString sender = context().publishMeta.value("sender");
+        if (!user.isEmpty() && !sender.isEmpty() && sender == user)
+            return Drop;
 
-		return Send;
-	}
+        return Send;
+    }
 };
 
-class SkipUsersFilter : public Filter, public Filter::MessageFilter
-{
+class SkipUsersFilter : public Filter, public Filter::MessageFilter {
 public:
-	SkipUsersFilter() :
-		Filter("skip-users")
-	{
-	}
+    SkipUsersFilter() : Filter("skip-users") {}
 
-	virtual void start(const Filter::Context &context, const QByteArray &content)
-	{
-		setContext(context);
+    virtual void start(const Filter::Context &context, const QByteArray &content) {
+        setContext(context);
 
-		Result r;
-		r.sendAction = sendAction();
-		r.content = content;
-		finished(r);
-	}
+        Result r;
+        r.sendAction = sendAction();
+        r.content = content;
+        finished(r);
+    }
 
-	virtual SendAction sendAction() const
-	{
-		QString user = context().subscriptionMeta.value("user");
+    virtual SendAction sendAction() const {
+        QString user = context().subscriptionMeta.value("user");
 
-		QStringList skip_users;
-		foreach(const QString &part, context().publishMeta.value("skip_users").split(','))
-		{
-			QString s = part.trimmed();
-			if(!s.isEmpty())
-				skip_users += s;
-		}
+        QStringList skip_users;
+        foreach (const QString &part, context().publishMeta.value("skip_users").split(',')) {
+            QString s = part.trimmed();
+            if (!s.isEmpty())
+                skip_users += s;
+        }
 
-		if(!user.isEmpty() && skip_users.contains(user))
-			return Drop;
+        if (!user.isEmpty() && skip_users.contains(user))
+            return Drop;
 
-		return Send;
-	}
+        return Send;
+    }
 };
 
-class RequireSubFilter : public Filter, public Filter::MessageFilter
-{
+class RequireSubFilter : public Filter, public Filter::MessageFilter {
 public:
-	RequireSubFilter() :
-		Filter("require-sub")
-	{
-	}
+    RequireSubFilter() : Filter("require-sub") {}
 
-	virtual void start(const Filter::Context &context, const QByteArray &content)
-	{
-		setContext(context);
+    virtual void start(const Filter::Context &context, const QByteArray &content) {
+        setContext(context);
 
-		Result r;
-		r.sendAction = sendAction();
-		r.content = content;
-		finished(r);
-	}
+        Result r;
+        r.sendAction = sendAction();
+        r.content = content;
+        finished(r);
+    }
 
-	virtual SendAction sendAction() const
-	{
-		QString require_sub = context().publishMeta.value("require_sub");
-		if(!require_sub.isEmpty() && !context().prevIds.keys().contains(require_sub))
-			return Drop;
+    virtual SendAction sendAction() const {
+        QString require_sub = context().publishMeta.value("require_sub");
+        if (!require_sub.isEmpty() && !context().prevIds.keys().contains(require_sub))
+            return Drop;
 
-		return Send;
-	}
+        return Send;
+    }
 };
 
-class BuildIdFilter : public Filter, public Filter::MessageFilter
-{
+class BuildIdFilter : public Filter, public Filter::MessageFilter {
 public:
-	IdFormat::ContentRenderer *idContentRenderer;
+    IdFormat::ContentRenderer *idContentRenderer;
 
-	BuildIdFilter() :
-		Filter("build-id"),
-		idContentRenderer(0)
-	{
-	}
+    BuildIdFilter() : Filter("build-id"), idContentRenderer(0) {}
 
-	~BuildIdFilter()
-	{
-		delete idContentRenderer;
-	}
+    ~BuildIdFilter() { delete idContentRenderer; }
 
-	bool ensureInit()
-	{
-		if(!idContentRenderer)
-		{
-			QString idFormat = context().subscriptionMeta.value("id_format");
-			if(idFormat.isNull())
-			{
-				setError("no sub meta 'id_format'");
-				return false;
-			}
+    bool ensureInit() {
+        if (!idContentRenderer) {
+            QString idFormat = context().subscriptionMeta.value("id_format");
+            if (idFormat.isNull()) {
+                setError("no sub meta 'id_format'");
+                return false;
+            }
 
-			QHash<QString, QByteArray> idTemplateVars;
-			QHashIterator<QString, QString> it(context().prevIds);
-			while(it.hasNext())
-			{
-				it.next();
-				idTemplateVars.insert(it.key(), it.value().toUtf8());
-			}
+            QHash<QString, QByteArray> idTemplateVars;
+            QHashIterator<QString, QString> it(context().prevIds);
+            while (it.hasNext()) {
+                it.next();
+                idTemplateVars.insert(it.key(), it.value().toUtf8());
+            }
 
-			QString _error;
-			QByteArray id;
+            QString _error;
+            QByteArray id;
 
-			if(!idTemplateVars.isEmpty())
-			{
-				id = IdFormat::renderId(idFormat.toUtf8(), idTemplateVars, &_error);
-				if(id.isNull())
-				{
-					setError(QString("failed to render ID: %1").arg(_error));
-					return false;
-				}
-			}
+            if (!idTemplateVars.isEmpty()) {
+                id = IdFormat::renderId(idFormat.toUtf8(), idTemplateVars, &_error);
+                if (id.isNull()) {
+                    setError(QString("failed to render ID: %1").arg(_error));
+                    return false;
+                }
+            }
 
-			bool hex = false;
+            bool hex = false;
 
-			QString idEncoding = context().subscriptionMeta.value("id_encoding");
-			if(!idEncoding.isNull())
-			{
-				if(idEncoding == "hex")
-				{
-					hex = true;
-				}
-				else
-				{
-					setError(QString("unsupported encoding: %1").arg(idEncoding));
-					return false;
-				}
-			}
+            QString idEncoding = context().subscriptionMeta.value("id_encoding");
+            if (!idEncoding.isNull()) {
+                if (idEncoding == "hex") {
+                    hex = true;
+                } else {
+                    setError(QString("unsupported encoding: %1").arg(idEncoding));
+                    return false;
+                }
+            }
 
-			idContentRenderer = new IdFormat::ContentRenderer(id, hex);
-		}
+            idContentRenderer = new IdFormat::ContentRenderer(id, hex);
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	virtual void start(const Filter::Context &context, const QByteArray &content)
-	{
-		setContext(context);
+    virtual void start(const Filter::Context &context, const QByteArray &content) {
+        setContext(context);
 
-		Result r;
-		r.sendAction = sendAction();
-		r.content = process(content);
-		finished(r);
-	}
+        Result r;
+        r.sendAction = sendAction();
+        r.content = process(content);
+        finished(r);
+    }
 
-	virtual QByteArray update(const QByteArray &data)
-	{
-		if(!ensureInit())
-			return QByteArray();
+    virtual QByteArray update(const QByteArray &data) {
+        if (!ensureInit())
+            return QByteArray();
 
-		QByteArray buf = idContentRenderer->update(data);
-		if(buf.isNull())
-		{
-			setError(idContentRenderer->errorMessage());
-			return QByteArray();
-		}
+        QByteArray buf = idContentRenderer->update(data);
+        if (buf.isNull()) {
+            setError(idContentRenderer->errorMessage());
+            return QByteArray();
+        }
 
-		return buf;
-	}
+        return buf;
+    }
 
-	virtual QByteArray finalize()
-	{
-		if(!ensureInit())
-			return QByteArray();
+    virtual QByteArray finalize() {
+        if (!ensureInit())
+            return QByteArray();
 
-		QByteArray buf = idContentRenderer->finalize();
-		if(buf.isNull())
-		{
-			setError(idContentRenderer->errorMessage());
-			return QByteArray();
-		}
+        QByteArray buf = idContentRenderer->finalize();
+        if (buf.isNull()) {
+            setError(idContentRenderer->errorMessage());
+            return QByteArray();
+        }
 
-		return buf;
-	}
+        return buf;
+    }
 };
 
-class VarSubstFormatHandler : public Format::Handler
-{
+class VarSubstFormatHandler : public Format::Handler {
 public:
-	QHash<QString, QString> vars;
+    QHash<QString, QString> vars;
 
-	virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const
-	{
-		if(type != 's')
-		{
-			*error = QString("Unknown directive '%1'").arg(type);
-			return QByteArray();
-		}
+    virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const {
+        if (type != 's') {
+            *error = QString("Unknown directive '%1'").arg(type);
+            return QByteArray();
+        }
 
-		if(arg.isNull())
-		{
-			*error = QString("Directive 's' requires argument");
-			return QByteArray();
-		}
+        if (arg.isNull()) {
+            *error = QString("Directive 's' requires argument");
+            return QByteArray();
+        }
 
-		QString value = vars.value(arg);
-		if(value.isNull())
-		{
-			*error = QString("No such variable '%1'").arg(QString::fromUtf8(arg));
-			return QByteArray();
-		}
+        QString value = vars.value(arg);
+        if (value.isNull()) {
+            *error = QString("No such variable '%1'").arg(QString::fromUtf8(arg));
+            return QByteArray();
+        }
 
-		return value.toUtf8();
-	}
+        return value.toUtf8();
+    }
 };
 
-class VarSubstFilter : public Filter, public Filter::MessageFilter
-{
+class VarSubstFilter : public Filter, public Filter::MessageFilter {
 public:
-	VarSubstFilter() :
-		Filter("var-subst")
-	{
-	}
+    VarSubstFilter() : Filter("var-subst") {}
 
-	virtual void start(const Filter::Context &context, const QByteArray &content)
-	{
-		setContext(context);
+    virtual void start(const Filter::Context &context, const QByteArray &content) {
+        setContext(context);
 
-		Result r;
-		r.sendAction = sendAction();
-		r.content = process(content);
-		finished(r);
-	}
+        Result r;
+        r.sendAction = sendAction();
+        r.content = process(content);
+        finished(r);
+    }
 
-	virtual QByteArray update(const QByteArray &data)
-	{
-		VarSubstFormatHandler handler;
-		handler.vars = context().subscriptionMeta;
+    virtual QByteArray update(const QByteArray &data) {
+        VarSubstFormatHandler handler;
+        handler.vars = context().subscriptionMeta;
 
-		QString errorMessage;
-		QByteArray buf = Format::process(data, &handler, 0, &errorMessage);
-		if(buf.isNull())
-		{
-			setError(errorMessage);
-			return QByteArray();
-		}
+        QString errorMessage;
+        QByteArray buf = Format::process(data, &handler, 0, &errorMessage);
+        if (buf.isNull()) {
+            setError(errorMessage);
+            return QByteArray();
+        }
 
-		return buf;
-	}
+        return buf;
+    }
 
-	virtual QByteArray finalize()
-	{
-		return QByteArray("");
-	}
+    virtual QByteArray finalize() { return QByteArray(""); }
 };
 
 class HttpFilterInner;
 
-class HttpFilter : public Filter::MessageFilter
-{
+class HttpFilter : public Filter::MessageFilter {
 public:
-	enum Mode
-	{
-		Check,
-		Modify
-	};
+    enum Mode { Check, Modify };
 
-	std::shared_ptr<HttpFilterInner> inner;
-	boost::signals2::scoped_connection finishedConnection;
+    std::shared_ptr<HttpFilterInner> inner;
+    boost::signals2::scoped_connection finishedConnection;
 
-	class RequestAction : public RateLimiter::Action
-	{
-	public:
-		std::weak_ptr<HttpFilterInner> inner;
+    class RequestAction : public RateLimiter::Action {
+    public:
+        std::weak_ptr<HttpFilterInner> inner;
 
-		RequestAction(const std::shared_ptr<HttpFilterInner> &_inner) :
-			inner(_inner)
-		{
-		}
+        RequestAction(const std::shared_ptr<HttpFilterInner> &_inner) : inner(_inner) {}
 
-		virtual bool execute();
-	};
+        virtual bool execute();
+    };
 
-	HttpFilter(Mode mode);
+    HttpFilter(Mode mode);
 
-	virtual void start(const Filter::Context &context, const QByteArray &content);
+    virtual void start(const Filter::Context &context, const QByteArray &content);
 
-	void inner_finished(const Result &r);
+    void inner_finished(const Result &r);
 };
 
-class HttpFilterInner
-{
+class HttpFilterInner {
 public:
-	HttpFilter::Mode mode;
-	std::unique_ptr<ZhttpRequest> req;
-	Url uri;
-	HttpHeaders headers;
-	QByteArray origContent;
-	bool haveResponseHeader;
-	QByteArray responseBody;
-	int responseSizeMax;
+    HttpFilter::Mode mode;
+    std::unique_ptr<ZhttpRequest> req;
+    Url uri;
+    HttpHeaders headers;
+    QByteArray origContent;
+    bool haveResponseHeader;
+    QByteArray responseBody;
+    int responseSizeMax;
 
-	boost::signals2::signal<void(const Filter::MessageFilter::Result&)> finished;
+    boost::signals2::signal<void(const Filter::MessageFilter::Result &)> finished;
 
-	HttpFilterInner(HttpFilter::Mode _mode) :
-		mode(_mode),
-		haveResponseHeader(false),
-		responseSizeMax(-1)
-	{
-	}
+    HttpFilterInner(HttpFilter::Mode _mode)
+        : mode(_mode), haveResponseHeader(false), responseSizeMax(-1) {}
 
-	void setup(ZhttpManager *zhttpOut, const Url &_uri, const HttpHeaders &_headers, const Variant &passthroughData, const QByteArray &content, int _responseSizeMax)
-	{
-		uri = _uri;
-		headers = _headers;
-		origContent = content;
-		responseSizeMax = _responseSizeMax;
+    void setup(ZhttpManager *zhttpOut, const Url &_uri, const HttpHeaders &_headers,
+               const Variant &passthroughData, const QByteArray &content, int _responseSizeMax) {
+        uri = _uri;
+        headers = _headers;
+        origContent = content;
+        responseSizeMax = _responseSizeMax;
 
-		req.reset(zhttpOut->createRequest());
+        req.reset(zhttpOut->createRequest());
 
-		// Safe to not track, since req can't outlive this
-		req->readyRead.connect(boost::bind(&HttpFilterInner::req_readyRead, this));
-		req->error.connect(boost::bind(&HttpFilterInner::req_error, this));
+        // Safe to not track, since req can't outlive this
+        req->readyRead.connect(boost::bind(&HttpFilterInner::req_readyRead, this));
+        req->error.connect(boost::bind(&HttpFilterInner::req_error, this));
 
-		req->setPassthroughData(passthroughData);
-	}
+        req->setPassthroughData(passthroughData);
+    }
 
-	void startRequest()
-	{
-		// Set timeout since filters should be fast
-		req->setTimeout(REQUEST_TIMEOUT_SECS * 1000);
+    void startRequest() {
+        // Set timeout since filters should be fast
+        req->setTimeout(REQUEST_TIMEOUT_SECS * 1000);
 
-		req->start("POST", uri, headers);
+        req->start("POST", uri, headers);
 
-		if(mode == HttpFilter::Modify)
-			req->writeBody(origContent);
+        if (mode == HttpFilter::Modify)
+            req->writeBody(origContent);
 
-		req->endBody();
-	}
+        req->endBody();
+    }
 
-	void req_readyRead()
-	{
-		if(!haveResponseHeader)
-		{
-			haveResponseHeader = true;
+    void req_readyRead() {
+        if (!haveResponseHeader) {
+            haveResponseHeader = true;
 
-			int code = req->responseCode();
-			switch(code)
-			{
-				case 200:
-				case 204:
-					break;
-				default:
-					Filter::MessageFilter::Result r;
-					r.errorMessage = QString("unexpected network request status: code=%1").arg(code);
-					doFinished(r);
-					return;
-			}
-		}
+            int code = req->responseCode();
+            switch (code) {
+            case 200:
+            case 204:
+                break;
+            default:
+                Filter::MessageFilter::Result r;
+                r.errorMessage = QString("unexpected network request status: code=%1").arg(code);
+                doFinished(r);
+                return;
+            }
+        }
 
-		QByteArray body = req->readBody();
+        QByteArray body = req->readBody();
 
-		if(mode == HttpFilter::Modify)
-		{
-			if(responseSizeMax >= 0 && responseBody.size() + body.size() > responseSizeMax)
-			{
-				Filter::MessageFilter::Result r;
-				r.errorMessage = QString("network response exceeded %1 bytes").arg(responseSizeMax);
-				doFinished(r);
-				return;
-			}
+        if (mode == HttpFilter::Modify) {
+            if (responseSizeMax >= 0 && responseBody.size() + body.size() > responseSizeMax) {
+                Filter::MessageFilter::Result r;
+                r.errorMessage = QString("network response exceeded %1 bytes").arg(responseSizeMax);
+                doFinished(r);
+                return;
+            }
 
-			responseBody += body;
-		}
+            responseBody += body;
+        }
 
-		if(!req->isFinished())
-			return;
+        if (!req->isFinished())
+            return;
 
-		Filter::MessageFilter::Result r;
+        Filter::MessageFilter::Result r;
 
-		if(req->responseHeaders().get("Action") == "drop")
-		{
-			// Drop
-			r.sendAction = Filter::Drop;
-		}
-		else
-		{
-			// Accept
-			r.sendAction = Filter::Send;
+        if (req->responseHeaders().get("Action") == "drop") {
+            // Drop
+            r.sendAction = Filter::Drop;
+        } else {
+            // Accept
+            r.sendAction = Filter::Send;
 
-			switch(mode)
-			{
-				case HttpFilter::Check:
-					// As-is
-					r.content = origContent;
-					break;
-				case HttpFilter::Modify:
-					switch(req->responseCode())
-					{
-						case 204:
-							// As-is
-							r.content = origContent;
-							break;
-						default:
-							// Replace content
-							r.content = responseBody;
-							break;
-					}
-					break;
-			}
-		}
+            switch (mode) {
+            case HttpFilter::Check:
+                // As-is
+                r.content = origContent;
+                break;
+            case HttpFilter::Modify:
+                switch (req->responseCode()) {
+                case 204:
+                    // As-is
+                    r.content = origContent;
+                    break;
+                default:
+                    // Replace content
+                    r.content = responseBody;
+                    break;
+                }
+                break;
+            }
+        }
 
-		doFinished(r);
-	}
+        doFinished(r);
+    }
 
-	void req_error()
-	{
-		const char *s;
+    void req_error() {
+        const char *s;
 
-		switch(req->errorCondition())
-		{
-			case HttpRequest::ErrorConnect:
-				s = "connection refused";
-				break;
-			case HttpRequest::ErrorConnectTimeout:
-				s = "connection timed out";
-				break;
-			case HttpRequest::ErrorTls:
-				s = "tls error";
-				break;
-			case HttpRequest::ErrorDisconnected:
-				s = "disconnected";
-				break;
-			case HttpRequest::ErrorTimeout:
-				s = "request timed out";
-				break;
-			default:
-				s = "general error";
-				break;
-		}
+        switch (req->errorCondition()) {
+        case HttpRequest::ErrorConnect:
+            s = "connection refused";
+            break;
+        case HttpRequest::ErrorConnectTimeout:
+            s = "connection timed out";
+            break;
+        case HttpRequest::ErrorTls:
+            s = "tls error";
+            break;
+        case HttpRequest::ErrorDisconnected:
+            s = "disconnected";
+            break;
+        case HttpRequest::ErrorTimeout:
+            s = "request timed out";
+            break;
+        default:
+            s = "general error";
+            break;
+        }
 
-		Filter::MessageFilter::Result r;
-		r.errorMessage = QString("network request failed: %1").arg(s);
-		doFinished(r);
-	}
+        Filter::MessageFilter::Result r;
+        r.errorMessage = QString("network request failed: %1").arg(s);
+        doFinished(r);
+    }
 
-	void doFinished(const Filter::MessageFilter::Result &r)
-	{
-		req.reset();
+    void doFinished(const Filter::MessageFilter::Result &r) {
+        req.reset();
 
-		finished(r);
-	}
+        finished(r);
+    }
 };
 
-bool HttpFilter::RequestAction::execute()
-{
-	auto target = inner.lock();
-	if(!target)
-		return false;
+bool HttpFilter::RequestAction::execute() {
+    auto target = inner.lock();
+    if (!target)
+        return false;
 
-	target->startRequest();
-	return true;
+    target->startRequest();
+    return true;
 }
 
-HttpFilter::HttpFilter(Mode mode)
-{
-	inner = std::make_shared<HttpFilterInner>(mode);
+HttpFilter::HttpFilter(Mode mode) {
+    inner = std::make_shared<HttpFilterInner>(mode);
 
-	finishedConnection = inner->finished.connect(boost::bind(&HttpFilter::inner_finished, this, boost::placeholders::_1));
+    finishedConnection = inner->finished.connect(
+        boost::bind(&HttpFilter::inner_finished, this, boost::placeholders::_1));
 }
 
-void HttpFilter::start(const Filter::Context &context, const QByteArray &content)
-{
-	Url url = Url(context.subscriptionMeta.value("url"), Url::StrictMode);
-	if(!url.isValid())
-	{
-		Result r;
-		r.errorMessage = "invalid or missing url value";
-		finished(r);
-		return;
-	}
+void HttpFilter::start(const Filter::Context &context, const QByteArray &content) {
+    Url url = Url(context.subscriptionMeta.value("url"), Url::StrictMode);
+    if (!url.isValid()) {
+        Result r;
+        r.errorMessage = "invalid or missing url value";
+        finished(r);
+        return;
+    }
 
-	Url currentUri = context.currentUri;
-	if(currentUri.scheme() == "wss")
-		currentUri.setScheme("https");
-	else if(currentUri.scheme() == "ws")
-		currentUri.setScheme("http");
+    Url currentUri = context.currentUri;
+    if (currentUri.scheme() == "wss")
+        currentUri.setScheme("https");
+    else if (currentUri.scheme() == "ws")
+        currentUri.setScheme("http");
 
-	Url destUri = currentUri.resolved(url);
+    Url destUri = currentUri.resolved(url);
 
-	int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
-	int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
+    int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
+    int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 
-	VariantHash passthroughData;
+    VariantHash passthroughData;
 
-	passthroughData["route"] = context.route.toUtf8();
+    passthroughData["route"] = context.route.toUtf8();
 
-	// If dest link points to the same service as the current request,
-	// then we can assume the network would send the request back to
-	// us, so we can handle it internally. If the link points to a
-	// different service, then we can't make this assumption and need
-	// to make the request over the network. Note that such a request
-	// could still end up looping back to us
-	if(destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() && destPort == currentPort)
-	{
-		// Tell the proxy that we prefer the request to be handled
-		// internally, using the same route
-		passthroughData["prefer-internal"] = true;
-	}
+    // If dest link points to the same service as the current request,
+    // then we can assume the network would send the request back to
+    // us, so we can handle it internally. If the link points to a
+    // different service, then we can't make this assumption and need
+    // to make the request over the network. Note that such a request
+    // could still end up looping back to us
+    if (destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() &&
+        destPort == currentPort) {
+        // Tell the proxy that we prefer the request to be handled
+        // internally, using the same route
+        passthroughData["prefer-internal"] = true;
+    }
 
-	// Needed in case internal routing is not used
-	if(context.trusted)
-		passthroughData["trusted"] = true;
+    // Needed in case internal routing is not used
+    if (context.trusted)
+        passthroughData["trusted"] = true;
 
-	HttpHeaders headers;
+    HttpHeaders headers;
 
-	{
-		VariantMap vmap;
-		QHashIterator<QString, QString> it(context.subscriptionMeta);
-		while(it.hasNext())
-		{
-			it.next();
-			vmap[it.key()] = it.value();
-		}
+    {
+        VariantMap vmap;
+        QHashIterator<QString, QString> it(context.subscriptionMeta);
+        while (it.hasNext()) {
+            it.next();
+            vmap[it.key()] = it.value();
+        }
 
-		QJsonDocument doc = QJsonDocument(QJsonObject::fromVariantMap(vmap));
-		headers += HttpHeader("Sub-Meta", doc.toJson(QJsonDocument::Compact));
-	}
+        QJsonDocument doc = QJsonDocument(QJsonObject::fromVariantMap(vmap));
+        headers += HttpHeader("Sub-Meta", doc.toJson(QJsonDocument::Compact));
+    }
 
-	{
-		VariantMap vmap;
-		QHashIterator<QString, QString> it(context.publishMeta);
-		while(it.hasNext())
-		{
-			it.next();
-			vmap[it.key()] = it.value();
-		}
+    {
+        VariantMap vmap;
+        QHashIterator<QString, QString> it(context.publishMeta);
+        while (it.hasNext()) {
+            it.next();
+            vmap[it.key()] = it.value();
+        }
 
-		QJsonDocument doc = QJsonDocument(QJsonObject::fromVariantMap(vmap));
-		headers += HttpHeader("Pub-Meta", doc.toJson(QJsonDocument::Compact));
-	}
+        QJsonDocument doc = QJsonDocument(QJsonObject::fromVariantMap(vmap));
+        headers += HttpHeader("Pub-Meta", doc.toJson(QJsonDocument::Compact));
+    }
 
-	{
-		QHashIterator<QString, QString> it(context.prevIds);
-		while(it.hasNext())
-		{
-			it.next();
-			const QString &name = it.key();
-			const QString &prevId = it.value();
+    {
+        QHashIterator<QString, QString> it(context.prevIds);
+        while (it.hasNext()) {
+            it.next();
+            const QString &name = it.key();
+            const QString &prevId = it.value();
 
-			if(!prevId.isNull())
-				headers += HttpHeader("Grip-Last", name.toUtf8() + "; last-id=" + prevId.toUtf8());
-		}
-	}
+            if (!prevId.isNull())
+                headers += HttpHeader("Grip-Last", name.toUtf8() + "; last-id=" + prevId.toUtf8());
+        }
+    }
 
-	inner->setup(context.zhttpOut, destUri, headers, passthroughData, content, context.responseSizeMax);
+    inner->setup(context.zhttpOut, destUri, headers, passthroughData, content,
+                 context.responseSizeMax);
 
-	QString key = QString::fromUtf8(destUri.toEncoded());
+    QString key = QString::fromUtf8(destUri.toEncoded());
 
-	assert(context.limiter);
+    assert(context.limiter);
 
-	if(!context.limiter->addAction(key, new RequestAction(inner)))
-	{
-		// The limiter shouldn't have an hwm, but let's handle the error
-		// here in case one is ever added
+    if (!context.limiter->addAction(key, new RequestAction(inner))) {
+        // The limiter shouldn't have an hwm, but let's handle the error
+        // here in case one is ever added
 
-		Result r;
-		r.errorMessage = "network request limit reached";
-		finished(r);
-		return;
-	}
+        Result r;
+        r.errorMessage = "network request limit reached";
+        finished(r);
+        return;
+    }
 }
 
-void HttpFilter::inner_finished(const Result &r)
-{
-	finished(r);
-}
+void HttpFilter::inner_finished(const Result &r) { finished(r); }
 
-}
+} // namespace
 
 Filter::MessageFilter::~MessageFilter() = default;
 
-Filter::Filter(const QString &name) :
-	name_(name)
-{
-}
+Filter::Filter(const QString &name) : name_(name) {}
 
 Filter::~Filter() = default;
 
-Filter::SendAction Filter::sendAction() const
-{
-	return Send;
+Filter::SendAction Filter::sendAction() const { return Send; }
+
+QByteArray Filter::update(const QByteArray &data) { return data; }
+
+QByteArray Filter::finalize() { return QByteArray(""); }
+
+QByteArray Filter::process(const QByteArray &data) {
+    QByteArray out = update(data);
+    if (out.isNull())
+        return QByteArray();
+
+    QByteArray buf = finalize();
+    if (buf.isNull())
+        return QByteArray();
+
+    return out + buf;
 }
 
-QByteArray Filter::update(const QByteArray &data)
-{
-	return data;
+Filter *Filter::create(const QString &name) {
+    if (name == "skip-self")
+        return new SkipSelfFilter;
+    else if (name == "skip-users")
+        return new SkipUsersFilter;
+    else if (name == "require-sub")
+        return new RequireSubFilter;
+    else if (name == "build-id")
+        return new BuildIdFilter;
+    else if (name == "var-subst")
+        return new VarSubstFilter;
+    else
+        return 0;
 }
 
-QByteArray Filter::finalize()
-{
-	return QByteArray("");
+Filter::MessageFilter *Filter::createMessageFilter(const QString &name) {
+    if (name == "skip-self")
+        return new SkipSelfFilter;
+    else if (name == "skip-users")
+        return new SkipUsersFilter;
+    else if (name == "require-sub")
+        return new RequireSubFilter;
+    else if (name == "build-id")
+        return new BuildIdFilter;
+    else if (name == "var-subst")
+        return new VarSubstFilter;
+    else if (name == "http-check")
+        return new HttpFilter(HttpFilter::Check);
+    else if (name == "http-modify")
+        return new HttpFilter(HttpFilter::Modify);
+    else
+        return 0;
 }
 
-QByteArray Filter::process(const QByteArray &data)
-{
-	QByteArray out = update(data);
-	if(out.isNull())
-		return QByteArray();
-
-	QByteArray buf = finalize();
-	if(buf.isNull())
-		return QByteArray();
-
-	return out + buf;
+QStringList Filter::names() {
+    return (QStringList() << "skip-self"
+                          << "skip-users"
+                          << "require-sub"
+                          << "build-id"
+                          << "var-subst"
+                          << "http-check"
+                          << "http-modify");
 }
 
-Filter *Filter::create(const QString &name)
-{
-	if(name == "skip-self")
-		return new SkipSelfFilter;
-	else if(name == "skip-users")
-		return new SkipUsersFilter;
-	else if(name == "require-sub")
-		return new RequireSubFilter;
-	else if(name == "build-id")
-		return new BuildIdFilter;
-	else if(name == "var-subst")
-		return new VarSubstFilter;
-	else
-		return 0;
+Filter::Targets Filter::targets(const QString &name) {
+    if (name == "skip-self")
+        return Filter::MessageDelivery;
+    else if (name == "skip-users")
+        return Filter::MessageDelivery;
+    else if (name == "require-sub")
+        return Filter::MessageDelivery;
+    else if (name == "build-id")
+        return Filter::Targets(Filter::MessageContent | Filter::ResponseContent);
+    else if (name == "var-subst")
+        return Filter::MessageContent;
+    else if (name == "http-check")
+        return Filter::MessageDelivery;
+    else if (name == "http-modify")
+        return Filter::Targets(Filter::MessageDelivery | Filter::MessageContent);
+    else
+        return Filter::Targets(0);
 }
 
-Filter::MessageFilter *Filter::createMessageFilter(const QString &name)
-{
-	if(name == "skip-self")
-		return new SkipSelfFilter;
-	else if(name == "skip-users")
-		return new SkipUsersFilter;
-	else if(name == "require-sub")
-		return new RequireSubFilter;
-	else if(name == "build-id")
-		return new BuildIdFilter;
-	else if(name == "var-subst")
-		return new VarSubstFilter;
-	else if(name == "http-check")
-		return new HttpFilter(HttpFilter::Check);
-	else if(name == "http-modify")
-		return new HttpFilter(HttpFilter::Modify);
-	else
-		return 0;
+Filter::MessageFilterStack::MessageFilterStack(const QStringList &filterNames) {
+    assert(filterNames.count() <= MESSAGEFILTERSTACK_SIZE_MAX);
+
+    foreach (const QString &name, filterNames) {
+        MessageFilter *f = createMessageFilter(name);
+        if (f)
+            filters_.emplace_back(std::unique_ptr<MessageFilter>(f));
+    }
 }
 
-QStringList Filter::names()
-{
-	return (QStringList()
-		<< "skip-self"
-		<< "skip-users"
-		<< "require-sub"
-		<< "build-id"
-		<< "var-subst"
-		<< "http-check"
-		<< "http-modify");
+void Filter::MessageFilterStack::start(const Filter::Context &context, const QByteArray &content) {
+    context_ = context;
+    content_ = content;
+    lastSendAction_ = Send;
+
+    nextFilter();
 }
 
-Filter::Targets Filter::targets(const QString &name)
-{
-	if(name == "skip-self")
-		return Filter::MessageDelivery;
-	else if(name == "skip-users")
-		return Filter::MessageDelivery;
-	else if(name == "require-sub")
-		return Filter::MessageDelivery;
-	else if(name == "build-id")
-		return Filter::Targets(Filter::MessageContent | Filter::ResponseContent);
-	else if(name == "var-subst")
-		return Filter::MessageContent;
-	else if(name == "http-check")
-		return Filter::MessageDelivery;
-	else if(name == "http-modify")
-		return Filter::Targets(Filter::MessageDelivery | Filter::MessageContent);
-	else
-		return Filter::Targets(0);
+void Filter::MessageFilterStack::nextFilter() {
+    if (filters_.empty()) {
+        Result r;
+        r.sendAction = lastSendAction_;
+        r.content = content_;
+        finished(r);
+        return;
+    }
+
+    finishedConnection_ = filters_.front()->finished.connect(
+        boost::bind(&MessageFilterStack::filterFinished, this, boost::placeholders::_1)),
+
+    // May call filterFinished immediately
+        filters_.front()->start(context_, content_);
 }
 
-Filter::MessageFilterStack::MessageFilterStack(const QStringList &filterNames)
-{
-	assert(filterNames.count() <= MESSAGEFILTERSTACK_SIZE_MAX);
+void Filter::MessageFilterStack::filterFinished(const Result &result) {
+    if (!result.errorMessage.isNull()) {
+        filters_.clear();
 
-	foreach(const QString &name, filterNames)
-	{
-		MessageFilter *f = createMessageFilter(name);
-		if(f)
-			filters_.emplace_back(std::unique_ptr<MessageFilter>(f));
-	}
-}
+        Result r;
+        r.errorMessage = result.errorMessage;
+        finished(r);
+        return;
+    }
 
-void Filter::MessageFilterStack::start(const Filter::Context &context, const QByteArray &content)
-{
-	context_ = context;
-	content_ = content;
-	lastSendAction_ = Send;
+    lastSendAction_ = result.sendAction;
+    content_ = result.content;
 
-	nextFilter();
-}
+    switch (lastSendAction_) {
+    case Send:
+        // Remove the finished filter
+        filters_.erase(filters_.begin());
+        break;
+    case Drop:
+        // Stop filtering. Remove the finished filter and any remaining
+        filters_.clear();
+        break;
+    }
 
-void Filter::MessageFilterStack::nextFilter()
-{
-	if(filters_.empty())
-	{
-		Result r;
-		r.sendAction = lastSendAction_;
-		r.content = content_;
-		finished(r);
-		return;
-	}
-
-	finishedConnection_ = filters_.front()->finished.connect(boost::bind(&MessageFilterStack::filterFinished, this, boost::placeholders::_1)),
-
-	// May call filterFinished immediately
-	filters_.front()->start(context_, content_);
-}
-
-void Filter::MessageFilterStack::filterFinished(const Result &result)
-{
-	if(!result.errorMessage.isNull())
-	{
-		filters_.clear();
-
-		Result r;
-		r.errorMessage = result.errorMessage;
-		finished(r);
-		return;
-	}
-
-	lastSendAction_ = result.sendAction;
-	content_ = result.content;
-
-	switch(lastSendAction_)
-	{
-		case Send:
-			// Remove the finished filter
-			filters_.erase(filters_.begin());
-			break;
-		case Drop:
-			// Stop filtering. Remove the finished filter and any remaining
-			filters_.clear();
-			break;
-	}
-
-	// Will emit finished if there are no remaining filters
-	nextFilter();
+    // Will emit finished if there are no remaining filters
+    nextFilter();
 }

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -24,13 +24,13 @@
 #ifndef FILTER_H
 #define FILTER_H
 
+#include "ratelimiter.h"
+#include "url.h"
+#include "zhttprequest.h"
+#include <QHash>
 #include <QString>
 #include <QStringList>
-#include <QHash>
-#include "url.h"
 #include <boost/signals2.hpp>
-#include "zhttprequest.h"
-#include "ratelimiter.h"
 
 #define MESSAGEFILTERSTACK_SIZE_MAX 5
 
@@ -40,113 +40,101 @@
 
 class ZhttpManager;
 
-class Filter
-{
+class Filter {
 public:
-	enum SendAction
-	{
-		Send,
-		Drop
-	};
+    enum SendAction { Send, Drop };
 
-	enum Targets
-	{
-		MessageDelivery = 0x01,
-		MessageContent  = 0x02,
-		ResponseContent = 0x04,
-	};
+    enum Targets {
+        MessageDelivery = 0x01,
+        MessageContent = 0x02,
+        ResponseContent = 0x04,
+    };
 
-	class Context
-	{
-	public:
-		QHash<QString, QString> prevIds;
-		QHash<QString, QString> subscriptionMeta;
-		QHash<QString, QString> publishMeta;
+    class Context {
+    public:
+        QHash<QString, QString> prevIds;
+        QHash<QString, QString> subscriptionMeta;
+        QHash<QString, QString> publishMeta;
 
-		// For network access
-		ZhttpManager *zhttpOut;
-		Url currentUri;
-		QString route;
-		bool trusted;
-		std::shared_ptr<RateLimiter> limiter;
-		int responseSizeMax;
+        // For network access
+        ZhttpManager *zhttpOut;
+        Url currentUri;
+        QString route;
+        bool trusted;
+        std::shared_ptr<RateLimiter> limiter;
+        int responseSizeMax;
 
-		Context() :
-			zhttpOut(0),
-			trusted(false),
-			responseSizeMax(DEFAULT_FILTER_RESPONSE_SIZE_MAX)
-		{
-		}
-	};
+        Context()
+            : zhttpOut(0), trusted(false), responseSizeMax(DEFAULT_FILTER_RESPONSE_SIZE_MAX) {}
+    };
 
-	class MessageFilter
-	{
-	public:
-		class Result
-		{
-		public:
-			SendAction sendAction;
-			QByteArray content;
-			QString errorMessage; // Non-null on error
-		};
+    class MessageFilter {
+    public:
+        class Result {
+        public:
+            SendAction sendAction;
+            QByteArray content;
+            QString errorMessage; // Non-null on error
+        };
 
-		virtual ~MessageFilter();
+        virtual ~MessageFilter();
 
-		// May emit finished immediately
-		virtual void start(const Filter::Context &context, const QByteArray &content = QByteArray()) = 0;
+        // May emit finished immediately
+        virtual void start(const Filter::Context &context,
+                           const QByteArray &content = QByteArray()) = 0;
 
-		boost::signals2::signal<void(const Result&)> finished;
-	};
+        boost::signals2::signal<void(const Result &)> finished;
+    };
 
-	class MessageFilterStack : public MessageFilter
-	{
-	public:
-		MessageFilterStack(const QStringList &filterNames);
+    class MessageFilterStack : public MessageFilter {
+    public:
+        MessageFilterStack(const QStringList &filterNames);
 
-		// Reimplemented
-		virtual void start(const Filter::Context &context, const QByteArray &content = QByteArray());
+        // Reimplemented
+        virtual void start(const Filter::Context &context,
+                           const QByteArray &content = QByteArray());
 
-	private:
-		std::vector<std::unique_ptr<MessageFilter>> filters_;
-		Filter::Context context_;
-		QByteArray content_;
-		SendAction lastSendAction_;
-		boost::signals2::scoped_connection finishedConnection_;
+    private:
+        std::vector<std::unique_ptr<MessageFilter>> filters_;
+        Filter::Context context_;
+        QByteArray content_;
+        SendAction lastSendAction_;
+        boost::signals2::scoped_connection finishedConnection_;
 
-		void nextFilter();
-		void filterFinished(const Result &result);
-	};
+        void nextFilter();
+        void filterFinished(const Result &result);
+    };
 
-	virtual ~Filter();
+    virtual ~Filter();
 
-	const QString & name() const { return name_; }
-	const Context & context() const { return context_; }
-	QString errorMessage() const { return errorMessage_; }
+    const QString &name() const { return name_; }
+    const Context &context() const { return context_; }
+    QString errorMessage() const { return errorMessage_; }
 
-	void setContext(const Context &context) { context_ = context; }
+    void setContext(const Context &context) { context_ = context; }
 
-	virtual SendAction sendAction() const;
+    virtual SendAction sendAction() const;
 
-	// Return null array on error
-	virtual QByteArray update(const QByteArray &data);
-	virtual QByteArray finalize();
+    // Return null array on error
+    virtual QByteArray update(const QByteArray &data);
+    virtual QByteArray finalize();
 
-	QByteArray process(const QByteArray &data);
+    QByteArray process(const QByteArray &data);
 
-	static Filter *create(const QString &name);
-	static MessageFilter *createMessageFilter(const QString &name);
-	static QStringList names();
-	static Targets targets(const QString &name);
+    static Filter *create(const QString &name);
+    static MessageFilter *createMessageFilter(const QString &name);
+    static QStringList names();
+    static Targets targets(const QString &name);
 
 protected:
-	Filter(const QString &name = QString());
+    Filter(const QString &name = QString());
 
-	void setError(const QString &s) { errorMessage_ = s; }
+    void setError(const QString &s) { errorMessage_ = s; }
 
 private:
-	QString name_;
-	Context context_;
-	QString errorMessage_;
+    QString name_;
+    Context context_;
+    QString errorMessage_;
 };
 
 #endif

--- a/src/handler/filterstack.cpp
+++ b/src/handler/filterstack.cpp
@@ -22,83 +22,66 @@
 
 #include "filterstack.h"
 
-FilterStack::FilterStack(const Filter::Context &context, const QStringList &filters)
-{
-	foreach(const QString &name, filters)
-	{
-		Filter *f = Filter::create(name);
-		if(f)
-		{
-			f->setContext(context);
-			filters_ += f;
-		}
-	}
+FilterStack::FilterStack(const Filter::Context &context, const QStringList &filters) {
+    foreach (const QString &name, filters) {
+        Filter *f = Filter::create(name);
+        if (f) {
+            f->setContext(context);
+            filters_ += f;
+        }
+    }
 }
 
-FilterStack::FilterStack(const Filter::Context &context, const QList<Filter*> &filters)
-{
-	filters_ = filters;
+FilterStack::FilterStack(const Filter::Context &context, const QList<Filter *> &filters) {
+    filters_ = filters;
 
-	foreach(Filter *f, filters_)
-		f->setContext(context);
+    foreach (Filter *f, filters_)
+        f->setContext(context);
 }
 
-FilterStack::~FilterStack()
-{
-	qDeleteAll(filters_);
+FilterStack::~FilterStack() { qDeleteAll(filters_); }
+
+Filter::SendAction FilterStack::sendAction() const {
+    foreach (Filter *f, filters_) {
+        SendAction a = f->sendAction();
+        if (a == Drop)
+            return Drop;
+    }
+
+    return Send;
 }
 
-Filter::SendAction FilterStack::sendAction() const
-{
-	foreach(Filter *f, filters_)
-	{
-		SendAction a = f->sendAction();
-		if(a == Drop)
-			return Drop;
-	}
-
-	return Send;
+QByteArray FilterStack::update(const QByteArray &data) {
+    QByteArray buf = data;
+    foreach (Filter *f, filters_) {
+        buf = f->update(buf);
+        if (buf.isNull()) {
+            setError(QString("%1: %2").arg(f->name(), f->errorMessage()));
+            return QByteArray();
+        }
+    }
+    return buf;
 }
 
-QByteArray FilterStack::update(const QByteArray &data)
-{
-	QByteArray buf = data;
-	foreach(Filter *f, filters_)
-	{
-		buf = f->update(buf);
-		if(buf.isNull())
-		{
-			setError(QString("%1: %2").arg(f->name(), f->errorMessage()));
-			return QByteArray();
-		}
-	}
-	return buf;
-}
+QByteArray FilterStack::finalize() {
+    QByteArray out("");
+    foreach (Filter *f, filters_) {
+        if (!out.isEmpty()) {
+            out = f->update(out);
+            if (out.isNull()) {
+                setError(QString("%1: %2").arg(f->name(), f->errorMessage()));
+                return QByteArray();
+            }
+        }
 
-QByteArray FilterStack::finalize()
-{
-	QByteArray out("");
-	foreach(Filter *f, filters_)
-	{
-		if(!out.isEmpty())
-		{
-			out = f->update(out);
-			if(out.isNull())
-			{
-				setError(QString("%1: %2").arg(f->name(), f->errorMessage()));
-				return QByteArray();
-			}
-		}
+        QByteArray buf = f->finalize();
+        if (buf.isNull()) {
+            setError(QString("%1: %2").arg(f->name(), f->errorMessage()));
+            return QByteArray();
+        }
 
-		QByteArray buf = f->finalize();
-		if(buf.isNull())
-		{
-			setError(QString("%1: %2").arg(f->name(), f->errorMessage()));
-			return QByteArray();
-		}
+        out += buf;
+    }
 
-		out += buf;
-	}
-
-	return out;
+    return out;
 }

--- a/src/handler/filterstack.h
+++ b/src/handler/filterstack.h
@@ -23,26 +23,25 @@
 #ifndef FILTERSTACK_H
 #define FILTERSTACK_H
 
-#include <QStringList>
 #include "filter.h"
+#include <QStringList>
 
-class FilterStack : public Filter
-{
+class FilterStack : public Filter {
 public:
-	FilterStack(const Filter::Context &context, const QStringList &filters);
+    FilterStack(const Filter::Context &context, const QStringList &filters);
 
-	// Takes ownership of filters in list
-	FilterStack(const Filter::Context &context, const QList<Filter*> &filters);
+    // Takes ownership of filters in list
+    FilterStack(const Filter::Context &context, const QList<Filter *> &filters);
 
-	~FilterStack();
+    ~FilterStack();
 
-	// Reimplemented
-	virtual SendAction sendAction() const;
-	virtual QByteArray update(const QByteArray &data);
-	virtual QByteArray finalize();
+    // Reimplemented
+    virtual SendAction sendAction() const;
+    virtual QByteArray update(const QByteArray &data);
+    virtual QByteArray finalize();
 
 private:
-	QList<Filter*> filters_;
+    QList<Filter *> filters_;
 };
 
 #endif

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -20,314 +20,298 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <unordered_map>
+#include "filter.h"
+#include "log.h"
+#include "ratelimiter.h"
+#include "test.h"
+#include "zhttpmanager.h"
 #include <QDir>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <boost/signals2.hpp>
-#include "test.h"
-#include "log.h"
-#include "zhttpmanager.h"
-#include "ratelimiter.h"
-#include "filter.h"
+#include <unordered_map>
 
 namespace {
 
-class HttpFilterServer
-{
+class HttpFilterServer {
 public:
-	std::unique_ptr<ZhttpManager> zhttpIn;
-	std::unordered_map<ZhttpRequest*, std::unique_ptr<ZhttpRequest>> reqs;
+    std::unique_ptr<ZhttpManager> zhttpIn;
+    std::unordered_map<ZhttpRequest *, std::unique_ptr<ZhttpRequest>> reqs;
 
-	HttpFilterServer(const QDir &workDir)
-	{
-		zhttpIn = std::make_unique<ZhttpManager>();
-		zhttpIn->setInstanceId("filter-test-server");
-		zhttpIn->setBind(true);
-		zhttpIn->setServerInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in")));
-		zhttpIn->setServerInStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in-stream")));
-		zhttpIn->setServerOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-out")));
-		zhttpIn->requestReady.connect(boost::bind(&HttpFilterServer::zhttpIn_requestReady, this));
-	}
+    HttpFilterServer(const QDir &workDir) {
+        zhttpIn = std::make_unique<ZhttpManager>();
+        zhttpIn->setInstanceId("filter-test-server");
+        zhttpIn->setBind(true);
+        zhttpIn->setServerInSpecs(QStringList()
+                                  << QString("ipc://%1").arg(workDir.filePath("filter-test-in")));
+        zhttpIn->setServerInStreamSpecs(
+            QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in-stream")));
+        zhttpIn->setServerOutSpecs(QStringList()
+                                   << QString("ipc://%1").arg(workDir.filePath("filter-test-out")));
+        zhttpIn->requestReady.connect(boost::bind(&HttpFilterServer::zhttpIn_requestReady, this));
+    }
 
-	void zhttpIn_requestReady()
-	{
-		ZhttpRequest *req = zhttpIn->takeNextRequest();
-		if(!req)
-			return;
+    void zhttpIn_requestReady() {
+        ZhttpRequest *req = zhttpIn->takeNextRequest();
+        if (!req)
+            return;
 
-		req->readyRead.connect(boost::bind(&HttpFilterServer::req_readyRead, this, req));
-		req->bytesWritten.connect(boost::bind(&HttpFilterServer::req_bytesWritten, this, req, boost::placeholders::_1));
+        req->readyRead.connect(boost::bind(&HttpFilterServer::req_readyRead, this, req));
+        req->bytesWritten.connect(
+            boost::bind(&HttpFilterServer::req_bytesWritten, this, req, boost::placeholders::_1));
 
-		reqs.emplace(std::make_pair(req, std::unique_ptr<ZhttpRequest>(req)));
+        reqs.emplace(std::make_pair(req, std::unique_ptr<ZhttpRequest>(req)));
 
-		req_readyRead(req);
-	}
+        req_readyRead(req);
+    }
 
-	void req_readyRead(ZhttpRequest *req)
-	{
-		if(!req->isInputFinished())
-			return;
+    void req_readyRead(ZhttpRequest *req) {
+        if (!req->isInputFinished())
+            return;
 
-		handle(req);
-	}
+        handle(req);
+    }
 
-	void req_bytesWritten(ZhttpRequest *req, int written)
-	{
-		Q_UNUSED(written);
+    void req_bytesWritten(ZhttpRequest *req, int written) {
+        Q_UNUSED(written);
 
-		if(!req->isFinished())
-			return;
+        if (!req->isFinished())
+            return;
 
-		reqs.erase(req);
-	}
+        reqs.erase(req);
+    }
 
-	void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		req->beginResponse(code, reason, headers);
-		req->writeBody(body);
-		req->endBody();
-	}
+    void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body) {
+        req->beginResponse(code, reason, headers);
+        req->writeBody(body);
+        req->endBody();
+    }
 
-	void respondOk(ZhttpRequest *req, int code, bool accept, const QByteArray &body)
-	{
-		HttpHeaders headers;
-		if(!accept)
-			headers += HttpHeader("Action", "drop");
+    void respondOk(ZhttpRequest *req, int code, bool accept, const QByteArray &body) {
+        HttpHeaders headers;
+        if (!accept)
+            headers += HttpHeader("Action", "drop");
 
-		respond(req, code, "OK", headers, body);
-	}
+        respond(req, code, "OK", headers, body);
+    }
 
-	void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QByteArray &body)
-	{
-		respond(req, code, reason, HttpHeaders(), body);
-	}
+    void respondError(ZhttpRequest *req, int code, const QByteArray &reason,
+                      const QByteArray &body) {
+        respond(req, code, reason, HttpHeaders(), body);
+    }
 
-	void handle(ZhttpRequest *req)
-	{
-		if(req->requestMethod() != "POST")
-		{
-			respondError(req, 400, "Bad Request", "Method must be POST\n");
-			return;
-		}
+    void handle(ZhttpRequest *req) {
+        if (req->requestMethod() != "POST") {
+            respondError(req, 400, "Bad Request", "Method must be POST\n");
+            return;
+        }
 
-		Url uri = req->requestUri();
-		QByteArray body = req->readBody();
+        Url uri = req->requestUri();
+        QByteArray body = req->readBody();
 
-		if(uri.path() == "/filter/accept")
-		{
-			respondOk(req, 200, true, "");
-		}
-		else if(uri.path() == "/filter/drop")
-		{
-			respondOk(req, 200, false, "");
-		}
-		else if(uri.path() == "/filter/modify")
-		{
-			if(req->requestHeaders().get("Grip-Last") != "test; last-id=a")
-			{
-				respondError(req, 400, "Bad Request", "Unexpected Grip-Last");
-				return;
-			}
+        if (uri.path() == "/filter/accept") {
+            respondOk(req, 200, true, "");
+        } else if (uri.path() == "/filter/drop") {
+            respondOk(req, 200, false, "");
+        } else if (uri.path() == "/filter/modify") {
+            if (req->requestHeaders().get("Grip-Last") != "test; last-id=a") {
+                respondError(req, 400, "Bad Request", "Unexpected Grip-Last");
+                return;
+            }
 
-			QJsonDocument subMetaDoc = QJsonDocument::fromJson(req->requestHeaders().get("Sub-Meta").asQByteArray());
-			QJsonObject subMeta = subMetaDoc.object();
-			QJsonDocument pubMetaDoc = QJsonDocument::fromJson(req->requestHeaders().get("Pub-Meta").asQByteArray());
-			QJsonObject pubMeta = pubMetaDoc.object();
+            QJsonDocument subMetaDoc =
+                QJsonDocument::fromJson(req->requestHeaders().get("Sub-Meta").asQByteArray());
+            QJsonObject subMeta = subMetaDoc.object();
+            QJsonDocument pubMetaDoc =
+                QJsonDocument::fromJson(req->requestHeaders().get("Pub-Meta").asQByteArray());
+            QJsonObject pubMeta = pubMetaDoc.object();
 
-			QString prepend = subMeta["prepend"].toString();
-			QString append = pubMeta["append"].toString();
+            QString prepend = subMeta["prepend"].toString();
+            QString append = pubMeta["append"].toString();
 
-			if(!prepend.isEmpty() || !append.isEmpty())
-				respondOk(req, 200, true, prepend.toUtf8() + body + append.toUtf8());
-			else
-				respondOk(req, 204, true, "");
-		}
-		else if(uri.path() == "/filter/large")
-		{
-			respondOk(req, 200, true, QByteArray(1001, 'a'));
-		}
-		else
-		{
-			respondError(req, 400, "Bad Request", "Bad Request\n");
-		}
-	}
+            if (!prepend.isEmpty() || !append.isEmpty())
+                respondOk(req, 200, true, prepend.toUtf8() + body + append.toUtf8());
+            else
+                respondOk(req, 204, true, "");
+        } else if (uri.path() == "/filter/large") {
+            respondOk(req, 200, true, QByteArray(1001, 'a'));
+        } else {
+            respondError(req, 400, "Bad Request", "Bad Request\n");
+        }
+    }
 };
 
-class TestState
-{
+class TestState {
 public:
-	std::unique_ptr<HttpFilterServer> filterServer;
-	std::unique_ptr<ZhttpManager> zhttpOut;
-	std::shared_ptr<RateLimiter> limiter;
+    std::unique_ptr<HttpFilterServer> filterServer;
+    std::unique_ptr<ZhttpManager> zhttpOut;
+    std::shared_ptr<RateLimiter> limiter;
 
-	TestState(std::function<void (int)> loop_wait)
-	{
-		log_setOutputLevel(LOG_LEVEL_WARNING);
+    TestState(std::function<void(int)> loop_wait) {
+        log_setOutputLevel(LOG_LEVEL_WARNING);
 
-		QDir outDir(qgetenv("OUT_DIR"));
-		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+        QDir outDir(qgetenv("OUT_DIR"));
+        QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
-		filterServer = std::make_unique<HttpFilterServer>(workDir);
+        filterServer = std::make_unique<HttpFilterServer>(workDir);
 
-		zhttpOut = std::make_unique<ZhttpManager>();
+        zhttpOut = std::make_unique<ZhttpManager>();
 
-		limiter = std::make_shared<RateLimiter>();
+        limiter = std::make_shared<RateLimiter>();
 
-		bool connected = false;
-		zhttpOut->probeAcked.connect([&] {
-			connected = true;
-		});
+        bool connected = false;
+        zhttpOut->probeAcked.connect([&] { connected = true; });
 
-		zhttpOut->setInstanceId("filter-test-client");
-		zhttpOut->setProbe(true);
-		zhttpOut->setClientOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in")));
-		zhttpOut->setClientOutStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in-stream")));
-		zhttpOut->setClientInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-out")));
+        zhttpOut->setInstanceId("filter-test-client");
+        zhttpOut->setProbe(true);
+        zhttpOut->setClientOutSpecs(QStringList()
+                                    << QString("ipc://%1").arg(workDir.filePath("filter-test-in")));
+        zhttpOut->setClientOutStreamSpecs(
+            QStringList() << QString("ipc://%1").arg(workDir.filePath("filter-test-in-stream")));
+        zhttpOut->setClientInSpecs(QStringList()
+                                   << QString("ipc://%1").arg(workDir.filePath("filter-test-out")));
 
-		while(!connected)
-			loop_wait(10);
-	}
+        while (!connected)
+            loop_wait(10);
+    }
 
-	~TestState()
-	{
-		limiter.reset();
-		zhttpOut.reset();
-		filterServer.reset();
-	}
+    ~TestState() {
+        limiter.reset();
+        zhttpOut.reset();
+        filterServer.reset();
+    }
 };
 
+} // namespace
+
+static Filter::MessageFilter::Result runMessageFilters(const QStringList &filterNames,
+                                                       const Filter::Context &context,
+                                                       const QByteArray &content,
+                                                       std::function<void(int)> loop_wait) {
+    Filter::MessageFilterStack fs(filterNames);
+
+    bool finished = false;
+    Filter::MessageFilter::Result r;
+
+    fs.finished.connect([&](const Filter::MessageFilter::Result &_r) {
+        finished = true;
+        r = _r;
+    });
+
+    fs.start(context, content);
+
+    while (!finished)
+        loop_wait(10);
+
+    return r;
 }
 
-static Filter::MessageFilter::Result runMessageFilters(const QStringList &filterNames, const Filter::Context &context, const QByteArray &content, std::function<void (int)> loop_wait)
-{
-	Filter::MessageFilterStack fs(filterNames);
+static void messageFilters(std::function<void(int)> loop_wait) {
+    QStringList filterNames = QStringList() << "skip-self" << "var-subst";
 
-	bool finished = false;
-	Filter::MessageFilter::Result r;
+    Filter::Context context;
+    context.subscriptionMeta["user"] = "alice";
 
-	fs.finished.connect([&](const Filter::MessageFilter::Result &_r) {
-		finished = true;
-		r = _r;
-	});
+    QByteArray content = "hello %(user)s";
 
-	fs.start(context, content);
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Send);
+        TEST_ASSERT_EQ(r.content, "hello alice");
+    }
 
-	while(!finished)
-		loop_wait(10);
-
-	return r;
+    {
+        context.publishMeta["sender"] = "alice";
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Drop);
+    }
 }
 
-static void messageFilters(std::function<void (int)> loop_wait)
-{
-	QStringList filterNames = QStringList() << "skip-self" << "var-subst";
+static void httpCheck(std::function<void(int)> loop_wait) {
+    TestState state(loop_wait);
 
-	Filter::Context context;
-	context.subscriptionMeta["user"] = "alice";
+    QStringList filterNames = QStringList() << "http-check";
 
-	QByteArray content = "hello %(user)s";
+    Filter::Context context;
+    context.subscriptionMeta["url"] = "/filter/accept";
+    context.zhttpOut = state.zhttpOut.get();
+    context.currentUri = "http://localhost/";
+    context.limiter = state.limiter;
 
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT(r.errorMessage.isNull());
-		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
-		TEST_ASSERT_EQ(r.content, "hello alice");
-	}
+    QByteArray content = "hello world";
 
-	{
-		context.publishMeta["sender"] = "alice";
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT(r.errorMessage.isNull());
-		TEST_ASSERT_EQ(r.sendAction, Filter::Drop);
-	}
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Send);
+        TEST_ASSERT_EQ(r.content, "hello world");
+    }
+
+    context.subscriptionMeta["url"] = "/filter/drop";
+
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Drop);
+    }
+
+    context.subscriptionMeta["url"] = "/filter/error";
+
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT_EQ(r.errorMessage, "unexpected network request status: code=400");
+    }
 }
 
-static void httpCheck(std::function<void (int)> loop_wait)
-{
-	TestState state(loop_wait);
+static void httpModify(std::function<void(int)> loop_wait) {
+    TestState state(loop_wait);
 
-	QStringList filterNames = QStringList() << "http-check";
+    QStringList filterNames = QStringList() << "http-modify";
 
-	Filter::Context context;
-	context.subscriptionMeta["url"] = "/filter/accept";
-	context.zhttpOut = state.zhttpOut.get();
-	context.currentUri = "http://localhost/";
-	context.limiter = state.limiter;
+    Filter::Context context;
+    context.prevIds["test"] = "a";
+    context.subscriptionMeta["url"] = "/filter/modify";
+    context.zhttpOut = state.zhttpOut.get();
+    context.currentUri = "http://localhost/";
+    context.limiter = state.limiter;
 
-	QByteArray content = "hello world";
+    QByteArray content = "hello world";
 
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT(r.errorMessage.isNull());
-		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
-		TEST_ASSERT_EQ(r.content, "hello world");
-	}
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Send);
+        TEST_ASSERT_EQ(r.content, "hello world");
+    }
 
-	context.subscriptionMeta["url"] = "/filter/drop";
+    context.subscriptionMeta["prepend"] = "<<<";
+    context.publishMeta["append"] = ">>>";
 
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT(r.errorMessage.isNull());
-		TEST_ASSERT_EQ(r.sendAction, Filter::Drop);
-	}
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Send);
+        TEST_ASSERT_EQ(r.content, "<<<hello world>>>");
+    }
 
-	context.subscriptionMeta["url"] = "/filter/error";
+    context.subscriptionMeta.clear();
+    context.publishMeta.clear();
+    context.subscriptionMeta["url"] = "/filter/large";
+    context.responseSizeMax = 1000;
 
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT_EQ(r.errorMessage, "unexpected network request status: code=400");
-	}
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT_EQ(r.errorMessage, "network response exceeded 1000 bytes");
+    }
 }
 
-static void httpModify(std::function<void (int)> loop_wait)
-{
-	TestState state(loop_wait);
+extern "C" int filter_test(ffi::TestException *out_ex) {
+    TEST_CATCH(test_with_event_loop(messageFilters));
+    TEST_CATCH(test_with_event_loop(httpCheck));
+    TEST_CATCH(test_with_event_loop(httpModify));
 
-	QStringList filterNames = QStringList() << "http-modify";
-
-	Filter::Context context;
-	context.prevIds["test"] = "a";
-	context.subscriptionMeta["url"] = "/filter/modify";
-	context.zhttpOut = state.zhttpOut.get();
-	context.currentUri = "http://localhost/";
-	context.limiter = state.limiter;
-
-	QByteArray content = "hello world";
-
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT(r.errorMessage.isNull());
-		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
-		TEST_ASSERT_EQ(r.content, "hello world");
-	}
-
-	context.subscriptionMeta["prepend"] = "<<<";
-	context.publishMeta["append"] = ">>>";
-
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT(r.errorMessage.isNull());
-		TEST_ASSERT_EQ(r.sendAction, Filter::Send);
-		TEST_ASSERT_EQ(r.content, "<<<hello world>>>");
-	}
-
-	context.subscriptionMeta.clear();
-	context.publishMeta.clear();
-	context.subscriptionMeta["url"] = "/filter/large";
-	context.responseSizeMax = 1000;
-
-	{
-		auto r = runMessageFilters(filterNames, context, content, loop_wait);
-		TEST_ASSERT_EQ(r.errorMessage, "network response exceeded 1000 bytes");
-	}
-}
-
-extern "C" int filter_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(test_with_event_loop(messageFilters));
-	TEST_CATCH(test_with_event_loop(httpCheck));
-	TEST_CATCH(test_with_event_loop(httpModify));
-
-	return 0;
+    return 0;
 }

--- a/src/handler/format.cpp
+++ b/src/handler/format.cpp
@@ -26,174 +26,137 @@
 
 namespace Format {
 
-QByteArray process(const QByteArray &format, Handler *handler, int *partialPos, QString *error)
-{
-	QByteArray out("");
-	for(int n = 0; n < format.length(); ++n)
-	{
-		char c = format.at(n);
+QByteArray process(const QByteArray &format, Handler *handler, int *partialPos, QString *error) {
+    QByteArray out("");
+    for (int n = 0; n < format.length(); ++n) {
+        char c = format.at(n);
 
-		if(c == '%')
-		{
-			int markerPos = n;
+        if (c == '%') {
+            int markerPos = n;
 
-			if(n + 1 >= format.length())
-			{
-				if(partialPos)
-				{
-					*partialPos = markerPos;
-					return out;
-				}
-				else
-				{
-					if(error)
-						*error = QString("Expected directive after '%' at position %1").arg(n);
-					return QByteArray();
-				}
-			}
+            if (n + 1 >= format.length()) {
+                if (partialPos) {
+                    *partialPos = markerPos;
+                    return out;
+                } else {
+                    if (error)
+                        *error = QString("Expected directive after '%' at position %1").arg(n);
+                    return QByteArray();
+                }
+            }
 
-			++n;
-			c = format.at(n);
+            ++n;
+            c = format.at(n);
 
-			if(c == '(')
-			{
-				int fieldStart = n;
+            if (c == '(') {
+                int fieldStart = n;
 
-				if(n + 1 >= format.length())
-				{
-					if(partialPos)
-					{
-						*partialPos = markerPos;
-						return out;
-					}
-					else
-					{
-						if(error)
-							*error = QString("Expected character after '(' at position %1").arg(n);
-						return QByteArray();
-					}
-				}
+                if (n + 1 >= format.length()) {
+                    if (partialPos) {
+                        *partialPos = markerPos;
+                        return out;
+                    } else {
+                        if (error)
+                            *error = QString("Expected character after '(' at position %1").arg(n);
+                        return QByteArray();
+                    }
+                }
 
-				++n;
+                ++n;
 
-				QByteArray arg;
+                QByteArray arg;
 
-				// Scan for ')'
-				bool ok = false;
-				for(; n < format.length(); ++n)
-				{
-					c = format.at(n);
+                // Scan for ')'
+                bool ok = false;
+                for (; n < format.length(); ++n) {
+                    c = format.at(n);
 
-					if(c == '\\')
-					{
-						if(n + 1 >= format.length())
-						{
-							if(partialPos)
-							{
-								*partialPos = markerPos;
-								return out;
-							}
-							else
-							{
-								if(error)
-									*error = QString("Expected character after '\\' at position %1").arg(n);
-								return QByteArray();
-							}
-						}
+                    if (c == '\\') {
+                        if (n + 1 >= format.length()) {
+                            if (partialPos) {
+                                *partialPos = markerPos;
+                                return out;
+                            } else {
+                                if (error)
+                                    *error = QString("Expected character after '\\' at position %1")
+                                                 .arg(n);
+                                return QByteArray();
+                            }
+                        }
 
-						++n;
-						c = format.at(n);
+                        ++n;
+                        c = format.at(n);
 
-						arg += c;
-					}
-					else if(c == ')')
-					{
-						ok = true;
-						break;
-					}
-					else
-					{
-						arg += c;
-					}
-				}
-				if(!ok)
-				{
-					if(partialPos)
-					{
-						*partialPos = markerPos;
-						return out;
-					}
-					else
-					{
-						if(error)
-							*error = QString("Unterminated field starting at position %1").arg(fieldStart);
-						return QByteArray();
-					}
-				}
+                        arg += c;
+                    } else if (c == ')') {
+                        ok = true;
+                        break;
+                    } else {
+                        arg += c;
+                    }
+                }
+                if (!ok) {
+                    if (partialPos) {
+                        *partialPos = markerPos;
+                        return out;
+                    } else {
+                        if (error)
+                            *error = QString("Unterminated field starting at position %1")
+                                         .arg(fieldStart);
+                        return QByteArray();
+                    }
+                }
 
-				if(n + 1 >= format.length())
-				{
-					if(partialPos)
-					{
-						*partialPos = markerPos;
-						return out;
-					}
-					else
-					{
-						if(error)
-							*error = QString("Expected directive after ')' at position %1").arg(n);
-						return QByteArray();
-					}
-				}
+                if (n + 1 >= format.length()) {
+                    if (partialPos) {
+                        *partialPos = markerPos;
+                        return out;
+                    } else {
+                        if (error)
+                            *error = QString("Expected directive after ')' at position %1").arg(n);
+                        return QByteArray();
+                    }
+                }
 
-				++n;
-				c = format.at(n);
+                ++n;
+                c = format.at(n);
 
-				QString _error;
-				QByteArray result = handler->handle(c, arg, &_error);
-				if(result.isNull())
-				{
-					if(error)
-						*error = QString("%1 at position %2").arg(_error, QString::number(n));
-					return QByteArray();
-				}
+                QString _error;
+                QByteArray result = handler->handle(c, arg, &_error);
+                if (result.isNull()) {
+                    if (error)
+                        *error = QString("%1 at position %2").arg(_error, QString::number(n));
+                    return QByteArray();
+                }
 
-				out += result;
-			}
-			else if(c == '%')
-			{
-				out += c;
-			}
-			else if(isalpha(c))
-			{
-				QString _error;
-				QByteArray result = handler->handle(c, QByteArray(), &_error);
-				if(result.isNull())
-				{
-					if(error)
-						*error = QString("%1 at position %2").arg(_error, QString::number(n));
-					return QByteArray();
-				}
+                out += result;
+            } else if (c == '%') {
+                out += c;
+            } else if (isalpha(c)) {
+                QString _error;
+                QByteArray result = handler->handle(c, QByteArray(), &_error);
+                if (result.isNull()) {
+                    if (error)
+                        *error = QString("%1 at position %2").arg(_error, QString::number(n));
+                    return QByteArray();
+                }
 
-				out += result;
-			}
-			else
-			{
-				if(error)
-					*error = QString("Unknown directive '%1' at position %2").arg(QString(c), QString::number(n));
-				return QByteArray();
-			}
-		}
-		else
-		{
-			out += c;
-		}
-	}
+                out += result;
+            } else {
+                if (error)
+                    *error = QString("Unknown directive '%1' at position %2")
+                                 .arg(QString(c), QString::number(n));
+                return QByteArray();
+            }
+        } else {
+            out += c;
+        }
+    }
 
-	if(partialPos)
-		*partialPos = format.length();
+    if (partialPos)
+        *partialPos = format.length();
 
-	return out;
+    return out;
 }
 
-}
+} // namespace Format

--- a/src/handler/format.h
+++ b/src/handler/format.h
@@ -28,17 +28,17 @@
 
 namespace Format {
 
-class Handler
-{
+class Handler {
 public:
-	virtual ~Handler() {}
+    virtual ~Handler() {}
 
-	// Returns null array on error
-	virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const = 0;
+    // Returns null array on error
+    virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const = 0;
 };
 
-QByteArray process(const QByteArray &format, Handler *handler, int *partialPos = 0, QString *error = 0);
+QByteArray process(const QByteArray &format, Handler *handler, int *partialPos = 0,
+                   QString *error = 0);
 
-}
+} // namespace Format
 
 #endif

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -21,332 +21,333 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <assert.h>
-#include <unistd.h>
-#include <iostream>
-#include <QCommandLineParser>
-#include <QStringList>
-#include <QFile>
-#include <QFileInfo>
-#include <QDir>
-#include "rust/bindings.h"
-#include "reactor.h"
-#include "executor.h"
-#include "timer.h"
+#include "config.h"
 #include "defercall.h"
 #include "eventloop.h"
-#include "processquit.h"
-#include "log.h"
-#include "simplehttpserver.h"
-#include "httpsession.h"
-#include "wssession.h"
-#include "httpsessionupdatemanager.h"
-#include "settings.h"
-#include "config.h"
-#include "handlerengine.h"
+#include "executor.h"
 #include "handlerargsdata.h"
+#include "handlerengine.h"
+#include "httpsession.h"
+#include "httpsessionupdatemanager.h"
+#include "log.h"
+#include "processquit.h"
+#include "reactor.h"
+#include "rust/bindings.h"
+#include "settings.h"
+#include "simplehttpserver.h"
+#include "timer.h"
+#include "wssession.h"
+#include <QCommandLineParser>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QStringList>
+#include <assert.h>
+#include <iostream>
+#include <unistd.h>
 
 #define DEFAULT_HTTP_MAX_HEADERS_SIZE 10000
 #define DEFAULT_HTTP_MAX_BODY_SIZE 1000000
 
-static void trimlist(QStringList *list)
-{
-	for(int n = 0; n < list->count(); ++n)
-	{
-		if((*list)[n].isEmpty())
-		{
-			list->removeAt(n);
-			--n; // Adjust position
-		}
-	}
+static void trimlist(QStringList *list) {
+    for (int n = 0; n < list->count(); ++n) {
+        if ((*list)[n].isEmpty()) {
+            list->removeAt(n);
+            --n; // Adjust position
+        }
+    }
 }
 
-static QStringList expandSpecs(const QStringList &l, int peerCount)
-{
-	if(l.count() == 1 && l[0].startsWith("ipc:") && peerCount > 1)
-	{
-		QString base = l[0];
+static QStringList expandSpecs(const QStringList &l, int peerCount) {
+    if (l.count() == 1 && l[0].startsWith("ipc:") && peerCount > 1) {
+        QString base = l[0];
 
-		QStringList out;
-		for(int i = 0; i < peerCount; ++i)
-			out += base + QString("-%1").arg(i);
+        QStringList out;
+        for (int i = 0; i < peerCount; ++i)
+            out += base + QString("-%1").arg(i);
 
-		return out;
-	}
+        return out;
+    }
 
-	return l;
+    return l;
 }
 
-static QString firstSpec(const QString &s, int peerCount)
-{
-	if(s.startsWith("ipc:") && peerCount > 1)
-		return s + "-0";
+static QString firstSpec(const QString &s, int peerCount) {
+    if (s.startsWith("ipc:") && peerCount > 1)
+        return s + "-0";
 
-	return s;
+    return s;
 }
 
-static int runLoop(const HandlerEngine::Configuration &config)
-{
-	// Includes worst-case subscriptions and update registrations
-	int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
-		(config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +
-		TIMERS_PER_UNIQUE_UPDATE_REGISTRATION;
+static int runLoop(const HandlerEngine::Configuration &config) {
+    // Includes worst-case subscriptions and update registrations
+    int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
+                           (config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +
+                           TIMERS_PER_UNIQUE_UPDATE_REGISTRATION;
 
-	// Enough timers for sessions, plus an extra 100 for misc
-	int timersMax = (config.connectionsMax * timersPerSession) + 100;
+    // Enough timers for sessions, plus an extra 100 for misc
+    int timersMax = (config.connectionsMax * timersPerSession) + 100;
 
-	// Enough for control requests and prometheus requests, plus an
-	// extra 100 for misc. Client sessions don't use socket notifiers
-	int socketNotifiersMax = (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX)) + 100;
+    // Enough for control requests and prometheus requests, plus an
+    // extra 100 for misc. Client sessions don't use socket notifiers
+    int socketNotifiersMax = (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST *
+                              (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX)) +
+                             100;
 
-	int registrationsMax = timersMax + socketNotifiersMax;
+    int registrationsMax = timersMax + socketNotifiersMax;
 
-	Reactor reactor(registrationsMax);
-	Executor executor(1); // For the one event loop task
+    Reactor reactor(registrationsMax);
+    Executor executor(1); // For the one event loop task
 
-	EventLoop *loop = nullptr;
-	std::unique_ptr<DeferCall> deferCall;
-	std::unique_ptr<HandlerEngine> engine;
-	std::optional<int> exitCode;
+    EventLoop *loop = nullptr;
+    std::unique_ptr<DeferCall> deferCall;
+    std::unique_ptr<HandlerEngine> engine;
+    std::optional<int> exitCode;
 
-	std::function<void ()> setup = [&] {
-		loop = EventLoop::instance();
+    std::function<void()> setup = [&] {
+        loop = EventLoop::instance();
 
-		deferCall = std::make_unique<DeferCall>();
+        deferCall = std::make_unique<DeferCall>();
 
-		deferCall->defer([&] {
-			engine = std::make_unique<HandlerEngine>();
+        deferCall->defer([&] {
+            engine = std::make_unique<HandlerEngine>();
 
-			ProcessQuit::instance()->quit.connect([&] {
-				log_info("stopping...");
+            ProcessQuit::instance()->quit.connect([&] {
+                log_info("stopping...");
 
-				// Remove the handler, so if we get another signal then we crash out
-				ProcessQuit::cleanup();
+                // Remove the handler, so if we get another signal then we crash out
+                ProcessQuit::cleanup();
 
-				engine.reset();
+                engine.reset();
 
-				log_debug("stopped");
+                log_debug("stopped");
 
-				loop->exit(0);
-			});
+                loop->exit(0);
+            });
 
-			ProcessQuit::instance()->hup.connect([&] {
-				log_info("reloading");
-				log_rotate();
-				engine->reload();
-			});
+            ProcessQuit::instance()->hup.connect([&] {
+                log_info("reloading");
+                log_rotate();
+                engine->reload();
+            });
 
-			if(!engine->start(config))
-			{
-				engine.reset();
-				loop->exit(1);
-				return;
-			}
+            if (!engine->start(config)) {
+                engine.reset();
+                loop->exit(1);
+                return;
+            }
 
-			log_info("started");
-		});
-	};
+            log_info("started");
+        });
+    };
 
-	std::function<void (int)> done = [&](int code) {
-		deferCall.reset();
+    std::function<void(int)> done = [&](int code) {
+        deferCall.reset();
 
-		exitCode = code;
-	};
+        exitCode = code;
+    };
 
-	auto fut = EventLoop::task(registrationsMax, &setup, &done);
+    auto fut = EventLoop::task(registrationsMax, &setup, &done);
 
-	assert(Executor::currentSpawn(fut));
+    assert(Executor::currentSpawn(fut));
 
-	assert(executor.run([&](std::optional<int> ms) { return reactor.poll(ms); }));
+    assert(executor.run([&](std::optional<int> ms) { return reactor.poll(ms); }));
 
-	return exitCode.value();
+    return exitCode.value();
 }
 
 extern "C" {
 
-int handler_init(const ffi::HandlerCliArgs *argsFfi)
-{
-	HandlerArgsData args(argsFfi);
+int handler_init(const ffi::HandlerCliArgs *argsFfi) {
+    HandlerArgsData args(argsFfi);
 
-	// Set the log level
-	if(args.logLevel != -1)
-		log_setOutputLevel(args.logLevel);
-	else
-		log_setOutputLevel(LOG_LEVEL_INFO);
+    // Set the log level
+    if (args.logLevel != -1)
+        log_setOutputLevel(args.logLevel);
+    else
+        log_setOutputLevel(LOG_LEVEL_INFO);
 
-	// Set the log file if specified
-	if(!args.logFile.isEmpty())
-	{
-		if(!log_setFile(args.logFile))
-		{
-			log_error("failed to open log file: %s", qPrintable(args.logFile));
-			return 1;
-		}
-	}
+    // Set the log file if specified
+    if (!args.logFile.isEmpty()) {
+        if (!log_setFile(args.logFile)) {
+            log_error("failed to open log file: %s", qPrintable(args.logFile));
+            return 1;
+        }
+    }
 
-	log_debug("starting...");
+    log_debug("starting...");
 
-	// QSettings doesn't inform us if the config file can't be opened, so do that ourselves
-	{
-		QFile file(args.configFile);
-		if(!file.open(QIODevice::ReadOnly))
-		{
-			log_error("failed to open config file: %s", qPrintable(args.configFile));
-			return 1;
-		}
-	}
+    // QSettings doesn't inform us if the config file can't be opened, so do that
+    // ourselves
+    {
+        QFile file(args.configFile);
+        if (!file.open(QIODevice::ReadOnly)) {
+            log_error("failed to open config file: %s", qPrintable(args.configFile));
+            return 1;
+        }
+    }
 
-	Settings settings(args.configFile);
-	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
-	if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
+    Settings settings(args.configFile);
+    if (!args.ipcPrefix.isEmpty())
+        settings.setIpcPrefix(args.ipcPrefix);
+    if (args.portOffset != -1)
+        settings.setPortOffset(args.portOffset);
 
-	QStringList services = settings.value("runner/services").toStringList();
+    QStringList services = settings.value("runner/services").toStringList();
 
-	QStringList connmgr_in_stream_specs = settings.value("proxy/connmgr_in_stream_specs").toStringList();
-	trimlist(&connmgr_in_stream_specs);
-	QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
-	trimlist(&connmgr_out_specs);
-	QStringList condure_in_stream_specs = settings.value("proxy/condure_in_stream_specs").toStringList();
-	trimlist(&condure_in_stream_specs);
-	connmgr_in_stream_specs += condure_in_stream_specs;
-	QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
-	trimlist(&condure_out_specs);
-	connmgr_out_specs += condure_out_specs;
-	int proxyWorkerCount = settings.value("proxy/workers", 1).toInt();
-	QStringList m2a_in_stream_specs = settings.value("handler/m2a_in_stream_specs").toStringList();
-	trimlist(&m2a_in_stream_specs);
-	QStringList m2a_out_specs = settings.value("handler/m2a_out_specs").toStringList();
-	trimlist(&m2a_out_specs);
-	QStringList intreq_out_specs = settings.value("handler/proxy_intreq_out_specs").toStringList();
-	trimlist(&intreq_out_specs);
-	QStringList intreq_out_stream_specs = settings.value("handler/proxy_intreq_out_stream_specs").toStringList();
-	trimlist(&intreq_out_stream_specs);
-	QStringList intreq_in_specs = settings.value("handler/proxy_intreq_in_specs").toStringList();
-	trimlist(&intreq_in_specs);
-	QStringList proxy_inspect_specs = settings.value("handler/proxy_inspect_specs").toStringList();
-	trimlist(&proxy_inspect_specs);
-	QString proxy_inspect_spec = settings.value("handler/proxy_inspect_spec").toString();
-	if(!proxy_inspect_spec.isEmpty())
-		proxy_inspect_specs += proxy_inspect_spec;
-	QStringList proxy_accept_specs = settings.value("handler/proxy_accept_specs").toStringList();
-	trimlist(&proxy_accept_specs);
-	QString proxy_accept_spec = settings.value("handler/proxy_accept_spec").toString();
-	if(!proxy_accept_spec.isEmpty())
-		proxy_accept_specs += proxy_accept_spec;
-	QStringList proxy_retry_out_specs = settings.value("handler/proxy_retry_out_specs").toStringList();
-	trimlist(&proxy_retry_out_specs);
-	QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
-	if(!proxy_retry_out_spec.isEmpty())
-		proxy_retry_out_specs += proxy_retry_out_spec;
-	QStringList ws_control_init_specs = settings.value("handler/proxy_ws_control_init_specs").toStringList();
-	trimlist(&ws_control_init_specs);
-	QStringList ws_control_stream_specs = settings.value("handler/proxy_ws_control_stream_specs").toStringList();
-	trimlist(&ws_control_stream_specs);
-	QString stats_spec = settings.value("handler/stats_spec").toString();
-	QString command_spec = settings.value("handler/command_spec").toString();
-	QString state_spec = settings.value("handler/state_spec").toString();
-	QStringList proxy_stats_specs = settings.value("handler/proxy_stats_specs").toStringList();
-	trimlist(&proxy_stats_specs);
-	QString proxy_stats_spec = settings.value("handler/proxy_stats_spec").toString();
-	if(!proxy_stats_spec.isEmpty())
-		proxy_stats_specs += proxy_stats_spec;
-	QString proxy_command_spec = settings.value("handler/proxy_command_spec").toString();
-	QString push_in_spec = settings.value("handler/push_in_spec").toString();
-	QStringList push_in_sub_specs = settings.value("handler/push_in_sub_specs").toStringList();
-	trimlist(&push_in_sub_specs);
-	QString push_in_sub_spec = settings.value("handler/push_in_sub_spec").toString();
-	if(!push_in_sub_spec.isEmpty())
-		push_in_sub_specs += push_in_sub_spec;
-	bool push_in_sub_connect = settings.value("handler/push_in_sub_connect").toBool();
-	QString push_in_http_addr = settings.value("handler/push_in_http_addr").toString();
-	int push_in_http_port = settings.adjustedPort("handler/push_in_http_port");
-	int push_in_http_max_headers_size = settings.value("handler/push_in_http_max_headers_size", DEFAULT_HTTP_MAX_HEADERS_SIZE).toInt();
-	int push_in_http_max_body_size = settings.value("handler/push_in_http_max_body_size", DEFAULT_HTTP_MAX_BODY_SIZE).toInt();
-	bool ok;
-	int ipcFileMode = settings.value("handler/ipc_file_mode", -1).toString().toInt(&ok, 8);
-	bool shareAll = settings.value("handler/share_all").toBool();
-	int messageRate = settings.value("handler/message_rate", -1).toInt();
-	int messageHwm = settings.value("handler/message_hwm", -1).toInt();
-	int messageBlockSize = settings.value("handler/message_block_size", -1).toInt();
-	int messageWait = settings.value("handler/message_wait", 5000).toInt();
-	int idCacheTtl = settings.value("handler/id_cache_ttl", 0).toInt();
-	bool updateOnFirstSubscription = settings.value("handler/update_on_first_subscription", true).toBool();
-	int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
-	int connectionSubscriptionMax = settings.value("handler/connection_subscription_max", 20).toInt();
-	int subscriptionLinger = settings.value("handler/subscription_linger", 60).toInt();
-	int statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
-	int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
-	int statsSubscriptionTtl = settings.value("handler/stats_subscription_ttl", 60).toInt();
-	int statsReportInterval = settings.value("handler/stats_report_interval", 10).toInt();
-	QString statsFormat = settings.value("handler/stats_format").toString();
-	QString prometheusPort = settings.value("handler/prometheus_port").toString();
-	QString prometheusPrefix = settings.value("handler/prometheus_prefix").toString();
+    QStringList connmgr_in_stream_specs =
+        settings.value("proxy/connmgr_in_stream_specs").toStringList();
+    trimlist(&connmgr_in_stream_specs);
+    QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
+    trimlist(&connmgr_out_specs);
+    QStringList condure_in_stream_specs =
+        settings.value("proxy/condure_in_stream_specs").toStringList();
+    trimlist(&condure_in_stream_specs);
+    connmgr_in_stream_specs += condure_in_stream_specs;
+    QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
+    trimlist(&condure_out_specs);
+    connmgr_out_specs += condure_out_specs;
+    int proxyWorkerCount = settings.value("proxy/workers", 1).toInt();
+    QStringList m2a_in_stream_specs = settings.value("handler/m2a_in_stream_specs").toStringList();
+    trimlist(&m2a_in_stream_specs);
+    QStringList m2a_out_specs = settings.value("handler/m2a_out_specs").toStringList();
+    trimlist(&m2a_out_specs);
+    QStringList intreq_out_specs = settings.value("handler/proxy_intreq_out_specs").toStringList();
+    trimlist(&intreq_out_specs);
+    QStringList intreq_out_stream_specs =
+        settings.value("handler/proxy_intreq_out_stream_specs").toStringList();
+    trimlist(&intreq_out_stream_specs);
+    QStringList intreq_in_specs = settings.value("handler/proxy_intreq_in_specs").toStringList();
+    trimlist(&intreq_in_specs);
+    QStringList proxy_inspect_specs = settings.value("handler/proxy_inspect_specs").toStringList();
+    trimlist(&proxy_inspect_specs);
+    QString proxy_inspect_spec = settings.value("handler/proxy_inspect_spec").toString();
+    if (!proxy_inspect_spec.isEmpty())
+        proxy_inspect_specs += proxy_inspect_spec;
+    QStringList proxy_accept_specs = settings.value("handler/proxy_accept_specs").toStringList();
+    trimlist(&proxy_accept_specs);
+    QString proxy_accept_spec = settings.value("handler/proxy_accept_spec").toString();
+    if (!proxy_accept_spec.isEmpty())
+        proxy_accept_specs += proxy_accept_spec;
+    QStringList proxy_retry_out_specs =
+        settings.value("handler/proxy_retry_out_specs").toStringList();
+    trimlist(&proxy_retry_out_specs);
+    QString proxy_retry_out_spec = settings.value("handler/proxy_retry_out_spec").toString();
+    if (!proxy_retry_out_spec.isEmpty())
+        proxy_retry_out_specs += proxy_retry_out_spec;
+    QStringList ws_control_init_specs =
+        settings.value("handler/proxy_ws_control_init_specs").toStringList();
+    trimlist(&ws_control_init_specs);
+    QStringList ws_control_stream_specs =
+        settings.value("handler/proxy_ws_control_stream_specs").toStringList();
+    trimlist(&ws_control_stream_specs);
+    QString stats_spec = settings.value("handler/stats_spec").toString();
+    QString command_spec = settings.value("handler/command_spec").toString();
+    QString state_spec = settings.value("handler/state_spec").toString();
+    QStringList proxy_stats_specs = settings.value("handler/proxy_stats_specs").toStringList();
+    trimlist(&proxy_stats_specs);
+    QString proxy_stats_spec = settings.value("handler/proxy_stats_spec").toString();
+    if (!proxy_stats_spec.isEmpty())
+        proxy_stats_specs += proxy_stats_spec;
+    QString proxy_command_spec = settings.value("handler/proxy_command_spec").toString();
+    QString push_in_spec = settings.value("handler/push_in_spec").toString();
+    QStringList push_in_sub_specs = settings.value("handler/push_in_sub_specs").toStringList();
+    trimlist(&push_in_sub_specs);
+    QString push_in_sub_spec = settings.value("handler/push_in_sub_spec").toString();
+    if (!push_in_sub_spec.isEmpty())
+        push_in_sub_specs += push_in_sub_spec;
+    bool push_in_sub_connect = settings.value("handler/push_in_sub_connect").toBool();
+    QString push_in_http_addr = settings.value("handler/push_in_http_addr").toString();
+    int push_in_http_port = settings.adjustedPort("handler/push_in_http_port");
+    int push_in_http_max_headers_size =
+        settings.value("handler/push_in_http_max_headers_size", DEFAULT_HTTP_MAX_HEADERS_SIZE)
+            .toInt();
+    int push_in_http_max_body_size =
+        settings.value("handler/push_in_http_max_body_size", DEFAULT_HTTP_MAX_BODY_SIZE).toInt();
+    bool ok;
+    int ipcFileMode = settings.value("handler/ipc_file_mode", -1).toString().toInt(&ok, 8);
+    bool shareAll = settings.value("handler/share_all").toBool();
+    int messageRate = settings.value("handler/message_rate", -1).toInt();
+    int messageHwm = settings.value("handler/message_hwm", -1).toInt();
+    int messageBlockSize = settings.value("handler/message_block_size", -1).toInt();
+    int messageWait = settings.value("handler/message_wait", 5000).toInt();
+    int idCacheTtl = settings.value("handler/id_cache_ttl", 0).toInt();
+    bool updateOnFirstSubscription =
+        settings.value("handler/update_on_first_subscription", true).toBool();
+    int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
+    int connectionSubscriptionMax =
+        settings.value("handler/connection_subscription_max", 20).toInt();
+    int subscriptionLinger = settings.value("handler/subscription_linger", 60).toInt();
+    int statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
+    int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
+    int statsSubscriptionTtl = settings.value("handler/stats_subscription_ttl", 60).toInt();
+    int statsReportInterval = settings.value("handler/stats_report_interval", 10).toInt();
+    QString statsFormat = settings.value("handler/stats_format").toString();
+    QString prometheusPort = settings.value("handler/prometheus_port").toString();
+    QString prometheusPrefix = settings.value("handler/prometheus_prefix").toString();
 
-	if(m2a_in_stream_specs.isEmpty() || m2a_out_specs.isEmpty())
-	{
-		log_error("must set m2a_in_stream_specs and m2a_out_specs");
-		return 1;
-	}
+    if (m2a_in_stream_specs.isEmpty() || m2a_out_specs.isEmpty()) {
+        log_error("must set m2a_in_stream_specs and m2a_out_specs");
+        return 1;
+    }
 
-	if(proxy_inspect_specs.isEmpty() || proxy_accept_specs.isEmpty() || proxy_retry_out_specs.isEmpty())
-	{
-		log_error("must set proxy_inspect_specs, proxy_accept_specs, and proxy_retry_out_specs");
-		return 1;
-	}
+    if (proxy_inspect_specs.isEmpty() || proxy_accept_specs.isEmpty() ||
+        proxy_retry_out_specs.isEmpty()) {
+        log_error("must set proxy_inspect_specs, proxy_accept_specs, and "
+                  "proxy_retry_out_specs");
+        return 1;
+    }
 
-	HandlerEngine::Configuration config;
-	config.appVersion = Config::get().version;
-	config.instanceId = "handler_" + QByteArray::number(getpid());
-	if(!services.contains("mongrel2") && (!connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
-	{
-		config.serverInStreamSpecs = connmgr_in_stream_specs;
-		config.serverOutSpecs = connmgr_out_specs;
-	}
-	else
-	{
-		config.serverInStreamSpecs = m2a_in_stream_specs;
-		config.serverOutSpecs = m2a_out_specs;
-	}
-	config.clientOutSpecs = expandSpecs(intreq_out_specs, proxyWorkerCount);
-	config.clientOutStreamSpecs = expandSpecs(intreq_out_stream_specs, proxyWorkerCount);
-	config.clientInSpecs = expandSpecs(intreq_in_specs, proxyWorkerCount);
-	config.inspectSpecs = expandSpecs(proxy_inspect_specs, proxyWorkerCount);
-	config.acceptSpecs = expandSpecs(proxy_accept_specs, proxyWorkerCount);
-	config.retryOutSpecs = expandSpecs(proxy_retry_out_specs, proxyWorkerCount);
-	config.wsControlInitSpecs = expandSpecs(ws_control_init_specs, proxyWorkerCount);
-	config.wsControlStreamSpecs = expandSpecs(ws_control_stream_specs, proxyWorkerCount);
-	config.statsSpec = stats_spec;
-	config.commandSpec = command_spec;
-	config.stateSpec = state_spec;
-	config.proxyStatsSpecs = expandSpecs(proxy_stats_specs, proxyWorkerCount);
-	config.proxyCommandSpec = firstSpec(proxy_command_spec, proxyWorkerCount);
-	config.pushInSpec = push_in_spec;
-	config.pushInSubSpecs = push_in_sub_specs;
-	config.pushInSubConnect = push_in_sub_connect;
-	config.pushInHttpAddr = QHostAddress(push_in_http_addr);
-	config.pushInHttpPort = push_in_http_port;
-	config.pushInHttpMaxHeadersSize = push_in_http_max_headers_size;
-	config.pushInHttpMaxBodySize = push_in_http_max_body_size;
-	config.ipcFileMode = ipcFileMode;
-	config.shareAll = shareAll;
-	config.messageRate = messageRate;
-	config.messageHwm = messageHwm;
-	config.messageBlockSize = messageBlockSize;
-	config.messageWait = messageWait;
-	config.idCacheTtl = idCacheTtl;
-	config.updateOnFirstSubscription = updateOnFirstSubscription;
-	config.connectionsMax = clientMaxconn;
-	config.connectionSubscriptionMax = connectionSubscriptionMax;
-	config.subscriptionLinger = subscriptionLinger;
-	config.statsConnectionSend = statsConnectionSend;
-	config.statsConnectionTtl = statsConnectionTtl;
-	config.statsSubscriptionTtl = statsSubscriptionTtl;
-	config.statsReportInterval = statsReportInterval;
-	config.statsFormat = statsFormat;
-	config.prometheusPort = prometheusPort;
-	config.prometheusPrefix = prometheusPrefix;
+    HandlerEngine::Configuration config;
+    config.appVersion = Config::get().version;
+    config.instanceId = "handler_" + QByteArray::number(getpid());
+    if (!services.contains("mongrel2") &&
+        (!connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty())) {
+        config.serverInStreamSpecs = connmgr_in_stream_specs;
+        config.serverOutSpecs = connmgr_out_specs;
+    } else {
+        config.serverInStreamSpecs = m2a_in_stream_specs;
+        config.serverOutSpecs = m2a_out_specs;
+    }
+    config.clientOutSpecs = expandSpecs(intreq_out_specs, proxyWorkerCount);
+    config.clientOutStreamSpecs = expandSpecs(intreq_out_stream_specs, proxyWorkerCount);
+    config.clientInSpecs = expandSpecs(intreq_in_specs, proxyWorkerCount);
+    config.inspectSpecs = expandSpecs(proxy_inspect_specs, proxyWorkerCount);
+    config.acceptSpecs = expandSpecs(proxy_accept_specs, proxyWorkerCount);
+    config.retryOutSpecs = expandSpecs(proxy_retry_out_specs, proxyWorkerCount);
+    config.wsControlInitSpecs = expandSpecs(ws_control_init_specs, proxyWorkerCount);
+    config.wsControlStreamSpecs = expandSpecs(ws_control_stream_specs, proxyWorkerCount);
+    config.statsSpec = stats_spec;
+    config.commandSpec = command_spec;
+    config.stateSpec = state_spec;
+    config.proxyStatsSpecs = expandSpecs(proxy_stats_specs, proxyWorkerCount);
+    config.proxyCommandSpec = firstSpec(proxy_command_spec, proxyWorkerCount);
+    config.pushInSpec = push_in_spec;
+    config.pushInSubSpecs = push_in_sub_specs;
+    config.pushInSubConnect = push_in_sub_connect;
+    config.pushInHttpAddr = QHostAddress(push_in_http_addr);
+    config.pushInHttpPort = push_in_http_port;
+    config.pushInHttpMaxHeadersSize = push_in_http_max_headers_size;
+    config.pushInHttpMaxBodySize = push_in_http_max_body_size;
+    config.ipcFileMode = ipcFileMode;
+    config.shareAll = shareAll;
+    config.messageRate = messageRate;
+    config.messageHwm = messageHwm;
+    config.messageBlockSize = messageBlockSize;
+    config.messageWait = messageWait;
+    config.idCacheTtl = idCacheTtl;
+    config.updateOnFirstSubscription = updateOnFirstSubscription;
+    config.connectionsMax = clientMaxconn;
+    config.connectionSubscriptionMax = connectionSubscriptionMax;
+    config.subscriptionLinger = subscriptionLinger;
+    config.statsConnectionSend = statsConnectionSend;
+    config.statsConnectionTtl = statsConnectionTtl;
+    config.statsSubscriptionTtl = statsSubscriptionTtl;
+    config.statsReportInterval = statsReportInterval;
+    config.statsFormat = statsFormat;
+    config.prometheusPort = prometheusPort;
+    config.prometheusPrefix = prometheusPrefix;
 
-	return runLoop(config);
+    return runLoop(config);
 }
-
 }

--- a/src/handler/handlerargsdata.cpp
+++ b/src/handler/handlerargsdata.cpp
@@ -23,11 +23,10 @@
 
 #include "handlerargsdata.h"
 
-HandlerArgsData::HandlerArgsData(const ffi::HandlerCliArgs *argsFfi)
-{
-	configFile = QString::fromUtf8(argsFfi->config_file);
-	logFile    = QString::fromUtf8(argsFfi->log_file);
-	logLevel   = argsFfi->log_level;
-	ipcPrefix  = QString::fromUtf8(argsFfi->ipc_prefix);
-	portOffset = argsFfi->port_offset;
+HandlerArgsData::HandlerArgsData(const ffi::HandlerCliArgs *argsFfi) {
+    configFile = QString::fromUtf8(argsFfi->config_file);
+    logFile = QString::fromUtf8(argsFfi->log_file);
+    logLevel = argsFfi->log_level;
+    ipcPrefix = QString::fromUtf8(argsFfi->ipc_prefix);
+    portOffset = argsFfi->port_offset;
 }

--- a/src/handler/handlerargsdata.h
+++ b/src/handler/handlerargsdata.h
@@ -24,19 +24,18 @@
 #ifndef HANDLERARGSDATA_H
 #define HANDLERARGSDATA_H
 
-#include <QString>
 #include "rust/bindings.h"
+#include <QString>
 
-class HandlerArgsData
-{
+class HandlerArgsData {
 public:
-	QString configFile;
-	QString logFile;
-	int logLevel;
-	QString ipcPrefix;
-	int portOffset;
+    QString configFile;
+    QString logFile;
+    int logLevel;
+    QString ipcPrefix;
+    int portOffset;
 
-	HandlerArgsData(const ffi::HandlerCliArgs *argsFfi);
+    HandlerArgsData(const ffi::HandlerCliArgs *argsFfi);
 };
 
 #endif

--- a/src/handler/handlerargstest.cpp
+++ b/src/handler/handlerargstest.cpp
@@ -20,70 +20,72 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "rust/bindings.h"
-#include "test.h"
-#include "log.h"
 #include "config.h"
-#include "settings.h"
 #include "handlerargsdata.h"
+#include "log.h"
+#include "rust/bindings.h"
+#include "settings.h"
+#include "test.h"
 
-static void handlerargstest()
-{
-	// Get file for example config
-	std::string configFile = "examples/config/pushpin.conf";
+static void handlerargstest() {
+    // Get file for example config
+    std::string configFile = "examples/config/pushpin.conf";
 
-	ffi::HandlerCliArgs argsFfi = {
-		const_cast<char*>(configFile.c_str()),  // config_file
-		const_cast<char*>("handler-log.txt"),   // log_file
-		3,                                      // log_level
-		const_cast<char*>("ipc:prefix"),        // ipc_prefix
-		81                                      // port_offset
-	};
+    ffi::HandlerCliArgs argsFfi = {
+        const_cast<char *>(configFile.c_str()), // config_file
+        const_cast<char *>("handler-log.txt"),  // log_file
+        3,                                      // log_level
+        const_cast<char *>("ipc:prefix"),       // ipc_prefix
+        81                                      // port_offset
+    };
 
-	// Verify HandlerArgsData parsing
-	HandlerArgsData args(&argsFfi);
-	TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
-	TEST_ASSERT_EQ(args.logFile, QString("handler-log.txt"));
-	TEST_ASSERT_EQ(args.logLevel, 3);
-	TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
-	TEST_ASSERT_EQ(args.portOffset, 81);
+    // Verify HandlerArgsData parsing
+    HandlerArgsData args(&argsFfi);
+    TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
+    TEST_ASSERT_EQ(args.logFile, QString("handler-log.txt"));
+    TEST_ASSERT_EQ(args.logLevel, 3);
+    TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
+    TEST_ASSERT_EQ(args.portOffset, 81);
 
-	Settings settings(args.configFile);
-	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
-	if (args.portOffset != -1) settings.setPortOffset(args.portOffset);
+    Settings settings(args.configFile);
+    if (!args.ipcPrefix.isEmpty())
+        settings.setIpcPrefix(args.ipcPrefix);
+    if (args.portOffset != -1)
+        settings.setPortOffset(args.portOffset);
 
-	// Test command-line overrides were applied
-	TEST_ASSERT_EQ(settings.portOffset(), 81);
-	TEST_ASSERT_EQ(settings.ipcPrefix(), QString("ipc:prefix"));
+    // Test command-line overrides were applied
+    TEST_ASSERT_EQ(settings.portOffset(), 81);
+    TEST_ASSERT_EQ(settings.ipcPrefix(), QString("ipc:prefix"));
 
-	ffi::HandlerCliArgs argsFfiEmpty = {
-		const_cast<char*>(configFile.c_str()),  // config_file
-		const_cast<char*>(""),                  // log_file
-		2,                                      // log_level
-		const_cast<char*>(""),                  // ipc_prefix
-		-1                                      // port_offset
-	};
+    ffi::HandlerCliArgs argsFfiEmpty = {
+        const_cast<char *>(configFile.c_str()), // config_file
+        const_cast<char *>(""),                 // log_file
+        2,                                      // log_level
+        const_cast<char *>(""),                 // ipc_prefix
+        -1                                      // port_offset
+    };
 
-	// Verify HandlerArgsData parsing with empty arguments
-	HandlerArgsData argsEmpty(&argsFfiEmpty);
-	TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
-	TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
-	TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
-	TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
-	TEST_ASSERT_EQ(argsEmpty.portOffset, -1);
+    // Verify HandlerArgsData parsing with empty arguments
+    HandlerArgsData argsEmpty(&argsFfiEmpty);
+    TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
+    TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
+    TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
+    TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
+    TEST_ASSERT_EQ(argsEmpty.portOffset, -1);
 
-	Settings settingsEmpty(argsEmpty.configFile);
-	if (!argsEmpty.ipcPrefix.isEmpty()) settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
-	if (argsEmpty.portOffset != -1) settingsEmpty.setPortOffset(argsEmpty.portOffset);
+    Settings settingsEmpty(argsEmpty.configFile);
+    if (!argsEmpty.ipcPrefix.isEmpty())
+        settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
+    if (argsEmpty.portOffset != -1)
+        settingsEmpty.setPortOffset(argsEmpty.portOffset);
 
-	// Test that no overrides were applied (should use config file defaults)
-	TEST_ASSERT_EQ(settingsEmpty.portOffset(), 0);
-	TEST_ASSERT_EQ(settingsEmpty.ipcPrefix(), QString("pushpin-"));
+    // Test that no overrides were applied (should use config file defaults)
+    TEST_ASSERT_EQ(settingsEmpty.portOffset(), 0);
+    TEST_ASSERT_EQ(settingsEmpty.ipcPrefix(), QString("pushpin-"));
 }
 
-extern "C" int handlerargs_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(handlerargstest());
+extern "C" int handlerargs_test(ffi::TestException *out_ex) {
+    TEST_CATCH(handlerargstest());
 
-	return 0;
+    return 0;
 }

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -23,57 +23,57 @@
 
 #include "handlerengine.h"
 
-#include <assert.h>
-#include <algorithm>
-#include <QUrlQuery>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "zmqreqmessage.h"
-#include "qtcompat.h"
-#include "variant.h"
-#include "tnetstring.h"
-#include "timer.h"
+#include "cidset.h"
+#include "conncheckworker.h"
+#include "controlrequest.h"
 #include "defercall.h"
+#include "deferred.h"
+#include "detectrule.h"
+#include "filterstack.h"
+#include "httpsession.h"
+#include "httpsessionupdatemanager.h"
+#include "inspectdata.h"
+#include "instruct.h"
+#include "jsonpointer.h"
+#include "lastids.h"
 #include "log.h"
 #include "logutil.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "packet/retryrequestpacket.h"
-#include "packet/wscontrolpacket.h"
 #include "packet/statspacket.h"
-#include "inspectdata.h"
-#include "zutil.h"
-#include "zrpcmanager.h"
-#include "zrpcrequest.h"
-#include "zhttpmanager.h"
-#include "zhttprequest.h"
-#include "statsmanager.h"
-#include "deferred.h"
-#include "simplehttpserver.h"
-#include "variantutil.h"
-#include "detectrule.h"
-#include "lastids.h"
-#include "cidset.h"
-#include "sessionrequest.h"
-#include "requeststate.h"
-#include "wscontrolmessage.h"
+#include "packet/wscontrolpacket.h"
 #include "publishformat.h"
 #include "publishitem.h"
-#include "jsonpointer.h"
 #include "publishlastids.h"
-#include "instruct.h"
-#include "httpsession.h"
-#include "wssession.h"
-#include "controlrequest.h"
-#include "conncheckworker.h"
-#include "refreshworker.h"
+#include "qtcompat.h"
 #include "ratelimiter.h"
-#include "httpsessionupdatemanager.h"
+#include "refreshworker.h"
+#include "requeststate.h"
 #include "sequencer.h"
-#include "filterstack.h"
+#include "sessionrequest.h"
+#include "simplehttpserver.h"
+#include "statsmanager.h"
+#include "timer.h"
+#include "tnetstring.h"
+#include "variant.h"
+#include "variantutil.h"
+#include "wscontrolmessage.h"
+#include "wssession.h"
+#include "zhttpmanager.h"
+#include "zhttprequest.h"
+#include "zmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zrpcmanager.h"
+#include "zrpcrequest.h"
+#include "zutil.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrlQuery>
+#include <algorithm>
+#include <assert.h>
 
 #define DEFAULT_HWM 101000
 #define SUB_SNDHWM 0 // Infinite
@@ -90,3079 +90,2813 @@
 
 using namespace VariantUtil;
 
-static QList<PublishItem> parseItems(const VariantList &vitems, bool *ok = 0, QString *errorMessage = 0)
-{
-	QList<PublishItem> out;
+static QList<PublishItem> parseItems(const VariantList &vitems, bool *ok = 0,
+                                     QString *errorMessage = 0) {
+    QList<PublishItem> out;
 
-	for(const Variant &vitem : vitems)
-	{
-		bool ok_;
-		PublishItem item = PublishItem::fromVariant(vitem, QString(), &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return QList<PublishItem>();
-		}
+    for (const Variant &vitem : vitems) {
+        bool ok_;
+        PublishItem item = PublishItem::fromVariant(vitem, QString(), &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return QList<PublishItem>();
+        }
 
-		out += item;
-	}
+        out += item;
+    }
 
-	setSuccess(ok, errorMessage);
-	return out;
+    setSuccess(ok, errorMessage);
+    return out;
 }
 
-class InspectWorker : public Deferred
-{
+class InspectWorker : public Deferred {
 public:
-	std::unique_ptr<ZrpcRequest> req;
-	ZrpcManager *stateClient;
-	bool shareAll;
-	HttpRequestData requestData;
-	bool truncated;
-	bool autoShare;
-	QString sid;
-	LastIds lastIds;
-	std::map<Deferred*, std::unique_ptr<Deferred>> deferreds;
+    std::unique_ptr<ZrpcRequest> req;
+    ZrpcManager *stateClient;
+    bool shareAll;
+    HttpRequestData requestData;
+    bool truncated;
+    bool autoShare;
+    QString sid;
+    LastIds lastIds;
+    std::map<Deferred *, std::unique_ptr<Deferred>> deferreds;
 
-	InspectWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, bool _shareAll) :
-		req(_req),
-		stateClient(_stateClient),
-		shareAll(_shareAll),
-		truncated(false),
-		autoShare(false)
-	{
-		if(req->method() == "inspect")
-		{
-			VariantHash args = req->args();
+    InspectWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, bool _shareAll)
+        : req(_req),
+          stateClient(_stateClient),
+          shareAll(_shareAll),
+          truncated(false),
+          autoShare(false) {
+        if (req->method() == "inspect") {
+            VariantHash args = req->args();
 
-			if(!args.contains("method") || typeId(args["method"]) != VariantType::ByteArray)
-			{
-				respondError("bad-request");
-				return;
-			}
+            if (!args.contains("method") || typeId(args["method"]) != VariantType::ByteArray) {
+                respondError("bad-request");
+                return;
+            }
 
-			requestData.method = QString::fromLatin1(args["method"].toByteArray());
+            requestData.method = QString::fromLatin1(args["method"].toByteArray());
 
-			if(!args.contains("uri") || typeId(args["uri"]) != VariantType::ByteArray)
-			{
-				respondError("bad-request");
-				return;
-			}
+            if (!args.contains("uri") || typeId(args["uri"]) != VariantType::ByteArray) {
+                respondError("bad-request");
+                return;
+            }
 
-			requestData.uri = Url(args["uri"].toString(), Url::StrictMode);
-			if(!requestData.uri.isValid())
-			{
-				respondError("bad-request");
-				return;
-			}
+            requestData.uri = Url(args["uri"].toString(), Url::StrictMode);
+            if (!requestData.uri.isValid()) {
+                respondError("bad-request");
+                return;
+            }
 
-			if(!args.contains("headers") || typeId(args["headers"]) != VariantType::List)
-			{
-				respondError("bad-request");
-				return;
-			}
+            if (!args.contains("headers") || typeId(args["headers"]) != VariantType::List) {
+                respondError("bad-request");
+                return;
+            }
 
-			for(const Variant &vheader : args["headers"].toList())
-			{
-				if(typeId(vheader) != VariantType::List)
-				{
-					respondError("bad-request");
-					return;
-				}
+            for (const Variant &vheader : args["headers"].toList()) {
+                if (typeId(vheader) != VariantType::List) {
+                    respondError("bad-request");
+                    return;
+                }
 
-				VariantList vlist = vheader.toList();
-				if(vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray || typeId(vlist[1]) != VariantType::ByteArray)
-				{
-					respondError("bad-request");
-					return;
-				}
+                VariantList vlist = vheader.toList();
+                if (vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray ||
+                    typeId(vlist[1]) != VariantType::ByteArray) {
+                    respondError("bad-request");
+                    return;
+                }
 
-				requestData.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
-			}
+                requestData.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
+            }
 
-			if(!args.contains("body") || typeId(args["body"]) != VariantType::ByteArray)
-			{
-				respondError("bad-request");
-				return;
-			}
+            if (!args.contains("body") || typeId(args["body"]) != VariantType::ByteArray) {
+                respondError("bad-request");
+                return;
+            }
 
-			requestData.body = args["body"].toByteArray();
+            requestData.body = args["body"].toByteArray();
 
-			truncated = false;
-			if(args.contains("truncated"))
-			{
-				if(typeId(args["truncated"]) != VariantType::Bool)
-				{
-					respondError("bad-request");
-					return;
-				}
+            truncated = false;
+            if (args.contains("truncated")) {
+                if (typeId(args["truncated"]) != VariantType::Bool) {
+                    respondError("bad-request");
+                    return;
+                }
 
-				truncated = args["truncated"].toBool();
-			}
+                truncated = args["truncated"].toBool();
+            }
 
-			bool getSession = false;
-			if(args.contains("get-session"))
-			{
-				if(typeId(args["get-session"]) != VariantType::Bool)
-				{
-					respondError("bad-request");
-					return;
-				}
+            bool getSession = false;
+            if (args.contains("get-session")) {
+                if (typeId(args["get-session"]) != VariantType::Bool) {
+                    respondError("bad-request");
+                    return;
+                }
 
-				getSession = args["get-session"].toBool();
-			}
+                getSession = args["get-session"].toBool();
+            }
 
-			autoShare = false;
-			if(args.contains("auto-share"))
-			{
-				if(typeId(args["auto-share"]) != VariantType::Bool)
-				{
-					respondError("bad-request");
-					return;
-				}
+            autoShare = false;
+            if (args.contains("auto-share")) {
+                if (typeId(args["auto-share"]) != VariantType::Bool) {
+                    respondError("bad-request");
+                    return;
+                }
 
-				autoShare = args["auto-share"].toBool();
-			}
+                autoShare = args["auto-share"].toBool();
+            }
 
-			if(getSession && stateClient)
-			{
-				// Determine session info
+            if (getSession && stateClient) {
+                // Determine session info
 
-				auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesGet(stateClient, requestData.uri.host().toUtf8(), requestData.uri.path(Url::FullyEncoded).toUtf8()));
+                auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesGet(
+                    stateClient, requestData.uri.host().toUtf8(),
+                    requestData.uri.path(Url::FullyEncoded).toUtf8()));
 
-				// Safe to not track, since d can't outlive this
-				d->finished.connect(boost::bind(&InspectWorker::sessionDetectRulesGet_finished, this, d.get(), boost::placeholders::_1));
+                // Safe to not track, since d can't outlive this
+                d->finished.connect(boost::bind(&InspectWorker::sessionDetectRulesGet_finished,
+                                                this, d.get(), boost::placeholders::_1));
 
-				deferreds[d.get()] = std::move(d);
-				return;
-			}
+                deferreds[d.get()] = std::move(d);
+                return;
+            }
 
-			doFinish();
-		}
-		else
-		{
-			respondError("method-not-found");
-		}
-	}
+            doFinish();
+        } else {
+            respondError("method-not-found");
+        }
+    }
 
 private:
-	void respondError(const QByteArray &condition)
-	{
-		req->respondError(condition);
-		setFinished(true);
-	}
+    void respondError(const QByteArray &condition) {
+        req->respondError(condition);
+        setFinished(true);
+    }
 
-	void doFinish()
-	{
-		VariantHash result;
-		result["no-proxy"] = false;
+    void doFinish() {
+        VariantHash result;
+        result["no-proxy"] = false;
 
-		if(autoShare && requestData.method == "GET")
-		{
-			// Auto share matches requests based on URI path (not query) and
-			// Grip-Last headers. The reason the query part is not
-			// considered is because it may vary per client and Grip-Last
-			// supersedes whatever is in the query
+        if (autoShare && requestData.method == "GET") {
+            // Auto share matches requests based on URI path (not query) and
+            // Grip-Last headers. The reason the query part is not
+            // considered is because it may vary per client and Grip-Last
+            // supersedes whatever is in the query
 
-			Url uri = requestData.uri;
-			uri.setQuery(QString()); // Remove the query part
+            Url uri = requestData.uri;
+            uri.setQuery(QString()); // Remove the query part
 
-			QList<QByteArray> gripLastHeaders = requestData.headers.getAll("Grip-Last").asQByteArrayList();
-			std::sort(gripLastHeaders.begin(), gripLastHeaders.end());
+            QList<QByteArray> gripLastHeaders =
+                requestData.headers.getAll("Grip-Last").asQByteArrayList();
+            std::sort(gripLastHeaders.begin(), gripLastHeaders.end());
 
-			QByteArray key = "auto|" + uri.toEncoded();
+            QByteArray key = "auto|" + uri.toEncoded();
 
-			foreach(const QByteArray &h, gripLastHeaders)
-				key += '|' + h;
+            foreach (const QByteArray &h, gripLastHeaders)
+                key += '|' + h;
 
-			result["sharing-key"] = key;
-		}
-		else if(shareAll)
-			result["sharing-key"] = requestData.method.toLatin1() + '|' + requestData.uri.toEncoded();
+            result["sharing-key"] = key;
+        } else if (shareAll)
+            result["sharing-key"] =
+                requestData.method.toLatin1() + '|' + requestData.uri.toEncoded();
 
-		if(!sid.isEmpty())
-		{
-			result["sid"] = sid.toUtf8();
+        if (!sid.isEmpty()) {
+            result["sid"] = sid.toUtf8();
 
-			if(!lastIds.isEmpty())
-			{
-				VariantHash vlastIds;
-				QHashIterator<QString, QString> it(lastIds);
-				while(it.hasNext())
-				{
-					it.next();
-					vlastIds.insert(it.key(), it.value().toUtf8());
-				}
+            if (!lastIds.isEmpty()) {
+                VariantHash vlastIds;
+                QHashIterator<QString, QString> it(lastIds);
+                while (it.hasNext()) {
+                    it.next();
+                    vlastIds.insert(it.key(), it.value().toUtf8());
+                }
 
-				result["last-ids"] = vlastIds;
-			}
-		}
+                result["last-ids"] = vlastIds;
+            }
+        }
 
-		req->respond(result);
-		setFinished(true);
-	}
+        req->respond(result);
+        setFinished(true);
+    }
 
-	void sessionDetectRulesGet_finished(Deferred *d, const DeferredResult &result)
-	{
-		deferreds.erase(d);
+    void sessionDetectRulesGet_finished(Deferred *d, const DeferredResult &result) {
+        deferreds.erase(d);
 
-		if(result.success)
-		{
-			QList<DetectRule> rules = result.value.value<DetectRuleList>();
-			log_debug("retrieved %d rules", rules.count());
+        if (result.success) {
+            QList<DetectRule> rules = result.value.value<DetectRuleList>();
+            log_debug("retrieved %d rules", rules.count());
 
-			foreach(const DetectRule &rule, rules)
-			{
-				QByteArray jsonData;
+            foreach (const DetectRule &rule, rules) {
+                QByteArray jsonData;
 
-				if(!rule.jsonParam.isEmpty())
-				{
-					QUrlQuery tmp(QString::fromUtf8(requestData.body));
-					jsonData = tmp.queryItemValue(rule.jsonParam, Url::FullyDecoded).toUtf8();
-				}
-				else
-				{
-					jsonData = requestData.body;
-				}
+                if (!rule.jsonParam.isEmpty()) {
+                    QUrlQuery tmp(QString::fromUtf8(requestData.body));
+                    jsonData = tmp.queryItemValue(rule.jsonParam, Url::FullyDecoded).toUtf8();
+                } else {
+                    jsonData = requestData.body;
+                }
 
-				QJsonParseError e;
-				QJsonDocument doc = QJsonDocument::fromJson(jsonData, &e);
-				if(e.error != QJsonParseError::NoError)
-					continue;
+                QJsonParseError e;
+                QJsonDocument doc = QJsonDocument::fromJson(jsonData, &e);
+                if (e.error != QJsonParseError::NoError)
+                    continue;
 
-				Variant vdata;
-				if(doc.isObject())
-					vdata = doc.object().toVariantMap();
-				else if(doc.isArray())
-					vdata = doc.array().toVariantList();
-				else
-					continue;
+                Variant vdata;
+                if (doc.isObject())
+                    vdata = doc.object().toVariantMap();
+                else if (doc.isArray())
+                    vdata = doc.array().toVariantList();
+                else
+                    continue;
 
-				JsonPointer ptr = JsonPointer::resolve(&vdata, rule.sidPtr);
-				if(!ptr.isNull() && ptr.exists())
-				{
-					bool ok;
-					sid = getString(ptr.value(), &ok);
-					if(!ok)
-						continue;
+                JsonPointer ptr = JsonPointer::resolve(&vdata, rule.sidPtr);
+                if (!ptr.isNull() && ptr.exists()) {
+                    bool ok;
+                    sid = getString(ptr.value(), &ok);
+                    if (!ok)
+                        continue;
 
-					break;
-				}
-			}
+                    break;
+                }
+            }
 
-			if(!sid.isEmpty())
-			{
-				auto d = std::unique_ptr<Deferred>(SessionRequest::getLastIds(stateClient, sid));
+            if (!sid.isEmpty()) {
+                auto d = std::unique_ptr<Deferred>(SessionRequest::getLastIds(stateClient, sid));
 
-				// Safe to not track, since d can't outlive this
-				d->finished.connect(boost::bind(&InspectWorker::sessionGetLastIds_finished, this, d.get(), boost::placeholders::_1));
+                // Safe to not track, since d can't outlive this
+                d->finished.connect(boost::bind(&InspectWorker::sessionGetLastIds_finished, this,
+                                                d.get(), boost::placeholders::_1));
 
-				deferreds[d.get()] = std::move(d);
-				return;
-			}
-		}
-		else
-		{
-			// Log error but keep going
-			log_error("failed to detect session: condition=%d", result.value.toInt());
-		}
+                deferreds[d.get()] = std::move(d);
+                return;
+            }
+        } else {
+            // Log error but keep going
+            log_error("failed to detect session: condition=%d", result.value.toInt());
+        }
 
-		doFinish();
-	}
+        doFinish();
+    }
 
-	void sessionGetLastIds_finished(Deferred *d, const DeferredResult &result)
-	{
-		deferreds.erase(d);
+    void sessionGetLastIds_finished(Deferred *d, const DeferredResult &result) {
+        deferreds.erase(d);
 
-		if(result.success)
-		{
-			lastIds = result.value.value<LastIds>();
-		}
-		else
-		{
-			QByteArray errorCondition = result.value.toByteArray();
+        if (result.success) {
+            lastIds = result.value.value<LastIds>();
+        } else {
+            QByteArray errorCondition = result.value.toByteArray();
 
-			if(errorCondition != "item-not-found")
-			{
-				// Log error but keep going
-				log_error("failed to detect session: condition=%d", result.value.toInt());
-			}
-		}
+            if (errorCondition != "item-not-found") {
+                // Log error but keep going
+                log_error("failed to detect session: condition=%d", result.value.toInt());
+            }
+        }
 
-		doFinish();
-	}
+        doFinish();
+    }
 };
 
 class Subscription;
 
-class CommonState
-{
+class CommonState {
 public:
-	QHash<ZhttpRequest::Rid, std::shared_ptr<HttpSession>> httpSessions;
-	QHash<QString, std::shared_ptr<WsSession>> wsSessions;
-	QHash<QString, QSet<HttpSession*> > responseSessionsByChannel;
-	QHash<QString, QSet<HttpSession*> > streamSessionsByChannel;
-	QHash<QString, QSet<WsSession*> > wsSessionsByChannel;
-	PublishLastIds publishLastIds;
-	QHash<QString, Subscription*> subs;
+    QHash<ZhttpRequest::Rid, std::shared_ptr<HttpSession>> httpSessions;
+    QHash<QString, std::shared_ptr<WsSession>> wsSessions;
+    QHash<QString, QSet<HttpSession *>> responseSessionsByChannel;
+    QHash<QString, QSet<HttpSession *>> streamSessionsByChannel;
+    QHash<QString, QSet<WsSession *>> wsSessionsByChannel;
+    PublishLastIds publishLastIds;
+    QHash<QString, Subscription *> subs;
 
-	CommonState() :
-		publishLastIds(1000000)
-	{
-	}
+    CommonState() : publishLastIds(1000000) {}
 };
 
-class AcceptWorker : public Deferred
-{
+class AcceptWorker : public Deferred {
 public:
-	std::unique_ptr<ZrpcRequest> req;
-	ZrpcManager *stateClient;
-	CommonState *cs;
-	ZhttpManager *zhttpIn;
-	ZhttpManager *zhttpOut;
-	StatsManager *stats;
-	RateLimiter *updateLimiter;
-	std::shared_ptr<RateLimiter> filterLimiter;
-	std::shared_ptr<HttpSessionUpdateManager> httpSessionUpdateManager;
-	QString route;
-	QString statsRoute;
-	QString channelPrefix;
-	int logLevel;
-	QStringList implicitChannels;
-	bool trusted;
-	QHash<ZhttpRequest::Rid, RequestState> requestStates;
-	HttpRequestData requestData;
-	HttpRequestData origRequestData;
-	bool haveInspectInfo;
-	InspectData inspectInfo;
-	HttpResponseData responseData;
-	bool responseSent;
-	QString sid;
-	LastIds lastIds;
-	QList<std::shared_ptr<HttpSession>> sessions;
-	int connectionSubscriptionMax;
-	QSet<QByteArray> needRemoveFromStats;
-	std::map<Deferred*, std::unique_ptr<Deferred>> deferreds;
-
-	AcceptWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, CommonState *_cs, ZhttpManager *_zhttpIn, ZhttpManager *_zhttpOut, StatsManager *_stats, RateLimiter *_updateLimiter, const std::shared_ptr<RateLimiter> &_filterLimiter, const std::shared_ptr<HttpSessionUpdateManager> &_httpSessionUpdateManager, int _connectionSubscriptionMax) :
-		req(_req),
-		stateClient(_stateClient),
-		cs(_cs),
-		zhttpIn(_zhttpIn),
-		zhttpOut(_zhttpOut),
-		stats(_stats),
-		updateLimiter(_updateLimiter),
-		filterLimiter(_filterLimiter),
-		httpSessionUpdateManager(_httpSessionUpdateManager),
-		logLevel(-1),
-		trusted(false),
-		haveInspectInfo(false),
-		responseSent(false),
-		connectionSubscriptionMax(_connectionSubscriptionMax)
-	{
-	}
-
-	~AcceptWorker()
-	{
-		foreach(const QByteArray &cid, needRemoveFromStats)
-			stats->removeConnection(cid, false);
-	}
-
-	// NOTE: to ensure sequential processing of conn-max packets, this
-	// method must process any such packets contained within the accept
-	// request before returning. The conn-max packets must not be processed
-	// asynchronously
-	void start()
-	{
-		VariantHash args = req->args();
-
-		// Process conn-max packets before doing anything else
-		if(args.contains("conn-max"))
-		{
-			if(typeId(args["conn-max"]) != VariantType::List)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			VariantList packets = args["conn-max"].toList();
-
-			for(const Variant &data : packets)
-			{
-				StatsPacket p;
-				if(!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax)
-				{
-					respondError("bad-request");
-					return;
-				}
-
-				stats->processExternalPacket(p, false);
-			}
-		}
-
-		if(args.contains("route"))
-		{
-			if(typeId(args["route"]) != VariantType::ByteArray)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			route = QString::fromUtf8(args["route"].toByteArray());
-		}
-
-		if(args.contains("separate-stats"))
-		{
-			if(typeId(args["separate-stats"]) != VariantType::Bool)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			bool separateStats = args["separate-stats"].toBool();
-
-			if(!route.isEmpty() && separateStats)
-				statsRoute = route;
-		}
-
-		if(args.contains("channel-prefix"))
-		{
-			if(typeId(args["channel-prefix"]) != VariantType::ByteArray)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			channelPrefix = QString::fromUtf8(args["channel-prefix"].toByteArray());
-		}
-
-		if(args.contains("log-level"))
-		{
-			if(!canConvert(args["log-level"], VariantType::Int))
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			logLevel = args["log-level"].toInt();
-		}
-
-		if(args.contains("channels"))
-		{
-			if(typeId(args["channels"]) != VariantType::List)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			VariantList vchannels = args["channels"].toList();
-			for(const Variant &v : vchannels)
-			{
-				if(typeId(v) != VariantType::ByteArray)
-				{
-					respondError("bad-request");
-					return;
-				}
-
-				implicitChannels += QString::fromUtf8(v.toByteArray());
-			}
-		}
-
-		if(args.contains("trusted"))
-		{
-			if(typeId(args["trusted"]) != VariantType::Bool)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			trusted = args["trusted"].toBool();
-		}
-
-		// Parse requests
-
-		if(!args.contains("requests") || typeId(args["requests"]) != VariantType::List)
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		for(const Variant &vr : args["requests"].toList())
-		{
-			RequestState rs = RequestState::fromVariant(vr);
-			if(rs.rid.first.isEmpty())
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			requestStates.insert(rs.rid, rs);
-		}
-
-		// Parse request-data
-
-		requestData = parseRequestData(args, "request-data");
-		if(requestData.method.isEmpty())
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		// Parse orig-request-data
-
-		origRequestData = parseRequestData(args, "orig-request-data");
-		if(origRequestData.method.isEmpty())
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		// Parse response
-
-		if(!args.contains("response") || typeId(args["response"]) != VariantType::Hash)
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		VariantHash rd = args["response"].toHash();
-
-		if(!rd.contains("code") || !canConvert(rd["code"], VariantType::Int))
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		responseData.code = rd["code"].toInt();
-
-		if(!rd.contains("reason") || typeId(rd["reason"]) != VariantType::ByteArray)
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		responseData.reason = rd["reason"].toByteArray();
-
-		if(!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List)
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		for(const Variant &vheader : rd["headers"].toList())
-		{
-			if(typeId(vheader) != VariantType::List)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			VariantList vlist = vheader.toList();
-			if(vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray || typeId(vlist[1]) != VariantType::ByteArray)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			responseData.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
-		}
-
-		if(!rd.contains("body") || typeId(rd["body"]) != VariantType::ByteArray)
-		{
-			respondError("bad-request");
-			return;
-		}
-
-		responseData.body = rd["body"].toByteArray();
-
-		if(args.contains("inspect"))
-		{
-			if(typeId(args["inspect"]) != VariantType::Hash)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			VariantHash vinspect = args["inspect"].toHash();
-
-			if(!vinspect.contains("no-proxy") || typeId(vinspect["no-proxy"]) != VariantType::Bool)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			inspectInfo.doProxy = !vinspect["no-proxy"].toBool();
-
-			inspectInfo.sharingKey.clear();
-			if(vinspect.contains("sharing-key"))
-			{
-				if(typeId(vinspect["sharing-key"]) != VariantType::ByteArray)
-				{
-					respondError("bad-request");
-					return;
-				}
-
-				inspectInfo.sharingKey = vinspect["sharing-key"].toByteArray();
-			}
-
-			if(vinspect.contains("sid"))
-			{
-				if(typeId(vinspect["sid"]) != VariantType::ByteArray)
-				{
-					respondError("bad-request");
-					return;
-				}
-
-				inspectInfo.sid = vinspect["sid"].toByteArray();
-			}
-
-			if(vinspect.contains("last-ids"))
-			{
-				if(typeId(vinspect["last-ids"]) != VariantType::Hash)
-				{
-					respondError("bad-request");
-					return;
-				}
-
-				VariantHash vlastIds = vinspect["last-ids"].toHash();
-				for(auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it)
-				{
-					if(typeId(it.value()) != VariantType::ByteArray)
-					{
-						respondError("bad-request");
-						return;
-					}
-
-					QByteArray key = it.key().toUtf8();
-					QByteArray val = it.value().toByteArray();
-					inspectInfo.lastIds.insert(key, val);
-				}
-			}
-
-			inspectInfo.userData = vinspect["user-data"];
-
-			haveInspectInfo = true;
-		}
-
-		if(args.contains("response-sent"))
-		{
-			if(typeId(args["response-sent"]) != VariantType::Bool)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			responseSent = args["response-sent"].toBool();
-		}
-
-		bool useSession = false;
-		if(args.contains("use-session"))
-		{
-			if(typeId(args["use-session"]) != VariantType::Bool)
-			{
-				respondError("bad-request");
-				return;
-			}
-
-			useSession = args["use-session"].toBool();
-		}
-
-		sid = QString::fromUtf8(responseData.headers.get("Grip-Session-Id").asQByteArray());
-
-		QList<DetectRule> rules;
-		QList<HttpHeaderParameters> ruleHeaders = responseData.headers.getAllAsParameters("Grip-Session-Detect", HttpHeaders::ParseAllParameters);
-		foreach(const HttpHeaderParameters &params, ruleHeaders)
-		{
-			if(params.contains("path-prefix") && params.contains("sid-ptr"))
-			{
-				DetectRule rule;
-				rule.domain = requestData.uri.host();
-				rule.pathPrefix = params.get("path-prefix").asQByteArray();
-				rule.sidPtr = QString::fromUtf8(params.get("sid-ptr").asQByteArray());
-				if(params.contains("json-param"))
-					rule.jsonParam = QString::fromUtf8(params.get("json-param").asQByteArray());
-				rules += rule;
-			}
-		}
-
-		QList<HttpHeaderParameters> lastHeaders = responseData.headers.getAllAsParameters("Grip-Last");
-		foreach(const HttpHeaderParameters &params, lastHeaders)
-		{
-			lastIds.insert(params[0].first.asQByteArray(), params.get("last-id").asQByteArray());
-		}
-
-		// We need to "atomically" process conn-max packets and add
-		// connections to the stats manager. We do this by processing the
-		// conn-max packets above and adding to the stats manager below,
-		// without returning to the event loop in between
-		foreach(const RequestState &rs, requestStates)
-		{
-			QByteArray cid = rs.rid.first + ':' + rs.rid.second;
-
-			int reportOffset = stats->connectionSendEnabled() ? -1 : qMax(rs.unreportedTime, 0);
-
-			needRemoveFromStats += cid;
-			stats->addConnection(cid, statsRoute.toUtf8(), StatsManager::Http, rs.logicalPeerAddress, rs.isHttps, true, reportOffset);
-		}
-
-		if(useSession && stateClient)
-		{
-			if(!rules.isEmpty())
-			{
-				auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesSet(stateClient, rules));
-
-				// Safe to not track, since d can't outlive this
-				d->finished.connect(boost::bind(&AcceptWorker::sessionDetectRulesSet_finished, this, d.get(), boost::placeholders::_1));
-
-				deferreds[d.get()] = std::move(d);
-			}
-			else
-			{
-				afterSetRules();
-			}
-
-			return;
-		}
-
-		afterSessionCalls();
-	}
-
-	QList<std::shared_ptr<HttpSession>> takeSessions()
-	{
-		// Swap instead of std::move since sessions is a member and should have a known state
-		QList<std::shared_ptr<HttpSession>> out;
-		out.swap(sessions);
-		return out;
-	}
-
-	Signal sessionsReady;
-	boost::signals2::signal<void(const QByteArray &,const RetryRequestPacket&)> retryPacketReady;
+    std::unique_ptr<ZrpcRequest> req;
+    ZrpcManager *stateClient;
+    CommonState *cs;
+    ZhttpManager *zhttpIn;
+    ZhttpManager *zhttpOut;
+    StatsManager *stats;
+    RateLimiter *updateLimiter;
+    std::shared_ptr<RateLimiter> filterLimiter;
+    std::shared_ptr<HttpSessionUpdateManager> httpSessionUpdateManager;
+    QString route;
+    QString statsRoute;
+    QString channelPrefix;
+    int logLevel;
+    QStringList implicitChannels;
+    bool trusted;
+    QHash<ZhttpRequest::Rid, RequestState> requestStates;
+    HttpRequestData requestData;
+    HttpRequestData origRequestData;
+    bool haveInspectInfo;
+    InspectData inspectInfo;
+    HttpResponseData responseData;
+    bool responseSent;
+    QString sid;
+    LastIds lastIds;
+    QList<std::shared_ptr<HttpSession>> sessions;
+    int connectionSubscriptionMax;
+    QSet<QByteArray> needRemoveFromStats;
+    std::map<Deferred *, std::unique_ptr<Deferred>> deferreds;
+
+    AcceptWorker(ZrpcRequest *_req, ZrpcManager *_stateClient, CommonState *_cs,
+                 ZhttpManager *_zhttpIn, ZhttpManager *_zhttpOut, StatsManager *_stats,
+                 RateLimiter *_updateLimiter, const std::shared_ptr<RateLimiter> &_filterLimiter,
+                 const std::shared_ptr<HttpSessionUpdateManager> &_httpSessionUpdateManager,
+                 int _connectionSubscriptionMax)
+        : req(_req),
+          stateClient(_stateClient),
+          cs(_cs),
+          zhttpIn(_zhttpIn),
+          zhttpOut(_zhttpOut),
+          stats(_stats),
+          updateLimiter(_updateLimiter),
+          filterLimiter(_filterLimiter),
+          httpSessionUpdateManager(_httpSessionUpdateManager),
+          logLevel(-1),
+          trusted(false),
+          haveInspectInfo(false),
+          responseSent(false),
+          connectionSubscriptionMax(_connectionSubscriptionMax) {}
+
+    ~AcceptWorker() {
+        foreach (const QByteArray &cid, needRemoveFromStats)
+            stats->removeConnection(cid, false);
+    }
+
+    // NOTE: to ensure sequential processing of conn-max packets, this
+    // method must process any such packets contained within the accept
+    // request before returning. The conn-max packets must not be processed
+    // asynchronously
+    void start() {
+        VariantHash args = req->args();
+
+        // Process conn-max packets before doing anything else
+        if (args.contains("conn-max")) {
+            if (typeId(args["conn-max"]) != VariantType::List) {
+                respondError("bad-request");
+                return;
+            }
+
+            VariantList packets = args["conn-max"].toList();
+
+            for (const Variant &data : packets) {
+                StatsPacket p;
+                if (!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax) {
+                    respondError("bad-request");
+                    return;
+                }
+
+                stats->processExternalPacket(p, false);
+            }
+        }
+
+        if (args.contains("route")) {
+            if (typeId(args["route"]) != VariantType::ByteArray) {
+                respondError("bad-request");
+                return;
+            }
+
+            route = QString::fromUtf8(args["route"].toByteArray());
+        }
+
+        if (args.contains("separate-stats")) {
+            if (typeId(args["separate-stats"]) != VariantType::Bool) {
+                respondError("bad-request");
+                return;
+            }
+
+            bool separateStats = args["separate-stats"].toBool();
+
+            if (!route.isEmpty() && separateStats)
+                statsRoute = route;
+        }
+
+        if (args.contains("channel-prefix")) {
+            if (typeId(args["channel-prefix"]) != VariantType::ByteArray) {
+                respondError("bad-request");
+                return;
+            }
+
+            channelPrefix = QString::fromUtf8(args["channel-prefix"].toByteArray());
+        }
+
+        if (args.contains("log-level")) {
+            if (!canConvert(args["log-level"], VariantType::Int)) {
+                respondError("bad-request");
+                return;
+            }
+
+            logLevel = args["log-level"].toInt();
+        }
+
+        if (args.contains("channels")) {
+            if (typeId(args["channels"]) != VariantType::List) {
+                respondError("bad-request");
+                return;
+            }
+
+            VariantList vchannels = args["channels"].toList();
+            for (const Variant &v : vchannels) {
+                if (typeId(v) != VariantType::ByteArray) {
+                    respondError("bad-request");
+                    return;
+                }
+
+                implicitChannels += QString::fromUtf8(v.toByteArray());
+            }
+        }
+
+        if (args.contains("trusted")) {
+            if (typeId(args["trusted"]) != VariantType::Bool) {
+                respondError("bad-request");
+                return;
+            }
+
+            trusted = args["trusted"].toBool();
+        }
+
+        // Parse requests
+
+        if (!args.contains("requests") || typeId(args["requests"]) != VariantType::List) {
+            respondError("bad-request");
+            return;
+        }
+
+        for (const Variant &vr : args["requests"].toList()) {
+            RequestState rs = RequestState::fromVariant(vr);
+            if (rs.rid.first.isEmpty()) {
+                respondError("bad-request");
+                return;
+            }
+
+            requestStates.insert(rs.rid, rs);
+        }
+
+        // Parse request-data
+
+        requestData = parseRequestData(args, "request-data");
+        if (requestData.method.isEmpty()) {
+            respondError("bad-request");
+            return;
+        }
+
+        // Parse orig-request-data
+
+        origRequestData = parseRequestData(args, "orig-request-data");
+        if (origRequestData.method.isEmpty()) {
+            respondError("bad-request");
+            return;
+        }
+
+        // Parse response
+
+        if (!args.contains("response") || typeId(args["response"]) != VariantType::Hash) {
+            respondError("bad-request");
+            return;
+        }
+
+        VariantHash rd = args["response"].toHash();
+
+        if (!rd.contains("code") || !canConvert(rd["code"], VariantType::Int)) {
+            respondError("bad-request");
+            return;
+        }
+
+        responseData.code = rd["code"].toInt();
+
+        if (!rd.contains("reason") || typeId(rd["reason"]) != VariantType::ByteArray) {
+            respondError("bad-request");
+            return;
+        }
+
+        responseData.reason = rd["reason"].toByteArray();
+
+        if (!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List) {
+            respondError("bad-request");
+            return;
+        }
+
+        for (const Variant &vheader : rd["headers"].toList()) {
+            if (typeId(vheader) != VariantType::List) {
+                respondError("bad-request");
+                return;
+            }
+
+            VariantList vlist = vheader.toList();
+            if (vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray ||
+                typeId(vlist[1]) != VariantType::ByteArray) {
+                respondError("bad-request");
+                return;
+            }
+
+            responseData.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
+        }
+
+        if (!rd.contains("body") || typeId(rd["body"]) != VariantType::ByteArray) {
+            respondError("bad-request");
+            return;
+        }
+
+        responseData.body = rd["body"].toByteArray();
+
+        if (args.contains("inspect")) {
+            if (typeId(args["inspect"]) != VariantType::Hash) {
+                respondError("bad-request");
+                return;
+            }
+
+            VariantHash vinspect = args["inspect"].toHash();
+
+            if (!vinspect.contains("no-proxy") ||
+                typeId(vinspect["no-proxy"]) != VariantType::Bool) {
+                respondError("bad-request");
+                return;
+            }
+
+            inspectInfo.doProxy = !vinspect["no-proxy"].toBool();
+
+            inspectInfo.sharingKey.clear();
+            if (vinspect.contains("sharing-key")) {
+                if (typeId(vinspect["sharing-key"]) != VariantType::ByteArray) {
+                    respondError("bad-request");
+                    return;
+                }
+
+                inspectInfo.sharingKey = vinspect["sharing-key"].toByteArray();
+            }
+
+            if (vinspect.contains("sid")) {
+                if (typeId(vinspect["sid"]) != VariantType::ByteArray) {
+                    respondError("bad-request");
+                    return;
+                }
+
+                inspectInfo.sid = vinspect["sid"].toByteArray();
+            }
+
+            if (vinspect.contains("last-ids")) {
+                if (typeId(vinspect["last-ids"]) != VariantType::Hash) {
+                    respondError("bad-request");
+                    return;
+                }
+
+                VariantHash vlastIds = vinspect["last-ids"].toHash();
+                for (auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it) {
+                    if (typeId(it.value()) != VariantType::ByteArray) {
+                        respondError("bad-request");
+                        return;
+                    }
+
+                    QByteArray key = it.key().toUtf8();
+                    QByteArray val = it.value().toByteArray();
+                    inspectInfo.lastIds.insert(key, val);
+                }
+            }
+
+            inspectInfo.userData = vinspect["user-data"];
+
+            haveInspectInfo = true;
+        }
+
+        if (args.contains("response-sent")) {
+            if (typeId(args["response-sent"]) != VariantType::Bool) {
+                respondError("bad-request");
+                return;
+            }
+
+            responseSent = args["response-sent"].toBool();
+        }
+
+        bool useSession = false;
+        if (args.contains("use-session")) {
+            if (typeId(args["use-session"]) != VariantType::Bool) {
+                respondError("bad-request");
+                return;
+            }
+
+            useSession = args["use-session"].toBool();
+        }
+
+        sid = QString::fromUtf8(responseData.headers.get("Grip-Session-Id").asQByteArray());
+
+        QList<DetectRule> rules;
+        QList<HttpHeaderParameters> ruleHeaders = responseData.headers.getAllAsParameters(
+            "Grip-Session-Detect", HttpHeaders::ParseAllParameters);
+        foreach (const HttpHeaderParameters &params, ruleHeaders) {
+            if (params.contains("path-prefix") && params.contains("sid-ptr")) {
+                DetectRule rule;
+                rule.domain = requestData.uri.host();
+                rule.pathPrefix = params.get("path-prefix").asQByteArray();
+                rule.sidPtr = QString::fromUtf8(params.get("sid-ptr").asQByteArray());
+                if (params.contains("json-param"))
+                    rule.jsonParam = QString::fromUtf8(params.get("json-param").asQByteArray());
+                rules += rule;
+            }
+        }
+
+        QList<HttpHeaderParameters> lastHeaders =
+            responseData.headers.getAllAsParameters("Grip-Last");
+        foreach (const HttpHeaderParameters &params, lastHeaders) {
+            lastIds.insert(params[0].first.asQByteArray(), params.get("last-id").asQByteArray());
+        }
+
+        // We need to "atomically" process conn-max packets and add
+        // connections to the stats manager. We do this by processing the
+        // conn-max packets above and adding to the stats manager below,
+        // without returning to the event loop in between
+        foreach (const RequestState &rs, requestStates) {
+            QByteArray cid = rs.rid.first + ':' + rs.rid.second;
+
+            int reportOffset = stats->connectionSendEnabled() ? -1 : qMax(rs.unreportedTime, 0);
+
+            needRemoveFromStats += cid;
+            stats->addConnection(cid, statsRoute.toUtf8(), StatsManager::Http,
+                                 rs.logicalPeerAddress, rs.isHttps, true, reportOffset);
+        }
+
+        if (useSession && stateClient) {
+            if (!rules.isEmpty()) {
+                auto d =
+                    std::unique_ptr<Deferred>(SessionRequest::detectRulesSet(stateClient, rules));
+
+                // Safe to not track, since d can't outlive this
+                d->finished.connect(boost::bind(&AcceptWorker::sessionDetectRulesSet_finished, this,
+                                                d.get(), boost::placeholders::_1));
+
+                deferreds[d.get()] = std::move(d);
+            } else {
+                afterSetRules();
+            }
+
+            return;
+        }
+
+        afterSessionCalls();
+    }
+
+    QList<std::shared_ptr<HttpSession>> takeSessions() {
+        // Swap instead of std::move since sessions is a member and should have a
+        // known state
+        QList<std::shared_ptr<HttpSession>> out;
+        out.swap(sessions);
+        return out;
+    }
+
+    Signal sessionsReady;
+    boost::signals2::signal<void(const QByteArray &, const RetryRequestPacket &)> retryPacketReady;
 
 private:
-	static HttpRequestData parseRequestData(const VariantHash &args, const QString &field)
-	{
-		if(!args.contains(field) || typeId(args[field]) != VariantType::Hash)
-			return HttpRequestData();
+    static HttpRequestData parseRequestData(const VariantHash &args, const QString &field) {
+        if (!args.contains(field) || typeId(args[field]) != VariantType::Hash)
+            return HttpRequestData();
 
-		VariantHash rd = args[field].toHash();
+        VariantHash rd = args[field].toHash();
 
-		if(!rd.contains("method") || typeId(rd["method"]) != VariantType::ByteArray)
-			return HttpRequestData();
+        if (!rd.contains("method") || typeId(rd["method"]) != VariantType::ByteArray)
+            return HttpRequestData();
 
-		HttpRequestData out;
-		out.method = QString::fromLatin1(rd["method"].toByteArray());
+        HttpRequestData out;
+        out.method = QString::fromLatin1(rd["method"].toByteArray());
 
-		if(!rd.contains("uri") || typeId(rd["uri"]) != VariantType::ByteArray)
-			return HttpRequestData();
+        if (!rd.contains("uri") || typeId(rd["uri"]) != VariantType::ByteArray)
+            return HttpRequestData();
 
-		out.uri = Url(rd["uri"].toString(), Url::StrictMode);
-		if(!out.uri.isValid())
-			return HttpRequestData();
+        out.uri = Url(rd["uri"].toString(), Url::StrictMode);
+        if (!out.uri.isValid())
+            return HttpRequestData();
 
-		if(!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List)
-			return HttpRequestData();
+        if (!rd.contains("headers") || typeId(rd["headers"]) != VariantType::List)
+            return HttpRequestData();
 
-		for(const Variant &vheader : rd["headers"].toList())
-		{
-			if(typeId(vheader) != VariantType::List)
-				return HttpRequestData();
+        for (const Variant &vheader : rd["headers"].toList()) {
+            if (typeId(vheader) != VariantType::List)
+                return HttpRequestData();
 
-			VariantList vlist = vheader.toList();
-			if(vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray || typeId(vlist[1]) != VariantType::ByteArray)
-				return HttpRequestData();
+            VariantList vlist = vheader.toList();
+            if (vlist.count() != 2 || typeId(vlist[0]) != VariantType::ByteArray ||
+                typeId(vlist[1]) != VariantType::ByteArray)
+                return HttpRequestData();
 
-			out.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
-		}
+            out.headers += HttpHeader(vlist[0].toByteArray(), vlist[1].toByteArray());
+        }
 
-		if(!rd.contains("body") || typeId(rd["body"]) != VariantType::ByteArray)
-			return HttpRequestData();
+        if (!rd.contains("body") || typeId(rd["body"]) != VariantType::ByteArray)
+            return HttpRequestData();
 
-		out.body = rd["body"].toByteArray();
+        out.body = rd["body"].toByteArray();
 
-		return out;
-	}
+        return out;
+    }
 
-	void respondError(const QByteArray &condition, const Variant &result = Variant())
-	{
-		req->respondError(condition, result);
-		setFinished(true);
-	}
+    void respondError(const QByteArray &condition, const Variant &result = Variant()) {
+        req->respondError(condition, result);
+        setFinished(true);
+    }
 
-	void afterSetRules()
-	{
-		if(!sid.isEmpty())
-		{
-			auto d = std::unique_ptr<Deferred>(SessionRequest::createOrUpdate(stateClient, sid, lastIds));
+    void afterSetRules() {
+        if (!sid.isEmpty()) {
+            auto d = std::unique_ptr<Deferred>(
+                SessionRequest::createOrUpdate(stateClient, sid, lastIds));
 
-			// Safe to not track, since d can't outlive this
-			d->finished.connect(boost::bind(&AcceptWorker::sessionCreateOrUpdate_finished, this, d.get(), boost::placeholders::_1));
+            // Safe to not track, since d can't outlive this
+            d->finished.connect(boost::bind(&AcceptWorker::sessionCreateOrUpdate_finished, this,
+                                            d.get(), boost::placeholders::_1));
 
-			deferreds[d.get()] = std::move(d);
-		}
-		else
-		{
-			afterSessionCalls();
-		}
-	}
+            deferreds[d.get()] = std::move(d);
+        } else {
+            afterSessionCalls();
+        }
+    }
 
-	void afterSessionCalls()
-	{
-		bool ok;
-		QString errorMessage;
-		Instruct instruct = Instruct::fromResponse(responseData, &ok, &errorMessage);
-		if(!ok)
-		{
-			respondError("bad-format", errorMessage.toUtf8());
-			return;
-		}
+    void afterSessionCalls() {
+        bool ok;
+        QString errorMessage;
+        Instruct instruct = Instruct::fromResponse(responseData, &ok, &errorMessage);
+        if (!ok) {
+            respondError("bad-format", errorMessage.toUtf8());
+            return;
+        }
 
-		// Don't relay these headers. Their meaning is handled by
-		// zurl and they only apply to the outgoing hop.
-		instruct.response.headers.removeAll("Connection");
-		instruct.response.headers.removeAll("Keep-Alive");
-		instruct.response.headers.removeAll("Content-Encoding");
-		instruct.response.headers.removeAll("Transfer-Encoding");
+        // Don't relay these headers. Their meaning is handled by
+        // zurl and they only apply to the outgoing hop.
+        instruct.response.headers.removeAll("Connection");
+        instruct.response.headers.removeAll("Keep-Alive");
+        instruct.response.headers.removeAll("Content-Encoding");
+        instruct.response.headers.removeAll("Transfer-Encoding");
 
-		if(instruct.holdMode == Instruct::NoHold && instruct.nextLink.isEmpty())
-		{
-			VariantHash result;
+        if (instruct.holdMode == Instruct::NoHold && instruct.nextLink.isEmpty()) {
+            VariantHash result;
 
-			if(!responseSent)
-			{
-				// Apply ResponseContent filters of all channels
-				QStringList allFilters;
-				foreach(const Instruct::Channel &c, instruct.channels)
-				{
-					foreach(const QString &filter, c.filters)
-					{
-						if((Filter::targets(filter) & Filter::ResponseContent) && !allFilters.contains(filter))
-							allFilters += filter;
-					}
-				}
+            if (!responseSent) {
+                // Apply ResponseContent filters of all channels
+                QStringList allFilters;
+                foreach (const Instruct::Channel &c, instruct.channels) {
+                    foreach (const QString &filter, c.filters) {
+                        if ((Filter::targets(filter) & Filter::ResponseContent) &&
+                            !allFilters.contains(filter))
+                            allFilters += filter;
+                    }
+                }
 
-				Filter::Context fc;
-				fc.subscriptionMeta = instruct.meta;
+                Filter::Context fc;
+                fc.subscriptionMeta = instruct.meta;
 
-				FilterStack fs(fc, allFilters);
-				QByteArray body = fs.process(instruct.response.body);
-				if(body.isNull())
-				{
-					req->respondError("bad-format", QString("filter error: %1").arg(fs.errorMessage()).toUtf8());
+                FilterStack fs(fc, allFilters);
+                QByteArray body = fs.process(instruct.response.body);
+                if (body.isNull()) {
+                    req->respondError("bad-format",
+                                      QString("filter error: %1").arg(fs.errorMessage()).toUtf8());
 
-					setFinished(true);
-					return;
-				}
+                    setFinished(true);
+                    return;
+                }
 
-				instruct.response.headers.removeAll("Content-Length");
+                instruct.response.headers.removeAll("Content-Length");
 
-				VariantHash vresponse;
-				vresponse["code"] = instruct.response.code;
-				vresponse["reason"] = instruct.response.reason;
-				VariantList vheaders;
-				foreach(const HttpHeader &h, instruct.response.headers)
-				{
-					VariantList vheader;
-					vheader += h.first.asQByteArray();
-					vheader += h.second.asQByteArray();
-					vheaders += Variant(vheader);
-				}
-				vresponse["headers"] = vheaders;
-				vresponse["body"] = body;
+                VariantHash vresponse;
+                vresponse["code"] = instruct.response.code;
+                vresponse["reason"] = instruct.response.reason;
+                VariantList vheaders;
+                foreach (const HttpHeader &h, instruct.response.headers) {
+                    VariantList vheader;
+                    vheader += h.first.asQByteArray();
+                    vheader += h.second.asQByteArray();
+                    vheaders += Variant(vheader);
+                }
+                vresponse["headers"] = vheaders;
+                vresponse["body"] = body;
 
-				result["response"] = vresponse;
-			}
+                result["response"] = vresponse;
+            }
 
-			req->respond(result);
+            req->respond(result);
 
-			setFinished(true);
-			return;
-		}
+            setFinished(true);
+            return;
+        }
 
-		QByteArray reqFrom = req->from();
+        QByteArray reqFrom = req->from();
 
-		VariantHash result;
-		result["accepted"] = true;
-		req->respond(result);
+        VariantHash result;
+        result["accepted"] = true;
+        req->respond(result);
 
-		log_debug("accepting %d requests from %s", requestStates.count(), reqFrom.data());
+        log_debug("accepting %d requests from %s", requestStates.count(), reqFrom.data());
 
-		if(instruct.holdMode == Instruct::ResponseHold)
-		{
-			bool conflict = false;
-			foreach(const Instruct::Channel &c, instruct.channels)
-			{
-				if(!c.prevId.isNull())
-				{
-					QString name = channelPrefix + c.name;
+        if (instruct.holdMode == Instruct::ResponseHold) {
+            bool conflict = false;
+            foreach (const Instruct::Channel &c, instruct.channels) {
+                if (!c.prevId.isNull()) {
+                    QString name = channelPrefix + c.name;
 
-					QString lastId = cs->publishLastIds.value(name);
-					if(!lastId.isNull() && lastId != c.prevId)
-					{
-						log_debug("last ID inconsistency (got=%s, expected=%s), retrying", qPrintable(c.prevId), qPrintable(lastId));
-						cs->publishLastIds.remove(name);
-						conflict = true;
+                    QString lastId = cs->publishLastIds.value(name);
+                    if (!lastId.isNull() && lastId != c.prevId) {
+                        log_debug("last ID inconsistency (got=%s, expected=%s), retrying",
+                                  qPrintable(c.prevId), qPrintable(lastId));
+                        cs->publishLastIds.remove(name);
+                        conflict = true;
 
-						// NOTE: don't exit loop here. We want to clear
-						// the last ids of all conflicting channels
-					}
-				}
-			}
+                        // NOTE: don't exit loop here. We want to clear
+                        // the last ids of all conflicting channels
+                    }
+                }
+            }
 
-			if(conflict)
-			{
-				RetryRequestPacket rp;
+            if (conflict) {
+                RetryRequestPacket rp;
 
-				foreach(const RequestState &rs, requestStates)
-				{
-					QByteArray cid = rs.rid.first + ':' + rs.rid.second;
+                foreach (const RequestState &rs, requestStates) {
+                    QByteArray cid = rs.rid.first + ':' + rs.rid.second;
 
-					needRemoveFromStats.remove(cid);
+                    needRemoveFromStats.remove(cid);
 
-					int unreportedTime = stats->removeConnection(cid, true, reqFrom);
+                    int unreportedTime = stats->removeConnection(cid, true, reqFrom);
 
-					RetryRequestPacket::Request rpreq;
-					rpreq.rid = rs.rid;
-					rpreq.https = rs.isHttps;
-					rpreq.peerAddress = rs.peerAddress;
-					rpreq.debug = rs.debug;
-					rpreq.autoCrossOrigin = rs.autoCrossOrigin;
-					rpreq.jsonpCallback = rs.jsonpCallback;
-					rpreq.jsonpExtendedResponse = rs.jsonpExtendedResponse;
-					if(!stats->connectionSendEnabled())
-						rpreq.unreportedTime = unreportedTime;
-					rpreq.inSeq = rs.inSeq;
-					rpreq.outSeq = rs.outSeq;
-					rpreq.outCredits = rs.outCredits;
-					rpreq.routerResp = rs.routerResp;
-					rpreq.userData = rs.userData;
+                    RetryRequestPacket::Request rpreq;
+                    rpreq.rid = rs.rid;
+                    rpreq.https = rs.isHttps;
+                    rpreq.peerAddress = rs.peerAddress;
+                    rpreq.debug = rs.debug;
+                    rpreq.autoCrossOrigin = rs.autoCrossOrigin;
+                    rpreq.jsonpCallback = rs.jsonpCallback;
+                    rpreq.jsonpExtendedResponse = rs.jsonpExtendedResponse;
+                    if (!stats->connectionSendEnabled())
+                        rpreq.unreportedTime = unreportedTime;
+                    rpreq.inSeq = rs.inSeq;
+                    rpreq.outSeq = rs.outSeq;
+                    rpreq.outCredits = rs.outCredits;
+                    rpreq.routerResp = rs.routerResp;
+                    rpreq.userData = rs.userData;
 
-					rp.requests += rpreq;
-				}
+                    rp.requests += rpreq;
+                }
 
-				rp.requestData = origRequestData;
+                rp.requestData = origRequestData;
 
-				if(haveInspectInfo)
-				{
-					rp.haveInspectInfo = true;
-					rp.inspectInfo.doProxy = inspectInfo.doProxy;
-					rp.inspectInfo.sharingKey = inspectInfo.sharingKey;
-					rp.inspectInfo.sid = inspectInfo.sid;
-					rp.inspectInfo.lastIds = inspectInfo.lastIds;
-					rp.inspectInfo.userData = inspectInfo.userData;
-				}
+                if (haveInspectInfo) {
+                    rp.haveInspectInfo = true;
+                    rp.inspectInfo.doProxy = inspectInfo.doProxy;
+                    rp.inspectInfo.sharingKey = inspectInfo.sharingKey;
+                    rp.inspectInfo.sid = inspectInfo.sid;
+                    rp.inspectInfo.lastIds = inspectInfo.lastIds;
+                    rp.inspectInfo.userData = inspectInfo.userData;
+                }
 
-				// If prev-id set on channels, set as inspect lastids so the proxy
-				// will pass as Grip-Last in the next request
-				foreach(const Instruct::Channel &c, instruct.channels)
-				{
-					if(!c.prevId.isNull())
-					{
-						if(!rp.haveInspectInfo)
-						{
-							rp.haveInspectInfo = true;
-							rp.inspectInfo.doProxy = true;
-						}
+                // If prev-id set on channels, set as inspect lastids so the proxy
+                // will pass as Grip-Last in the next request
+                foreach (const Instruct::Channel &c, instruct.channels) {
+                    if (!c.prevId.isNull()) {
+                        if (!rp.haveInspectInfo) {
+                            rp.haveInspectInfo = true;
+                            rp.inspectInfo.doProxy = true;
+                        }
 
-						rp.inspectInfo.lastIds.insert(c.name.toUtf8(), c.prevId.toUtf8());
-					}
-				}
+                        rp.inspectInfo.lastIds.insert(c.name.toUtf8(), c.prevId.toUtf8());
+                    }
+                }
 
-				rp.route = route.toUtf8();
-				rp.retrySeq = stats->lastRetrySeq(reqFrom);
+                rp.route = route.toUtf8();
+                rp.retrySeq = stats->lastRetrySeq(reqFrom);
 
-				retryPacketReady(reqFrom, rp);
+                retryPacketReady(reqFrom, rp);
 
-				setFinished(true);
-				return;
-			}
-		}
+                setFinished(true);
+                return;
+            }
+        }
 
-		foreach(const RequestState &rs, requestStates)
-		{
-			ZhttpRequest::Rid rid(rs.rid.first, rs.rid.second);
+        foreach (const RequestState &rs, requestStates) {
+            ZhttpRequest::Rid rid(rs.rid.first, rs.rid.second);
 
-			if(zhttpIn->serverRequestByRid(rid))
-			{
-				log_error("received accept request for rid we already have (%s, %s), skipping", rid.first.data(), rid.second.data());
-				continue;
-			}
+            if (zhttpIn->serverRequestByRid(rid)) {
+                log_error("received accept request for rid we already have (%s, %s), "
+                          "skipping",
+                          rid.first.data(), rid.second.data());
+                continue;
+            }
 
-			ZhttpRequest::ServerState ss;
-			ss.rid = ZhttpRequest::Rid(rs.rid.first, rs.rid.second);
-			ss.peerAddress = rs.peerAddress;
-			ss.requestMethod = requestData.method;
-			ss.requestUri = requestData.uri;
-			ss.requestUri.setScheme(rs.isHttps ? "https" : "http");
-			ss.requestHeaders = requestData.headers;
-			ss.requestBody = requestData.body;
-			ss.responseCode = rs.responseCode;
-			ss.inSeq = rs.inSeq;
-			ss.outSeq = rs.outSeq;
-			ss.outCredits = rs.outCredits;
-			ss.routerResp = rs.routerResp;
-			ss.userData = rs.userData;
+            ZhttpRequest::ServerState ss;
+            ss.rid = ZhttpRequest::Rid(rs.rid.first, rs.rid.second);
+            ss.peerAddress = rs.peerAddress;
+            ss.requestMethod = requestData.method;
+            ss.requestUri = requestData.uri;
+            ss.requestUri.setScheme(rs.isHttps ? "https" : "http");
+            ss.requestHeaders = requestData.headers;
+            ss.requestBody = requestData.body;
+            ss.responseCode = rs.responseCode;
+            ss.inSeq = rs.inSeq;
+            ss.outSeq = rs.outSeq;
+            ss.outCredits = rs.outCredits;
+            ss.routerResp = rs.routerResp;
+            ss.userData = rs.userData;
 
-			// Take over responsibility for request
-			ZhttpRequest *httpReq = zhttpIn->createRequestFromState(ss);
+            // Take over responsibility for request
+            ZhttpRequest *httpReq = zhttpIn->createRequestFromState(ss);
 
-			QSet<QString> implicitChannelsSet;
-			foreach(const QString &channel, implicitChannels)
-				implicitChannelsSet += channel;
+            QSet<QString> implicitChannelsSet;
+            foreach (const QString &channel, implicitChannels)
+                implicitChannelsSet += channel;
 
-			HttpSession::AcceptData adata;
-			adata.from = reqFrom;
-			adata.requestData = origRequestData;
-			adata.logicalPeerAddress = rs.logicalPeerAddress;
-			adata.debug = rs.debug;
-			adata.isRetry = rs.isRetry;
-			adata.autoCrossOrigin = rs.autoCrossOrigin;
-			adata.jsonpCallback = rs.jsonpCallback;
-			adata.jsonpExtendedResponse = rs.jsonpExtendedResponse;
-			adata.unreportedTime = rs.unreportedTime;
-			adata.route = route;
-			adata.statsRoute = statsRoute;
-			adata.channelPrefix = channelPrefix;
-			adata.logLevel = logLevel;
-			adata.implicitChannels = implicitChannelsSet;
-			adata.sid = sid;
-			adata.responseSent = responseSent;
-			adata.trusted = trusted;
-			adata.haveInspectInfo = haveInspectInfo;
-			adata.inspectInfo = inspectInfo;
+            HttpSession::AcceptData adata;
+            adata.from = reqFrom;
+            adata.requestData = origRequestData;
+            adata.logicalPeerAddress = rs.logicalPeerAddress;
+            adata.debug = rs.debug;
+            adata.isRetry = rs.isRetry;
+            adata.autoCrossOrigin = rs.autoCrossOrigin;
+            adata.jsonpCallback = rs.jsonpCallback;
+            adata.jsonpExtendedResponse = rs.jsonpExtendedResponse;
+            adata.unreportedTime = rs.unreportedTime;
+            adata.route = route;
+            adata.statsRoute = statsRoute;
+            adata.channelPrefix = channelPrefix;
+            adata.logLevel = logLevel;
+            adata.implicitChannels = implicitChannelsSet;
+            adata.sid = sid;
+            adata.responseSent = responseSent;
+            adata.trusted = trusted;
+            adata.haveInspectInfo = haveInspectInfo;
+            adata.inspectInfo = inspectInfo;
 
-			QByteArray cid = rid.first + ':' + rid.second;
-			needRemoveFromStats.remove(cid);
+            QByteArray cid = rid.first + ':' + rid.second;
+            needRemoveFromStats.remove(cid);
 
-			sessions += std::make_shared<HttpSession>(httpReq, adata, instruct, zhttpOut, stats, updateLimiter, filterLimiter, &cs->publishLastIds, httpSessionUpdateManager, connectionSubscriptionMax);
-		}
+            sessions += std::make_shared<HttpSession>(
+                httpReq, adata, instruct, zhttpOut, stats, updateLimiter, filterLimiter,
+                &cs->publishLastIds, httpSessionUpdateManager, connectionSubscriptionMax);
+        }
 
-		// Engine should directly connect to this and register the holds
-		// immediately, to avoid a race with the lastId check
-		sessionsReady();
+        // Engine should directly connect to this and register the holds
+        // immediately, to avoid a race with the lastId check
+        sessionsReady();
 
-		setFinished(true);
-	}
+        setFinished(true);
+    }
 
-	void sessionDetectRulesSet_finished(Deferred *d, const DeferredResult &result)
-	{
-		deferreds.erase(d);
+    void sessionDetectRulesSet_finished(Deferred *d, const DeferredResult &result) {
+        deferreds.erase(d);
 
-		if(!result.success)
-			log_error("couldn't store detection rules: condition=%d", result.value.toInt());
+        if (!result.success)
+            log_error("couldn't store detection rules: condition=%d", result.value.toInt());
 
-		afterSetRules();
-	}
+        afterSetRules();
+    }
 
-	void sessionCreateOrUpdate_finished(Deferred *d, const DeferredResult &result)
-	{
-		deferreds.erase(d);
+    void sessionCreateOrUpdate_finished(Deferred *d, const DeferredResult &result) {
+        deferreds.erase(d);
 
-		if(!result.success)
-			log_error("couldn't create/update session: condition=%d", result.value.toInt());
+        if (!result.success)
+            log_error("couldn't create/update session: condition=%d", result.value.toInt());
 
-		afterSessionCalls();
-	}
+        afterSessionCalls();
+    }
 };
 
-class Subscription
-{
+class Subscription {
 public:
-	Subscription(const QString &channel) :
-		channel_(channel)
-	{
-	}
+    Subscription(const QString &channel) : channel_(channel) {}
 
-	const QString & channel() const
-	{
-		return channel_;
-	}
+    const QString &channel() const { return channel_; }
 
-	void start()
-	{
-		timer_ = std::make_unique<Timer>();
-		timer_->timeout.connect(boost::bind(&Subscription::timer_timeout, this));
-		timer_->setSingleShot(true);
-		timer_->start(SUBSCRIBED_DELAY);
-	}
+    void start() {
+        timer_ = std::make_unique<Timer>();
+        timer_->timeout.connect(boost::bind(&Subscription::timer_timeout, this));
+        timer_->setSingleShot(true);
+        timer_->start(SUBSCRIBED_DELAY);
+    }
 
-	Signal subscribed;
+    Signal subscribed;
 
 private:
-	QString channel_;
-	std::unique_ptr<Timer> timer_;
+    QString channel_;
+    std::unique_ptr<Timer> timer_;
 
-	void timer_timeout()
-	{
-		subscribed();
-	}
+    void timer_timeout() { subscribed(); }
 };
 
-class HandlerEngine::Private
-{
+class HandlerEngine::Private {
 public:
-	class PublishAction : public RateLimiter::Action
-	{
-	public:
-		std::weak_ptr<HandlerEngine::Private> ep;
-		std::weak_ptr<ClientSession> target;
-		PublishItem item;
-		QList<QByteArray> exposeHeaders;
-
-		PublishAction(const std::weak_ptr<HandlerEngine::Private> _ep, const std::weak_ptr<ClientSession> _target, const PublishItem &_item, const QList<QByteArray> &_exposeHeaders = QList<QByteArray>()) :
-			ep(_ep),
-			target(_target),
-			item(_item),
-			exposeHeaders(_exposeHeaders)
-		{
-		}
-
-		virtual bool execute()
-		{
-			auto epl = ep.lock();
-			if(!epl)
-				return false;
-
-			auto targetl = target.lock();
-			if(!targetl)
-				return false;
-
-			epl->publishSend(targetl, item, exposeHeaders);
-			return true;
-		}
-	};
-
-	struct WSSessionConnections {
-		Connection sendConnection;
-		Connection expConnection;
-		Connection errorConnection;
-	};
-
-	HandlerEngine *q;
-	Configuration config;
-	std::unique_ptr<ZhttpManager> zhttpIn;
-	std::unique_ptr<ZhttpManager> zhttpOut;
-	std::unique_ptr<ZrpcManager> inspectServer;
-	std::unique_ptr<ZrpcManager> acceptServer;
-	std::unique_ptr<ZrpcManager> stateClient;
-	std::unique_ptr<ZrpcManager> controlServer;
-	std::unique_ptr<ZrpcManager> proxyControlClient;
-	std::unique_ptr<ZmqSocket> inPullSock;
-	std::unique_ptr<ZmqValve> inPullValve;
-	std::unique_ptr<ZmqSocket> inSubSock;
-	std::unique_ptr<ZmqValve> inSubValve;
-	std::unique_ptr<ZmqSocket> retrySock;
-	std::unique_ptr<ZmqSocket> wsControlInitSock;
-	std::unique_ptr<ZmqValve> wsControlInitValve;
-	std::unique_ptr<ZmqSocket> wsControlStreamSock;
-	std::unique_ptr<ZmqValve> wsControlStreamValve;
-	std::unique_ptr<ZmqSocket> statsSock;
-	std::unique_ptr<ZmqSocket> proxyStatsSock;
-	std::unique_ptr<ZmqValve> proxyStatsValve;
-	std::unique_ptr<SimpleHttpServer> controlHttpServer;
-	std::unique_ptr<StatsManager> stats;
-	std::unique_ptr<RateLimiter> publishLimiter;
-	std::unique_ptr<RateLimiter> updateLimiter;
-	std::shared_ptr<RateLimiter> filterLimiter;
-	std::shared_ptr<HttpSessionUpdateManager> httpSessionUpdateManager;
-	std::unique_ptr<Sequencer> sequencer;
-	CommonState cs;
-	QSet<InspectWorker*> inspectWorkers;
-	QSet<AcceptWorker*> acceptWorkers;
-	std::unique_ptr<Deferred> report;
-	std::map<Deferred*, std::unique_ptr<Deferred>> deferreds;
-	Connection inspectReqReadyConnection;
-	Connection acceptReqReadyConnection;
-	Connection controlReqReadyConnection;
-	Connection controlServerConnection;
-	Connection itemReadyConnection;
-	map<Subscription*, Connection> subscribedConnection;
-	Connection connectionsRefreshedConnection;
-	Connection unsubscribedConnection;
-	map<WsSession*, WSSessionConnections> wsSessionConnectionMap;
-	Connection pullConnection;
-	Connection controlInitValveConnection;
-	Connection controlStreamValveConnection;
-	Connection inSubValveConnection;
-	Connection proxyStatConnection;
-
-	Private(HandlerEngine *_q) :
-		q(_q)
-	{
-		qRegisterMetaType<DetectRuleList>();
-
-		publishLimiter = std::make_unique<RateLimiter>();
-		updateLimiter = std::make_unique<RateLimiter>();
-		filterLimiter = std::make_shared<RateLimiter>();
-
-		httpSessionUpdateManager = std::make_shared<HttpSessionUpdateManager>();
-
-		sequencer = std::make_unique<Sequencer>(&cs.publishLastIds);
-		itemReadyConnection = sequencer->itemReady.connect(boost::bind(&Private::sequencer_itemReady, this, boost::placeholders::_1));
-	}
-
-	~Private()
-	{
-		qDeleteAll(inspectWorkers);
-		qDeleteAll(acceptWorkers);
-		deferreds.clear();
-		cs.wsSessions.clear();
-		cs.httpSessions.clear();
-		qDeleteAll(cs.subs);
-	}
-
-	bool start(const Configuration &_config)
-	{
-		config = _config;
-
-		publishLimiter->setRate(config.messageRate);
-		publishLimiter->setHwm(config.messageHwm);
-
-		updateLimiter->setRate(10);
-		updateLimiter->setBatchWaitEnabled(true);
-
-		filterLimiter->setRate(100);
-
-		sequencer->setWaitMax(config.messageWait);
-		sequencer->setIdCacheTtl(config.idCacheTtl);
-
-		zhttpIn = std::make_unique<ZhttpManager>();
-		zhttpIn->setInstanceId(config.instanceId);
-		zhttpIn->setServerInStreamSpecs(config.serverInStreamSpecs);
-		zhttpIn->setServerOutSpecs(config.serverOutSpecs);
-
-		zhttpOut = std::make_unique<ZhttpManager>();
-		zhttpOut->setInstanceId(config.instanceId);
-		zhttpOut->setClientOutSpecs(config.clientOutSpecs);
-		zhttpOut->setClientOutStreamSpecs(config.clientOutStreamSpecs);
-		zhttpOut->setClientInSpecs(config.clientInSpecs);
-
-		log_debug("zhttp in stream: %s", qPrintable(config.serverInStreamSpecs.join(", ")));
-		log_debug("zhttp out: %s", qPrintable(config.serverOutSpecs.join(", ")));
-
-		if(!config.inspectSpecs.isEmpty())
-		{
-			inspectServer = std::make_unique<ZrpcManager>();
-			inspectServer->setBind(false);
-			inspectServer->setIpcFileMode(config.ipcFileMode);
-			inspectReqReadyConnection = inspectServer->requestReady.connect(boost::bind(&Private::inspectServer_requestReady, this));
-
-			if(!inspectServer->setServerSpecs(config.inspectSpecs))
-			{
-				// Zrpcmanager logs error
-				return false;
-			}
-
-			log_debug("inspect server: %s", qPrintable(config.inspectSpecs.join(", ")));
-		}
-
-		if(!config.acceptSpecs.isEmpty())
-		{
-			acceptServer = std::make_unique<ZrpcManager>();
-			acceptServer->setBind(false);
-			acceptServer->setIpcFileMode(config.ipcFileMode);
-			acceptReqReadyConnection = acceptServer->requestReady.connect(boost::bind(&Private::acceptServer_requestReady, this));
-
-			if(!acceptServer->setServerSpecs(config.acceptSpecs))
-			{
-				// Zrpcmanager logs error
-				return false;
-			}
-
-			log_debug("accept server: %s", qPrintable(config.acceptSpecs.join(", ")));
-		}
-
-		if(!config.stateSpec.isEmpty())
-		{
-			stateClient = std::make_unique<ZrpcManager>();
-			stateClient->setBind(true);
-			stateClient->setIpcFileMode(config.ipcFileMode);
-			stateClient->setTimeout(STATE_RPC_TIMEOUT);
-
-			if(!stateClient->setClientSpecs(QStringList() << config.stateSpec))
-			{
-				// Zrpcmanager logs error
-				return false;
-			}
-
-			log_debug("state client: %s", qPrintable(config.stateSpec));
-		}
-
-		if(!config.commandSpec.isEmpty())
-		{
-			controlServer = std::make_unique<ZrpcManager>();
-			controlServer->setBind(true);
-			controlServer->setIpcFileMode(config.ipcFileMode);
-			controlReqReadyConnection = controlServer->requestReady.connect(boost::bind(&Private::controlServer_requestReady, this));
-
-			if(!controlServer->setServerSpecs(QStringList() << config.commandSpec))
-			{
-				// Zrpcmanager logs error
-				return false;
-			}
-
-			log_debug("control server: %s", qPrintable(config.commandSpec));
-		}
-
-		if(!config.pushInSpec.isEmpty())
-		{
-			inPullSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
-			inPullSock->setHwm(DEFAULT_HWM);
-
-			QString errorMessage;
-			if(!ZUtil::setupSocket(inPullSock.get(), config.pushInSpec, true, config.ipcFileMode, &errorMessage))
-			{
-				log_error("%s", qPrintable(errorMessage));
-				return false;
-			}
-
-			inPullValve = std::make_unique<ZmqValve>(inPullSock.get());
-			pullConnection = inPullValve->readyRead.connect(boost::bind(&Private::inPull_readyRead, this, boost::placeholders::_1));
-
-			log_debug("in pull: %s", qPrintable(config.pushInSpec));
-		}
-
-		if(!config.pushInSubSpecs.isEmpty())
-		{
-			inSubSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-			inSubSock->setSendHwm(SUB_SNDHWM);
-			inSubSock->setShutdownWaitTime(0);
-
-			QString errorMessage;
-			if(!ZUtil::setupSocket(inSubSock.get(), config.pushInSubSpecs, !config.pushInSubConnect, config.ipcFileMode, &errorMessage))
-			{
-				log_error("%s", qPrintable(errorMessage));
-				return false;
-			}
-
-			if(config.pushInSubConnect)
-			{
-				// Some sane TCP keep-alive settings
-				// idle=30, cnt=6, intvl=5
-				inSubSock->setTcpKeepAliveEnabled(true);
-				inSubSock->setTcpKeepAliveParameters(30, 6, 5);
-			}
-
-			inSubValve = std::make_unique<ZmqValve>(inSubSock.get());
-			inSubValveConnection = inSubValve->readyRead.connect(boost::bind(&Private::inSub_readyRead, this, boost::placeholders::_1));
-
-			log_debug("in sub: %s", qPrintable(config.pushInSubSpecs.join(", ")));
-		}
-
-		if(!config.retryOutSpecs.isEmpty())
-		{
-			retrySock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-			retrySock->setImmediateEnabled(true);
-			retrySock->setHwm(DEFAULT_HWM);
-			retrySock->setShutdownWaitTime(RETRY_WAIT_TIME);
-			retrySock->setRouterMandatoryEnabled(true);
-
-			foreach(const QString &spec, config.retryOutSpecs)
-			{
-				QString errorMessage;
-				if(!ZUtil::setupSocket(retrySock.get(), spec, false, config.ipcFileMode, &errorMessage))
-				{
-					log_error("%s", qPrintable(errorMessage));
-					return false;
-				}
-			}
-
-			log_debug("retry: %s", qPrintable(config.retryOutSpecs.join(", ")));
-		}
-
-		if(!config.wsControlInitSpecs.isEmpty() && !config.wsControlStreamSpecs.isEmpty())
-		{
-			wsControlInitSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
-			wsControlInitSock->setHwm(DEFAULT_HWM);
-
-			foreach(const QString &spec, config.wsControlInitSpecs)
-			{
-				QString errorMessage;
-				if(!ZUtil::setupSocket(wsControlInitSock.get(), spec, false, config.ipcFileMode, &errorMessage))
-				{
-					log_error("%s", qPrintable(errorMessage));
-					return false;
-				}
-			}
-
-			wsControlInitValve = std::make_unique<ZmqValve>(wsControlInitSock.get());
-			controlInitValveConnection = wsControlInitValve->readyRead.connect(boost::bind(&Private::wsControlInit_readyRead, this, boost::placeholders::_1));
-
-			log_debug("ws control init: %s", qPrintable(config.wsControlInitSpecs.join(", ")));
-
-			wsControlStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-			wsControlStreamSock->setIdentity(config.instanceId);
-			wsControlStreamSock->setImmediateEnabled(true);
-			wsControlStreamSock->setHwm(DEFAULT_HWM);
-			wsControlStreamSock->setShutdownWaitTime(WSCONTROL_WAIT_TIME);
-
-			foreach(const QString &spec, config.wsControlStreamSpecs)
-			{
-				QString errorMessage;
-				if(!ZUtil::setupSocket(wsControlStreamSock.get(), spec, false, config.ipcFileMode, &errorMessage))
-				{
-					log_error("%s", qPrintable(errorMessage));
-					return false;
-				}
-			}
-
-			wsControlStreamValve = std::make_unique<ZmqValve>(wsControlStreamSock.get());
-			controlStreamValveConnection = wsControlStreamValve->readyRead.connect(boost::bind(&Private::wsControlStream_readyRead, this, boost::placeholders::_1));
-
-			log_debug("ws control stream: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
-		}
-
-		stats = std::make_unique<StatsManager>(config.connectionsMax, config.connectionsMax * config.connectionSubscriptionMax, PROMETHEUS_CONNECTIONS_MAX);
-		connectionsRefreshedConnection = stats->connectionsRefreshed.connect(boost::bind(&Private::stats_connectionsRefreshed, this, boost::placeholders::_1));
-		unsubscribedConnection = stats->unsubscribed.connect(boost::bind(&Private::stats_unsubscribed, this, boost::placeholders::_1, boost::placeholders::_2));
-
-		stats->setConnectionSendEnabled(config.statsConnectionSend);
-		stats->setConnectionTtl(config.statsConnectionTtl);
-		stats->setSubscriptionTtl(config.statsSubscriptionTtl);
-		stats->setSubscriptionLinger(config.subscriptionLinger);
-		stats->setReportInterval(config.statsReportInterval);
-
-		if(config.statsFormat == "json")
-		{
-			stats->setOutputFormat(StatsManager::JsonFormat);
-		}
-		else
-		{
-			stats->setOutputFormat(StatsManager::TnetStringFormat);
-		}
-
-		if(!config.statsSpec.isEmpty())
-		{
-			stats->setInstanceId(config.instanceId);
-			stats->setIpcFileMode(config.ipcFileMode);
-
-			if(!stats->setSpec(config.statsSpec))
-			{
-				// Statsmanager logs error
-				return false;
-			}
-
-			log_debug("stats: %s", qPrintable(config.statsSpec));
-		}
-
-		if(!config.prometheusPort.isEmpty())
-		{
-			stats->setPrometheusPrefix(config.prometheusPrefix);
-
-			if(!stats->setPrometheusPort(config.prometheusPort))
-			{
-				log_error("unable to bind to prometheus port: %s", qPrintable(config.prometheusPort));
-				return false;
-			}
-		}
-
-		if(!config.proxyStatsSpecs.isEmpty())
-		{
-			proxyStatsSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-			proxyStatsSock->setHwm(DEFAULT_HWM);
-			proxyStatsSock->setShutdownWaitTime(0);
-			proxyStatsSock->subscribe("");
-
-			foreach(const QString &spec, config.proxyStatsSpecs)
-			{
-				QString errorMessage;
-				if(!ZUtil::setupSocket(proxyStatsSock.get(), spec, false, config.ipcFileMode, &errorMessage))
-				{
-						log_error("%s", qPrintable(errorMessage));
-						return false;
-				}
-			}
-
-			proxyStatsValve = std::make_unique<ZmqValve>(proxyStatsSock.get());
-			proxyStatConnection = proxyStatsValve->readyRead.connect(boost::bind(&Private::proxyStats_readyRead, this, boost::placeholders::_1));
-
-			log_debug("proxy stats: %s", qPrintable(config.proxyStatsSpecs.join(", ")));
-		}
-
-		if(!config.proxyCommandSpec.isEmpty())
-		{
-			proxyControlClient = std::make_unique<ZrpcManager>();
-			proxyControlClient->setIpcFileMode(config.ipcFileMode);
-			proxyControlClient->setTimeout(PROXY_RPC_TIMEOUT);
-
-			if(!proxyControlClient->setClientSpecs(QStringList() << config.proxyCommandSpec))
-			{
-				// Zrpcmanager logs error
-				return false;
-			}
-
-			log_debug("proxy control client: %s", qPrintable(config.proxyCommandSpec));
-		}
-
-		if(config.pushInHttpPort != -1)
-		{
-			controlHttpServer = std::make_unique<SimpleHttpServer>(CONTROL_CONNECTIONS_MAX, config.pushInHttpMaxHeadersSize, config.pushInHttpMaxBodySize);
-			controlServerConnection = controlHttpServer->requestReady.connect(boost::bind(&Private::controlHttpServer_requestReady, this));
-			controlHttpServer->listen(config.pushInHttpAddr, config.pushInHttpPort);
-
-			log_info("http control server: %s:%d", qPrintable(config.pushInHttpAddr.toString()), config.pushInHttpPort);
-		}
-
-		if(inPullValve)
-			inPullValve->open();
-		if(inSubValve)
-			inSubValve->open();
-		if(wsControlInitValve)
-			wsControlInitValve->open();
-		if(wsControlStreamValve)
-			wsControlStreamValve->open();
-		if(proxyStatsValve)
-			proxyStatsValve->open();
-
-		return true;
-	}
-
-	void reload()
-	{
-		// Nothing to do
-	}
+    class PublishAction : public RateLimiter::Action {
+    public:
+        std::weak_ptr<HandlerEngine::Private> ep;
+        std::weak_ptr<ClientSession> target;
+        PublishItem item;
+        QList<QByteArray> exposeHeaders;
+
+        PublishAction(const std::weak_ptr<HandlerEngine::Private> _ep,
+                      const std::weak_ptr<ClientSession> _target, const PublishItem &_item,
+                      const QList<QByteArray> &_exposeHeaders = QList<QByteArray>())
+            : ep(_ep), target(_target), item(_item), exposeHeaders(_exposeHeaders) {}
+
+        virtual bool execute() {
+            auto epl = ep.lock();
+            if (!epl)
+                return false;
+
+            auto targetl = target.lock();
+            if (!targetl)
+                return false;
+
+            epl->publishSend(targetl, item, exposeHeaders);
+            return true;
+        }
+    };
+
+    struct WSSessionConnections {
+        Connection sendConnection;
+        Connection expConnection;
+        Connection errorConnection;
+    };
+
+    HandlerEngine *q;
+    Configuration config;
+    std::unique_ptr<ZhttpManager> zhttpIn;
+    std::unique_ptr<ZhttpManager> zhttpOut;
+    std::unique_ptr<ZrpcManager> inspectServer;
+    std::unique_ptr<ZrpcManager> acceptServer;
+    std::unique_ptr<ZrpcManager> stateClient;
+    std::unique_ptr<ZrpcManager> controlServer;
+    std::unique_ptr<ZrpcManager> proxyControlClient;
+    std::unique_ptr<ZmqSocket> inPullSock;
+    std::unique_ptr<ZmqValve> inPullValve;
+    std::unique_ptr<ZmqSocket> inSubSock;
+    std::unique_ptr<ZmqValve> inSubValve;
+    std::unique_ptr<ZmqSocket> retrySock;
+    std::unique_ptr<ZmqSocket> wsControlInitSock;
+    std::unique_ptr<ZmqValve> wsControlInitValve;
+    std::unique_ptr<ZmqSocket> wsControlStreamSock;
+    std::unique_ptr<ZmqValve> wsControlStreamValve;
+    std::unique_ptr<ZmqSocket> statsSock;
+    std::unique_ptr<ZmqSocket> proxyStatsSock;
+    std::unique_ptr<ZmqValve> proxyStatsValve;
+    std::unique_ptr<SimpleHttpServer> controlHttpServer;
+    std::unique_ptr<StatsManager> stats;
+    std::unique_ptr<RateLimiter> publishLimiter;
+    std::unique_ptr<RateLimiter> updateLimiter;
+    std::shared_ptr<RateLimiter> filterLimiter;
+    std::shared_ptr<HttpSessionUpdateManager> httpSessionUpdateManager;
+    std::unique_ptr<Sequencer> sequencer;
+    CommonState cs;
+    QSet<InspectWorker *> inspectWorkers;
+    QSet<AcceptWorker *> acceptWorkers;
+    std::unique_ptr<Deferred> report;
+    std::map<Deferred *, std::unique_ptr<Deferred>> deferreds;
+    Connection inspectReqReadyConnection;
+    Connection acceptReqReadyConnection;
+    Connection controlReqReadyConnection;
+    Connection controlServerConnection;
+    Connection itemReadyConnection;
+    map<Subscription *, Connection> subscribedConnection;
+    Connection connectionsRefreshedConnection;
+    Connection unsubscribedConnection;
+    map<WsSession *, WSSessionConnections> wsSessionConnectionMap;
+    Connection pullConnection;
+    Connection controlInitValveConnection;
+    Connection controlStreamValveConnection;
+    Connection inSubValveConnection;
+    Connection proxyStatConnection;
+
+    Private(HandlerEngine *_q) : q(_q) {
+        qRegisterMetaType<DetectRuleList>();
+
+        publishLimiter = std::make_unique<RateLimiter>();
+        updateLimiter = std::make_unique<RateLimiter>();
+        filterLimiter = std::make_shared<RateLimiter>();
+
+        httpSessionUpdateManager = std::make_shared<HttpSessionUpdateManager>();
+
+        sequencer = std::make_unique<Sequencer>(&cs.publishLastIds);
+        itemReadyConnection = sequencer->itemReady.connect(
+            boost::bind(&Private::sequencer_itemReady, this, boost::placeholders::_1));
+    }
+
+    ~Private() {
+        qDeleteAll(inspectWorkers);
+        qDeleteAll(acceptWorkers);
+        deferreds.clear();
+        cs.wsSessions.clear();
+        cs.httpSessions.clear();
+        qDeleteAll(cs.subs);
+    }
+
+    bool start(const Configuration &_config) {
+        config = _config;
+
+        publishLimiter->setRate(config.messageRate);
+        publishLimiter->setHwm(config.messageHwm);
+
+        updateLimiter->setRate(10);
+        updateLimiter->setBatchWaitEnabled(true);
+
+        filterLimiter->setRate(100);
+
+        sequencer->setWaitMax(config.messageWait);
+        sequencer->setIdCacheTtl(config.idCacheTtl);
+
+        zhttpIn = std::make_unique<ZhttpManager>();
+        zhttpIn->setInstanceId(config.instanceId);
+        zhttpIn->setServerInStreamSpecs(config.serverInStreamSpecs);
+        zhttpIn->setServerOutSpecs(config.serverOutSpecs);
+
+        zhttpOut = std::make_unique<ZhttpManager>();
+        zhttpOut->setInstanceId(config.instanceId);
+        zhttpOut->setClientOutSpecs(config.clientOutSpecs);
+        zhttpOut->setClientOutStreamSpecs(config.clientOutStreamSpecs);
+        zhttpOut->setClientInSpecs(config.clientInSpecs);
+
+        log_debug("zhttp in stream: %s", qPrintable(config.serverInStreamSpecs.join(", ")));
+        log_debug("zhttp out: %s", qPrintable(config.serverOutSpecs.join(", ")));
+
+        if (!config.inspectSpecs.isEmpty()) {
+            inspectServer = std::make_unique<ZrpcManager>();
+            inspectServer->setBind(false);
+            inspectServer->setIpcFileMode(config.ipcFileMode);
+            inspectReqReadyConnection = inspectServer->requestReady.connect(
+                boost::bind(&Private::inspectServer_requestReady, this));
+
+            if (!inspectServer->setServerSpecs(config.inspectSpecs)) {
+                // Zrpcmanager logs error
+                return false;
+            }
+
+            log_debug("inspect server: %s", qPrintable(config.inspectSpecs.join(", ")));
+        }
+
+        if (!config.acceptSpecs.isEmpty()) {
+            acceptServer = std::make_unique<ZrpcManager>();
+            acceptServer->setBind(false);
+            acceptServer->setIpcFileMode(config.ipcFileMode);
+            acceptReqReadyConnection = acceptServer->requestReady.connect(
+                boost::bind(&Private::acceptServer_requestReady, this));
+
+            if (!acceptServer->setServerSpecs(config.acceptSpecs)) {
+                // Zrpcmanager logs error
+                return false;
+            }
+
+            log_debug("accept server: %s", qPrintable(config.acceptSpecs.join(", ")));
+        }
+
+        if (!config.stateSpec.isEmpty()) {
+            stateClient = std::make_unique<ZrpcManager>();
+            stateClient->setBind(true);
+            stateClient->setIpcFileMode(config.ipcFileMode);
+            stateClient->setTimeout(STATE_RPC_TIMEOUT);
+
+            if (!stateClient->setClientSpecs(QStringList() << config.stateSpec)) {
+                // Zrpcmanager logs error
+                return false;
+            }
+
+            log_debug("state client: %s", qPrintable(config.stateSpec));
+        }
+
+        if (!config.commandSpec.isEmpty()) {
+            controlServer = std::make_unique<ZrpcManager>();
+            controlServer->setBind(true);
+            controlServer->setIpcFileMode(config.ipcFileMode);
+            controlReqReadyConnection = controlServer->requestReady.connect(
+                boost::bind(&Private::controlServer_requestReady, this));
+
+            if (!controlServer->setServerSpecs(QStringList() << config.commandSpec)) {
+                // Zrpcmanager logs error
+                return false;
+            }
+
+            log_debug("control server: %s", qPrintable(config.commandSpec));
+        }
+
+        if (!config.pushInSpec.isEmpty()) {
+            inPullSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+            inPullSock->setHwm(DEFAULT_HWM);
+
+            QString errorMessage;
+            if (!ZUtil::setupSocket(inPullSock.get(), config.pushInSpec, true, config.ipcFileMode,
+                                    &errorMessage)) {
+                log_error("%s", qPrintable(errorMessage));
+                return false;
+            }
+
+            inPullValve = std::make_unique<ZmqValve>(inPullSock.get());
+            pullConnection = inPullValve->readyRead.connect(
+                boost::bind(&Private::inPull_readyRead, this, boost::placeholders::_1));
+
+            log_debug("in pull: %s", qPrintable(config.pushInSpec));
+        }
+
+        if (!config.pushInSubSpecs.isEmpty()) {
+            inSubSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+            inSubSock->setSendHwm(SUB_SNDHWM);
+            inSubSock->setShutdownWaitTime(0);
+
+            QString errorMessage;
+            if (!ZUtil::setupSocket(inSubSock.get(), config.pushInSubSpecs,
+                                    !config.pushInSubConnect, config.ipcFileMode, &errorMessage)) {
+                log_error("%s", qPrintable(errorMessage));
+                return false;
+            }
+
+            if (config.pushInSubConnect) {
+                // Some sane TCP keep-alive settings
+                // idle=30, cnt=6, intvl=5
+                inSubSock->setTcpKeepAliveEnabled(true);
+                inSubSock->setTcpKeepAliveParameters(30, 6, 5);
+            }
+
+            inSubValve = std::make_unique<ZmqValve>(inSubSock.get());
+            inSubValveConnection = inSubValve->readyRead.connect(
+                boost::bind(&Private::inSub_readyRead, this, boost::placeholders::_1));
+
+            log_debug("in sub: %s", qPrintable(config.pushInSubSpecs.join(", ")));
+        }
+
+        if (!config.retryOutSpecs.isEmpty()) {
+            retrySock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+            retrySock->setImmediateEnabled(true);
+            retrySock->setHwm(DEFAULT_HWM);
+            retrySock->setShutdownWaitTime(RETRY_WAIT_TIME);
+            retrySock->setRouterMandatoryEnabled(true);
+
+            foreach (const QString &spec, config.retryOutSpecs) {
+                QString errorMessage;
+                if (!ZUtil::setupSocket(retrySock.get(), spec, false, config.ipcFileMode,
+                                        &errorMessage)) {
+                    log_error("%s", qPrintable(errorMessage));
+                    return false;
+                }
+            }
+
+            log_debug("retry: %s", qPrintable(config.retryOutSpecs.join(", ")));
+        }
+
+        if (!config.wsControlInitSpecs.isEmpty() && !config.wsControlStreamSpecs.isEmpty()) {
+            wsControlInitSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+            wsControlInitSock->setHwm(DEFAULT_HWM);
+
+            foreach (const QString &spec, config.wsControlInitSpecs) {
+                QString errorMessage;
+                if (!ZUtil::setupSocket(wsControlInitSock.get(), spec, false, config.ipcFileMode,
+                                        &errorMessage)) {
+                    log_error("%s", qPrintable(errorMessage));
+                    return false;
+                }
+            }
+
+            wsControlInitValve = std::make_unique<ZmqValve>(wsControlInitSock.get());
+            controlInitValveConnection = wsControlInitValve->readyRead.connect(
+                boost::bind(&Private::wsControlInit_readyRead, this, boost::placeholders::_1));
+
+            log_debug("ws control init: %s", qPrintable(config.wsControlInitSpecs.join(", ")));
+
+            wsControlStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+            wsControlStreamSock->setIdentity(config.instanceId);
+            wsControlStreamSock->setImmediateEnabled(true);
+            wsControlStreamSock->setHwm(DEFAULT_HWM);
+            wsControlStreamSock->setShutdownWaitTime(WSCONTROL_WAIT_TIME);
+
+            foreach (const QString &spec, config.wsControlStreamSpecs) {
+                QString errorMessage;
+                if (!ZUtil::setupSocket(wsControlStreamSock.get(), spec, false, config.ipcFileMode,
+                                        &errorMessage)) {
+                    log_error("%s", qPrintable(errorMessage));
+                    return false;
+                }
+            }
+
+            wsControlStreamValve = std::make_unique<ZmqValve>(wsControlStreamSock.get());
+            controlStreamValveConnection = wsControlStreamValve->readyRead.connect(
+                boost::bind(&Private::wsControlStream_readyRead, this, boost::placeholders::_1));
+
+            log_debug("ws control stream: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
+        }
+
+        stats = std::make_unique<StatsManager>(
+            config.connectionsMax, config.connectionsMax * config.connectionSubscriptionMax,
+            PROMETHEUS_CONNECTIONS_MAX);
+        connectionsRefreshedConnection = stats->connectionsRefreshed.connect(
+            boost::bind(&Private::stats_connectionsRefreshed, this, boost::placeholders::_1));
+        unsubscribedConnection = stats->unsubscribed.connect(boost::bind(
+            &Private::stats_unsubscribed, this, boost::placeholders::_1, boost::placeholders::_2));
+
+        stats->setConnectionSendEnabled(config.statsConnectionSend);
+        stats->setConnectionTtl(config.statsConnectionTtl);
+        stats->setSubscriptionTtl(config.statsSubscriptionTtl);
+        stats->setSubscriptionLinger(config.subscriptionLinger);
+        stats->setReportInterval(config.statsReportInterval);
+
+        if (config.statsFormat == "json") {
+            stats->setOutputFormat(StatsManager::JsonFormat);
+        } else {
+            stats->setOutputFormat(StatsManager::TnetStringFormat);
+        }
+
+        if (!config.statsSpec.isEmpty()) {
+            stats->setInstanceId(config.instanceId);
+            stats->setIpcFileMode(config.ipcFileMode);
+
+            if (!stats->setSpec(config.statsSpec)) {
+                // Statsmanager logs error
+                return false;
+            }
+
+            log_debug("stats: %s", qPrintable(config.statsSpec));
+        }
+
+        if (!config.prometheusPort.isEmpty()) {
+            stats->setPrometheusPrefix(config.prometheusPrefix);
+
+            if (!stats->setPrometheusPort(config.prometheusPort)) {
+                log_error("unable to bind to prometheus port: %s",
+                          qPrintable(config.prometheusPort));
+                return false;
+            }
+        }
+
+        if (!config.proxyStatsSpecs.isEmpty()) {
+            proxyStatsSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+            proxyStatsSock->setHwm(DEFAULT_HWM);
+            proxyStatsSock->setShutdownWaitTime(0);
+            proxyStatsSock->subscribe("");
+
+            foreach (const QString &spec, config.proxyStatsSpecs) {
+                QString errorMessage;
+                if (!ZUtil::setupSocket(proxyStatsSock.get(), spec, false, config.ipcFileMode,
+                                        &errorMessage)) {
+                    log_error("%s", qPrintable(errorMessage));
+                    return false;
+                }
+            }
+
+            proxyStatsValve = std::make_unique<ZmqValve>(proxyStatsSock.get());
+            proxyStatConnection = proxyStatsValve->readyRead.connect(
+                boost::bind(&Private::proxyStats_readyRead, this, boost::placeholders::_1));
+
+            log_debug("proxy stats: %s", qPrintable(config.proxyStatsSpecs.join(", ")));
+        }
+
+        if (!config.proxyCommandSpec.isEmpty()) {
+            proxyControlClient = std::make_unique<ZrpcManager>();
+            proxyControlClient->setIpcFileMode(config.ipcFileMode);
+            proxyControlClient->setTimeout(PROXY_RPC_TIMEOUT);
+
+            if (!proxyControlClient->setClientSpecs(QStringList() << config.proxyCommandSpec)) {
+                // Zrpcmanager logs error
+                return false;
+            }
+
+            log_debug("proxy control client: %s", qPrintable(config.proxyCommandSpec));
+        }
+
+        if (config.pushInHttpPort != -1) {
+            controlHttpServer = std::make_unique<SimpleHttpServer>(CONTROL_CONNECTIONS_MAX,
+                                                                   config.pushInHttpMaxHeadersSize,
+                                                                   config.pushInHttpMaxBodySize);
+            controlServerConnection = controlHttpServer->requestReady.connect(
+                boost::bind(&Private::controlHttpServer_requestReady, this));
+            controlHttpServer->listen(config.pushInHttpAddr, config.pushInHttpPort);
+
+            log_info("http control server: %s:%d", qPrintable(config.pushInHttpAddr.toString()),
+                     config.pushInHttpPort);
+        }
+
+        if (inPullValve)
+            inPullValve->open();
+        if (inSubValve)
+            inSubValve->open();
+        if (wsControlInitValve)
+            wsControlInitValve->open();
+        if (wsControlStreamValve)
+            wsControlStreamValve->open();
+        if (proxyStatsValve)
+            proxyStatsValve->open();
+
+        return true;
+    }
+
+    void reload() {
+        // Nothing to do
+    }
 
 private:
-	void handlePublishItem(const PublishItem &item)
-	{
-		// Only sequence if someone is listening, because we
-		// clear lastId on unsubscribe and don't want it to
-		// be set again until after a subscription returns
-
-		bool seq = (!item.noSeq && cs.subs.contains(item.channel));
-
-		sequencer->addItem(item, seq);
-	}
-
-	void writeRetryPacket(const QByteArray &instanceAddress, const RetryRequestPacket &packet)
-	{
-		if(!retrySock)
-		{
-			log_error("retry: can't write, no socket");
-			return;
-		}
-
-		Variant vout = packet.toVariant();
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("OUT retry: to=%s %s", instanceAddress.data(), qPrintable(TnetString::variantToString(vout, -1)));
-
-		QList<QByteArray> msg;
-		msg += instanceAddress;
-		msg += QByteArray();
-		msg += TnetString::fromVariant(vout);
-		retrySock->write(msg);
-	}
-
-	void writeWsControlItems(const QByteArray &instanceAddress, const QList<WsControlPacket::Item> &items)
-	{
-		if(!wsControlStreamSock)
-		{
-			log_error("wscontrol: can't write, no socket");
-			return;
-		}
-
-		WsControlPacket out;
-		out.from = config.instanceId;
-		out.items = items;
-
-		Variant vout = out.toVariant();
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("OUT wscontrol: to=%s %s", instanceAddress.data(), qPrintable(TnetString::variantToString(vout, -1)));
-
-		QList<QByteArray> msg;
-		msg += instanceAddress;
-		msg += QByteArray();
-		msg += TnetString::fromVariant(vout);
-		wsControlStreamSock->write(msg);
-	}
-
-	void addSub(const QString &channel)
-	{
-		if(!cs.subs.contains(channel))
-		{
-			Subscription *sub = new Subscription(channel);
-			subscribedConnection[sub] = sub->subscribed.connect(boost::bind(&Private::sub_subscribed, this, sub));
-			cs.subs.insert(channel, sub);
-			sub->start();
-
-			if(inSubSock)
-			{
-				log_debug("SUB socket subscribe: %s", qPrintable(channel));
-				inSubSock->subscribe(channel.toUtf8());
-			}
-		}
-	}
-
-	void removeSub(const QString &channel)
-	{
-		if(cs.subs.contains(channel))
-		{
-			Subscription *sub = cs.subs[channel];
-			cs.subs.remove(channel);
-			subscribedConnection.erase(sub);
-			delete sub;
-
-			sequencer->clearPendingForChannel(channel);
-			cs.publishLastIds.remove(channel);
-
-			if(inSubSock)
-			{
-				log_debug("SUB socket unsubscribe: %s", qPrintable(channel));
-				inSubSock->unsubscribe(channel.toUtf8());
-			}
-		}
-	}
-
-	void removeWsSession(WsSession *s)
-	{
-		removeSessionChannels(s);
-
-		log_debug("removed ws session: %s", qPrintable(s->cid));
-
-		wsSessionConnectionMap.erase(s);
-		cs.wsSessions.remove(s->cid);
-	}
-
-	void httpControlRespond(SimpleHttpRequest *req, int code, const QByteArray &reason, const QString &body, const QByteArray &contentType = QByteArray(), const HttpHeaders &headers = HttpHeaders(), int items = -1)
-	{
-		HttpHeaders outHeaders = headers;
-		if(!contentType.isEmpty())
-			outHeaders += HttpHeader("Content-Type", contentType);
-		else
-			outHeaders += HttpHeader("Content-Type", "text/plain");
-
-		req->respond(code, reason, outHeaders, body.toUtf8());
-		req->finished.connect([=] { DeferCall::deleteLater(req); });
-
-		QString msg = QString("control: %1 %2 code=%3 %4").arg(req->requestMethod(), QString::fromUtf8(req->requestUri()), QString::number(code), QString::number(body.size()));
-		if(items > -1)
-			msg += QString(" items=%1").arg(items);
-
-		log_debug("%s", qPrintable(msg));
-	}
-
-	void publishSend(const std::shared_ptr<ClientSession> &target, const PublishItem &item, const QList<QByteArray> &exposeHeaders)
-	{
-		if(auto hs = std::dynamic_pointer_cast<HttpSession>(target))
-			hs->publish(item, exposeHeaders);
-		else if(auto s = std::dynamic_pointer_cast<WsSession>(target))
-			s->publish(item);
-	}
-
-	int blocksForData(int size) const
-	{
-		if(config.messageBlockSize <= 0)
-			return -1;
-
-		return (size + config.messageBlockSize - 1) / config.messageBlockSize;
-	}
-
-	void updateSessions(const QString &channel = QString())
-	{
-		if(!channel.isNull())
-		{
-			QSet<HttpSession*> sessions = cs.responseSessionsByChannel.value(channel);
-			foreach(HttpSession *hs, sessions)
-				hs->update();
-
-			sessions = cs.streamSessionsByChannel.value(channel);
-			foreach(HttpSession *hs, sessions)
-				hs->update();
-		}
-		else
-		{
-			foreach(const std::shared_ptr<HttpSession> &hs, cs.httpSessions)
-				hs->update();
-		}
-	}
-
-	void recoverCommand()
-	{
-		cs.publishLastIds.clear();
-		updateSessions();
-	}
-
-	void removeSessionChannel(HttpSession *hs, const QString &channel)
-	{
-		Instruct::HoldMode mode = hs->holdMode();
-		assert(mode == Instruct::ResponseHold || mode == Instruct::StreamHold);
-
-		QHash<QString, QSet<HttpSession*> > *sessionsByChannel;
-		QString modeStr;
-
-		if(mode == Instruct::ResponseHold)
-		{
-			sessionsByChannel = &cs.responseSessionsByChannel;
-			modeStr = "response";
-		}
-		else // StreamHold
-		{
-			sessionsByChannel = &cs.streamSessionsByChannel;
-			modeStr = "stream";
-		}
-
-		if(!sessionsByChannel->contains(channel))
-			return;
-
-		QSet<HttpSession*> &cur = (*sessionsByChannel)[channel];
-		if(!cur.contains(hs))
-			return;
-
-		cur.remove(hs);
-
-		if(!cur.isEmpty())
-		{
-			stats->addSubscription(modeStr, channel, cur.count());
-		}
-		else
-		{
-			sessionsByChannel->remove(channel);
-
-			// Linger the unsub in case client long-polls again
-			bool linger = (mode == Instruct::ResponseHold);
-
-			stats->removeSubscription(modeStr, channel, linger);
-		}
-	}
-
-	void removeSessionChannel(WsSession *s, const QString &channel)
-	{
-		if(!cs.wsSessionsByChannel.contains(channel))
-			return;
-
-		QSet<WsSession*> &cur = cs.wsSessionsByChannel[channel];
-		if(!cur.contains(s))
-			return;
-
-		cur.remove(s);
-
-		if(!cur.isEmpty())
-		{
-			stats->addSubscription("ws", channel, cur.count());
-		}
-		else
-		{
-			cs.wsSessionsByChannel.remove(channel);
-
-			stats->removeSubscription("ws", channel, false);
-		}
-	}
-
-	void removeSessionChannels(WsSession *s)
-	{
-		QHashIterator<QString, Instruct::Channel> it(s->channels);
-		while(it.hasNext())
-		{
-			it.next();
-			const QString &channel = it.key();
-			removeSessionChannel(s, channel);
-		}
-	}
-
-	static void hs_subscribe_cb(void *data, std::tuple<HttpSession *, const QString &> value)
-	{
-		Private *self = (Private *)data;
-
-		self->hs_subscribe(std::get<0>(value), std::get<1>(value));
-	}
-
-	static void hs_unsubscribe_cb(void *data, std::tuple<HttpSession *, const QString &> value)
-	{
-		Private *self = (Private *)data;
-
-		self->hs_unsubscribe(std::get<0>(value), std::get<1>(value));
-	}
-
-	static void hs_finished_cb(void *data, std::tuple<HttpSession *> value)
-	{
-		Private *self = (Private *)data;
-
-		self->hs_finished(std::get<0>(value));
-	}
-
-	void inspectServer_requestReady()
-	{
-		if(inspectWorkers.count() >= INSPECT_WORKERS_MAX)
-			return;
-
-		ZrpcRequest *req = inspectServer->takeNext();
-		if(!req)
-			return;
-
-		InspectWorker *w = new InspectWorker(req, stateClient.get(), config.shareAll);
-
-		// Safe to not track, since w can't outlive this
-		w->finished.connect(boost::bind(&Private::inspectWorker_finished, this, w, boost::placeholders::_1));
-
-		inspectWorkers += w;
-	}
-
-	void acceptServer_requestReady()
-	{
-		if(acceptWorkers.count() >= ACCEPT_WORKERS_MAX)
-			return;
-
-		ZrpcRequest *req = acceptServer->takeNext();
-		if(!req)
-			return;
-
-		if(req->method() == "accept")
-		{
-			// NOTE: to ensure sequential processing of conn-max packets,
-			// we need to process any such packets contained within the
-			// accept request immediately before returning to the event loop.
-			// the start() call will do this
-
-			AcceptWorker *w = new AcceptWorker(req, stateClient.get(), &cs, zhttpIn.get(), zhttpOut.get(), stats.get(), updateLimiter.get(), filterLimiter, httpSessionUpdateManager, config.connectionSubscriptionMax);
-
-			// Safe to not track, since w can't outlive this
-			w->finished.connect(boost::bind(&Private::acceptWorker_finished, this, w, boost::placeholders::_1));
-			w->sessionsReady.connect(boost::bind(&Private::acceptWorker_sessionsReady, this, w));
-			w->retryPacketReady.connect(boost::bind(&Private::acceptWorker_retryPacketReady, this, boost::placeholders::_1, boost::placeholders::_2));
-
-			acceptWorkers += w;
-
-			w->start();
-		}
-		else if(req->method() == "conn-max")
-		{
-			VariantHash args = req->args();
-
-			if(args.contains("conn-max"))
-			{
-				if(typeId(args["conn-max"]) == VariantType::List)
-				{
-					VariantList packets = args["conn-max"].toList();
-
-					for(const Variant &data : packets)
-					{
-						StatsPacket p;
-						if(!p.fromVariant("conn-max", data) || p.type != StatsPacket::ConnectionsMax)
-							continue;
-
-						stats->processExternalPacket(p, false);
-					}
-				}
-			}
-
-			delete req;
-		}
-		else
-		{
-			req->respondError("method-not-found");
-			delete req;
-		}
-	}
-
-	void controlServer_requestReady()
-	{
-		ZrpcRequest *req = controlServer->takeNext();
-		if(!req)
-			return;
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("IN command: %s args=%s", qPrintable(req->method()), qPrintable(TnetString::variantToString(req->args(), -1)));
-
-		if(req->method() == "conncheck")
-		{
-			auto d = std::make_unique<ConnCheckWorker>(req, proxyControlClient.get(), stats.get());
-
-			// Safe to not track, since d can't outlive this
-			d->finished.connect(boost::bind(&Private::deferred_finished, this, d.get(), boost::placeholders::_1));
-
-			deferreds[d.get()] = std::move(d);
-		}
-		else if(req->method() == "get-zmq-uris")
-		{
-			VariantHash out;
-			if(!config.commandSpec.isEmpty())
-				out["command"] = config.commandSpec.toUtf8();
-			if(!config.pushInSpec.isEmpty())
-				out["publish-pull"] = config.pushInSpec.toUtf8();
-			if(!config.pushInSubSpecs.isEmpty() && !config.pushInSubConnect)
-				out["publish-sub"] = config.pushInSubSpecs[0].toUtf8();
-			req->respond(out);
-			delete req;
-		}
-		else if(req->method() == "recover")
-		{
-			recoverCommand();
-			req->respond();
-			delete req;
-		}
-		else if(req->method() == "refresh")
-		{
-			auto d = std::make_unique<RefreshWorker>(req, proxyControlClient.get(), &cs.wsSessionsByChannel);
-
-			// Safe to not track, since d can't outlive this
-			d->finished.connect(boost::bind(&Private::deferred_finished, this, d.get(), boost::placeholders::_1));
-
-			deferreds[d.get()] = std::move(d);
-		}
-		else if(req->method() == "publish")
-		{
-			VariantHash args = req->args();
-
-			if(!args.contains("items"))
-			{
-				req->respondError("bad-request", "Invalid format: object does not contain 'items'");
-				delete req;
-				return;
-			}
-
-			if(typeId(args["items"]) != VariantType::List)
-			{
-				req->respondError("bad-request", "Invalid format: object contains 'items' with wrong type");
-				delete req;
-				return;
-			}
-
-			VariantList vitems = args["items"].toList();
-
-			bool ok;
-			QString errorMessage;
-			QList<PublishItem> items = parseItems(vitems, &ok, &errorMessage);
-			if(!ok)
-			{
-				req->respondError("bad-request", QString("Invalid format: %1").arg(errorMessage));
-				delete req;
-				return;
-			}
-
-			req->respond();
-			delete req;
-
-			foreach(const PublishItem &item, items)
-				handlePublishItem(item);
-		}
-		else
-		{
-			req->respondError("method-not-found");
-			delete req;
-		}
-	}
-
-	void sequencer_itemReady(const PublishItem &item)
-	{
-		QList<HttpSession*> responseSessions;
-		QList<HttpSession*> streamSessions;
-		QList<WsSession*> wsSessions;
-		QSet<QString> sids;
-
-		int largestBlocks = -1;
-		if(item.size >= 0)
-			largestBlocks = blocksForData(item.size);
-
-		if(item.formats.contains(PublishFormat::HttpResponse))
-		{
-			if(item.size < 0)
-				largestBlocks = qMax(blocksForData(item.formats[PublishFormat::HttpResponse].body.size()), largestBlocks);
-
-			QSet<HttpSession*> sessions = cs.responseSessionsByChannel.value(item.channel);
-			foreach(HttpSession *hs, sessions)
-			{
-				assert(hs->holdMode() == Instruct::ResponseHold);
-				assert(hs->channels().contains(item.channel));
-
-				responseSessions += hs;
-
-				if(!hs->sid().isEmpty())
-					sids += hs->sid();
-			}
-		}
-
-		if(item.formats.contains(PublishFormat::HttpStream))
-		{
-			if(item.size < 0)
-				largestBlocks = qMax(blocksForData(item.formats[PublishFormat::HttpStream].body.size()), largestBlocks);
-
-			QSet<HttpSession*> sessions = cs.streamSessionsByChannel.value(item.channel);
-			foreach(HttpSession *hs, sessions)
-			{
-				// Note: we used to assert that the session was currently a
-				// stream hold and subscribed to the target channel,
-				// however with the new grip-link stuff it is possible for
-				// the session to temporarily switch to NoHold, and for
-				// channels to become unsubscribed. So we'll do a
-				// conditional statement instead
-				if(!hs->channels().contains(item.channel))
-					continue;
-
-				streamSessions += hs;
-
-				if(!hs->sid().isEmpty())
-					sids += hs->sid();
-			}
-		}
-
-		if(item.formats.contains(PublishFormat::WebSocketMessage))
-		{
-			if(item.size < 0)
-				largestBlocks = qMax(blocksForData(item.formats[PublishFormat::WebSocketMessage].body.size()), largestBlocks);
-
-			QSet<WsSession*> wsbc = cs.wsSessionsByChannel.value(item.channel);
-			foreach(WsSession *s, wsbc)
-			{
-				assert(s->channels.contains(item.channel));
-
-				wsSessions += s;
-
-				if(!s->sid.isEmpty())
-					sids += s->sid;
-			}
-		}
-
-		// Always add for non-identified route
-		stats->addMessageReceived(QByteArray(), largestBlocks);
-
-		if(!responseSessions.isEmpty())
-		{
-			PublishItem i = item;
-			i.format = item.formats.value(PublishFormat::HttpResponse);
-			i.formats.clear();
-
-			PublishFormat &f = i.format;
-
-			QList<QByteArray> exposeHeaders = f.headers.getAll("Grip-Expose-Headers").asQByteArrayList();
-
-			// Remove grip headers from the push
-			for(int n = 0; n < f.headers.count(); ++n)
-			{
-				// Strip out grip headers
-				if(qstrnicmp(f.headers[n].first.data(), "Grip-", 5) == 0)
-				{
-					f.headers.removeAt(n);
-					--n; // Adjust position
-				}
-			}
-
-			log_debug("relaying to %d http-response subscribers", responseSessions.count());
-
-			// FIXME: if bodyPatch is used then body is empty. We should
-			// really be calculating blocks after applying patch
-
-			int blocks;
-			if(item.size >= 0)
-				blocks = blocksForData(item.size);
-			else
-				blocks = blocksForData(f.body.size());
-
-			foreach(HttpSession *hsp, responseSessions)
-			{
-				std::shared_ptr<HttpSession> &hs = cs.httpSessions[hsp->rid()];
-
-				QString statsRoute = hs->statsRoute();
-
-				if(!publishLimiter->addAction(statsRoute, new PublishAction(q->d, hs, i, exposeHeaders), blocks != -1 ? blocks : 1))
-				{
-					if(!statsRoute.isEmpty())
-						log_warning("exceeded publish hwm (%d) for route %s, dropping message", config.messageHwm, qPrintable(statsRoute));
-					else
-						log_warning("exceeded publish hwm (%d), dropping message", config.messageHwm);
-				}
-
-				stats->addMessageSent(statsRoute.toUtf8(), "http-response", blocks);
-			}
-
-			stats->addMessage(i.channel, i.id, "http-response", responseSessions.count(), blocks != -1 ? blocks * responseSessions.count() : -1);
-		}
-
-		if(!streamSessions.isEmpty())
-		{
-			PublishItem i = item;
-			i.format = item.formats.value(PublishFormat::HttpStream);
-			i.formats.clear();
-
-			PublishFormat &f = i.format;
-
-			log_debug("relaying to %d http-stream subscribers", streamSessions.count());
-
-			int blocks;
-			if(item.size >= 0)
-				blocks = blocksForData(item.size);
-			else
-				blocks = blocksForData(f.body.size());
-
-			foreach(HttpSession *hsp, streamSessions)
-			{
-				std::shared_ptr<HttpSession> &hs = cs.httpSessions[hsp->rid()];
-
-				QString statsRoute = hs->statsRoute();
-
-				if(!publishLimiter->addAction(statsRoute, new PublishAction(q->d, hs, i), blocks != -1 ? blocks : 1))
-				{
-					if(!statsRoute.isEmpty())
-						log_warning("exceeded publish hwm (%d) for route %s, dropping message", config.messageHwm, qPrintable(statsRoute));
-					else
-						log_warning("exceeded publish hwm (%d), dropping message", config.messageHwm);
-				}
-
-				stats->addMessageSent(statsRoute.toUtf8(), "http-stream", blocks);
-			}
-
-			stats->addMessage(i.channel, i.id, "http-stream", streamSessions.count(), blocks != -1 ? blocks * streamSessions.count() : -1);
-		}
-
-		if(!wsSessions.isEmpty())
-		{
-			PublishItem i = item;
-			i.format = item.formats.value(PublishFormat::WebSocketMessage);
-			i.formats.clear();
-
-			PublishFormat &f = i.format;
-
-			log_debug("relaying to %d ws-message subscribers", wsSessions.count());
-
-			int blocks;
-			if(item.size >= 0)
-				blocks = blocksForData(item.size);
-			else
-				blocks = blocksForData(f.body.size());
-
-			foreach(WsSession *sp, wsSessions)
-			{
-				std::shared_ptr<WsSession> &s = cs.wsSessions[sp->cid];
-
-				QString statsRoute = s->statsRoute;
-
-				if(!publishLimiter->addAction(statsRoute, new PublishAction(q->d, s, i), blocks != -1 ? blocks : 1))
-				{
-					if(!statsRoute.isEmpty())
-						log_warning("exceeded publish hwm (%d) for route %s, dropping message", config.messageHwm, qPrintable(statsRoute));
-					else
-						log_warning("exceeded publish hwm (%d), dropping message", config.messageHwm);
-				}
-
-				stats->addMessageSent(statsRoute.toUtf8(), "ws-message", blocks);
-			}
-
-			stats->addMessage(i.channel, i.id, "ws-message", wsSessions.count(), blocks != -1 ? blocks * wsSessions.count() : -1);
-		}
-
-		int receivers = responseSessions.count() + streamSessions.count() + wsSessions.count();
-		log_info("publish channel=%s receivers=%d", qPrintable(item.channel), receivers);
-
-		if(!item.id.isNull() && !sids.isEmpty() && stateClient)
-		{
-			// Update sessions' last-id
-			QHash<QString, LastIds> sidLastIds;
-			foreach(const QString &sid, sids)
-			{
-				LastIds lastIds;
-				lastIds[item.channel] = item.id;
-				sidLastIds[sid] = lastIds;
-			}
-
-			auto d = std::unique_ptr<Deferred>(SessionRequest::updateMany(stateClient.get(), sidLastIds));
-
-			// Safe to not track, since d can't outlive this
-			d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, d.get(), boost::placeholders::_1));
-
-			deferreds[d.get()] = std::move(d);
-		}
-	}
+    void handlePublishItem(const PublishItem &item) {
+        // Only sequence if someone is listening, because we
+        // clear lastId on unsubscribe and don't want it to
+        // be set again until after a subscription returns
+
+        bool seq = (!item.noSeq && cs.subs.contains(item.channel));
+
+        sequencer->addItem(item, seq);
+    }
+
+    void writeRetryPacket(const QByteArray &instanceAddress, const RetryRequestPacket &packet) {
+        if (!retrySock) {
+            log_error("retry: can't write, no socket");
+            return;
+        }
+
+        Variant vout = packet.toVariant();
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("OUT retry: to=%s %s", instanceAddress.data(),
+                      qPrintable(TnetString::variantToString(vout, -1)));
+
+        QList<QByteArray> msg;
+        msg += instanceAddress;
+        msg += QByteArray();
+        msg += TnetString::fromVariant(vout);
+        retrySock->write(msg);
+    }
+
+    void writeWsControlItems(const QByteArray &instanceAddress,
+                             const QList<WsControlPacket::Item> &items) {
+        if (!wsControlStreamSock) {
+            log_error("wscontrol: can't write, no socket");
+            return;
+        }
+
+        WsControlPacket out;
+        out.from = config.instanceId;
+        out.items = items;
+
+        Variant vout = out.toVariant();
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("OUT wscontrol: to=%s %s", instanceAddress.data(),
+                      qPrintable(TnetString::variantToString(vout, -1)));
+
+        QList<QByteArray> msg;
+        msg += instanceAddress;
+        msg += QByteArray();
+        msg += TnetString::fromVariant(vout);
+        wsControlStreamSock->write(msg);
+    }
+
+    void addSub(const QString &channel) {
+        if (!cs.subs.contains(channel)) {
+            Subscription *sub = new Subscription(channel);
+            subscribedConnection[sub] =
+                sub->subscribed.connect(boost::bind(&Private::sub_subscribed, this, sub));
+            cs.subs.insert(channel, sub);
+            sub->start();
+
+            if (inSubSock) {
+                log_debug("SUB socket subscribe: %s", qPrintable(channel));
+                inSubSock->subscribe(channel.toUtf8());
+            }
+        }
+    }
+
+    void removeSub(const QString &channel) {
+        if (cs.subs.contains(channel)) {
+            Subscription *sub = cs.subs[channel];
+            cs.subs.remove(channel);
+            subscribedConnection.erase(sub);
+            delete sub;
+
+            sequencer->clearPendingForChannel(channel);
+            cs.publishLastIds.remove(channel);
+
+            if (inSubSock) {
+                log_debug("SUB socket unsubscribe: %s", qPrintable(channel));
+                inSubSock->unsubscribe(channel.toUtf8());
+            }
+        }
+    }
+
+    void removeWsSession(WsSession *s) {
+        removeSessionChannels(s);
+
+        log_debug("removed ws session: %s", qPrintable(s->cid));
+
+        wsSessionConnectionMap.erase(s);
+        cs.wsSessions.remove(s->cid);
+    }
+
+    void httpControlRespond(SimpleHttpRequest *req, int code, const QByteArray &reason,
+                            const QString &body, const QByteArray &contentType = QByteArray(),
+                            const HttpHeaders &headers = HttpHeaders(), int items = -1) {
+        HttpHeaders outHeaders = headers;
+        if (!contentType.isEmpty())
+            outHeaders += HttpHeader("Content-Type", contentType);
+        else
+            outHeaders += HttpHeader("Content-Type", "text/plain");
+
+        req->respond(code, reason, outHeaders, body.toUtf8());
+        req->finished.connect([=] { DeferCall::deleteLater(req); });
+
+        QString msg = QString("control: %1 %2 code=%3 %4")
+                          .arg(req->requestMethod(), QString::fromUtf8(req->requestUri()),
+                               QString::number(code), QString::number(body.size()));
+        if (items > -1)
+            msg += QString(" items=%1").arg(items);
+
+        log_debug("%s", qPrintable(msg));
+    }
+
+    void publishSend(const std::shared_ptr<ClientSession> &target, const PublishItem &item,
+                     const QList<QByteArray> &exposeHeaders) {
+        if (auto hs = std::dynamic_pointer_cast<HttpSession>(target))
+            hs->publish(item, exposeHeaders);
+        else if (auto s = std::dynamic_pointer_cast<WsSession>(target))
+            s->publish(item);
+    }
+
+    int blocksForData(int size) const {
+        if (config.messageBlockSize <= 0)
+            return -1;
+
+        return (size + config.messageBlockSize - 1) / config.messageBlockSize;
+    }
+
+    void updateSessions(const QString &channel = QString()) {
+        if (!channel.isNull()) {
+            QSet<HttpSession *> sessions = cs.responseSessionsByChannel.value(channel);
+            foreach (HttpSession *hs, sessions)
+                hs->update();
+
+            sessions = cs.streamSessionsByChannel.value(channel);
+            foreach (HttpSession *hs, sessions)
+                hs->update();
+        } else {
+            foreach (const std::shared_ptr<HttpSession> &hs, cs.httpSessions)
+                hs->update();
+        }
+    }
+
+    void recoverCommand() {
+        cs.publishLastIds.clear();
+        updateSessions();
+    }
+
+    void removeSessionChannel(HttpSession *hs, const QString &channel) {
+        Instruct::HoldMode mode = hs->holdMode();
+        assert(mode == Instruct::ResponseHold || mode == Instruct::StreamHold);
+
+        QHash<QString, QSet<HttpSession *>> *sessionsByChannel;
+        QString modeStr;
+
+        if (mode == Instruct::ResponseHold) {
+            sessionsByChannel = &cs.responseSessionsByChannel;
+            modeStr = "response";
+        } else // StreamHold
+        {
+            sessionsByChannel = &cs.streamSessionsByChannel;
+            modeStr = "stream";
+        }
+
+        if (!sessionsByChannel->contains(channel))
+            return;
+
+        QSet<HttpSession *> &cur = (*sessionsByChannel)[channel];
+        if (!cur.contains(hs))
+            return;
+
+        cur.remove(hs);
+
+        if (!cur.isEmpty()) {
+            stats->addSubscription(modeStr, channel, cur.count());
+        } else {
+            sessionsByChannel->remove(channel);
+
+            // Linger the unsub in case client long-polls again
+            bool linger = (mode == Instruct::ResponseHold);
+
+            stats->removeSubscription(modeStr, channel, linger);
+        }
+    }
+
+    void removeSessionChannel(WsSession *s, const QString &channel) {
+        if (!cs.wsSessionsByChannel.contains(channel))
+            return;
+
+        QSet<WsSession *> &cur = cs.wsSessionsByChannel[channel];
+        if (!cur.contains(s))
+            return;
+
+        cur.remove(s);
+
+        if (!cur.isEmpty()) {
+            stats->addSubscription("ws", channel, cur.count());
+        } else {
+            cs.wsSessionsByChannel.remove(channel);
+
+            stats->removeSubscription("ws", channel, false);
+        }
+    }
+
+    void removeSessionChannels(WsSession *s) {
+        QHashIterator<QString, Instruct::Channel> it(s->channels);
+        while (it.hasNext()) {
+            it.next();
+            const QString &channel = it.key();
+            removeSessionChannel(s, channel);
+        }
+    }
+
+    static void hs_subscribe_cb(void *data, std::tuple<HttpSession *, const QString &> value) {
+        Private *self = (Private *)data;
+
+        self->hs_subscribe(std::get<0>(value), std::get<1>(value));
+    }
+
+    static void hs_unsubscribe_cb(void *data, std::tuple<HttpSession *, const QString &> value) {
+        Private *self = (Private *)data;
+
+        self->hs_unsubscribe(std::get<0>(value), std::get<1>(value));
+    }
+
+    static void hs_finished_cb(void *data, std::tuple<HttpSession *> value) {
+        Private *self = (Private *)data;
+
+        self->hs_finished(std::get<0>(value));
+    }
+
+    void inspectServer_requestReady() {
+        if (inspectWorkers.count() >= INSPECT_WORKERS_MAX)
+            return;
+
+        ZrpcRequest *req = inspectServer->takeNext();
+        if (!req)
+            return;
+
+        InspectWorker *w = new InspectWorker(req, stateClient.get(), config.shareAll);
+
+        // Safe to not track, since w can't outlive this
+        w->finished.connect(
+            boost::bind(&Private::inspectWorker_finished, this, w, boost::placeholders::_1));
+
+        inspectWorkers += w;
+    }
+
+    void acceptServer_requestReady() {
+        if (acceptWorkers.count() >= ACCEPT_WORKERS_MAX)
+            return;
+
+        ZrpcRequest *req = acceptServer->takeNext();
+        if (!req)
+            return;
+
+        if (req->method() == "accept") {
+            // NOTE: to ensure sequential processing of conn-max packets,
+            // we need to process any such packets contained within the
+            // accept request immediately before returning to the event loop.
+            // the start() call will do this
+
+            AcceptWorker *w =
+                new AcceptWorker(req, stateClient.get(), &cs, zhttpIn.get(), zhttpOut.get(),
+                                 stats.get(), updateLimiter.get(), filterLimiter,
+                                 httpSessionUpdateManager, config.connectionSubscriptionMax);
+
+            // Safe to not track, since w can't outlive this
+            w->finished.connect(
+                boost::bind(&Private::acceptWorker_finished, this, w, boost::placeholders::_1));
+            w->sessionsReady.connect(boost::bind(&Private::acceptWorker_sessionsReady, this, w));
+            w->retryPacketReady.connect(boost::bind(&Private::acceptWorker_retryPacketReady, this,
+                                                    boost::placeholders::_1,
+                                                    boost::placeholders::_2));
+
+            acceptWorkers += w;
+
+            w->start();
+        } else if (req->method() == "conn-max") {
+            VariantHash args = req->args();
+
+            if (args.contains("conn-max")) {
+                if (typeId(args["conn-max"]) == VariantType::List) {
+                    VariantList packets = args["conn-max"].toList();
+
+                    for (const Variant &data : packets) {
+                        StatsPacket p;
+                        if (!p.fromVariant("conn-max", data) ||
+                            p.type != StatsPacket::ConnectionsMax)
+                            continue;
+
+                        stats->processExternalPacket(p, false);
+                    }
+                }
+            }
+
+            delete req;
+        } else {
+            req->respondError("method-not-found");
+            delete req;
+        }
+    }
+
+    void controlServer_requestReady() {
+        ZrpcRequest *req = controlServer->takeNext();
+        if (!req)
+            return;
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("IN command: %s args=%s", qPrintable(req->method()),
+                      qPrintable(TnetString::variantToString(req->args(), -1)));
+
+        if (req->method() == "conncheck") {
+            auto d = std::make_unique<ConnCheckWorker>(req, proxyControlClient.get(), stats.get());
+
+            // Safe to not track, since d can't outlive this
+            d->finished.connect(
+                boost::bind(&Private::deferred_finished, this, d.get(), boost::placeholders::_1));
+
+            deferreds[d.get()] = std::move(d);
+        } else if (req->method() == "get-zmq-uris") {
+            VariantHash out;
+            if (!config.commandSpec.isEmpty())
+                out["command"] = config.commandSpec.toUtf8();
+            if (!config.pushInSpec.isEmpty())
+                out["publish-pull"] = config.pushInSpec.toUtf8();
+            if (!config.pushInSubSpecs.isEmpty() && !config.pushInSubConnect)
+                out["publish-sub"] = config.pushInSubSpecs[0].toUtf8();
+            req->respond(out);
+            delete req;
+        } else if (req->method() == "recover") {
+            recoverCommand();
+            req->respond();
+            delete req;
+        } else if (req->method() == "refresh") {
+            auto d = std::make_unique<RefreshWorker>(req, proxyControlClient.get(),
+                                                     &cs.wsSessionsByChannel);
+
+            // Safe to not track, since d can't outlive this
+            d->finished.connect(
+                boost::bind(&Private::deferred_finished, this, d.get(), boost::placeholders::_1));
+
+            deferreds[d.get()] = std::move(d);
+        } else if (req->method() == "publish") {
+            VariantHash args = req->args();
+
+            if (!args.contains("items")) {
+                req->respondError("bad-request", "Invalid format: object does not contain 'items'");
+                delete req;
+                return;
+            }
+
+            if (typeId(args["items"]) != VariantType::List) {
+                req->respondError("bad-request",
+                                  "Invalid format: object contains 'items' with wrong type");
+                delete req;
+                return;
+            }
+
+            VariantList vitems = args["items"].toList();
+
+            bool ok;
+            QString errorMessage;
+            QList<PublishItem> items = parseItems(vitems, &ok, &errorMessage);
+            if (!ok) {
+                req->respondError("bad-request", QString("Invalid format: %1").arg(errorMessage));
+                delete req;
+                return;
+            }
+
+            req->respond();
+            delete req;
+
+            foreach (const PublishItem &item, items)
+                handlePublishItem(item);
+        } else {
+            req->respondError("method-not-found");
+            delete req;
+        }
+    }
+
+    void sequencer_itemReady(const PublishItem &item) {
+        QList<HttpSession *> responseSessions;
+        QList<HttpSession *> streamSessions;
+        QList<WsSession *> wsSessions;
+        QSet<QString> sids;
+
+        int largestBlocks = -1;
+        if (item.size >= 0)
+            largestBlocks = blocksForData(item.size);
+
+        if (item.formats.contains(PublishFormat::HttpResponse)) {
+            if (item.size < 0)
+                largestBlocks =
+                    qMax(blocksForData(item.formats[PublishFormat::HttpResponse].body.size()),
+                         largestBlocks);
+
+            QSet<HttpSession *> sessions = cs.responseSessionsByChannel.value(item.channel);
+            foreach (HttpSession *hs, sessions) {
+                assert(hs->holdMode() == Instruct::ResponseHold);
+                assert(hs->channels().contains(item.channel));
+
+                responseSessions += hs;
+
+                if (!hs->sid().isEmpty())
+                    sids += hs->sid();
+            }
+        }
+
+        if (item.formats.contains(PublishFormat::HttpStream)) {
+            if (item.size < 0)
+                largestBlocks =
+                    qMax(blocksForData(item.formats[PublishFormat::HttpStream].body.size()),
+                         largestBlocks);
+
+            QSet<HttpSession *> sessions = cs.streamSessionsByChannel.value(item.channel);
+            foreach (HttpSession *hs, sessions) {
+                // Note: we used to assert that the session was currently a
+                // stream hold and subscribed to the target channel,
+                // however with the new grip-link stuff it is possible for
+                // the session to temporarily switch to NoHold, and for
+                // channels to become unsubscribed. So we'll do a
+                // conditional statement instead
+                if (!hs->channels().contains(item.channel))
+                    continue;
+
+                streamSessions += hs;
+
+                if (!hs->sid().isEmpty())
+                    sids += hs->sid();
+            }
+        }
+
+        if (item.formats.contains(PublishFormat::WebSocketMessage)) {
+            if (item.size < 0)
+                largestBlocks =
+                    qMax(blocksForData(item.formats[PublishFormat::WebSocketMessage].body.size()),
+                         largestBlocks);
+
+            QSet<WsSession *> wsbc = cs.wsSessionsByChannel.value(item.channel);
+            foreach (WsSession *s, wsbc) {
+                assert(s->channels.contains(item.channel));
+
+                wsSessions += s;
+
+                if (!s->sid.isEmpty())
+                    sids += s->sid;
+            }
+        }
+
+        // Always add for non-identified route
+        stats->addMessageReceived(QByteArray(), largestBlocks);
+
+        if (!responseSessions.isEmpty()) {
+            PublishItem i = item;
+            i.format = item.formats.value(PublishFormat::HttpResponse);
+            i.formats.clear();
+
+            PublishFormat &f = i.format;
+
+            QList<QByteArray> exposeHeaders =
+                f.headers.getAll("Grip-Expose-Headers").asQByteArrayList();
+
+            // Remove grip headers from the push
+            for (int n = 0; n < f.headers.count(); ++n) {
+                // Strip out grip headers
+                if (qstrnicmp(f.headers[n].first.data(), "Grip-", 5) == 0) {
+                    f.headers.removeAt(n);
+                    --n; // Adjust position
+                }
+            }
+
+            log_debug("relaying to %d http-response subscribers", responseSessions.count());
+
+            // FIXME: if bodyPatch is used then body is empty. We should
+            // really be calculating blocks after applying patch
+
+            int blocks;
+            if (item.size >= 0)
+                blocks = blocksForData(item.size);
+            else
+                blocks = blocksForData(f.body.size());
+
+            foreach (HttpSession *hsp, responseSessions) {
+                std::shared_ptr<HttpSession> &hs = cs.httpSessions[hsp->rid()];
+
+                QString statsRoute = hs->statsRoute();
+
+                if (!publishLimiter->addAction(statsRoute,
+                                               new PublishAction(q->d, hs, i, exposeHeaders),
+                                               blocks != -1 ? blocks : 1)) {
+                    if (!statsRoute.isEmpty())
+                        log_warning("exceeded publish hwm (%d) for route %s, dropping message",
+                                    config.messageHwm, qPrintable(statsRoute));
+                    else
+                        log_warning("exceeded publish hwm (%d), dropping message",
+                                    config.messageHwm);
+                }
+
+                stats->addMessageSent(statsRoute.toUtf8(), "http-response", blocks);
+            }
+
+            stats->addMessage(i.channel, i.id, "http-response", responseSessions.count(),
+                              blocks != -1 ? blocks * responseSessions.count() : -1);
+        }
+
+        if (!streamSessions.isEmpty()) {
+            PublishItem i = item;
+            i.format = item.formats.value(PublishFormat::HttpStream);
+            i.formats.clear();
+
+            PublishFormat &f = i.format;
+
+            log_debug("relaying to %d http-stream subscribers", streamSessions.count());
+
+            int blocks;
+            if (item.size >= 0)
+                blocks = blocksForData(item.size);
+            else
+                blocks = blocksForData(f.body.size());
+
+            foreach (HttpSession *hsp, streamSessions) {
+                std::shared_ptr<HttpSession> &hs = cs.httpSessions[hsp->rid()];
+
+                QString statsRoute = hs->statsRoute();
+
+                if (!publishLimiter->addAction(statsRoute, new PublishAction(q->d, hs, i),
+                                               blocks != -1 ? blocks : 1)) {
+                    if (!statsRoute.isEmpty())
+                        log_warning("exceeded publish hwm (%d) for route %s, dropping message",
+                                    config.messageHwm, qPrintable(statsRoute));
+                    else
+                        log_warning("exceeded publish hwm (%d), dropping message",
+                                    config.messageHwm);
+                }
+
+                stats->addMessageSent(statsRoute.toUtf8(), "http-stream", blocks);
+            }
+
+            stats->addMessage(i.channel, i.id, "http-stream", streamSessions.count(),
+                              blocks != -1 ? blocks * streamSessions.count() : -1);
+        }
+
+        if (!wsSessions.isEmpty()) {
+            PublishItem i = item;
+            i.format = item.formats.value(PublishFormat::WebSocketMessage);
+            i.formats.clear();
+
+            PublishFormat &f = i.format;
+
+            log_debug("relaying to %d ws-message subscribers", wsSessions.count());
+
+            int blocks;
+            if (item.size >= 0)
+                blocks = blocksForData(item.size);
+            else
+                blocks = blocksForData(f.body.size());
+
+            foreach (WsSession *sp, wsSessions) {
+                std::shared_ptr<WsSession> &s = cs.wsSessions[sp->cid];
+
+                QString statsRoute = s->statsRoute;
+
+                if (!publishLimiter->addAction(statsRoute, new PublishAction(q->d, s, i),
+                                               blocks != -1 ? blocks : 1)) {
+                    if (!statsRoute.isEmpty())
+                        log_warning("exceeded publish hwm (%d) for route %s, dropping message",
+                                    config.messageHwm, qPrintable(statsRoute));
+                    else
+                        log_warning("exceeded publish hwm (%d), dropping message",
+                                    config.messageHwm);
+                }
+
+                stats->addMessageSent(statsRoute.toUtf8(), "ws-message", blocks);
+            }
+
+            stats->addMessage(i.channel, i.id, "ws-message", wsSessions.count(),
+                              blocks != -1 ? blocks * wsSessions.count() : -1);
+        }
+
+        int receivers = responseSessions.count() + streamSessions.count() + wsSessions.count();
+        log_info("publish channel=%s receivers=%d", qPrintable(item.channel), receivers);
+
+        if (!item.id.isNull() && !sids.isEmpty() && stateClient) {
+            // Update sessions' last-id
+            QHash<QString, LastIds> sidLastIds;
+            foreach (const QString &sid, sids) {
+                LastIds lastIds;
+                lastIds[item.channel] = item.id;
+                sidLastIds[sid] = lastIds;
+            }
+
+            auto d = std::unique_ptr<Deferred>(
+                SessionRequest::updateMany(stateClient.get(), sidLastIds));
+
+            // Safe to not track, since d can't outlive this
+            d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, d.get(),
+                                            boost::placeholders::_1));
+
+            deferreds[d.get()] = std::move(d);
+        }
+    }
 
 private:
-	void report_finished(const DeferredResult &result)
-	{
-		Q_UNUSED(result);
-
-		report.reset();
-	}
-
-	void sessionUpdateMany_finished(Deferred *d, const DeferredResult &result)
-	{
-		deferreds.erase(d);
-
-		if(!result.success)
-			log_error("couldn't update session: condition=%d", result.value.toInt());
-	}
-
-	void sessionCreateOrUpdate_finished(Deferred *d, const DeferredResult &result)
-	{
-		deferreds.erase(d);
-
-		if(!result.success)
-			log_error("couldn't create/update session: condition=%d", result.value.toInt());
-	}
-
-	void inspectWorker_finished(InspectWorker *w, const DeferredResult &result)
-	{
-		Q_UNUSED(result);
-
-		inspectWorkers.remove(w);
-		delete w;
-
-		// Try to read again
-		inspectServer_requestReady();
-	}
-
-	void acceptWorker_finished(AcceptWorker *w, const DeferredResult &result)
-	{
-		Q_UNUSED(result);
-
-		acceptWorkers.remove(w);
-		delete w;
-
-		// Try to read again
-		acceptServer_requestReady();
-	}
-
-	void deferred_finished(Deferred *d, const DeferredResult &result)
-	{
-		Q_UNUSED(result);
-
-		deferreds.erase(d);
-	}
-	
-	void sub_subscribed(Subscription *sub)
-	{
-		if(config.updateOnFirstSubscription)
-			updateSessions(sub->channel());
-	}
-
-	void acceptWorker_sessionsReady(AcceptWorker *w)
-	{
-		QList<std::shared_ptr<HttpSession>> sessions = w->takeSessions();
-		foreach(const std::shared_ptr<HttpSession> &hs, sessions)
-		{
-			// NOTE: for performance reasons we do not call hs->setParent and
-			// instead leave the object unparented
-
-			hs->subscribeCallback().add(Private::hs_subscribe_cb, this);
-			hs->unsubscribeCallback().add(Private::hs_unsubscribe_cb, this);
-			hs->finishedCallback().add(Private::hs_finished_cb, this);
-
-			cs.httpSessions.insert(hs->rid(), hs);
-
-			hs->start();
-		}
-	}
-
-	void acceptWorker_retryPacketReady(const QByteArray &instanceAddress, const RetryRequestPacket &packet)
-	{
-		writeRetryPacket(instanceAddress, packet);
-	}
-
-	void stats_connectionsRefreshed(const QList<QByteArray> &ids)
-	{
-		if(stateClient)
-		{
-			// Find sids of the connections
-			QHash<QString, LastIds> sidLastIds;
-			foreach(const QByteArray &id, ids)
-			{
-				int at = id.indexOf(':');
-				assert(at != -1);
-				ZhttpRequest::Rid rid(id.mid(0, at), id.mid(at + 1));
-
-				HttpSession *hs = cs.httpSessions.value(rid).get();
-				if(hs && !hs->sid().isEmpty())
-					sidLastIds[hs->sid()] = LastIds();
-			}
-
-			if(!sidLastIds.isEmpty())
-			{
-				auto d = std::unique_ptr<Deferred>(SessionRequest::updateMany(stateClient.get(), sidLastIds));
-
-				// Safe to not track, since d can't outlive this
-				d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, d.get(), boost::placeholders::_1));
-
-				deferreds[d.get()] = std::move(d);
-			}
-		}
-	}
-
-	void stats_unsubscribed(const QString &mode, const QString &channel)
-	{
-		// NOTE: this callback may be invoked while looping over certain structures,
-		// so be careful what you touch
-
-		Q_UNUSED(mode);
-
-		if(!cs.responseSessionsByChannel.contains(channel) && !cs.streamSessionsByChannel.contains(channel) && !cs.wsSessionsByChannel.contains(channel))
-			removeSub(channel);
-	}
-
-	Variant parseJsonOrTnetstring(const CowByteArray &message, bool *ok = 0, QString *errorMessage = 0)
-	{
-		Variant data;
-		bool ok_;
-		if(message.length() > 0 && message[0] == 'J') {
-			QJsonParseError e;
-			QJsonDocument doc = QJsonDocument::fromJson(message.mid(1).asQByteArray(), &e);
-			if(e.error != QJsonParseError::NoError)
-			{
-				if(errorMessage)
-					*errorMessage = QString("received message with invalid format (json parse failed)");
-				if(ok)
-					*ok = false;
-				return data;
-			}
-
-			if(doc.isObject())
-			{
-				data = doc.object().toVariantMap();
-			}
-			else
-			{
-				if(errorMessage)
-					*errorMessage = QString("received message with invalid format (not a valid json object)");
-				if(ok)
-					*ok = false;
-				return data;
-			}
-		}
-		else
-		{
-			int offset = 0;
-			if(message.length() > 0 && message[0] == 'T') {
-				offset = 1;
-			}
-
-			data = TnetString::toVariant(message, offset, &ok_);
-			if(!ok_)
-			{
-				if(errorMessage)
-					*errorMessage = QString("received message with invalid format (tnetstring parse failed)");
-				if(ok)
-					*ok = false;
-				return data;
-			}
-		}
-		if(ok)
-			*ok = true;
-		return data;
-	}
-
-	void inPull_readyRead(const CowByteArrayList &message)
-	{
-		if(message.count() != 1)
-		{
-			log_warning("IN pull: received message with parts != 1, skipping");
-			return;
-		}
-
-		bool ok;
-		QString errorMessage;
-		Variant data = parseJsonOrTnetstring(message[0], &ok, &errorMessage);
-		if(!ok)
-		{
-			log_warning("IN pull: %s, skipping", qPrintable(errorMessage));
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("IN pull: %s", qPrintable(TnetString::variantToString(data, -1)));
-
-		PublishItem item = PublishItem::fromVariant(data, QString(), &ok, &errorMessage);
-		if(!ok)
-		{
-			log_warning("IN pull: received message with invalid format: %s, skipping", qPrintable(errorMessage));
-			return;
-		}
-
-		handlePublishItem(item);
-	}
-
-	void inSub_readyRead(const CowByteArrayList &message)
-	{
-		if(message.count() != 2)
-		{
-			log_warning("IN sub: received message with parts != 2, skipping");
-			return;
-		}
-
-		bool ok;
-		QString errorMessage;
-		Variant data = parseJsonOrTnetstring(message[1], &ok, &errorMessage);
-		if(!ok) {
-			log_warning("IN sub: %s, skipping", qPrintable(errorMessage));
-			return;
-		}
-
-		QString channel = QString::fromUtf8(message[0].asQByteArray());
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("IN sub: channel=%s %s", qPrintable(channel), qPrintable(TnetString::variantToString(data, -1)));
-
-		PublishItem item = PublishItem::fromVariant(data, channel, &ok, &errorMessage);
-		if(!ok)
-		{
-			log_warning("IN sub: received message with invalid format: %s, skipping", qPrintable(errorMessage));
-			return;
-		}
-
-		handlePublishItem(item);
-	}
-
-	void wsControlInit_readyRead(const CowByteArrayList &message)
-	{
-		if(message.count() != 1)
-		{
-			log_warning("IN wscontrol: received message with parts != 1, skipping");
-			return;
-		}
-
-		wsControlIn_readyRead(message[0]);
-	}
-
-	void wsControlStream_readyRead(const CowByteArrayList &message)
-	{
-		ZmqReqMessage req(message);
-
-		if(req.content().count() != 1)
-		{
-			log_warning("IN wscontrol: received message with parts != 1, skipping");
-			return;
-		}
-
-		wsControlIn_readyRead(req.content()[0]);
-	}
-
-	void wsControlIn_readyRead(const CowByteArray &message)
-	{
-		bool ok;
-		Variant data = TnetString::toVariant(message, 0, &ok);
-		if(!ok)
-		{
-			log_warning("IN wscontrol: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("IN wscontrol: %s", qPrintable(TnetString::variantToString(data, -1)));
-
-		WsControlPacket packet;
-		if(!packet.fromVariant(data))
-		{
-			log_warning("IN wscontrol: received message with invalid format, skipping");
-			return;
-		}
-
-		QStringList createOrUpdateSids;
-		QHash<QString, LastIds> updateSids;
-
-		QList<WsControlPacket::Item> outItems;
-
-		foreach(const WsControlPacket::Item &item, packet.items)
-		{
-			if(item.type != WsControlPacket::Item::Ack && !item.requestId.isEmpty())
-			{
-				// Ack receipt
-				WsControlPacket::Item i;
-				i.cid = item.cid;
-				i.type = WsControlPacket::Item::Ack;
-				i.requestId = item.requestId;
-				outItems += i;
-			}
-
-			if(item.type == WsControlPacket::Item::Here)
-			{
-				std::shared_ptr<WsSession> s = cs.wsSessions.value(item.cid);
-				if(!s)
-				{
-					s = std::make_shared<WsSession>();
-					wsSessionConnectionMap[s.get()] = {
-						s->send.connect(boost::bind(&Private::wssession_send, this, boost::placeholders::_1, s.get())),
-						s->expired.connect(boost::bind(&Private::wssession_expired, this, s.get())),
-						s->error.connect(boost::bind(&Private::wssession_error, this, s.get()))
-					};
-					s->peer = packet.from;
-					s->cid = QString::fromUtf8(item.cid);
-					s->ttl = item.ttl;
-					s->requestData.uri = item.uri;
-					s->zhttpOut = zhttpOut.get();
-					s->filterLimiter = filterLimiter;
-					s->refreshExpiration();
-					cs.wsSessions.insert(s->cid, s);
-					log_debug("added ws session: %s", qPrintable(s->cid));
-				}
-
-				s->debug = item.debug;
-				s->route = item.route;
-				s->statsRoute = item.separateStats ? item.route : QString();
-				s->targetTrusted = item.trusted;
-				s->channelPrefix = QString::fromUtf8(item.channelPrefix);
-				if(item.logLevel >= 0)
-					s->logLevel = item.logLevel;
-
-				if(!s->sid.isEmpty())
-					updateSids[s->sid] = LastIds();
-
-				continue;
-			}
-
-			// Any other type must be for a known cid
-			WsSession *s = cs.wsSessions.value(QString::fromUtf8(item.cid)).get();
-			if(!s)
-			{
-				// Send cancel, causing the proxy to close the connection. Client
-				// will need to retry to repair
-				WsControlPacket::Item i;
-				i.cid = item.cid;
-				i.type = WsControlPacket::Item::Cancel;
-				outItems += i;
-				continue;
-			}
-
-			if(item.type == WsControlPacket::Item::KeepAlive)
-			{
-				s->ttl = item.ttl;
-				s->refreshExpiration();
-			}
-			else if(item.type == WsControlPacket::Item::Gone || item.type == WsControlPacket::Item::Cancel)
-			{
-				removeWsSession(s);
-			}
-			else if(item.type == WsControlPacket::Item::Grip)
-			{
-				QJsonParseError e;
-				QJsonDocument doc = QJsonDocument::fromJson(item.message, &e);
-				if(e.error != QJsonParseError::NoError || (!doc.isObject() && !doc.isArray()))
-				{
-					log_debug("grip control message is not valid json");
-					continue;
-				}
-
-				if(doc.isObject())
-					data = doc.object().toVariantMap();
-				else // IsArray
-					data = doc.array().toVariantList();
-
-				QString errorMessage;
-				WsControlMessage cm = WsControlMessage::fromVariant(data, &ok, &errorMessage);
-				if(!ok)
-				{
-					log_debug("failed to parse grip control message: %s", qPrintable(errorMessage));
-					continue;
-				}
-
-				if(cm.type == WsControlMessage::Subscribe)
-				{
-					if(s->channels.count() < config.connectionSubscriptionMax)
-					{
-						if(cm.filters.count() > MESSAGEFILTERSTACK_SIZE_MAX)
-						{
-							s->sendCloseError(QString("too many filters for channel '%1'").arg(cm.channel));
-							continue;
-						}
-
-						QString channel = s->channelPrefix + cm.channel;
-
-						Instruct::Channel c;
-						c.name = cm.channel;
-						c.filters = cm.filters;
-
-						s->channels.insert(channel, c);
-
-						if(!cs.wsSessionsByChannel.contains(channel))
-							cs.wsSessionsByChannel.insert(channel, QSet<WsSession*>());
-
-						cs.wsSessionsByChannel[channel] += s;
-
-						log_debug("ws session %s subscribed to %s", qPrintable(s->cid), qPrintable(channel));
-
-						stats->addSubscription("ws", channel, cs.wsSessionsByChannel.value(channel).count());
-						addSub(channel);
-
-						log_info("subscribe %s channel=%s", qPrintable(s->requestData.uri.toString(Url::FullyEncoded)), qPrintable(channel));
-					}
-					else
-					{
-						auto routeInfo = LogUtil::RouteInfo(s->route, s->logLevel);
-						LogUtil::logForRoute(routeInfo, "wssession: too many subscriptions");
-					}
-				}
-				else if(cm.type == WsControlMessage::Unsubscribe)
-				{
-					QString channel = s->channelPrefix + cm.channel;
-
-					if(!s->implicitChannels.contains(channel))
-					{
-						s->channels.remove(channel);
-
-						removeSessionChannel(s, channel);
-					}
-				}
-				else if(cm.type == WsControlMessage::Detach)
-				{
-					WsControlPacket::Item i;
-					i.cid = item.cid;
-					i.type = WsControlPacket::Item::Detach;
-					outItems += i;
-				}
-				else if(cm.type == WsControlMessage::Session)
-				{
-					if(!cm.sessionId.isEmpty())
-					{
-						s->sid = cm.sessionId;
-						createOrUpdateSids += cm.sessionId;
-					}
-					else
-					{
-						s->sid.clear();
-					}
-				}
-				else if(cm.type == WsControlMessage::SetMeta)
-				{
-					if(!cm.metaValue.isNull())
-						s->meta[cm.metaName] = cm.metaValue;
-					else
-						s->meta.remove(cm.metaName);
-				}
-				else if(cm.type == WsControlMessage::KeepAlive)
-				{
-					WsControlPacket::Item i;
-					i.cid = item.cid;
-					i.type = WsControlPacket::Item::KeepAliveSetup;
-
-					if(!cm.content.isNull())
-					{
-						QByteArray contentType;
-						switch(cm.messageType)
-						{
-							case WsControlMessage::Text:   contentType = "text"; break;
-							case WsControlMessage::Binary: contentType = "binary"; break;
-							case WsControlMessage::Ping:   contentType = "ping"; break;
-							case WsControlMessage::Pong:   contentType = "pong"; break;
-							default: continue; // Unrecognized type, ignore
-						}
-
-						s->keepAliveType = contentType;
-						s->keepAliveMessage = cm.content;
-
-						if(cm.keepAliveMode == "interval")
-							i.keepAliveMode = "interval";
-						else
-							i.keepAliveMode = "idle";
-
-						i.timeout = (cm.timeout > 0 ? cm.timeout : DEFAULT_WS_KEEPALIVE_TIMEOUT);
-					}
-					else
-					{
-						s->keepAliveType.clear();
-						s->keepAliveMessage.clear();
-					}
-
-					outItems += i;
-				}
-				else if(cm.type == WsControlMessage::SendDelayed)
-				{
-					QByteArray contentType;
-					switch(cm.messageType)
-					{
-						case WsControlMessage::Text:   contentType = "text"; break;
-						case WsControlMessage::Binary: contentType = "binary"; break;
-						case WsControlMessage::Ping:   contentType = "ping"; break;
-						case WsControlMessage::Pong:   contentType = "pong"; break;
-						default: continue; // Unrecognized type, ignore
-					}
-
-					int timeout = (cm.timeout > 0 ? cm.timeout : DEFAULT_WS_SENDDELAYED_TIMEOUT);
-
-					s->sendDelayed(contentType, cm.content, timeout);
-				}
-				else if(cm.type == WsControlMessage::FlushDelayed)
-				{
-					s->flushDelayed();
-				}
-			}
-			else if(item.type == WsControlPacket::Item::NeedKeepAlive)
-			{
-				if(!s->keepAliveMessage.isNull())
-				{
-					WsControlPacket::Item i;
-					i.cid = s->cid.toUtf8();
-					i.type = WsControlPacket::Item::Send;
-					i.contentType = s->keepAliveType;
-					i.message = s->keepAliveMessage;
-
-					outItems += i;
-
-					stats->addActivity(s->statsRoute.toUtf8(), 1);
-				}
-			}
-			else if(item.type == WsControlPacket::Item::Subscribe)
-			{
-				QString channel = QString::fromUtf8(item.channel);
-
-				s->implicitChannels += channel;
-
-				Instruct::Channel c;
-				c.name = channel;
-				s->channels.insert(channel, c);
-
-				if(!cs.wsSessionsByChannel.contains(channel))
-					cs.wsSessionsByChannel.insert(channel, QSet<WsSession*>());
-
-				cs.wsSessionsByChannel[channel] += s;
-
-				log_debug("ws session %s subscribed to %s", qPrintable(s->cid), qPrintable(channel));
-
-				stats->addSubscription("ws", channel, cs.wsSessionsByChannel.value(channel).count());
-				addSub(channel);
-
-				log_info("subscribe %s channel=%s", qPrintable(s->requestData.uri.toString(Url::FullyEncoded)), qPrintable(channel));
-			}
-			else if(item.type == WsControlPacket::Item::Ack)
-			{
-				int reqId = item.requestId.toInt();
-				s->ack(reqId);
-			}
-		}
-
-		if(!outItems.isEmpty())
-			writeWsControlItems(packet.from, outItems);
-
-		if(stateClient)
-		{
-			foreach(const QString &sid, createOrUpdateSids)
-			{
-				auto d = std::unique_ptr<Deferred>(SessionRequest::createOrUpdate(stateClient.get(), sid, LastIds()));
-
-				// Safe to not track, since d can't outlive this
-				d->finished.connect(boost::bind(&Private::sessionCreateOrUpdate_finished, this, d.get(), boost::placeholders::_1));
-
-				deferreds[d.get()] = std::move(d);
-			}
-
-			if(!updateSids.isEmpty())
-			{
-				auto d = std::unique_ptr<Deferred>(SessionRequest::updateMany(stateClient.get(), updateSids));
-
-				// Safe to not track, since d can't outlive this
-				d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, d.get(), boost::placeholders::_1));
-
-				deferreds[d.get()] = std::move(d);
-			}
-		}
-	}
-
-	void proxyStats_readyRead(const CowByteArrayList &message)
-	{
-		if(message.count() != 1)
-		{
-			log_warning("IN proxy stats: received message with parts != 1, skipping");
-			return;
-		}
-
-		int at = message[0].indexOf(' ');
-		if(at == -1)
-		{
-			log_warning("IN proxy stats: received message with invalid format, skipping");
-			return;
-		}
-
-		QByteArray type = message[0].mid(0, at).asQByteArray();
-
-		if(at + 1 >= message[0].length() || message[0][at + 1] != 'T')
-		{
-			log_warning("IN proxy stats: received message with unsupported format, skipping");
-			return;
-		}
-
-		bool ok;
-		Variant data = TnetString::toVariant(message[0], at + 2, &ok);
-		if(!ok)
-		{
-			log_warning("IN proxy stats: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("IN proxy stats: %s %s", type.data(), qPrintable(TnetString::variantToString(data, -1)));
-
-		StatsPacket p;
-		if(!p.fromVariant(type, data))
-		{
-			log_warning("IN proxy stats: received message with invalid format, skipping");
-			return;
-		}
-
-		if(p.type == StatsPacket::Activity)
-		{
-			if(p.count > 0)
-			{
-				// Merge with our own stats
-				stats->addActivity(p.route, p.count);
-			}
-		}
-		else if(p.type == StatsPacket::Counts)
-		{
-			if(p.requestsReceived > 0)
-			{
-				// Merge with our own stats
-				stats->addRequestsReceived(p.requestsReceived);
-			}
-		}
-		else if(p.type == StatsPacket::Connected || p.type == StatsPacket::Disconnected)
-		{
-			if(stats->connectionSendEnabled())
-			{
-				// Track proxy connections for reporting
-				bool localReplaced = stats->processExternalPacket(p, false);
-
-				if(!localReplaced)
-				{
-					// Forward the packet. This will stamp the from field and keep the rest
-					stats->sendPacket(p);
-				}
-			}
-		}
-		else if(p.type == StatsPacket::Report)
-		{
-			bool mergeConnectionReport = !stats->connectionSendEnabled();
-
-			// Merge into local report and don't forward
-			stats->processExternalPacket(p, mergeConnectionReport);
-		}
-	}
-
-	void controlHttpServer_requestReady()
-	{
-		SimpleHttpRequest *req = controlHttpServer->takeNext();
-		if(!req)
-			return;
-
-		QByteArray path = req->requestUri();
-		if(path.length() > 1 && path[path.length() - 1] == '/')
-			path.truncate(path.length() - 1);
-
-		HttpHeaders headers = req->requestHeaders();
-
-		QByteArray responseContentType;
-		if(headers.contains("Accept"))
-		{
-			foreach(const HttpHeaderParameters &params, headers.getAllAsParameters("Accept"))
-			{
-				if(params.isEmpty() || params[0].first.isEmpty())
-					continue;
-
-				QByteArray type = params[0].first.asQByteArray();
-
-				if(type == "text/plain" || type == "text/*" || type == "*/*" || type == "*")
-				{
-					responseContentType = "text/plain";
-				}
-				else if(type == "application/json" || type == "application/*")
-				{
-					responseContentType = "application/json";
-				}
-			}
-
-			if(responseContentType.isEmpty())
-			{
-				httpControlRespond(req, 406, "Not Acceptable", "Not Acceptable. Supported formats are text/plain and application/json.\n");
-				return;
-			}
-		}
-		else
-		{
-			responseContentType = "text/plain";
-		}
-
-		if(path == "/")
-		{
-			httpControlRespond(req, 200, "OK", "Pushpin API\n");
-		}
-		else if(path == "/publish")
-		{
-			if(req->requestMethod() == "POST")
-			{
-				QJsonParseError e;
-				QJsonDocument doc = QJsonDocument::fromJson(req->requestBody(), &e);
-				if(e.error != QJsonParseError::NoError)
-				{
-					httpControlRespond(req, 400, "Bad Request", "Body is not valid JSON.\n");
-					return;
-				}
-
-				if(!doc.isObject())
-				{
-					httpControlRespond(req, 400, "Bad Request", "Invalid format.\n");
-					return;
-				}
-
-				VariantMap mdata = doc.object().toVariantMap();
-				VariantList vitems;
-
-				if(!mdata.contains("items"))
-				{
-					httpControlRespond(req, 400, "Bad Request", "Invalid format: object does not contain 'items'\n");
-					return;
-				}
-
-				if(typeId(mdata["items"]) != VariantType::List)
-				{
-					httpControlRespond(req, 400, "Bad Request", "Invalid format: object contains 'items' with wrong type\n");
-					return;
-				}
-
-				vitems = mdata["items"].toList();
-
-				bool ok;
-				QString errorMessage;
-				QList<PublishItem> items = parseItems(vitems, &ok, &errorMessage);
-				if(!ok)
-				{
-					httpControlRespond(req, 400, "Bad Request", QString("Invalid format: %1\n").arg(errorMessage));
-					return;
-				}
-
-				QString message = "Published";
-				if(responseContentType == "application/json")
-				{
-					VariantMap obj;
-					obj["message"] = message;
-					QString body = QJsonDocument(QJsonObject::fromVariantMap(obj)).toJson(QJsonDocument::Compact);
-					httpControlRespond(req, 200, "OK", body + "\n", responseContentType, HttpHeaders(), items.count());
-				}
-				else // Text/plain
-				{
-					httpControlRespond(req, 200, "OK", message + "\n", responseContentType, HttpHeaders(), items.count());
-				}
-
-				foreach(const PublishItem &item, items)
-					handlePublishItem(item);
-			}
-			else
-			{
-				HttpHeaders headers;
-				headers += HttpHeader("Allow", "POST");
-				httpControlRespond(req, 405, "Method Not Allowed", "Method not allowed: " + req->requestMethod() + ".\n", QByteArray(), headers);
-			}
-		}
-		else if(path == "/recover")
-		{
-			if(req->requestMethod() == "POST")
-			{
-				QString message = "Updated";
-				if(responseContentType == "application/json")
-				{
-					VariantMap obj;
-					obj["message"] = message;
-					QString body = QJsonDocument(QJsonObject::fromVariantMap(obj)).toJson(QJsonDocument::Compact);
-					httpControlRespond(req, 200, "OK", body + "\n", responseContentType, HttpHeaders());
-				}
-				else // Text/plain
-				{
-					httpControlRespond(req, 200, "OK", message + "\n", responseContentType, HttpHeaders());
-				}
-
-				recoverCommand();
-			}
-			else
-			{
-				HttpHeaders headers;
-				headers += HttpHeader("Allow", "POST");
-				httpControlRespond(req, 405, "Method Not Allowed", "Method not allowed: " + req->requestMethod() + ".\n", QByteArray(), headers);
-			}
-		}
-		else
-		{
-			httpControlRespond(req, 404, "Not Found", "Not Found\n");
-		}
-	}
-
-	void hs_subscribe(HttpSession *hs, const QString &channel)
-	{
-		Instruct::HoldMode mode = hs->holdMode();
-		assert(mode == Instruct::ResponseHold || mode == Instruct::StreamHold);
-
-		QHash<QString, QSet<HttpSession*> > *sessionsByChannel;
-		QString modeStr;
-
-		if(mode == Instruct::ResponseHold)
-		{
-			log_debug("adding response hold on %s", qPrintable(channel));
-
-			sessionsByChannel = &cs.responseSessionsByChannel;
-			modeStr = "response";
-		}
-		else // StreamHold
-		{
-			log_debug("adding stream hold on %s", qPrintable(channel));
-
-			sessionsByChannel = &cs.streamSessionsByChannel;
-			modeStr = "stream";
-		}
-
-		if(!sessionsByChannel->contains(channel))
-			sessionsByChannel->insert(channel, QSet<HttpSession*>());
-
-		(*sessionsByChannel)[channel] += hs;
-
-		stats->addSubscription(modeStr, channel, sessionsByChannel->value(channel).count());
-		addSub(channel);
-
-		QString msg = QString("subscribe %1 channel=%2").arg(hs->requestUri().toString(Url::FullyEncoded), channel);
-		if(hs->isRetry())
-			msg += " retry";
-
-		log_info("%s", qPrintable(msg));
-	}
-
-	void hs_unsubscribe(HttpSession *hs, const QString &channel)
-	{
-		removeSessionChannel(hs, channel);
-	}
-
-	void hs_finished(HttpSession *hsp)
-	{
-		QByteArray addr = hsp->retryToAddress();
-		RetryRequestPacket rp = hsp->retryPacket();
-
-		std::shared_ptr<HttpSession> hs = cs.httpSessions.take(hsp->rid());
-
-		hs->subscribeCallback().remove(this);
-		hs->unsubscribeCallback().remove(this);
-		hs->finishedCallback().remove(this);
-		DeferCall::deleteLater(new std::shared_ptr<HttpSession>(hs));
-
-		if(!rp.requests.isEmpty())
-			writeRetryPacket(addr, rp);
-	}
-
-	void wssession_send(const WsControlPacket::Item &i, WsSession *s)
-	{
-		writeWsControlItems(s->peer, QList<WsControlPacket::Item>() << i);
-	}
-
-	void wssession_expired(WsSession *s)
-	{
-		removeWsSession(s);
-	}
-
-	void wssession_error(WsSession *s)
-	{
-		log_debug("ws session %s control error", qPrintable(s->cid));
-
-		WsControlPacket::Item i;
-		i.cid = s->cid.toUtf8();
-		i.type = WsControlPacket::Item::Cancel;
-
-		writeWsControlItems(s->peer, QList<WsControlPacket::Item>() << i);
-
-		removeWsSession(s);
-	}
+    void report_finished(const DeferredResult &result) {
+        Q_UNUSED(result);
+
+        report.reset();
+    }
+
+    void sessionUpdateMany_finished(Deferred *d, const DeferredResult &result) {
+        deferreds.erase(d);
+
+        if (!result.success)
+            log_error("couldn't update session: condition=%d", result.value.toInt());
+    }
+
+    void sessionCreateOrUpdate_finished(Deferred *d, const DeferredResult &result) {
+        deferreds.erase(d);
+
+        if (!result.success)
+            log_error("couldn't create/update session: condition=%d", result.value.toInt());
+    }
+
+    void inspectWorker_finished(InspectWorker *w, const DeferredResult &result) {
+        Q_UNUSED(result);
+
+        inspectWorkers.remove(w);
+        delete w;
+
+        // Try to read again
+        inspectServer_requestReady();
+    }
+
+    void acceptWorker_finished(AcceptWorker *w, const DeferredResult &result) {
+        Q_UNUSED(result);
+
+        acceptWorkers.remove(w);
+        delete w;
+
+        // Try to read again
+        acceptServer_requestReady();
+    }
+
+    void deferred_finished(Deferred *d, const DeferredResult &result) {
+        Q_UNUSED(result);
+
+        deferreds.erase(d);
+    }
+
+    void sub_subscribed(Subscription *sub) {
+        if (config.updateOnFirstSubscription)
+            updateSessions(sub->channel());
+    }
+
+    void acceptWorker_sessionsReady(AcceptWorker *w) {
+        QList<std::shared_ptr<HttpSession>> sessions = w->takeSessions();
+        foreach (const std::shared_ptr<HttpSession> &hs, sessions) {
+            // NOTE: for performance reasons we do not call hs->setParent and
+            // instead leave the object unparented
+
+            hs->subscribeCallback().add(Private::hs_subscribe_cb, this);
+            hs->unsubscribeCallback().add(Private::hs_unsubscribe_cb, this);
+            hs->finishedCallback().add(Private::hs_finished_cb, this);
+
+            cs.httpSessions.insert(hs->rid(), hs);
+
+            hs->start();
+        }
+    }
+
+    void acceptWorker_retryPacketReady(const QByteArray &instanceAddress,
+                                       const RetryRequestPacket &packet) {
+        writeRetryPacket(instanceAddress, packet);
+    }
+
+    void stats_connectionsRefreshed(const QList<QByteArray> &ids) {
+        if (stateClient) {
+            // Find sids of the connections
+            QHash<QString, LastIds> sidLastIds;
+            foreach (const QByteArray &id, ids) {
+                int at = id.indexOf(':');
+                assert(at != -1);
+                ZhttpRequest::Rid rid(id.mid(0, at), id.mid(at + 1));
+
+                HttpSession *hs = cs.httpSessions.value(rid).get();
+                if (hs && !hs->sid().isEmpty())
+                    sidLastIds[hs->sid()] = LastIds();
+            }
+
+            if (!sidLastIds.isEmpty()) {
+                auto d = std::unique_ptr<Deferred>(
+                    SessionRequest::updateMany(stateClient.get(), sidLastIds));
+
+                // Safe to not track, since d can't outlive this
+                d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, d.get(),
+                                                boost::placeholders::_1));
+
+                deferreds[d.get()] = std::move(d);
+            }
+        }
+    }
+
+    void stats_unsubscribed(const QString &mode, const QString &channel) {
+        // NOTE: this callback may be invoked while looping over certain structures,
+        // so be careful what you touch
+
+        Q_UNUSED(mode);
+
+        if (!cs.responseSessionsByChannel.contains(channel) &&
+            !cs.streamSessionsByChannel.contains(channel) &&
+            !cs.wsSessionsByChannel.contains(channel))
+            removeSub(channel);
+    }
+
+    Variant parseJsonOrTnetstring(const CowByteArray &message, bool *ok = 0,
+                                  QString *errorMessage = 0) {
+        Variant data;
+        bool ok_;
+        if (message.length() > 0 && message[0] == 'J') {
+            QJsonParseError e;
+            QJsonDocument doc = QJsonDocument::fromJson(message.mid(1).asQByteArray(), &e);
+            if (e.error != QJsonParseError::NoError) {
+                if (errorMessage)
+                    *errorMessage =
+                        QString("received message with invalid format (json parse failed)");
+                if (ok)
+                    *ok = false;
+                return data;
+            }
+
+            if (doc.isObject()) {
+                data = doc.object().toVariantMap();
+            } else {
+                if (errorMessage)
+                    *errorMessage =
+                        QString("received message with invalid format (not a valid json object)");
+                if (ok)
+                    *ok = false;
+                return data;
+            }
+        } else {
+            int offset = 0;
+            if (message.length() > 0 && message[0] == 'T') {
+                offset = 1;
+            }
+
+            data = TnetString::toVariant(message, offset, &ok_);
+            if (!ok_) {
+                if (errorMessage)
+                    *errorMessage =
+                        QString("received message with invalid format (tnetstring parse failed)");
+                if (ok)
+                    *ok = false;
+                return data;
+            }
+        }
+        if (ok)
+            *ok = true;
+        return data;
+    }
+
+    void inPull_readyRead(const CowByteArrayList &message) {
+        if (message.count() != 1) {
+            log_warning("IN pull: received message with parts != 1, skipping");
+            return;
+        }
+
+        bool ok;
+        QString errorMessage;
+        Variant data = parseJsonOrTnetstring(message[0], &ok, &errorMessage);
+        if (!ok) {
+            log_warning("IN pull: %s, skipping", qPrintable(errorMessage));
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("IN pull: %s", qPrintable(TnetString::variantToString(data, -1)));
+
+        PublishItem item = PublishItem::fromVariant(data, QString(), &ok, &errorMessage);
+        if (!ok) {
+            log_warning("IN pull: received message with invalid format: %s, skipping",
+                        qPrintable(errorMessage));
+            return;
+        }
+
+        handlePublishItem(item);
+    }
+
+    void inSub_readyRead(const CowByteArrayList &message) {
+        if (message.count() != 2) {
+            log_warning("IN sub: received message with parts != 2, skipping");
+            return;
+        }
+
+        bool ok;
+        QString errorMessage;
+        Variant data = parseJsonOrTnetstring(message[1], &ok, &errorMessage);
+        if (!ok) {
+            log_warning("IN sub: %s, skipping", qPrintable(errorMessage));
+            return;
+        }
+
+        QString channel = QString::fromUtf8(message[0].asQByteArray());
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("IN sub: channel=%s %s", qPrintable(channel),
+                      qPrintable(TnetString::variantToString(data, -1)));
+
+        PublishItem item = PublishItem::fromVariant(data, channel, &ok, &errorMessage);
+        if (!ok) {
+            log_warning("IN sub: received message with invalid format: %s, skipping",
+                        qPrintable(errorMessage));
+            return;
+        }
+
+        handlePublishItem(item);
+    }
+
+    void wsControlInit_readyRead(const CowByteArrayList &message) {
+        if (message.count() != 1) {
+            log_warning("IN wscontrol: received message with parts != 1, skipping");
+            return;
+        }
+
+        wsControlIn_readyRead(message[0]);
+    }
+
+    void wsControlStream_readyRead(const CowByteArrayList &message) {
+        ZmqReqMessage req(message);
+
+        if (req.content().count() != 1) {
+            log_warning("IN wscontrol: received message with parts != 1, skipping");
+            return;
+        }
+
+        wsControlIn_readyRead(req.content()[0]);
+    }
+
+    void wsControlIn_readyRead(const CowByteArray &message) {
+        bool ok;
+        Variant data = TnetString::toVariant(message, 0, &ok);
+        if (!ok) {
+            log_warning("IN wscontrol: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("IN wscontrol: %s", qPrintable(TnetString::variantToString(data, -1)));
+
+        WsControlPacket packet;
+        if (!packet.fromVariant(data)) {
+            log_warning("IN wscontrol: received message with invalid format, skipping");
+            return;
+        }
+
+        QStringList createOrUpdateSids;
+        QHash<QString, LastIds> updateSids;
+
+        QList<WsControlPacket::Item> outItems;
+
+        foreach (const WsControlPacket::Item &item, packet.items) {
+            if (item.type != WsControlPacket::Item::Ack && !item.requestId.isEmpty()) {
+                // Ack receipt
+                WsControlPacket::Item i;
+                i.cid = item.cid;
+                i.type = WsControlPacket::Item::Ack;
+                i.requestId = item.requestId;
+                outItems += i;
+            }
+
+            if (item.type == WsControlPacket::Item::Here) {
+                std::shared_ptr<WsSession> s = cs.wsSessions.value(item.cid);
+                if (!s) {
+                    s = std::make_shared<WsSession>();
+                    wsSessionConnectionMap[s.get()] = {
+                        s->send.connect(boost::bind(&Private::wssession_send, this,
+                                                    boost::placeholders::_1, s.get())),
+                        s->expired.connect(boost::bind(&Private::wssession_expired, this, s.get())),
+                        s->error.connect(boost::bind(&Private::wssession_error, this, s.get()))};
+                    s->peer = packet.from;
+                    s->cid = QString::fromUtf8(item.cid);
+                    s->ttl = item.ttl;
+                    s->requestData.uri = item.uri;
+                    s->zhttpOut = zhttpOut.get();
+                    s->filterLimiter = filterLimiter;
+                    s->refreshExpiration();
+                    cs.wsSessions.insert(s->cid, s);
+                    log_debug("added ws session: %s", qPrintable(s->cid));
+                }
+
+                s->debug = item.debug;
+                s->route = item.route;
+                s->statsRoute = item.separateStats ? item.route : QString();
+                s->targetTrusted = item.trusted;
+                s->channelPrefix = QString::fromUtf8(item.channelPrefix);
+                if (item.logLevel >= 0)
+                    s->logLevel = item.logLevel;
+
+                if (!s->sid.isEmpty())
+                    updateSids[s->sid] = LastIds();
+
+                continue;
+            }
+
+            // Any other type must be for a known cid
+            WsSession *s = cs.wsSessions.value(QString::fromUtf8(item.cid)).get();
+            if (!s) {
+                // Send cancel, causing the proxy to close the connection. Client
+                // will need to retry to repair
+                WsControlPacket::Item i;
+                i.cid = item.cid;
+                i.type = WsControlPacket::Item::Cancel;
+                outItems += i;
+                continue;
+            }
+
+            if (item.type == WsControlPacket::Item::KeepAlive) {
+                s->ttl = item.ttl;
+                s->refreshExpiration();
+            } else if (item.type == WsControlPacket::Item::Gone ||
+                       item.type == WsControlPacket::Item::Cancel) {
+                removeWsSession(s);
+            } else if (item.type == WsControlPacket::Item::Grip) {
+                QJsonParseError e;
+                QJsonDocument doc = QJsonDocument::fromJson(item.message, &e);
+                if (e.error != QJsonParseError::NoError || (!doc.isObject() && !doc.isArray())) {
+                    log_debug("grip control message is not valid json");
+                    continue;
+                }
+
+                if (doc.isObject())
+                    data = doc.object().toVariantMap();
+                else // IsArray
+                    data = doc.array().toVariantList();
+
+                QString errorMessage;
+                WsControlMessage cm = WsControlMessage::fromVariant(data, &ok, &errorMessage);
+                if (!ok) {
+                    log_debug("failed to parse grip control message: %s", qPrintable(errorMessage));
+                    continue;
+                }
+
+                if (cm.type == WsControlMessage::Subscribe) {
+                    if (s->channels.count() < config.connectionSubscriptionMax) {
+                        if (cm.filters.count() > MESSAGEFILTERSTACK_SIZE_MAX) {
+                            s->sendCloseError(
+                                QString("too many filters for channel '%1'").arg(cm.channel));
+                            continue;
+                        }
+
+                        QString channel = s->channelPrefix + cm.channel;
+
+                        Instruct::Channel c;
+                        c.name = cm.channel;
+                        c.filters = cm.filters;
+
+                        s->channels.insert(channel, c);
+
+                        if (!cs.wsSessionsByChannel.contains(channel))
+                            cs.wsSessionsByChannel.insert(channel, QSet<WsSession *>());
+
+                        cs.wsSessionsByChannel[channel] += s;
+
+                        log_debug("ws session %s subscribed to %s", qPrintable(s->cid),
+                                  qPrintable(channel));
+
+                        stats->addSubscription("ws", channel,
+                                               cs.wsSessionsByChannel.value(channel).count());
+                        addSub(channel);
+
+                        log_info("subscribe %s channel=%s",
+                                 qPrintable(s->requestData.uri.toString(Url::FullyEncoded)),
+                                 qPrintable(channel));
+                    } else {
+                        auto routeInfo = LogUtil::RouteInfo(s->route, s->logLevel);
+                        LogUtil::logForRoute(routeInfo, "wssession: too many subscriptions");
+                    }
+                } else if (cm.type == WsControlMessage::Unsubscribe) {
+                    QString channel = s->channelPrefix + cm.channel;
+
+                    if (!s->implicitChannels.contains(channel)) {
+                        s->channels.remove(channel);
+
+                        removeSessionChannel(s, channel);
+                    }
+                } else if (cm.type == WsControlMessage::Detach) {
+                    WsControlPacket::Item i;
+                    i.cid = item.cid;
+                    i.type = WsControlPacket::Item::Detach;
+                    outItems += i;
+                } else if (cm.type == WsControlMessage::Session) {
+                    if (!cm.sessionId.isEmpty()) {
+                        s->sid = cm.sessionId;
+                        createOrUpdateSids += cm.sessionId;
+                    } else {
+                        s->sid.clear();
+                    }
+                } else if (cm.type == WsControlMessage::SetMeta) {
+                    if (!cm.metaValue.isNull())
+                        s->meta[cm.metaName] = cm.metaValue;
+                    else
+                        s->meta.remove(cm.metaName);
+                } else if (cm.type == WsControlMessage::KeepAlive) {
+                    WsControlPacket::Item i;
+                    i.cid = item.cid;
+                    i.type = WsControlPacket::Item::KeepAliveSetup;
+
+                    if (!cm.content.isNull()) {
+                        QByteArray contentType;
+                        switch (cm.messageType) {
+                        case WsControlMessage::Text:
+                            contentType = "text";
+                            break;
+                        case WsControlMessage::Binary:
+                            contentType = "binary";
+                            break;
+                        case WsControlMessage::Ping:
+                            contentType = "ping";
+                            break;
+                        case WsControlMessage::Pong:
+                            contentType = "pong";
+                            break;
+                        default:
+                            continue; // Unrecognized type, ignore
+                        }
+
+                        s->keepAliveType = contentType;
+                        s->keepAliveMessage = cm.content;
+
+                        if (cm.keepAliveMode == "interval")
+                            i.keepAliveMode = "interval";
+                        else
+                            i.keepAliveMode = "idle";
+
+                        i.timeout = (cm.timeout > 0 ? cm.timeout : DEFAULT_WS_KEEPALIVE_TIMEOUT);
+                    } else {
+                        s->keepAliveType.clear();
+                        s->keepAliveMessage.clear();
+                    }
+
+                    outItems += i;
+                } else if (cm.type == WsControlMessage::SendDelayed) {
+                    QByteArray contentType;
+                    switch (cm.messageType) {
+                    case WsControlMessage::Text:
+                        contentType = "text";
+                        break;
+                    case WsControlMessage::Binary:
+                        contentType = "binary";
+                        break;
+                    case WsControlMessage::Ping:
+                        contentType = "ping";
+                        break;
+                    case WsControlMessage::Pong:
+                        contentType = "pong";
+                        break;
+                    default:
+                        continue; // Unrecognized type, ignore
+                    }
+
+                    int timeout = (cm.timeout > 0 ? cm.timeout : DEFAULT_WS_SENDDELAYED_TIMEOUT);
+
+                    s->sendDelayed(contentType, cm.content, timeout);
+                } else if (cm.type == WsControlMessage::FlushDelayed) {
+                    s->flushDelayed();
+                }
+            } else if (item.type == WsControlPacket::Item::NeedKeepAlive) {
+                if (!s->keepAliveMessage.isNull()) {
+                    WsControlPacket::Item i;
+                    i.cid = s->cid.toUtf8();
+                    i.type = WsControlPacket::Item::Send;
+                    i.contentType = s->keepAliveType;
+                    i.message = s->keepAliveMessage;
+
+                    outItems += i;
+
+                    stats->addActivity(s->statsRoute.toUtf8(), 1);
+                }
+            } else if (item.type == WsControlPacket::Item::Subscribe) {
+                QString channel = QString::fromUtf8(item.channel);
+
+                s->implicitChannels += channel;
+
+                Instruct::Channel c;
+                c.name = channel;
+                s->channels.insert(channel, c);
+
+                if (!cs.wsSessionsByChannel.contains(channel))
+                    cs.wsSessionsByChannel.insert(channel, QSet<WsSession *>());
+
+                cs.wsSessionsByChannel[channel] += s;
+
+                log_debug("ws session %s subscribed to %s", qPrintable(s->cid),
+                          qPrintable(channel));
+
+                stats->addSubscription("ws", channel,
+                                       cs.wsSessionsByChannel.value(channel).count());
+                addSub(channel);
+
+                log_info("subscribe %s channel=%s",
+                         qPrintable(s->requestData.uri.toString(Url::FullyEncoded)),
+                         qPrintable(channel));
+            } else if (item.type == WsControlPacket::Item::Ack) {
+                int reqId = item.requestId.toInt();
+                s->ack(reqId);
+            }
+        }
+
+        if (!outItems.isEmpty())
+            writeWsControlItems(packet.from, outItems);
+
+        if (stateClient) {
+            foreach (const QString &sid, createOrUpdateSids) {
+                auto d = std::unique_ptr<Deferred>(
+                    SessionRequest::createOrUpdate(stateClient.get(), sid, LastIds()));
+
+                // Safe to not track, since d can't outlive this
+                d->finished.connect(boost::bind(&Private::sessionCreateOrUpdate_finished, this,
+                                                d.get(), boost::placeholders::_1));
+
+                deferreds[d.get()] = std::move(d);
+            }
+
+            if (!updateSids.isEmpty()) {
+                auto d = std::unique_ptr<Deferred>(
+                    SessionRequest::updateMany(stateClient.get(), updateSids));
+
+                // Safe to not track, since d can't outlive this
+                d->finished.connect(boost::bind(&Private::sessionUpdateMany_finished, this, d.get(),
+                                                boost::placeholders::_1));
+
+                deferreds[d.get()] = std::move(d);
+            }
+        }
+    }
+
+    void proxyStats_readyRead(const CowByteArrayList &message) {
+        if (message.count() != 1) {
+            log_warning("IN proxy stats: received message with parts != 1, skipping");
+            return;
+        }
+
+        int at = message[0].indexOf(' ');
+        if (at == -1) {
+            log_warning("IN proxy stats: received message with invalid format, skipping");
+            return;
+        }
+
+        QByteArray type = message[0].mid(0, at).asQByteArray();
+
+        if (at + 1 >= message[0].length() || message[0][at + 1] != 'T') {
+            log_warning("IN proxy stats: received message with unsupported format, skipping");
+            return;
+        }
+
+        bool ok;
+        Variant data = TnetString::toVariant(message[0], at + 2, &ok);
+        if (!ok) {
+            log_warning("IN proxy stats: received message with invalid format "
+                        "(tnetstring parse failed), skipping");
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("IN proxy stats: %s %s", type.data(),
+                      qPrintable(TnetString::variantToString(data, -1)));
+
+        StatsPacket p;
+        if (!p.fromVariant(type, data)) {
+            log_warning("IN proxy stats: received message with invalid format, skipping");
+            return;
+        }
+
+        if (p.type == StatsPacket::Activity) {
+            if (p.count > 0) {
+                // Merge with our own stats
+                stats->addActivity(p.route, p.count);
+            }
+        } else if (p.type == StatsPacket::Counts) {
+            if (p.requestsReceived > 0) {
+                // Merge with our own stats
+                stats->addRequestsReceived(p.requestsReceived);
+            }
+        } else if (p.type == StatsPacket::Connected || p.type == StatsPacket::Disconnected) {
+            if (stats->connectionSendEnabled()) {
+                // Track proxy connections for reporting
+                bool localReplaced = stats->processExternalPacket(p, false);
+
+                if (!localReplaced) {
+                    // Forward the packet. This will stamp the from field and keep the
+                    // rest
+                    stats->sendPacket(p);
+                }
+            }
+        } else if (p.type == StatsPacket::Report) {
+            bool mergeConnectionReport = !stats->connectionSendEnabled();
+
+            // Merge into local report and don't forward
+            stats->processExternalPacket(p, mergeConnectionReport);
+        }
+    }
+
+    void controlHttpServer_requestReady() {
+        SimpleHttpRequest *req = controlHttpServer->takeNext();
+        if (!req)
+            return;
+
+        QByteArray path = req->requestUri();
+        if (path.length() > 1 && path[path.length() - 1] == '/')
+            path.truncate(path.length() - 1);
+
+        HttpHeaders headers = req->requestHeaders();
+
+        QByteArray responseContentType;
+        if (headers.contains("Accept")) {
+            foreach (const HttpHeaderParameters &params, headers.getAllAsParameters("Accept")) {
+                if (params.isEmpty() || params[0].first.isEmpty())
+                    continue;
+
+                QByteArray type = params[0].first.asQByteArray();
+
+                if (type == "text/plain" || type == "text/*" || type == "*/*" || type == "*") {
+                    responseContentType = "text/plain";
+                } else if (type == "application/json" || type == "application/*") {
+                    responseContentType = "application/json";
+                }
+            }
+
+            if (responseContentType.isEmpty()) {
+                httpControlRespond(req, 406, "Not Acceptable",
+                                   "Not Acceptable. Supported formats are text/plain "
+                                   "and application/json.\n");
+                return;
+            }
+        } else {
+            responseContentType = "text/plain";
+        }
+
+        if (path == "/") {
+            httpControlRespond(req, 200, "OK", "Pushpin API\n");
+        } else if (path == "/publish") {
+            if (req->requestMethod() == "POST") {
+                QJsonParseError e;
+                QJsonDocument doc = QJsonDocument::fromJson(req->requestBody(), &e);
+                if (e.error != QJsonParseError::NoError) {
+                    httpControlRespond(req, 400, "Bad Request", "Body is not valid JSON.\n");
+                    return;
+                }
+
+                if (!doc.isObject()) {
+                    httpControlRespond(req, 400, "Bad Request", "Invalid format.\n");
+                    return;
+                }
+
+                VariantMap mdata = doc.object().toVariantMap();
+                VariantList vitems;
+
+                if (!mdata.contains("items")) {
+                    httpControlRespond(req, 400, "Bad Request",
+                                       "Invalid format: object does not contain 'items'\n");
+                    return;
+                }
+
+                if (typeId(mdata["items"]) != VariantType::List) {
+                    httpControlRespond(req, 400, "Bad Request",
+                                       "Invalid format: object contains 'items' with wrong type\n");
+                    return;
+                }
+
+                vitems = mdata["items"].toList();
+
+                bool ok;
+                QString errorMessage;
+                QList<PublishItem> items = parseItems(vitems, &ok, &errorMessage);
+                if (!ok) {
+                    httpControlRespond(req, 400, "Bad Request",
+                                       QString("Invalid format: %1\n").arg(errorMessage));
+                    return;
+                }
+
+                QString message = "Published";
+                if (responseContentType == "application/json") {
+                    VariantMap obj;
+                    obj["message"] = message;
+                    QString body = QJsonDocument(QJsonObject::fromVariantMap(obj))
+                                       .toJson(QJsonDocument::Compact);
+                    httpControlRespond(req, 200, "OK", body + "\n", responseContentType,
+                                       HttpHeaders(), items.count());
+                } else // Text/plain
+                {
+                    httpControlRespond(req, 200, "OK", message + "\n", responseContentType,
+                                       HttpHeaders(), items.count());
+                }
+
+                foreach (const PublishItem &item, items)
+                    handlePublishItem(item);
+            } else {
+                HttpHeaders headers;
+                headers += HttpHeader("Allow", "POST");
+                httpControlRespond(req, 405, "Method Not Allowed",
+                                   "Method not allowed: " + req->requestMethod() + ".\n",
+                                   QByteArray(), headers);
+            }
+        } else if (path == "/recover") {
+            if (req->requestMethod() == "POST") {
+                QString message = "Updated";
+                if (responseContentType == "application/json") {
+                    VariantMap obj;
+                    obj["message"] = message;
+                    QString body = QJsonDocument(QJsonObject::fromVariantMap(obj))
+                                       .toJson(QJsonDocument::Compact);
+                    httpControlRespond(req, 200, "OK", body + "\n", responseContentType,
+                                       HttpHeaders());
+                } else // Text/plain
+                {
+                    httpControlRespond(req, 200, "OK", message + "\n", responseContentType,
+                                       HttpHeaders());
+                }
+
+                recoverCommand();
+            } else {
+                HttpHeaders headers;
+                headers += HttpHeader("Allow", "POST");
+                httpControlRespond(req, 405, "Method Not Allowed",
+                                   "Method not allowed: " + req->requestMethod() + ".\n",
+                                   QByteArray(), headers);
+            }
+        } else {
+            httpControlRespond(req, 404, "Not Found", "Not Found\n");
+        }
+    }
+
+    void hs_subscribe(HttpSession *hs, const QString &channel) {
+        Instruct::HoldMode mode = hs->holdMode();
+        assert(mode == Instruct::ResponseHold || mode == Instruct::StreamHold);
+
+        QHash<QString, QSet<HttpSession *>> *sessionsByChannel;
+        QString modeStr;
+
+        if (mode == Instruct::ResponseHold) {
+            log_debug("adding response hold on %s", qPrintable(channel));
+
+            sessionsByChannel = &cs.responseSessionsByChannel;
+            modeStr = "response";
+        } else // StreamHold
+        {
+            log_debug("adding stream hold on %s", qPrintable(channel));
+
+            sessionsByChannel = &cs.streamSessionsByChannel;
+            modeStr = "stream";
+        }
+
+        if (!sessionsByChannel->contains(channel))
+            sessionsByChannel->insert(channel, QSet<HttpSession *>());
+
+        (*sessionsByChannel)[channel] += hs;
+
+        stats->addSubscription(modeStr, channel, sessionsByChannel->value(channel).count());
+        addSub(channel);
+
+        QString msg = QString("subscribe %1 channel=%2")
+                          .arg(hs->requestUri().toString(Url::FullyEncoded), channel);
+        if (hs->isRetry())
+            msg += " retry";
+
+        log_info("%s", qPrintable(msg));
+    }
+
+    void hs_unsubscribe(HttpSession *hs, const QString &channel) {
+        removeSessionChannel(hs, channel);
+    }
+
+    void hs_finished(HttpSession *hsp) {
+        QByteArray addr = hsp->retryToAddress();
+        RetryRequestPacket rp = hsp->retryPacket();
+
+        std::shared_ptr<HttpSession> hs = cs.httpSessions.take(hsp->rid());
+
+        hs->subscribeCallback().remove(this);
+        hs->unsubscribeCallback().remove(this);
+        hs->finishedCallback().remove(this);
+        DeferCall::deleteLater(new std::shared_ptr<HttpSession>(hs));
+
+        if (!rp.requests.isEmpty())
+            writeRetryPacket(addr, rp);
+    }
+
+    void wssession_send(const WsControlPacket::Item &i, WsSession *s) {
+        writeWsControlItems(s->peer, QList<WsControlPacket::Item>() << i);
+    }
+
+    void wssession_expired(WsSession *s) { removeWsSession(s); }
+
+    void wssession_error(WsSession *s) {
+        log_debug("ws session %s control error", qPrintable(s->cid));
+
+        WsControlPacket::Item i;
+        i.cid = s->cid.toUtf8();
+        i.type = WsControlPacket::Item::Cancel;
+
+        writeWsControlItems(s->peer, QList<WsControlPacket::Item>() << i);
+
+        removeWsSession(s);
+    }
 };
 
-HandlerEngine::HandlerEngine()
-{
-	d = std::make_shared<Private>(this);
-}
+HandlerEngine::HandlerEngine() { d = std::make_shared<Private>(this); }
 
 HandlerEngine::~HandlerEngine() = default;
 
-bool HandlerEngine::start(const Configuration &config)
-{
-	return d->start(config);
-}
+bool HandlerEngine::start(const Configuration &config) { return d->start(config); }
 
-void HandlerEngine::reload()
-{
-	d->reload();
-}
+void HandlerEngine::reload() { d->reload(); }

--- a/src/handler/handlerengine.h
+++ b/src/handler/handlerengine.h
@@ -24,8 +24,8 @@
 #ifndef HANDLERENGINE_H
 #define HANDLERENGINE_H
 
-#include <QStringList>
 #include <QHostAddress>
+#include <QStringList>
 #include <boost/signals2.hpp>
 #include <map>
 
@@ -38,88 +38,84 @@ using std::map;
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
-class HandlerEngine
-{
+class HandlerEngine {
 public:
-	class Configuration
-	{
-	public:
-		QString appVersion;
-		QByteArray instanceId;
-		QStringList serverInStreamSpecs;
-		QStringList serverOutSpecs;
-		QStringList clientOutSpecs;
-		QStringList clientOutStreamSpecs;
-		QStringList clientInSpecs;
-		QStringList inspectSpecs;
-		QStringList acceptSpecs;
-		QStringList retryOutSpecs;
-		QStringList wsControlInitSpecs;
-		QStringList wsControlStreamSpecs;
-		QString statsSpec;
-		QString commandSpec;
-		QString stateSpec;
-		QStringList proxyStatsSpecs;
-		QString proxyCommandSpec;
-		QString pushInSpec;
-		QStringList pushInSubSpecs;
-		bool pushInSubConnect;
-		QHostAddress pushInHttpAddr;
-		int pushInHttpPort;
-		int pushInHttpMaxHeadersSize;
-		int pushInHttpMaxBodySize;
-		int ipcFileMode;
-		bool shareAll;
-		int messageRate;
-		int messageHwm;
-		int messageBlockSize;
-		int messageWait;
-		int idCacheTtl;
-		bool updateOnFirstSubscription;
-		int connectionsMax;
-		int connectionSubscriptionMax;
-		int subscriptionLinger;
-		bool statsConnectionSend;
-		int statsConnectionTtl;
-		int statsSubscriptionTtl;
-		int statsReportInterval;
-		QString statsFormat;
-		QString prometheusPort;
-		QString prometheusPrefix;
+    class Configuration {
+    public:
+        QString appVersion;
+        QByteArray instanceId;
+        QStringList serverInStreamSpecs;
+        QStringList serverOutSpecs;
+        QStringList clientOutSpecs;
+        QStringList clientOutStreamSpecs;
+        QStringList clientInSpecs;
+        QStringList inspectSpecs;
+        QStringList acceptSpecs;
+        QStringList retryOutSpecs;
+        QStringList wsControlInitSpecs;
+        QStringList wsControlStreamSpecs;
+        QString statsSpec;
+        QString commandSpec;
+        QString stateSpec;
+        QStringList proxyStatsSpecs;
+        QString proxyCommandSpec;
+        QString pushInSpec;
+        QStringList pushInSubSpecs;
+        bool pushInSubConnect;
+        QHostAddress pushInHttpAddr;
+        int pushInHttpPort;
+        int pushInHttpMaxHeadersSize;
+        int pushInHttpMaxBodySize;
+        int ipcFileMode;
+        bool shareAll;
+        int messageRate;
+        int messageHwm;
+        int messageBlockSize;
+        int messageWait;
+        int idCacheTtl;
+        bool updateOnFirstSubscription;
+        int connectionsMax;
+        int connectionSubscriptionMax;
+        int subscriptionLinger;
+        bool statsConnectionSend;
+        int statsConnectionTtl;
+        int statsSubscriptionTtl;
+        int statsReportInterval;
+        QString statsFormat;
+        QString prometheusPort;
+        QString prometheusPrefix;
 
-		Configuration() :
-			pushInSubConnect(false),
-			pushInHttpPort(-1),
-			pushInHttpMaxHeadersSize(-1),
-			pushInHttpMaxBodySize(-1),
-			ipcFileMode(-1),
-			shareAll(false),
-			messageRate(-1),
-			messageHwm(-1),
-			messageBlockSize(-1),
-			messageWait(-1),
-			idCacheTtl(-1),
-			updateOnFirstSubscription(false),
-			connectionsMax(-1),
-			connectionSubscriptionMax(-1),
-			subscriptionLinger(-1),
-			statsConnectionSend(false),
-			statsConnectionTtl(-1),
-			statsSubscriptionTtl(-1),
-			statsReportInterval(-1)
-		{
-		}
-	};
+        Configuration()
+            : pushInSubConnect(false),
+              pushInHttpPort(-1),
+              pushInHttpMaxHeadersSize(-1),
+              pushInHttpMaxBodySize(-1),
+              ipcFileMode(-1),
+              shareAll(false),
+              messageRate(-1),
+              messageHwm(-1),
+              messageBlockSize(-1),
+              messageWait(-1),
+              idCacheTtl(-1),
+              updateOnFirstSubscription(false),
+              connectionsMax(-1),
+              connectionSubscriptionMax(-1),
+              subscriptionLinger(-1),
+              statsConnectionSend(false),
+              statsConnectionTtl(-1),
+              statsSubscriptionTtl(-1),
+              statsReportInterval(-1) {}
+    };
 
-	HandlerEngine();
-	~HandlerEngine();
+    HandlerEngine();
+    ~HandlerEngine();
 
-	bool start(const Configuration &config);
-	void reload();
+    bool start(const Configuration &config);
+    void reload();
 
 private:
-	class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -21,884 +21,864 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <chrono>
-#include <thread>
-#include <QDir>
-#include "test.h"
+#include "handlerengine.h"
 #include "cowstring.h"
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "zmqreqmessage.h"
-#include "qtcompat.h"
+#include "eventloop.h"
 #include "log.h"
+#include "packet/httpresponsedata.h"
+#include "qtcompat.h"
+#include "test.h"
 #include "tnetstring.h"
 #include "variant.h"
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
-#include "packet/httpresponsedata.h"
-#include "eventloop.h"
-#include "handlerengine.h"
+#include "zmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include <QDir>
+#include <chrono>
+#include <thread>
 
 using namespace std::chrono_literals;
 
 namespace {
 
-class Wrapper
-{
+class Wrapper {
 public:
-	std::unique_ptr<ZmqSocket> zhttpClientOutStreamSock;
-	std::unique_ptr<ZmqValve> zhttpClientOutStreamValve;
-	std::unique_ptr<ZmqSocket> zhttpClientInSock;
-	std::unique_ptr<ZmqValve> zhttpClientInValve;
-	std::unique_ptr<ZmqSocket> zhttpServerInSock;
-	std::unique_ptr<ZmqValve> zhttpServerInValve;
-	std::unique_ptr<ZmqSocket> zhttpServerInStreamSock;
-	std::unique_ptr<ZmqValve> zhttpServerInStreamValve;
-	std::unique_ptr<ZmqSocket> zhttpServerOutSock;
-	std::unique_ptr<ZmqSocket> proxyAcceptSock;
-	std::unique_ptr<ZmqValve> proxyAcceptValve;
-	std::unique_ptr<ZmqSocket> publishPushSock;
+    std::unique_ptr<ZmqSocket> zhttpClientOutStreamSock;
+    std::unique_ptr<ZmqValve> zhttpClientOutStreamValve;
+    std::unique_ptr<ZmqSocket> zhttpClientInSock;
+    std::unique_ptr<ZmqValve> zhttpClientInValve;
+    std::unique_ptr<ZmqSocket> zhttpServerInSock;
+    std::unique_ptr<ZmqValve> zhttpServerInValve;
+    std::unique_ptr<ZmqSocket> zhttpServerInStreamSock;
+    std::unique_ptr<ZmqValve> zhttpServerInStreamValve;
+    std::unique_ptr<ZmqSocket> zhttpServerOutSock;
+    std::unique_ptr<ZmqSocket> proxyAcceptSock;
+    std::unique_ptr<ZmqValve> proxyAcceptValve;
+    std::unique_ptr<ZmqSocket> publishPushSock;
 
-	QDir workDir;
-	bool acceptSuccess;
-	VariantHash acceptValue;
-	bool finished;
-	QHash<QByteArray, HttpResponseData> responses;
-	int serverReqs;
-	bool serverFailed;
-	int serverOutSeq;
-	QByteArray requestBody;
-	Connection zhttpClientInValveConnection;
-	Connection zhttpClientOutStreamValveConnection;
-	Connection zhttpServerInValveConnection;
-	Connection zhttpServerInStreamValveConnection;
-	Connection proxyAcceptValveConnection;
+    QDir workDir;
+    bool acceptSuccess;
+    VariantHash acceptValue;
+    bool finished;
+    QHash<QByteArray, HttpResponseData> responses;
+    int serverReqs;
+    bool serverFailed;
+    int serverOutSeq;
+    QByteArray requestBody;
+    Connection zhttpClientInValveConnection;
+    Connection zhttpClientOutStreamValveConnection;
+    Connection zhttpServerInValveConnection;
+    Connection zhttpServerInStreamValveConnection;
+    Connection proxyAcceptValveConnection;
 
-	boost::signals2::signal<void()> connected;
+    boost::signals2::signal<void()> connected;
 
-	Wrapper(QDir _workDir) :
-		workDir(_workDir),
-		acceptSuccess(false),
-		finished(false),
-		serverReqs(0),
-		serverFailed(false),
-		serverOutSeq(0)
-	{
-		// Http sockets
+    Wrapper(QDir _workDir)
+        : workDir(_workDir),
+          acceptSuccess(false),
+          finished(false),
+          serverReqs(0),
+          serverFailed(false),
+          serverOutSeq(0) {
+        // Http sockets
 
-		zhttpClientOutStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		zhttpClientOutStreamValve = std::make_unique<ZmqValve>(zhttpClientOutStreamSock.get());
-		zhttpClientOutStreamValveConnection = zhttpClientOutStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientOutStream_readyRead, this, boost::placeholders::_1));
+        zhttpClientOutStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        zhttpClientOutStreamValve = std::make_unique<ZmqValve>(zhttpClientOutStreamSock.get());
+        zhttpClientOutStreamValveConnection = zhttpClientOutStreamValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpClientOutStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpClientInSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-		zhttpClientInValve = std::make_unique<ZmqValve>(zhttpClientInSock.get());
-		zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
+        zhttpClientInSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+        zhttpClientInValve = std::make_unique<ZmqValve>(zhttpClientInSock.get());
+        zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
-		zhttpServerInValve = std::make_unique<ZmqValve>(zhttpServerInSock.get());
-		zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
+        zhttpServerInSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+        zhttpServerInValve = std::make_unique<ZmqValve>(zhttpServerInSock.get());
+        zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		zhttpServerInStreamSock->setIdentity("test-server");
-		zhttpServerInStreamValve = std::make_unique<ZmqValve>(zhttpServerInStreamSock.get());
-		zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
+        zhttpServerInStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        zhttpServerInStreamSock->setIdentity("test-server");
+        zhttpServerInStreamValve = std::make_unique<ZmqValve>(zhttpServerInStreamSock.get());
+        zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
+        zhttpServerOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
 
-		// Proxy sockets
+        // Proxy sockets
 
-		proxyAcceptSock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
-		proxyAcceptValve = std::make_unique<ZmqValve>(proxyAcceptSock.get());
-		proxyAcceptValveConnection = proxyAcceptValve->readyRead.connect(boost::bind(&Wrapper::proxyAccept_readyRead, this, boost::placeholders::_1));
+        proxyAcceptSock = std::make_unique<ZmqSocket>(ZmqSocket::Dealer);
+        proxyAcceptValve = std::make_unique<ZmqValve>(proxyAcceptSock.get());
+        proxyAcceptValveConnection = proxyAcceptValve->readyRead.connect(
+            boost::bind(&Wrapper::proxyAccept_readyRead, this, boost::placeholders::_1));
 
-		// Publish sockets
+        // Publish sockets
 
-		publishPushSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
-	}
+        publishPushSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
+    }
 
-	void startHttp()
-	{
-		zhttpClientOutStreamSock->setIdentity("test-client");
-		zhttpClientOutStreamSock->setProbeRouterEnabled(true);
+    void startHttp() {
+        zhttpClientOutStreamSock->setIdentity("test-client");
+        zhttpClientOutStreamSock->setProbeRouterEnabled(true);
 
-		zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("hndtst-client-out-stream"));
-		zhttpClientInSock->bind("ipc://" + workDir.filePath("hndtst-client-in"));
-		zhttpServerInSock->bind("ipc://" + workDir.filePath("hndtst-server-in"));
-		zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("hndtst-server-in-stream"));
-		zhttpServerOutSock->bind("ipc://" + workDir.filePath("hndtst-server-out"));
+        zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("hndtst-client-out-stream"));
+        zhttpClientInSock->bind("ipc://" + workDir.filePath("hndtst-client-in"));
+        zhttpServerInSock->bind("ipc://" + workDir.filePath("hndtst-server-in"));
+        zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("hndtst-server-in-stream"));
+        zhttpServerOutSock->bind("ipc://" + workDir.filePath("hndtst-server-out"));
 
-		zhttpClientInSock->subscribe("test-client ");
+        zhttpClientInSock->subscribe("test-client ");
 
-		zhttpClientInValve->open();
-		zhttpClientOutStreamValve->open();
-		zhttpServerInValve->open();
-		zhttpServerInStreamValve->open();
-	}
+        zhttpClientInValve->open();
+        zhttpClientOutStreamValve->open();
+        zhttpServerInValve->open();
+        zhttpServerInStreamValve->open();
+    }
 
-	void startProxy()
-	{
-		proxyAcceptSock->bind("ipc://" + workDir.filePath("hndtst-accept"));
+    void startProxy() {
+        proxyAcceptSock->bind("ipc://" + workDir.filePath("hndtst-accept"));
 
-		proxyAcceptValve->open();
-	}
+        proxyAcceptValve->open();
+    }
 
-	void startPublish()
-	{
-		publishPushSock->connectToAddress("ipc://" + workDir.filePath("hndtst-publish-pull"));
-	}
+    void startPublish() {
+        publishPushSock->connectToAddress("ipc://" + workDir.filePath("hndtst-publish-pull"));
+    }
 
-	void reset()
-	{
-		acceptSuccess = false;
-		acceptValue.clear();
-		finished = false;
-		responses.clear();
-		serverReqs = 0;
-		serverFailed = false;
-		serverOutSeq = 0;
-		requestBody.clear();
-	}
+    void reset() {
+        acceptSuccess = false;
+        acceptValue.clear();
+        finished = false;
+        responses.clear();
+        serverReqs = 0;
+        serverFailed = false;
+        serverOutSeq = 0;
+        requestBody.clear();
+    }
 
-	void processClientIn(const CowByteArray &message)
-	{
-		log_debug("client in");
+    void processClientIn(const CowByteArray &message) {
+        log_debug("client in");
 
-		Variant v = TnetString::toVariant(message);
-		ZhttpResponsePacket zresp;
-		zresp.fromVariant(v);
-		if(zresp.type == ZhttpResponsePacket::Data)
-		{
-			if(!responses.contains(zresp.ids.first().id.asQByteArray()))
-			{
-				HttpResponseData rd;
-				rd.code = zresp.code;
-				rd.reason = zresp.reason.asQByteArray();
-				rd.headers = zresp.headers;
-				responses[zresp.ids.first().id.asQByteArray()] = rd;
-			}
+        Variant v = TnetString::toVariant(message);
+        ZhttpResponsePacket zresp;
+        zresp.fromVariant(v);
+        if (zresp.type == ZhttpResponsePacket::Data) {
+            if (!responses.contains(zresp.ids.first().id.asQByteArray())) {
+                HttpResponseData rd;
+                rd.code = zresp.code;
+                rd.reason = zresp.reason.asQByteArray();
+                rd.headers = zresp.headers;
+                responses[zresp.ids.first().id.asQByteArray()] = rd;
+            }
 
-			responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
+            responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
 
-			if(!zresp.more)
-				finished = true;
-		}
-	}
+            if (!zresp.more)
+                finished = true;
+        }
+    }
 
-	void zhttpClientIn_readyRead(const CowByteArrayList &message)
-	{
-		int at = message[0].indexOf(' ');
+    void zhttpClientIn_readyRead(const CowByteArrayList &message) {
+        int at = message[0].indexOf(' ');
 
-		processClientIn(message[0].mid(at + 2));
-	}
+        processClientIn(message[0].mid(at + 2));
+    }
 
-	void zhttpClientOutStream_readyRead(const CowByteArrayList &message)
-	{
-		if(message[2] == "probe-ack")
-		{
-			connected();
-			return;
-		}
+    void zhttpClientOutStream_readyRead(const CowByteArrayList &message) {
+        if (message[2] == "probe-ack") {
+            connected();
+            return;
+        }
 
-		processClientIn(message[2].mid(1));
-	}
+        processClientIn(message[2].mid(1));
+    }
 
-	void zhttpServerIn_readyRead(const CowByteArrayList &message)
-	{
-		++serverReqs;
-		log_debug("server in");
-		Variant v = TnetString::toVariant(message[0].mid(1));
-		ZhttpRequestPacket zreq;
-		zreq.fromVariant(v);
+    void zhttpServerIn_readyRead(const CowByteArrayList &message) {
+        ++serverReqs;
+        log_debug("server in");
+        Variant v = TnetString::toVariant(message[0].mid(1));
+        ZhttpRequestPacket zreq;
+        zreq.fromVariant(v);
 
-		handleServerIn(zreq);
-	}
+        handleServerIn(zreq);
+    }
 
-	void zhttpServerInStream_readyRead(const CowByteArrayList &message)
-	{
-		log_debug("server stream in");
-		Variant v = TnetString::toVariant(message[2].mid(1));
-		ZhttpRequestPacket zreq;
-		zreq.fromVariant(v);
+    void zhttpServerInStream_readyRead(const CowByteArrayList &message) {
+        log_debug("server stream in");
+        Variant v = TnetString::toVariant(message[2].mid(1));
+        ZhttpRequestPacket zreq;
+        zreq.fromVariant(v);
 
-		handleServerIn(zreq);
-	}
+        handleServerIn(zreq);
+    }
 
-	void handleServerIn(const ZhttpRequestPacket &zreq)
-	{
-		if(zreq.type == ZhttpRequestPacket::Cancel)
-		{
-			serverFailed = true;
-			return;
-		}
+    void handleServerIn(const ZhttpRequestPacket &zreq) {
+        if (zreq.type == ZhttpRequestPacket::Cancel) {
+            serverFailed = true;
+            return;
+        }
 
-		if(zreq.type == ZhttpRequestPacket::Data)
-			requestBody += zreq.body.asQByteArray();
+        if (zreq.type == ZhttpRequestPacket::Data)
+            requestBody += zreq.body.asQByteArray();
 
-		if(zreq.more)
-		{
-			// Ack
-			if(serverOutSeq == 0)
-			{
-				ZhttpResponsePacket zresp;
-				zresp.from = "test-server";
-				zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
-				zresp.type = ZhttpResponsePacket::Credit;
-				zresp.credits = 200000;
-				QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-				zhttpServerOutSock->write(QList<QByteArray>() << buf);
-			}
+        if (zreq.more) {
+            // Ack
+            if (serverOutSeq == 0) {
+                ZhttpResponsePacket zresp;
+                zresp.from = "test-server";
+                zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
+                zresp.type = ZhttpResponsePacket::Credit;
+                zresp.credits = 200000;
+                QByteArray buf =
+                    zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+                zhttpServerOutSock->write(QList<QByteArray>() << buf);
+            }
 
-			return;
-		}
+            return;
+        }
 
-		ZhttpResponsePacket zresp;
-		zresp.from = "test-server";
-		zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
-		zresp.type = ZhttpResponsePacket::Data;
-		zresp.code = 200;
-		zresp.reason = "OK";
+        ZhttpResponsePacket zresp;
+        zresp.from = "test-server";
+        zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
+        zresp.type = ZhttpResponsePacket::Data;
+        zresp.code = 200;
+        zresp.reason = "OK";
 
-		QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
 
-		zresp.headers += HttpHeader("Content-Type", "text/plain");
-		zresp.body = "this is what's next\n";
+        zresp.headers += HttpHeader("Content-Type", "text/plain");
+        zresp.body = "this is what's next\n";
 
-		zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
-		QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-		zhttpServerOutSock->write(QList<QByteArray>() << buf);
+        zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
+        QByteArray buf =
+            zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+        zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
-		// Zero out so we can accept another request
-		serverOutSeq = 0;
-	}
+        // Zero out so we can accept another request
+        serverOutSeq = 0;
+    }
 
-	void proxyAccept_readyRead(const CowByteArrayList &_message)
-	{
-		ZmqReqMessage message(_message);
-		Variant v = TnetString::toVariant(message.content()[0]);
+    void proxyAccept_readyRead(const CowByteArrayList &_message) {
+        ZmqReqMessage message(_message);
+        Variant v = TnetString::toVariant(message.content()[0]);
 
-		TEST_ASSERT(typeId(v) == VariantType::Hash);
-		VariantHash vresp = v.toHash();
+        TEST_ASSERT(typeId(v) == VariantType::Hash);
+        VariantHash vresp = v.toHash();
 
-		TEST_ASSERT(vresp.value("success").toBool());
+        TEST_ASSERT(vresp.value("success").toBool());
 
-		acceptSuccess = true;
+        acceptSuccess = true;
 
-		v = vresp.value("value");
-		TEST_ASSERT(typeId(v) == VariantType::Hash);
-		acceptValue = v.toHash();
-	}
+        v = vresp.value("value");
+        TEST_ASSERT(typeId(v) == VariantType::Hash);
+        acceptValue = v.toHash();
+    }
 };
 
-class TestState
-{
+class TestState {
 public:
-	HandlerEngine *engine;
-	Wrapper *wrapper;
+    HandlerEngine *engine;
+    Wrapper *wrapper;
 
-	TestState(std::function<void (int)> loop_wait)
-	{
-		log_setOutputLevel(LOG_LEVEL_WARNING);
-		//log_setOutputLevel(LOG_LEVEL_DEBUG);
+    TestState(std::function<void(int)> loop_wait) {
+        log_setOutputLevel(LOG_LEVEL_WARNING);
+        // log_setOutputLevel(LOG_LEVEL_DEBUG);
 
-		QDir outDir(qgetenv("OUT_DIR"));
-		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+        QDir outDir(qgetenv("OUT_DIR"));
+        QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
-		wrapper = new Wrapper(workDir);
+        wrapper = new Wrapper(workDir);
 
-		bool connected = false;
-		wrapper->connected.connect([&] {
-			connected = true;
-		});
+        bool connected = false;
+        wrapper->connected.connect([&] { connected = true; });
 
-		wrapper->startHttp();
-		wrapper->startProxy();
+        wrapper->startHttp();
+        wrapper->startProxy();
 
-		engine = new HandlerEngine;
+        engine = new HandlerEngine;
 
-		HandlerEngine::Configuration config;
-		config.instanceId = "handler";
-		config.serverInStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-client-out-stream"));
-		config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-client-in"));
-		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-in"));
-		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-in-stream"));
-		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-out"));
-		config.acceptSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-accept"));
-		config.pushInSpec = ("ipc://" + workDir.filePath("hndtst-publish-pull"));
-		config.connectionSubscriptionMax = 20;
-		config.connectionsMax = 20;
-		TEST_ASSERT(engine->start(config));
+        HandlerEngine::Configuration config;
+        config.instanceId = "handler";
+        config.serverInStreamSpecs = QStringList()
+                                     << ("ipc://" + workDir.filePath("hndtst-client-out-stream"));
+        config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-client-in"));
+        config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-in"));
+        config.clientOutStreamSpecs = QStringList()
+                                      << ("ipc://" + workDir.filePath("hndtst-server-in-stream"));
+        config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-server-out"));
+        config.acceptSpecs = QStringList() << ("ipc://" + workDir.filePath("hndtst-accept"));
+        config.pushInSpec = ("ipc://" + workDir.filePath("hndtst-publish-pull"));
+        config.connectionSubscriptionMax = 20;
+        config.connectionsMax = 20;
+        TEST_ASSERT(engine->start(config));
 
-		wrapper->startPublish();
+        wrapper->startPublish();
 
-		while(!connected)
-			loop_wait(10);
-	}
+        while (!connected)
+            loop_wait(10);
+    }
 
-	~TestState()
-	{
-		delete engine;
-		delete wrapper;
-	}
+    ~TestState() {
+        delete engine;
+        delete wrapper;
+    }
 };
 
+} // namespace
+
+static void runWithEventLoop(std::function<void(Wrapper *, std::function<void(int)>)> f) {
+    EventLoop loop(100);
+
+    auto loop_wait = [&](int ms) {
+        for (int i = ms; i > 0; i -= 10) {
+            std::this_thread::sleep_for(10ms);
+            loop.step();
+        }
+    };
+
+    {
+        TestState state(loop_wait);
+
+        f(state.wrapper, loop_wait);
+    }
 }
 
-static void runWithEventLoop(std::function<void (Wrapper *, std::function<void (int)>)> f)
-{
-	EventLoop loop(100);
+static void acceptNoHold(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	auto loop_wait = [&](int ms) {
-		for(int i = ms; i > 0; i -= 10)
-		{
-			std::this_thread::sleep_for(10ms);
-			loop.step();
-		}
-	};
+    QByteArray id = "1";
 
-	{
-		TestState state(loop_wait);
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-		f(state.wrapper, loop_wait);
-	}
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
+
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
+
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("hello world\n");
+
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
+
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
+
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
+
+    TEST_ASSERT(!wrapper->acceptValue.value("accepted").toBool());
+    TEST_ASSERT_EQ(wrapper->acceptValue["response"].toHash()["body"].toByteArray(),
+                   QByteArray("hello world\n"));
 }
 
-static void acceptNoHold(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+static void acceptNoHoldResponseSent(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	QByteArray id = "1";
+    QByteArray id = "2";
 
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
 
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
 
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("hello world\n");
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("hello world\n");
 
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
+    args["response-sent"] = true;
 
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
 
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
 
-	TEST_ASSERT(!wrapper->acceptValue.value("accepted").toBool());
-	TEST_ASSERT_EQ(wrapper->acceptValue["response"].toHash()["body"].toByteArray(), QByteArray("hello world\n"));
+    TEST_ASSERT(!wrapper->acceptValue.value("accepted").toBool());
+    TEST_ASSERT(!wrapper->acceptValue.contains("response"));
 }
 
-static void acceptNoHoldResponseSent(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+static void acceptNoHoldNext(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	QByteArray id = "2";
+    QByteArray id = "3";
 
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
 
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
 
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("hello world\n");
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    respHeaders +=
+        Variant(VariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("hello world\n");
 
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
-	args["response-sent"] = true;
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
 
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
 
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
 
-	TEST_ASSERT(!wrapper->acceptValue.value("accepted").toBool());
-	TEST_ASSERT(!wrapper->acceptValue.contains("response"));
+    TEST_ASSERT(wrapper->acceptValue.value("accepted").toBool());
+
+    while (!wrapper->finished)
+        loop_wait(10);
+
+    TEST_ASSERT(wrapper->responses.contains(id));
+    TEST_ASSERT_EQ(wrapper->responses.value(id).body,
+                   QByteArray("hello world\nthis is what's next\n"));
 }
 
-static void acceptNoHoldNext(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+static void acceptNoHoldNextResponseSent(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	QByteArray id = "3";
+    QByteArray id = "4";
 
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
+    reqState["response-code"] = 200;
 
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
 
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("hello world\n");
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    respHeaders +=
+        Variant(VariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("hello world\n");
 
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
+    args["response-sent"] = true;
 
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
 
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
 
-	TEST_ASSERT(wrapper->acceptValue.value("accepted").toBool());
+    TEST_ASSERT(wrapper->acceptValue.value("accepted").toBool());
 
-	while(!wrapper->finished)
-		loop_wait(10);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	TEST_ASSERT(wrapper->responses.contains(id));
-	TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("hello world\nthis is what's next\n"));
+    TEST_ASSERT(wrapper->responses.contains(id));
+    TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("this is what's next\n"));
 }
 
-static void acceptNoHoldNextResponseSent(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+static void publishResponse(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	QByteArray id = "4";
+    QByteArray id = "5";
 
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
-	reqState["response-code"] = 200;
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
 
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
 
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Link") << QByteArray("</next>; rel=next"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("hello world\n");
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("response"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("timeout\n");
 
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
-	args["response-sent"] = true;
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
 
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
 
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
 
-	TEST_ASSERT(wrapper->acceptValue.value("accepted").toBool());
+    data.clear();
 
-	while(!wrapper->finished)
-		loop_wait(10);
+    VariantHash hr;
+    hr["body"] = QByteArray("hello world\n");
 
-	TEST_ASSERT(wrapper->responses.contains(id));
-	TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("this is what's next\n"));
+    VariantHash formats;
+    formats["http-response"] = hr;
+
+    data["channel"] = QByteArray("apple");
+    data["formats"] = formats;
+
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
+
+    TEST_ASSERT(wrapper->responses.contains(id));
+    TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("hello world\n"));
 }
 
-static void publishResponse(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+static void publishStream(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	QByteArray id = "5";
+    QByteArray id = "6";
 
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
 
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
 
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("response"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("timeout\n");
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("stream open\n");
 
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
 
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
 
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
 
-	data.clear();
+    data.clear();
 
-	VariantHash hr;
-	hr["body"] = QByteArray("hello world\n");
+    {
+        VariantHash hs;
+        hs["content"] = QByteArray("hello world\n");
 
-	VariantHash formats;
-	formats["http-response"] = hr;
+        VariantHash formats;
+        formats["http-stream"] = hs;
 
-	data["channel"] = QByteArray("apple");
-	data["formats"] = formats;
+        data["channel"] = QByteArray("apple");
+        data["formats"] = formats;
+    }
 
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
 
-	TEST_ASSERT(wrapper->responses.contains(id));
-	TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("hello world\n"));
+    data.clear();
+
+    {
+        VariantHash hs;
+        hs["action"] = QByteArray("close");
+
+        VariantHash formats;
+        formats["http-stream"] = hs;
+
+        data["channel"] = QByteArray("apple");
+        data["formats"] = formats;
+    }
+
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+
+    while (!wrapper->finished)
+        loop_wait(10);
+
+    TEST_ASSERT(wrapper->responses.contains(id));
+    TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("stream open\nhello world\n"));
 }
 
-static void publishStream(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+static void publishStreamReorder(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
 
-	QByteArray id = "6";
+    QByteArray id = "7";
 
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
 
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
 
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
 
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("stream open\n");
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("stream open\n");
 
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
 
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
 
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
 
-	data.clear();
+    data.clear();
 
-	{
-		VariantHash hs;
-		hs["content"] = QByteArray("hello world\n");
+    {
+        VariantHash hs;
+        hs["content"] = QByteArray("one\n");
 
-		VariantHash formats;
-		formats["http-stream"] = hs;
+        VariantHash formats;
+        formats["http-stream"] = hs;
 
-		data["channel"] = QByteArray("apple");
-		data["formats"] = formats;
-	}
+        data["channel"] = QByteArray("apple");
+        data["id"] = QByteArray("a");
+        data["formats"] = formats;
+    }
 
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
 
-	data.clear();
+    data.clear();
 
-	{
-		VariantHash hs;
-		hs["action"] = QByteArray("close");
+    {
+        VariantHash hs;
+        hs["action"] = QByteArray("close");
 
-		VariantHash formats;
-		formats["http-stream"] = hs;
+        VariantHash formats;
+        formats["http-stream"] = hs;
 
-		data["channel"] = QByteArray("apple");
-		data["formats"] = formats;
-	}
+        data["channel"] = QByteArray("apple");
+        data["id"] = QByteArray("e");
+        data["prev-id"] = QByteArray("d");
+        data["formats"] = formats;
+    }
 
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
 
-	while(!wrapper->finished)
-		loop_wait(10);
+    data.clear();
 
-	TEST_ASSERT(wrapper->responses.contains(id));
-	TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("stream open\nhello world\n"));
+    {
+        VariantHash hs;
+        hs["content"] = QByteArray("four\n");
+
+        VariantHash formats;
+        formats["http-stream"] = hs;
+
+        data["channel"] = QByteArray("apple");
+        data["id"] = QByteArray("d");
+        data["prev-id"] = QByteArray("c");
+        data["formats"] = formats;
+    }
+
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+
+    data.clear();
+
+    {
+        VariantHash hs;
+        hs["content"] = QByteArray("three\n");
+
+        VariantHash formats;
+        formats["http-stream"] = hs;
+
+        data["channel"] = QByteArray("apple");
+        data["id"] = QByteArray("c");
+        data["prev-id"] = QByteArray("b");
+        data["formats"] = formats;
+    }
+
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+
+    data.clear();
+
+    {
+        VariantHash hs;
+        hs["content"] = QByteArray("two\n");
+
+        VariantHash formats;
+        formats["http-stream"] = hs;
+
+        data["channel"] = QByteArray("apple");
+        data["id"] = QByteArray("b");
+        data["prev-id"] = QByteArray("a");
+        data["formats"] = formats;
+    }
+
+    buf = TnetString::fromVariant(data);
+    wrapper->publishPushSock->write(QList<QByteArray>() << buf);
+
+    while (!wrapper->finished)
+        loop_wait(10);
+
+    TEST_ASSERT(wrapper->responses.contains(id));
+    TEST_ASSERT_EQ(wrapper->responses.value(id).body,
+                   QByteArray("stream open\none\ntwo\nthree\nfour\n"));
 }
 
-static void publishStreamReorder(Wrapper *wrapper, std::function<void (int)> loop_wait)
-{
-	wrapper->reset();
+extern "C" int handlerengine_test(ffi::TestException *out_ex) {
+    TEST_CATCH(runWithEventLoop(acceptNoHold));
+    TEST_CATCH(runWithEventLoop(acceptNoHoldResponseSent));
+    TEST_CATCH(runWithEventLoop(acceptNoHoldNext));
+    TEST_CATCH(runWithEventLoop(acceptNoHoldNextResponseSent));
+    TEST_CATCH(runWithEventLoop(publishResponse));
+    TEST_CATCH(runWithEventLoop(publishStream));
+    TEST_CATCH(runWithEventLoop(publishStreamReorder));
 
-	QByteArray id = "7";
-
-	VariantHash rid;
-	rid["sender"] = QByteArray("test-client");
-	rid["id"] = id;
-
-	VariantHash reqState;
-	reqState["rid"] = rid;
-	reqState["in-seq"] = 1;
-	reqState["out-seq"] = 1;
-	reqState["out-credits"] = 1000;
-	reqState["router-resp"] = true;
-
-	VariantHash req;
-	req["method"] = QByteArray("GET");
-	req["uri"] = QByteArray("http://example.com/path");
-	VariantList reqHeaders;
-	req["headers"] = reqHeaders;
-	req["body"] = QByteArray();
-
-	VariantHash resp;
-	resp["code"] = 200;
-	resp["reason"] = QByteArray("OK");
-	VariantList respHeaders;
-	respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Hold") << QByteArray("stream"));
-	respHeaders += Variant(VariantList() << QByteArray("Grip-Channel") << QByteArray("apple"));
-	resp["headers"] = respHeaders;
-	resp["body"] = QByteArray("stream open\n");
-
-	VariantHash args;
-	args["requests"] = VariantList() << reqState;
-	args["request-data"] = req;
-	args["orig-request-data"] = req;
-	args["response"] = resp;
-
-	VariantHash data;
-	data["id"] = id;
-	data["method"] = QByteArray("accept");
-	data["args"] = args;
-
-	QByteArray buf = TnetString::fromVariant(data);
-	wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
-	while(!wrapper->acceptSuccess)
-		loop_wait(10);
-
-	data.clear();
-
-	{
-		VariantHash hs;
-		hs["content"] = QByteArray("one\n");
-
-		VariantHash formats;
-		formats["http-stream"] = hs;
-
-		data["channel"] = QByteArray("apple");
-		data["id"] = QByteArray("a");
-		data["formats"] = formats;
-	}
-
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
-
-	data.clear();
-
-	{
-		VariantHash hs;
-		hs["action"] = QByteArray("close");
-
-		VariantHash formats;
-		formats["http-stream"] = hs;
-
-		data["channel"] = QByteArray("apple");
-		data["id"] = QByteArray("e");
-		data["prev-id"] = QByteArray("d");
-		data["formats"] = formats;
-	}
-
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
-
-	data.clear();
-
-	{
-		VariantHash hs;
-		hs["content"] = QByteArray("four\n");
-
-		VariantHash formats;
-		formats["http-stream"] = hs;
-
-		data["channel"] = QByteArray("apple");
-		data["id"] = QByteArray("d");
-		data["prev-id"] = QByteArray("c");
-		data["formats"] = formats;
-	}
-
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
-
-	data.clear();
-
-	{
-		VariantHash hs;
-		hs["content"] = QByteArray("three\n");
-
-		VariantHash formats;
-		formats["http-stream"] = hs;
-
-		data["channel"] = QByteArray("apple");
-		data["id"] = QByteArray("c");
-		data["prev-id"] = QByteArray("b");
-		data["formats"] = formats;
-	}
-
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
-
-	data.clear();
-
-	{
-		VariantHash hs;
-		hs["content"] = QByteArray("two\n");
-
-		VariantHash formats;
-		formats["http-stream"] = hs;
-
-		data["channel"] = QByteArray("apple");
-		data["id"] = QByteArray("b");
-		data["prev-id"] = QByteArray("a");
-		data["formats"] = formats;
-	}
-
-	buf = TnetString::fromVariant(data);
-	wrapper->publishPushSock->write(QList<QByteArray>() << buf);
-
-	while(!wrapper->finished)
-		loop_wait(10);
-
-	TEST_ASSERT(wrapper->responses.contains(id));
-	TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("stream open\none\ntwo\nthree\nfour\n"));
-}
-
-extern "C" int handlerengine_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(runWithEventLoop(acceptNoHold));
-	TEST_CATCH(runWithEventLoop(acceptNoHoldResponseSent));
-	TEST_CATCH(runWithEventLoop(acceptNoHoldNext));
-	TEST_CATCH(runWithEventLoop(acceptNoHoldNextResponseSent));
-	TEST_CATCH(runWithEventLoop(publishResponse));
-	TEST_CATCH(runWithEventLoop(publishStream));
-	TEST_CATCH(runWithEventLoop(publishStreamReorder));
-
-	return 0;
+    return 0;
 }

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -23,31 +23,31 @@
 
 #include "httpsession.h"
 
-#include <assert.h>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QRandomGenerator>
-#include "qtcompat.h"
-#include "variant.h"
-#include "timer.h"
-#include "defercall.h"
-#include "log.h"
 #include "bufferlist.h"
+#include "cors.h"
+#include "defercall.h"
+#include "filterstack.h"
+#include "httpsessionupdatemanager.h"
+#include "jsonpatch.h"
+#include "log.h"
+#include "logutil.h"
 #include "packet/retryrequestpacket.h"
+#include "publishformat.h"
+#include "publishitem.h"
+#include "publishlastids.h"
+#include "qtcompat.h"
+#include "ratelimiter.h"
+#include "statsmanager.h"
+#include "timer.h"
+#include "variant.h"
+#include "variantutil.h"
 #include "zhttpmanager.h"
 #include "zhttprequest.h"
-#include "cors.h"
-#include "jsonpatch.h"
-#include "statsmanager.h"
-#include "logutil.h"
-#include "variantutil.h"
-#include "publishitem.h"
-#include "publishformat.h"
-#include "ratelimiter.h"
-#include "publishlastids.h"
-#include "httpsessionupdatemanager.h"
-#include "filterstack.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRandomGenerator>
+#include <assert.h>
 
 #define RETRY_TIMEOUT 1000
 #define RETRY_MAX 5
@@ -56,1713 +56,1489 @@
 #define UPDATES_PER_ACTION_MAX 100
 #define PUBLISH_QUEUE_MAX 100
 
-static QByteArray applyBodyPatch(const QByteArray &in, const VariantList &bodyPatch)
-{
-	QByteArray body;
+static QByteArray applyBodyPatch(const QByteArray &in, const VariantList &bodyPatch) {
+    QByteArray body;
 
-	QJsonParseError e;
-	QJsonDocument doc = QJsonDocument::fromJson(in, &e);
-	if(e.error == QJsonParseError::NoError && (doc.isObject() || doc.isArray()))
-	{
-		Variant vbody;
-		if(doc.isObject())
-			vbody = doc.object().toVariantMap();
-		else // IsArray
-			vbody = doc.array().toVariantList();
+    QJsonParseError e;
+    QJsonDocument doc = QJsonDocument::fromJson(in, &e);
+    if (e.error == QJsonParseError::NoError && (doc.isObject() || doc.isArray())) {
+        Variant vbody;
+        if (doc.isObject())
+            vbody = doc.object().toVariantMap();
+        else // IsArray
+            vbody = doc.array().toVariantList();
 
-		QString errorMessage;
-		vbody = JsonPatch::patch(vbody, bodyPatch, &errorMessage);
-		if(vbody.isValid())
-			vbody = VariantUtil::convertToJsonStyle(vbody);
-		if(vbody.isValid() && (typeId(vbody) == VariantType::Map || typeId(vbody) == VariantType::List))
-		{
-			QJsonDocument doc;
-			if(typeId(vbody) == VariantType::Map)
-				doc = QJsonDocument(QJsonObject::fromVariantMap(vbody.toMap()));
-			else // List
-				doc = QJsonDocument(QJsonArray::fromVariantList(vbody.toList()));
+        QString errorMessage;
+        vbody = JsonPatch::patch(vbody, bodyPatch, &errorMessage);
+        if (vbody.isValid())
+            vbody = VariantUtil::convertToJsonStyle(vbody);
+        if (vbody.isValid() &&
+            (typeId(vbody) == VariantType::Map || typeId(vbody) == VariantType::List)) {
+            QJsonDocument doc;
+            if (typeId(vbody) == VariantType::Map)
+                doc = QJsonDocument(QJsonObject::fromVariantMap(vbody.toMap()));
+            else // List
+                doc = QJsonDocument(QJsonArray::fromVariantList(vbody.toList()));
 
-			body = doc.toJson(QJsonDocument::Compact);
+            body = doc.toJson(QJsonDocument::Compact);
 
-			if(in.endsWith("\r\n"))
-				body += "\r\n";
-			else if(in.endsWith("\n"))
-				body += '\n';
-		}
-		else
-		{
-			log_debug("httpsession: failed to apply JSON patch: %s", qPrintable(errorMessage));
-		}
-	}
-	else
-	{
-		log_debug("httpsession: failed to parse original response body as JSON");
-	}
+            if (in.endsWith("\r\n"))
+                body += "\r\n";
+            else if (in.endsWith("\n"))
+                body += '\n';
+        } else {
+            log_debug("httpsession: failed to apply JSON patch: %s", qPrintable(errorMessage));
+        }
+    } else {
+        log_debug("httpsession: failed to parse original response body as JSON");
+    }
 
-	return body;
+    return body;
 }
 
-class HttpSession::Private
-{
+class HttpSession::Private {
 public:
-	enum State
-	{
-		NotStarted,
-		SendingFirstInstructResponse,
-		WaitingToUpdate,
-		Pausing,
-		Proxying,
-		SendingQueue,
-		Holding,
-		Closing,
-		SendingGone,
-	};
+    enum State {
+        NotStarted,
+        SendingFirstInstructResponse,
+        WaitingToUpdate,
+        Pausing,
+        Proxying,
+        SendingQueue,
+        Holding,
+        Closing,
+        SendingGone,
+    };
 
-	enum Priority
-	{
-		LowPriority,
-		HighPriority
-	};
+    enum Priority { LowPriority, HighPriority };
 
-	class UpdateAction : public RateLimiter::Action
-	{
-	public:
-		QSet<HttpSession*> sessions;
+    class UpdateAction : public RateLimiter::Action {
+    public:
+        QSet<HttpSession *> sessions;
 
-		virtual bool execute()
-		{
-			if(sessions.isEmpty())
-				return false;
+        virtual bool execute() {
+            if (sessions.isEmpty())
+                return false;
 
-			foreach(HttpSession *q, sessions)
-				q->d->doUpdate();
+            foreach (HttpSession *q, sessions)
+                q->d->doUpdate();
 
-			return true;
-		}
-	};
+            return true;
+        }
+    };
 
-	class QueuedItem
-	{
-	public:
-		PublishItem item;
-		QList<QByteArray> exposeHeaders;
+    class QueuedItem {
+    public:
+        PublishItem item;
+        QList<QByteArray> exposeHeaders;
 
-		QueuedItem(const PublishItem &_item, const QList<QByteArray> &_exposeHeaders = QList<QByteArray>()) :
-			item(_item),
-			exposeHeaders(_exposeHeaders)
-		{
-		}
-	};
+        QueuedItem(const PublishItem &_item,
+                   const QList<QByteArray> &_exposeHeaders = QList<QByteArray>())
+            : item(_item), exposeHeaders(_exposeHeaders) {}
+    };
 
-	friend class UpdateAction;
+    friend class UpdateAction;
 
-	HttpSession *q;
-	State state;
-	std::unique_ptr<ZhttpRequest> req;
-	AcceptData adata;
-	Instruct instruct;
-	int logLevel;
-	QHash<QString, Instruct::Channel> channels;
-	std::unique_ptr<Timer> timer;
-	std::unique_ptr<Timer> retryTimer;
-	StatsManager *stats;
-	ZhttpManager *outZhttp;
-	std::unique_ptr<ZhttpRequest> outReq; // For fetching links
-	RateLimiter *updateLimiter;
-	std::shared_ptr<RateLimiter> filterLimiter;
-	PublishLastIds *publishLastIds;
-	std::shared_ptr<HttpSessionUpdateManager> updateManager;
-	BufferList firstInstructResponse;
-	bool haveOutReqHeaders;
-	int sentOutReqData;
-	int retries;
-	QString errorMessage;
-	Url currentUri;
-	Url nextUri;
-	Url goneUri;
-	bool needUpdate;
-	Priority needUpdatePriority;
-	UpdateAction *pendingAction;
-	QList<QueuedItem> publishQueue;
-	bool inProcessPublishQueue;
-	QByteArray retryToAddress;
-	RetryRequestPacket retryPacket;
-	LogUtil::Config logConfig;
-	std::unique_ptr<Filter::MessageFilterStack> messageFilters;
-	FilterStack *responseFilters;
-	QSet<QString> activeChannels;
-	int connectionSubscriptionMax;
-	bool connectionStatsActive;
-	Callback<std::tuple<HttpSession *, const QString &>> subscribeCallback;
-	Callback<std::tuple<HttpSession *, const QString &>> unsubscribeCallback;
-	Callback<std::tuple<HttpSession *>> finishedCallback;
-	Connection bytesWrittenConnection;
-	Connection writeBytesChangedConnection;
-	Connection errorConnection;
-	Connection pausedConnection;
-	Connection readyReadOutConnection;
-	Connection errorOutConnection;
-	Connection timerConnection;
-	Connection retryTimerConnection;
-	Connection messageFiltersFinishedConnection;
-	DeferCall deferCall;
+    HttpSession *q;
+    State state;
+    std::unique_ptr<ZhttpRequest> req;
+    AcceptData adata;
+    Instruct instruct;
+    int logLevel;
+    QHash<QString, Instruct::Channel> channels;
+    std::unique_ptr<Timer> timer;
+    std::unique_ptr<Timer> retryTimer;
+    StatsManager *stats;
+    ZhttpManager *outZhttp;
+    std::unique_ptr<ZhttpRequest> outReq; // For fetching links
+    RateLimiter *updateLimiter;
+    std::shared_ptr<RateLimiter> filterLimiter;
+    PublishLastIds *publishLastIds;
+    std::shared_ptr<HttpSessionUpdateManager> updateManager;
+    BufferList firstInstructResponse;
+    bool haveOutReqHeaders;
+    int sentOutReqData;
+    int retries;
+    QString errorMessage;
+    Url currentUri;
+    Url nextUri;
+    Url goneUri;
+    bool needUpdate;
+    Priority needUpdatePriority;
+    UpdateAction *pendingAction;
+    QList<QueuedItem> publishQueue;
+    bool inProcessPublishQueue;
+    QByteArray retryToAddress;
+    RetryRequestPacket retryPacket;
+    LogUtil::Config logConfig;
+    std::unique_ptr<Filter::MessageFilterStack> messageFilters;
+    FilterStack *responseFilters;
+    QSet<QString> activeChannels;
+    int connectionSubscriptionMax;
+    bool connectionStatsActive;
+    Callback<std::tuple<HttpSession *, const QString &>> subscribeCallback;
+    Callback<std::tuple<HttpSession *, const QString &>> unsubscribeCallback;
+    Callback<std::tuple<HttpSession *>> finishedCallback;
+    Connection bytesWrittenConnection;
+    Connection writeBytesChangedConnection;
+    Connection errorConnection;
+    Connection pausedConnection;
+    Connection readyReadOutConnection;
+    Connection errorOutConnection;
+    Connection timerConnection;
+    Connection retryTimerConnection;
+    Connection messageFiltersFinishedConnection;
+    DeferCall deferCall;
 
-	Private(HttpSession *_q, ZhttpRequest *_req, const HttpSession::AcceptData &_adata, const Instruct &_instruct, ZhttpManager *_outZhttp, StatsManager *_stats, RateLimiter *_updateLimiter, const std::shared_ptr<RateLimiter> _filterLimiter, PublishLastIds *_publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &_updateManager, int _connectionSubscriptionMax) :
-		q(_q),
-		req(_req),
-		logLevel(LOG_LEVEL_DEBUG),
-		stats(_stats),
-		outZhttp(_outZhttp),
-		updateLimiter(_updateLimiter),
-		filterLimiter(_filterLimiter),
-		publishLastIds(_publishLastIds),
-		updateManager(_updateManager),
-		haveOutReqHeaders(false),
-		sentOutReqData(0),
-		retries(0),
-		needUpdate(false),
-		pendingAction(0),
-		inProcessPublishQueue(false),
-		responseFilters(0),
-		connectionSubscriptionMax(_connectionSubscriptionMax),
-		connectionStatsActive(true)
-	{
-		state = NotStarted;
+    Private(HttpSession *_q, ZhttpRequest *_req, const HttpSession::AcceptData &_adata,
+            const Instruct &_instruct, ZhttpManager *_outZhttp, StatsManager *_stats,
+            RateLimiter *_updateLimiter, const std::shared_ptr<RateLimiter> _filterLimiter,
+            PublishLastIds *_publishLastIds,
+            const std::shared_ptr<HttpSessionUpdateManager> &_updateManager,
+            int _connectionSubscriptionMax)
+        : q(_q),
+          req(_req),
+          logLevel(LOG_LEVEL_DEBUG),
+          stats(_stats),
+          outZhttp(_outZhttp),
+          updateLimiter(_updateLimiter),
+          filterLimiter(_filterLimiter),
+          publishLastIds(_publishLastIds),
+          updateManager(_updateManager),
+          haveOutReqHeaders(false),
+          sentOutReqData(0),
+          retries(0),
+          needUpdate(false),
+          pendingAction(0),
+          inProcessPublishQueue(false),
+          responseFilters(0),
+          connectionSubscriptionMax(_connectionSubscriptionMax),
+          connectionStatsActive(true) {
+        state = NotStarted;
 
-		bytesWrittenConnection = req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1));
-		writeBytesChangedConnection = req->writeBytesChanged.connect(boost::bind(&Private::req_writeBytesChanged, this));
-		errorConnection = req->error.connect(boost::bind(&Private::req_error, this));
+        bytesWrittenConnection = req->bytesWritten.connect(
+            boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1));
+        writeBytesChangedConnection =
+            req->writeBytesChanged.connect(boost::bind(&Private::req_writeBytesChanged, this));
+        errorConnection = req->error.connect(boost::bind(&Private::req_error, this));
 
-		timer = std::make_unique<Timer>();
-		timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
+        timer = std::make_unique<Timer>();
+        timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
 
-		retryTimer = std::make_unique<Timer>();
-		retryTimer->timeout.connect(boost::bind(&Private::retryTimer_timeout, this));
-		retryTimer->setSingleShot(true);
+        retryTimer = std::make_unique<Timer>();
+        retryTimer->timeout.connect(boost::bind(&Private::retryTimer_timeout, this));
+        retryTimer->setSingleShot(true);
 
-		adata = _adata;
-		instruct = _instruct;
+        adata = _adata;
+        instruct = _instruct;
 
-		if(adata.logLevel >= 0)
-			logLevel = adata.logLevel;
+        if (adata.logLevel >= 0)
+            logLevel = adata.logLevel;
 
-		currentUri = req->requestUri();
+        currentUri = req->requestUri();
 
-		if(!instruct.nextLink.isEmpty())
-			nextUri = currentUri.resolved(instruct.nextLink);
+        if (!instruct.nextLink.isEmpty())
+            nextUri = currentUri.resolved(instruct.nextLink);
 
-		// Only work with a gone link provided at initialization time. This
-		// way each request can have a unique gone link, and still share
-		// instructions from next link fetches
-		if(!instruct.goneLink.isEmpty())
-			goneUri = currentUri.resolved(instruct.goneLink);
-	}
+        // Only work with a gone link provided at initialization time. This
+        // way each request can have a unique gone link, and still share
+        // instructions from next link fetches
+        if (!instruct.goneLink.isEmpty())
+            goneUri = currentUri.resolved(instruct.goneLink);
+    }
 
-	~Private()
-	{
-		cleanup();
-	}
+    ~Private() { cleanup(); }
 
-	void start()
-	{
-		assert(state == NotStarted);
+    void start() {
+        assert(state == NotStarted);
 
-		// Set up implicit channels
-		std::weak_ptr<Private> self = q->d;
-		foreach(const QString &name, adata.implicitChannels)
-		{
-			if(!channels.contains(name))
-			{
-				Instruct::Channel c;
-				c.name = name;
+        // Set up implicit channels
+        std::weak_ptr<Private> self = q->d;
+        foreach (const QString &name, adata.implicitChannels) {
+            if (!channels.contains(name)) {
+                Instruct::Channel c;
+                c.name = name;
 
-				channels.insert(name, c);
+                channels.insert(name, c);
 
-				subscribeCallback.call({q, name});
+                subscribeCallback.call({q, name});
 
-				assert(!self.expired()); // Deleting here would leak subscriptions/connections
-			}
-		}
+                assert(!self.expired()); // Deleting here would leak
+                                         // subscriptions/connections
+            }
+        }
 
-		if(instruct.channels.count() > connectionSubscriptionMax)
-		{
-			instruct.channels = instruct.channels.mid(0, connectionSubscriptionMax);
+        if (instruct.channels.count() > connectionSubscriptionMax) {
+            instruct.channels = instruct.channels.mid(0, connectionSubscriptionMax);
 
-			auto routeInfo = LogUtil::RouteInfo(adata.route, logLevel);
-			LogUtil::logForRoute(routeInfo, "httpsession: too many subscriptions");
-		}
+            auto routeInfo = LogUtil::RouteInfo(adata.route, logLevel);
+            LogUtil::logForRoute(routeInfo, "httpsession: too many subscriptions");
+        }
 
-		// Need to send initial content?
-		if((instruct.holdMode == Instruct::NoHold || instruct.holdMode == Instruct::StreamHold) && !adata.responseSent)
-		{
-			// Send initial response
-			HttpHeaders headers = instruct.response.headers;
-			headers.removeAll("Content-Length");
-			if(adata.autoCrossOrigin)
-				Cors::applyCorsHeaders(req->requestHeaders(), &headers);
+        // Need to send initial content?
+        if ((instruct.holdMode == Instruct::NoHold || instruct.holdMode == Instruct::StreamHold) &&
+            !adata.responseSent) {
+            // Send initial response
+            HttpHeaders headers = instruct.response.headers;
+            headers.removeAll("Content-Length");
+            if (adata.autoCrossOrigin)
+                Cors::applyCorsHeaders(req->requestHeaders(), &headers);
 
-			incCounter(Stats::ClientHeaderBytesSent, ZhttpManager::estimateResponseHeaderBytes(instruct.response.code, instruct.response.reason, headers));
+            incCounter(Stats::ClientHeaderBytesSent,
+                       ZhttpManager::estimateResponseHeaderBytes(
+                           instruct.response.code, instruct.response.reason, headers));
 
-			req->beginResponse(instruct.response.code, instruct.response.reason, headers);
+            req->beginResponse(instruct.response.code, instruct.response.reason, headers);
 
-			if(!instruct.response.body.isEmpty())
-			{
-				// Apply ResponseContent filters of all channels
-				QStringList allFilters;
-				foreach(const Instruct::Channel &c, instruct.channels)
-				{
-					foreach(const QString &filter, c.filters)
-					{
-						if((Filter::targets(filter) & Filter::ResponseContent) && !allFilters.contains(filter))
-							allFilters += filter;
-					}
-				}
+            if (!instruct.response.body.isEmpty()) {
+                // Apply ResponseContent filters of all channels
+                QStringList allFilters;
+                foreach (const Instruct::Channel &c, instruct.channels) {
+                    foreach (const QString &filter, c.filters) {
+                        if ((Filter::targets(filter) & Filter::ResponseContent) &&
+                            !allFilters.contains(filter))
+                            allFilters += filter;
+                    }
+                }
 
-				Filter::Context fc;
-				fc.subscriptionMeta = instruct.meta;
+                Filter::Context fc;
+                fc.subscriptionMeta = instruct.meta;
 
-				FilterStack fs(fc, allFilters);
-				instruct.response.body = fs.process(instruct.response.body);
-				if(instruct.response.body.isNull())
-				{
-					errorMessage = QString("filter error: %1").arg(fs.errorMessage());
-					doError();
-					return;
-				}
+                FilterStack fs(fc, allFilters);
+                instruct.response.body = fs.process(instruct.response.body);
+                if (instruct.response.body.isNull()) {
+                    errorMessage = QString("filter error: %1").arg(fs.errorMessage());
+                    doError();
+                    return;
+                }
 
-				state = SendingFirstInstructResponse;
+                state = SendingFirstInstructResponse;
 
-				firstInstructResponse += instruct.response.body;
-				tryWriteFirstInstructResponse();
-				return;
-			}
-		}
+                firstInstructResponse += instruct.response.body;
+                tryWriteFirstInstructResponse();
+                return;
+            }
+        }
 
-		firstInstructResponseDone();
-	}
+        firstInstructResponseDone();
+    }
 
-	void update(Priority priority)
-	{
-		if(state == Proxying || state == SendingQueue)
-		{
-			// If we are already in the process of updating, flag to update
-			// again after current one finishes
+    void update(Priority priority) {
+        if (state == Proxying || state == SendingQueue) {
+            // If we are already in the process of updating, flag to update
+            // again after current one finishes
 
-			if(needUpdate)
-			{
-				// If needUpdate was already flagged, then raise
-				// priority if needed
-				if(priority == HighPriority)
-					needUpdatePriority = priority;
-			}
-			else
-			{
-				needUpdate = true;
-				needUpdatePriority = priority;
-			}
-			return;
-		}
+            if (needUpdate) {
+                // If needUpdate was already flagged, then raise
+                // priority if needed
+                if (priority == HighPriority)
+                    needUpdatePriority = priority;
+            } else {
+                needUpdate = true;
+                needUpdatePriority = priority;
+            }
+            return;
+        }
 
-		if(state == WaitingToUpdate)
-		{
-			if(priority == HighPriority)
-			{
-				// Switching to high priority
-				cancelAction();
-				state = Holding;
-			}
-			else
-			{
-				// Already waiting, do nothing
-				return;
-			}
-		}
+        if (state == WaitingToUpdate) {
+            if (priority == HighPriority) {
+                // Switching to high priority
+                cancelAction();
+                state = Holding;
+            } else {
+                // Already waiting, do nothing
+                return;
+            }
+        }
 
-		if(state != Holding)
-			return;
+        if (state != Holding)
+            return;
 
-		needUpdate = false;
+        needUpdate = false;
 
-		if(instruct.holdMode != Instruct::ResponseHold && nextUri.isEmpty())
-		{
-			// Can't update without valid link
-			return;
-		}
+        if (instruct.holdMode != Instruct::ResponseHold && nextUri.isEmpty()) {
+            // Can't update without valid link
+            return;
+        }
 
-		// Turn off update timer during update
-		updateManager->unregisterSession(q);
+        // Turn off update timer during update
+        updateManager->unregisterSession(q);
 
-		if(priority == HighPriority)
-		{
-			doUpdate();
-		}
-		else // LowPriority
-		{
-			state = WaitingToUpdate;
+        if (priority == HighPriority) {
+            doUpdate();
+        } else // LowPriority
+        {
+            state = WaitingToUpdate;
 
-			QString key = QString::fromUtf8(nextUri.toEncoded());
+            QString key = QString::fromUtf8(nextUri.toEncoded());
 
-			UpdateAction *action = static_cast<UpdateAction*>(updateLimiter->lastAction(key));
-			if(!action || action->sessions.count() >= UPDATES_PER_ACTION_MAX)
-			{
-				action = new UpdateAction;
-				updateLimiter->addAction(key, action);
-			}
+            UpdateAction *action = static_cast<UpdateAction *>(updateLimiter->lastAction(key));
+            if (!action || action->sessions.count() >= UPDATES_PER_ACTION_MAX) {
+                action = new UpdateAction;
+                updateLimiter->addAction(key, action);
+            }
 
-			action->sessions += q;
-			pendingAction = action;
-		}
-	}
+            action->sessions += q;
+            pendingAction = action;
+        }
+    }
 
-	void publish(const PublishItem &item, const QList<QByteArray> &exposeHeaders)
-	{
-		const PublishFormat &f = item.format;
+    void publish(const PublishItem &item, const QList<QByteArray> &exposeHeaders) {
+        const PublishFormat &f = item.format;
 
-		if(f.type == PublishFormat::HttpResponse)
-		{
-			assert(instruct.holdMode == Instruct::ResponseHold);
+        if (f.type == PublishFormat::HttpResponse) {
+            assert(instruct.holdMode == Instruct::ResponseHold);
 
-			if(state == SendingQueue || state == Holding)
-			{
-				if(publishQueue.count() < PUBLISH_QUEUE_MAX)
-				{
-					publishQueue += QueuedItem(item, exposeHeaders);
+            if (state == SendingQueue || state == Holding) {
+                if (publishQueue.count() < PUBLISH_QUEUE_MAX) {
+                    publishQueue += QueuedItem(item, exposeHeaders);
 
-					if(state == Holding)
-						sendQueue();
-				}
-				else
-				{
-					log_debug("httpsession: publish queue at max, dropping");
-				}
-			}
-		}
-		else if(f.type == PublishFormat::HttpStream)
-		{
-			if(state == WaitingToUpdate || state == Proxying || state == SendingQueue || state == Holding)
-			{
-				if(publishQueue.count() < PUBLISH_QUEUE_MAX)
-				{
-					publishQueue += QueuedItem(item);
+                    if (state == Holding)
+                        sendQueue();
+                } else {
+                    log_debug("httpsession: publish queue at max, dropping");
+                }
+            }
+        } else if (f.type == PublishFormat::HttpStream) {
+            if (state == WaitingToUpdate || state == Proxying || state == SendingQueue ||
+                state == Holding) {
+                if (publishQueue.count() < PUBLISH_QUEUE_MAX) {
+                    publishQueue += QueuedItem(item);
 
-					if(state == Holding)
-						sendQueue();
-				}
-				else
-				{
-					log_debug("httpsession: publish queue at max, dropping");
-				}
-			}
-		}
-	}
+                    if (state == Holding)
+                        sendQueue();
+                } else {
+                    log_debug("httpsession: publish queue at max, dropping");
+                }
+            }
+        }
+    }
 
 private:
-	void cleanup()
-	{
-		cancelActivities();
-
-		if(connectionStatsActive)
-		{
-			connectionStatsActive = false;
-
-			ZhttpRequest::Rid rid = req->rid();
-			QByteArray cid = rid.first + ':' + rid.second;
-
-			stats->removeConnection(cid, false);
-		}
-	}
-
-	void cleanupOutReq()
-	{
-		readyReadOutConnection.disconnect();
-		errorOutConnection.disconnect();
-		outReq.reset();
-
-		delete responseFilters;
-		responseFilters = 0;
-	}
-
-	void cancelAction()
-	{
-		if(pendingAction)
-		{
-			pendingAction->sessions.remove(q);
-			pendingAction = 0;
-		}
-	}
-
-	void cancelActivities()
-	{
-		cleanupOutReq();
-		cancelAction();
-
-		publishQueue.clear();
-
-		timer->stop();
-		retryTimer->stop();
-
-		updateManager->unregisterSession(q);
-	}
-
-	void setupKeepAlive()
-	{
-		if(instruct.keepAliveTimeout >= 0)
-		{
-			int timeout = instruct.keepAliveTimeout * 1000;
-			timeout = qMax(timeout - (int)(QRandomGenerator::global()->generate() % KEEPALIVE_RAND_MAX), 0);
-			timer->setSingleShot(true);
-			timer->start(timeout);
-		}
-	}
-
-	void adjustKeepAlive()
-	{
-		// If idle mode, restart the timer. Else leave alone
-		if(timer && instruct.keepAliveMode == Instruct::Idle)
-			setupKeepAlive();
-	}
-
-	void prepareToClose()
-	{
-		state = Closing;
-
-		cancelActivities();
-	}
-
-	void tryWriteFirstInstructResponse()
-	{
-		int avail = req->writeBytesAvailable();
-		if(avail > 0)
-		{
-			writeBody(firstInstructResponse.take(avail));
-
-			if(firstInstructResponse.isEmpty())
-				firstInstructResponseDone();
-		}
-	}
-
-	void firstInstructResponseDone()
-	{
-		if(instruct.holdMode == Instruct::NoHold)
-		{
-			// NoHold instruct MUST have had a link to make it this far
-			assert(!nextUri.isEmpty());
-
-			doUpdate();
-		}
-		else // ResponseHold, StreamHold
-		{
-			prepareToSendQueueOrHold(true);
-		}
-	}
-
-	void doUpdate()
-	{
-		pendingAction = 0;
-
-		if(instruct.holdMode == Instruct::ResponseHold)
-		{
-			state = Pausing;
-
-			// Stop activity while pausing
-			timer->stop();
-
-			pausedConnection = req->paused.connect(boost::bind(&Private::req_paused, this));
-			req->pause();
-		}
-		else
-		{
-			state = Proxying;
-
-			requestNextLink();
-		}
-	}
-
-	void prepareToSendQueueOrHold(bool first = false)
-	{
-		assert(instruct.holdMode != Instruct::NoHold);
-
-		if(instruct.holdMode == Instruct::StreamHold)
-		{
-			// If prev ids used but not next link, error out
-			if(nextUri.isEmpty())
-			{
-				foreach(const Instruct::Channel &c, instruct.channels)
-				{
-					if(!c.prevId.isNull())
-					{
-						errorMessage = QString("channel '%1' specifies prev-id, but no next link found").arg(c.name);
-						doError();
-						return;
-					}
-				}
-			}
-		}
-
-		QList<QString> channelsRemoved;
-		QHashIterator<QString, Instruct::Channel> it(channels);
-		while(it.hasNext())
-		{
-			it.next();
-			const QString &name = it.key();
-
-			if(adata.implicitChannels.contains(name))
-				continue;
-
-			bool found = false;
-			foreach(const Instruct::Channel &c, instruct.channels)
-			{
-				if(adata.channelPrefix + c.name == name)
-				{
-					found = true;
-					break;
-				}
-			}
-			if(!found)
-			{
-				channelsRemoved += name;
-				channels.remove(name);
-			}
-		}
-
-		QList<QString> channelsAdded;
-		foreach(const Instruct::Channel &c, instruct.channels)
-		{
-			QString name = adata.channelPrefix + c.name;
-
-			if(!channels.contains(name))
-			{
-				channelsAdded += name;
-				channels.insert(name, c);
-			}
-			else
-			{
-				// Update channel properties
-				channels[name].prevId = c.prevId;
-				channels[name].filters = c.filters;
-			}
-		}
-
-		std::weak_ptr<Private> self = q->d;
-
-		foreach(const QString &channel, channelsRemoved)
-		{
-			unsubscribeCallback.call({q, channel});
-
-			assert(!self.expired()); // Deleting here would leak subscriptions/connections
-		}
-
-		foreach(const QString &channel, channelsAdded)
-		{
-			subscribeCallback.call({q, channel});
-
-			assert(!self.expired()); // Deleting here would leak subscriptions/connections
-		}
-
-		if(instruct.holdMode == Instruct::ResponseHold)
-		{
-			state = Holding;
-
-			// Set timeout
-			if(instruct.timeout >= 0)
-			{
-				timer->setSingleShot(true);
-				timer->start(instruct.timeout * 1000);
-			}
-		}
-		else // StreamHold
-		{
-			// If conflict on first hold, immediately recover. We don't
-			// do this on subsequent holds because there may be queued
-			// messages available to resolve the conflict
-			if(first)
-			{
-				bool conflict = false;
-				foreach(const Instruct::Channel &c, instruct.channels)
-				{
-					if(!c.prevId.isNull())
-					{
-						QString name = adata.channelPrefix + c.name;
-
-						QString lastId = publishLastIds->value(name);
-
-						if(!lastId.isNull() && lastId != c.prevId)
-						{
-							log_debug("last ID inconsistency (got=%s, expected=%s), retrying", qPrintable(c.prevId), qPrintable(lastId));
-							publishLastIds->remove(name);
-							conflict = true;
-
-							// NOTE: don't exit loop here. We want to clear
-							// the last ids of all conflicting channels
-						}
-					}
-				}
-
-				if(conflict)
-				{
-					// Update expects us to be in Holding state
-					state = Holding;
-
-					update(LowPriority);
-					return;
-				}
-			}
-
-			// Drop any non-matching queued items
-			while(!publishQueue.isEmpty())
-			{
-				const QueuedItem &qi = publishQueue.first();
-				const PublishItem &item = qi.item;
-
-				if(!channels.contains(item.channel))
-				{
-					// We don't care about this channel anymore
-					publishQueue.removeFirst();
-					continue;
-				}
-
-				Instruct::Channel &channel = channels[item.channel];
-
-				if(!channel.prevId.isNull() && channel.prevId != item.prevId)
-				{
-					// Item doesn't follow the hold
-					publishQueue.removeFirst();
-					continue;
-				}
-
-				break;
-			}
-
-			// If there are items to send, this will send them. If there are
-			// no items to send, this will end up changing state to Holding
-			sendQueue();
-		}
-	}
-
-	void sendQueue()
-	{
-		state = SendingQueue;
-
-		processPublishQueue();
-	}
-
-	void processPublishQueue()
-	{
-		assert(!inProcessPublishQueue);
-		inProcessPublishQueue = true;
-
-		while(state == SendingQueue && !publishQueue.isEmpty() && req->writeBytesAvailable() > 0 && !messageFilters)
-		{
-			const QueuedItem &qi = publishQueue.first();
-			const PublishItem &item = qi.item;
-
-			if(!channels.contains(item.channel))
-			{
-				log_debug("httpsession: received publish for channel with no subscription, dropping");
-				publishQueue.removeFirst();
-				continue;
-			}
-
-			Instruct::Channel &channel = channels[item.channel];
-
-			if(!channel.prevId.isNull())
-			{
-				if(channel.prevId != item.prevId)
-				{
-					log_debug("last ID inconsistency (got=%s, expected=%s), retrying", qPrintable(item.prevId), qPrintable(channel.prevId));
-					publishLastIds->remove(item.channel);
-
-					publishQueue.clear();
-
-					update(LowPriority);
-					break;
-				}
-			}
-
-			const PublishFormat &f = item.format;
-
-			if(f.haveContentFilters)
-			{
-				// Ensure content filters match
-				QStringList contentFilters;
-				foreach(const QString &f, channels[item.channel].filters)
-				{
-					if(Filter::targets(f) & Filter::MessageContent)
-						contentFilters += f;
-				}
-				if(contentFilters != f.contentFilters)
-				{
-					publishQueue.removeFirst();
-
-					if(adata.debug)
-					{
-						errorMessage = QString("content filter mismatch: subscription=%1 message=%2").arg(contentFilters.join(","), f.contentFilters.join(","));
-						doError();
-						break;
-					}
-
-					continue;
-				}
-			}
-
-			QByteArray body;
-			if(f.type == PublishFormat::HttpResponse && f.haveBodyPatch)
-				body = applyBodyPatch(instruct.response.body, f.bodyPatch);
-			else
-				body = f.body;
-
-			messageFilters = std::make_unique<Filter::MessageFilterStack>(channels[item.channel].filters);
-			messageFiltersFinishedConnection = messageFilters->finished.connect(boost::bind(&Private::messageFiltersFinished, this, boost::placeholders::_1));
-
-			QHash<QString, QString> prevIds;
-			QHashIterator<QString, Instruct::Channel> it(channels);
-			while(it.hasNext())
-			{
-				it.next();
-				const Instruct::Channel &c = it.value();
-				prevIds[c.name] = c.prevId;
-			}
-
-			Filter::Context fc;
-			fc.prevIds = prevIds;
-			fc.subscriptionMeta = instruct.meta;
-			fc.publishMeta = item.meta;
-			fc.zhttpOut = outZhttp;
-			fc.currentUri = currentUri;
-			fc.route = adata.route;
-			fc.trusted = adata.trusted;
-			fc.limiter = filterLimiter;
-
-			// May call messageFiltersFinished immediately. If it does, queue
-			// processing will continue. Else, the loop will end and queue
-			// processing will resume after the filters finish
-			messageFilters->start(fc, body);
-		}
-
-		if(!messageFilters)
-		{
-			// The state changed, the queue is empty, or the client buffer is full
-
-			if(state != SendingQueue || publishQueue.isEmpty())
-			{
-				// If the state changed or the queue is empty then we're done
-				sendQueueDone();
-			}
-			else
-			{
-				// Client buffer can only be full in stream mode
-				assert(instruct.holdMode == Instruct::StreamHold);
-
-				// NOTE: we can end up here multiple times in a single pass
-				// of the queue if the client buffer becomes full multiple
-				// times. So, whatever happens here should be idempotent and
-				// cheap.
-
-				// Turn off timers until we're able to send again
-				timer->stop();
-				updateManager->unregisterSession(q);
-			}
-		}
-
-		inProcessPublishQueue = false;
-	}
-
-	void sendQueueDone()
-	{
-		// if the state changed during queue processing (e.g. to Closing),
-		// Then we want to leave the state alone and do nothing else
-		if(state != SendingQueue)
-			return;
-
-		state = Holding;
-
-		if(instruct.holdMode == Instruct::StreamHold)
-		{
-			activeChannels.clear();
-
-			// Start keep alive timer, if it wasn't started already
-			if(!timer->isActive())
-				setupKeepAlive();
-
-			if(!nextUri.isEmpty() && instruct.nextLinkTimeout >= 0)
-				updateManager->registerSession(q, instruct.nextLinkTimeout, nextUri);
-		}
-
-		if(needUpdate)
-			update(needUpdatePriority);
-	}
-
-	void respond(int _code, const QByteArray &_reason, const HttpHeaders &_headers, const QByteArray &_body)
-	{
-		prepareToClose();
-
-		int code = _code;
-		QByteArray reason = _reason;
-		HttpHeaders headers = _headers;
-		QByteArray body = _body;
-
-		headers.removeAll("Content-Length"); // This will be reset if needed
-
-		if(adata.autoCrossOrigin)
-		{
-			if(!adata.jsonpCallback.isEmpty())
-			{
-				if(adata.jsonpExtendedResponse)
-				{
-					VariantMap result;
-					result["code"] = code;
-					result["reason"] = QString::fromUtf8(reason);
-
-					// Need to compact headers into a map
-					VariantMap vheaders;
-					foreach(const HttpHeader &h, headers)
-					{
-						// Don't add the same header name twice. We'll collect all values for a single header
-						bool found = false;
-						for(auto it = vheaders.constBegin(); it != vheaders.constEnd(); ++it)
-						{
-							const QString &name = it.key();
-
-							QByteArray uname = name.toUtf8();
-							if(qstricmp(uname.data(), h.first.data()) == 0)
-							{
-								found = true;
-								break;
-							}
-						}
-						if(found)
-							continue;
-
-						QList<QByteArray> values = headers.getAll(h.first).asQByteArrayList();
-						QString mergedValue;
-						for(int n = 0; n < values.count(); ++n)
-						{
-							mergedValue += QString::fromUtf8(values[n]);
-							if(n + 1 < values.count())
-								mergedValue += ", ";
-						}
-						vheaders[h.first.asQByteArray()] = mergedValue;
-					}
-					result["headers"] = vheaders;
-
-					result["body"] = QString::fromUtf8(body);
-
-					QByteArray resultJson = QJsonDocument(QJsonObject::fromVariantMap(result)).toJson(QJsonDocument::Compact);
-
-					body = "/**/" + adata.jsonpCallback + '(' + resultJson + ");\n";
-				}
-				else
-				{
-					if(body.endsWith("\r\n"))
-						body.truncate(body.size() - 2);
-					else if(body.endsWith("\n"))
-						body.truncate(body.size() - 1);
-					body = "/**/" + adata.jsonpCallback + '(' + body + ");\n";
-				}
-
-				headers.removeAll("Content-Type");
-				headers += HttpHeader("Content-Type", "application/javascript");
-				code = 200;
-				reason = "OK";
-			}
-			else
-			{
-				Cors::applyCorsHeaders(req->requestHeaders(), &headers);
-			}
-		}
-
-		incCounter(Stats::ClientHeaderBytesSent, ZhttpManager::estimateResponseHeaderBytes(code, reason, headers));
-
-		req->beginResponse(code, reason, headers);
-		writeBody(body);
-		req->endBody();
-	}
-
-	void respond(int code, const QByteArray &reason, const HttpHeaders &_headers, const QByteArray &body, const QList<QByteArray> &exposeHeaders)
-	{
-		// Inherit headers from the timeout response
-		HttpHeaders headers = instruct.response.headers;
-		foreach(const HttpHeader &h, _headers)
-			headers.removeAll(h.first);
-		foreach(const HttpHeader &h, _headers)
-			headers += h;
-
-		// If Grip-Expose-Headers was provided in the push, apply now
-		if(!exposeHeaders.isEmpty())
-		{
-			for(int n = 0; n < headers.count(); ++n)
-			{
-				const HttpHeader &h = headers[n];
-
-				bool found = false;
-				foreach(const QByteArray &e, exposeHeaders)
-				{
-					if(qstricmp(h.first.data(), e.data()) == 0)
-					{
-						found = true;
-						break;
-					}
-				}
-
-				if(found)
-				{
-					headers.removeAt(n);
-					--n; // Adjust position
-				}
-			}
-		}
-
-		respond(code, reason, headers, body);
-	}
-
-	void doFinish(bool retry = false)
-	{
-		cancelActivities();
-
-		ZhttpRequest::Rid rid = req->rid();
-		QByteArray cid = rid.first + ':' + rid.second;
-
-		std::weak_ptr<Private> self = q->d;
-
-		QHashIterator<QString, Instruct::Channel> it(channels);
-		while(it.hasNext())
-		{
-			it.next();
-			const QString &channel = it.key();
-
-			unsubscribeCallback.call({q, channel});
-
-			assert(!self.expired()); // Deleting here would leak subscriptions/connections
-		}
-
-		if(retry)
-		{
-			// Refresh before remove, to ensure transition
-			stats->refreshConnection(cid);
-
-			connectionStatsActive = false;
-
-			int unreportedTime = stats->removeConnection(cid, true, adata.from);
-
-			ZhttpRequest::ServerState ss = req->serverState();
-
-			RetryRequestPacket rp;
-
-			RetryRequestPacket::Request rpreq;
-			rpreq.rid = rid;
-			rpreq.https = (req->requestUri().scheme() == "https");
-			rpreq.peerAddress = req->peerAddress();
-			rpreq.debug = adata.debug;
-			rpreq.autoCrossOrigin = adata.autoCrossOrigin;
-			rpreq.jsonpCallback = adata.jsonpCallback;
-			rpreq.jsonpExtendedResponse = adata.jsonpExtendedResponse;
-			if(!stats->connectionSendEnabled())
-				rpreq.unreportedTime = unreportedTime;
-			rpreq.inSeq = ss.inSeq;
-			rpreq.outSeq = ss.outSeq;
-			rpreq.outCredits = ss.outCredits;
-			rpreq.routerResp = ss.routerResp;
-			rpreq.userData = ss.userData;
-
-			rp.requests += rpreq;
-
-			rp.requestData = adata.requestData;
-
-			if(adata.haveInspectInfo)
-			{
-				rp.haveInspectInfo = true;
-				rp.inspectInfo.doProxy = adata.inspectInfo.doProxy;
-				rp.inspectInfo.sharingKey = adata.inspectInfo.sharingKey;
-				rp.inspectInfo.sid = adata.inspectInfo.sid;
-				rp.inspectInfo.lastIds = adata.inspectInfo.lastIds;
-				rp.inspectInfo.userData = adata.inspectInfo.userData;
-			}
-
-			// If prev-id set on channels, set as inspect lastids so the proxy
-			// will pass as Grip-Last in the next request
-			QHashIterator<QString, Instruct::Channel> it(channels);
-			while(it.hasNext())
-			{
-				it.next();
-				const Instruct::Channel &c = it.value();
-
-				if(!c.prevId.isNull())
-				{
-					if(!rp.haveInspectInfo)
-					{
-						rp.haveInspectInfo = true;
-						rp.inspectInfo.doProxy = true;
-					}
-
-					rp.inspectInfo.lastIds.insert(c.name.toUtf8(), c.prevId.toUtf8());
-				}
-			}
-
-			rp.route = adata.route.toUtf8();
-			rp.retrySeq = stats->lastRetrySeq(adata.from);
-
-			retryToAddress = adata.from;
-			retryPacket = rp;
-		}
-		else
-		{
-			connectionStatsActive = false;
-
-			stats->removeConnection(cid, false);
-		}
-
-		if(!goneUri.isEmpty())
-		{
-			state = SendingGone;
-			prepareOutReq(goneUri);
-			outReq->start("POST", goneUri, HttpHeaders());
-			outReq->endBody();
-			return;
-		}
-
-		finished();
-	}
-
-	void finished()
-	{
-		ZhttpRequest::Rid rid = req->rid();
-		QByteArray cid = rid.first + ':' + rid.second;
-
-		log_debug("httpsession: cleaning up %s", cid.data());
-		cleanup();
-
-		finishedCallback.call({q});
-	}
-
-	void prepareOutReq(const Url &destUri, bool autoShare = false)
-	{
-		haveOutReqHeaders = false;
-		sentOutReqData = 0;
-
-		outReq.reset(outZhttp->createRequest());
-		readyReadOutConnection = outReq->readyRead.connect(boost::bind(&Private::outReq_readyRead, this));
-		errorOutConnection = outReq->error.connect(boost::bind(&Private::outReq_error, this));
-
-		int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
-		int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
-
-		VariantHash passthroughData;
-
-		passthroughData["route"] = adata.route.toUtf8();
-
-		// If next link points to the same service as the current request,
-		// then we can assume the network would send the request back to
-		// us, so we can handle it internally. If the link points to a
-		// different service, then we can't make this assumption and need
-		// to make the request over the network. Note that such a request
-		// could still end up looping back to us
-		if(destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() && destPort == currentPort)
-		{
-			// Tell the proxy that we prefer the request to be handled
-			// internally, using the same route
-			passthroughData["prefer-internal"] = true;
-		}
-
-		// Needed in case internal routing is not used
-		if(adata.trusted)
-			passthroughData["trusted"] = true;
-
-		// Share requests to the same URI
-		passthroughData["auto-share"] = autoShare;
-
-		outReq->setPassthroughData(passthroughData);
-	}
-
-	void requestNextLink()
-	{
-		log_debug("httpsession: next: %s", qPrintable(nextUri.toString()));
-
-		if(!outZhttp)
-		{
-			errorMessage = "Instruct contained link, but handler not configured for outbound requests.";
-			deferCall.defer([=] { doError(); });
-			return;
-		}
-
-		prepareOutReq(nextUri, true);
-
-		HttpHeaders headers;
-		foreach(const Instruct::Channel &c, channels.values())
-		{
-			if(!c.prevId.isNull())
-				headers += HttpHeader("Grip-Last", c.name.toUtf8() + "; last-id=" + c.prevId.toUtf8());
-		}
-
-		outReq->start("GET", nextUri, headers);
-		outReq->endBody();
-	}
-
-	void tryProcessOutReq()
-	{
-		if(outReq)
-		{
-			if(!haveOutReqHeaders)
-				return;
-
-			if(outReq->responseCode() < 200 || outReq->responseCode() >= 300)
-			{
-				outReq_error();
-				return;
-			}
-
-			if(state == Proxying)
-			{
-				if(outReq->bytesAvailable() > 0)
-				{
-					// Stop keep alive timer only if we have to send data. If the
-					// response body is empty, then the timer is left alone
-					timer->stop();
-
-					int avail = req->writeBytesAvailable();
-					if(avail <= 0)
-						return;
-
-					QByteArray buf = outReq->readBody(avail);
-
-					if(responseFilters)
-					{
-						buf = responseFilters->update(buf);
-						if(buf.isNull())
-						{
-							logRequestError(outReq->requestMethod(), outReq->requestUri(), outReq->requestHeaders());
-
-							errorMessage = QString("filter error: %1").arg(responseFilters->errorMessage());
-							doError();
-							return;
-						}
-					}
-
-					writeBody(buf);
-
-					sentOutReqData += buf.size();
-				}
-
-				if(outReq->bytesAvailable() == 0 && outReq->isFinished())
-				{
-					if(responseFilters)
-					{
-						QByteArray buf = responseFilters->finalize();
-						if(buf.isNull())
-						{
-							logRequestError(outReq->requestMethod(), outReq->requestUri(), outReq->requestHeaders());
-
-							errorMessage = QString("filter error: %1").arg(responseFilters->errorMessage());
-							doError();
-							return;
-						}
-
-						delete responseFilters;
-						responseFilters = 0;
-
-						if(!buf.isEmpty())
-						{
-							writeBody(buf);
-
-							sentOutReqData += buf.size();
-						}
-					}
-
-					HttpResponseData responseData;
-					responseData.code = outReq->responseCode();
-					responseData.reason = outReq->responseReason();
-					responseData.headers = outReq->responseHeaders();
-
-					logRequest(outReq->requestMethod(), outReq->requestUri(), outReq->requestHeaders(), responseData.code, sentOutReqData);
-
-					retries = 0;
-
-					cleanupOutReq();
-
-					currentUri = nextUri;
-
-					if(!instruct.nextLink.isEmpty())
-						nextUri = currentUri.resolved(instruct.nextLink);
-					else
-						nextUri.clear();
-
-					if(instruct.channels.count() > connectionSubscriptionMax)
-					{
-						instruct.channels = instruct.channels.mid(0, connectionSubscriptionMax);
-
-						auto routeInfo = LogUtil::RouteInfo(adata.route, logLevel);
-						LogUtil::logForRoute(routeInfo, "httpsession: too many subscriptions");
-					}
-
-					if(instruct.holdMode == Instruct::StreamHold)
-					{
-						if(instruct.keepAliveTimeout < 0)
-							timer->stop();
-
-						prepareToSendQueueOrHold();
-					}
-				}
-			}
-			else if(state == SendingGone)
-			{
-				// Response should be empty
-				if(outReq->bytesAvailable() > 0)
-				{
-					outReq_error();
-					return;
-				}
-
-				if(outReq->isFinished())
-				{
-					logRequest(outReq->requestMethod(), outReq->requestUri(), outReq->requestHeaders(), outReq->responseCode(), 0);
-
-					cleanupOutReq();
-
-					finished();
-					return;
-				}
-			}
-			else
-			{
-				// Unexpected state
-				assert(0);
-			}
-		}
-
-		if(state == Proxying && !outReq)
-		{
-			if(!nextUri.isEmpty())
-			{
-				if(req->writeBytesAvailable() > 0)
-					requestNextLink();
-			}
-			else
-			{
-				prepareToClose();
-
-				req->endBody();
-			}
-		}
-	}
-
-	void logRequest(const QString &method, const Url &uri, const HttpHeaders &headers, int code, int bodySize)
-	{
-		LogUtil::RequestData rd;
-
-		// Only log route id if explicitly set
-		if(!adata.statsRoute.isEmpty())
-			rd.routeId = adata.route;
-
-		rd.status = LogUtil::Response;
-
-		rd.requestData.method = method;
-		rd.requestData.uri = uri;
-		rd.requestData.headers = headers;
-
-		rd.responseData.code = code;
-		rd.responseBodySize = bodySize;
-
-		LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
-	}
-
-	void logRequestError(const QString &method, const Url &uri, const HttpHeaders &headers)
-	{
-		LogUtil::RequestData rd;
-
-		// Only log route id if explicitly set
-		if(!adata.statsRoute.isEmpty())
-			rd.routeId = adata.route;
-
-		rd.status = LogUtil::Error;
-
-		rd.requestData.method = method;
-		rd.requestData.uri = uri;
-		rd.requestData.headers = headers;
-
-		LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
-	}
-
-	void incCounter(Stats::Counter c, int count = 1)
-	{
-		stats->incCounter(adata.statsRoute.toUtf8(), c, count);
-	}
-
-	void writeBody(const QByteArray &body)
-	{
-		incCounter(Stats::ClientContentBytesSent, body.size());
-
-		req->writeBody(body);
-	}
-
-	void messageFiltersFinished(const Filter::MessageFilter::Result &result)
-	{
-		QueuedItem qi = publishQueue.takeFirst();
-
-		messageFiltersFinishedConnection.disconnect();
-		messageFilters.reset();
-
-		if(!result.errorMessage.isNull())
-		{
-			if(adata.debug)
-			{
-				errorMessage = QString("filter error: %1").arg(result.errorMessage);
-				doError();
-				return;
-			}
-		}
-		else
-		{
-			processItem(qi.item, result.sendAction, result.content, qi.exposeHeaders);
-		}
-
-		// If filters finished asynchronously then we need to resume processing
-		if(!inProcessPublishQueue)
-			processPublishQueue();
-	}
-
-	void processItem(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content, const QList<QByteArray> &exposeHeaders)
-	{
-		const PublishFormat &f = item.format;
-
-		Instruct::Channel &channel = channels[item.channel];
-
-		if(!channel.prevId.isNull())
-			channel.prevId = item.id;
-
-		if(instruct.holdMode == Instruct::ResponseHold)
-		{
-			if(sendAction == Filter::Drop)
-				return;
-
-			// NOTE: http-response mode doesn't support a close
-			// action since it's better to send a real response
-
-			if(f.action == PublishFormat::Send)
-			{
-				respond(f.code, f.reason, f.headers, content, exposeHeaders);
-			}
-			else if(f.action == PublishFormat::Hint)
-			{
-				update(HighPriority);
-			}
-		}
-		else if(instruct.holdMode == Instruct::StreamHold)
-		{
-			if(sendAction == Filter::Drop)
-				return;
-
-			if(f.action == PublishFormat::Send)
-			{
-				writeBody(content);
-
-				// Restart keep alive timer
-				adjustKeepAlive();
-
-				if(!nextUri.isEmpty() && instruct.nextLinkTimeout >= 0)
-				{
-					activeChannels += item.channel;
-					if(activeChannels.count() == channels.count())
-					{
-						activeChannels.clear();
-
-						// All channels had activity. Reset the timeout
-						updateManager->registerSession(q, instruct.nextLinkTimeout, nextUri, true);
-					}
-				}
-			}
-			else if(f.action == PublishFormat::Hint)
-			{
-				// Clear queue since any items will be redundant
-				publishQueue.clear();
-
-				update(HighPriority);
-			}
-			else if(f.action == PublishFormat::Close)
-			{
-				prepareToClose();
-				req->endBody();
-			}
-		}
-	}
-
-	void doError()
-	{
-		if(instruct.holdMode == Instruct::ResponseHold)
-		{
-			QByteArray msg;
-
-			if(adata.debug)
-				msg = errorMessage.toUtf8();
-			else
-				msg = "Error while proxying to origin.";
-
-			HttpHeaders headers;
-			headers += HttpHeader("Content-Type", "text/plain");
-			respond(502, "Bad Gateway", headers, msg + '\n');
-		}
-		else // StreamHold, NoHold
-		{
-			prepareToClose();
-
-			if(adata.debug)
-				writeBody("\n\n" + errorMessage.toUtf8() + '\n');
-
-			req->endBody();
-		}
-	}
-
-	void req_bytesWritten(int count)
-	{
-		Q_UNUSED(count);
-
-		if(req->isFinished())
-		{
-			doFinish();
-			return;
-		}
-	}
-
-	void req_writeBytesChanged()
-	{
-		if(state == SendingFirstInstructResponse)
-		{
-			tryWriteFirstInstructResponse();
-		}
-		else if(state == Proxying)
-		{
-			tryProcessOutReq();
-		}
-		else if(state == SendingQueue)
-		{
-			// In this state, the writeBytesChanged signal is only
-			// interesting if it indicates write bytes are available
-
-			if(req->writeBytesAvailable() > 0)
-				processPublishQueue();
-		}
-	}
-
-	void req_error()
-	{
-		doFinish();
-	}
-
-	void req_paused()
-	{
-		doFinish(true); // Finish for retry
-	}
-
-	void outReq_readyRead()
-	{
-		if(!haveOutReqHeaders)
-		{
-			haveOutReqHeaders = true;
-
-			if(state == Proxying)
-			{
-				HttpResponseData responseData;
-				responseData.code = outReq->responseCode();
-				responseData.reason = outReq->responseReason();
-				responseData.headers = outReq->responseHeaders();
-
-				bool ok;
-				Instruct i = Instruct::fromResponse(responseData, &ok, &errorMessage);
-				if(!ok)
-				{
-					doError();
-					return;
-				}
-
-				// Subsequent response must be non-hold or stream hold
-				if(i.holdMode != Instruct::NoHold && i.holdMode != Instruct::StreamHold)
-				{
-					errorMessage = "Next link returned non-stream hold.";
-					doError();
-					return;
-				}
-
-				// Accept the instruct as soon as it's available, so we can
-				// use its filters. If response processing ends up failing
-				// later on, the session will error out and the instruct
-				// won't be used for anything else
-				instruct = i;
-
-				// Apply ResponseContent filters of all channels
-				QStringList allFilters;
-				foreach(const Instruct::Channel &c, instruct.channels)
-				{
-					foreach(const QString &filter, c.filters)
-					{
-						if((Filter::targets(filter) & Filter::ResponseContent) && !allFilters.contains(filter))
-							allFilters += filter;
-					}
-				}
-
-				Filter::Context fc;
-				fc.subscriptionMeta = instruct.meta;
-
-				responseFilters = new FilterStack(fc, allFilters);
-			}
-		}
-
-		tryProcessOutReq();
-	}
-
-	void outReq_error()
-	{
-		logRequestError(outReq->requestMethod(), outReq->requestUri(), outReq->requestHeaders());
-
-		cleanupOutReq();
-
-		if(state == Proxying)
-		{
-			log_debug("httpsession: failed to retrieve next link");
-
-			// Can't retry if we started sending data
-
-			if(sentOutReqData <= 0 && retries < RETRY_MAX)
-			{
-				int delay = RETRY_TIMEOUT;
-				for(int n = 0; n < retries; ++n)
-					delay *= 2;
-				delay += QRandomGenerator::global()->generate() % RETRY_RAND_MAX;
-
-				log_debug("httpsession: trying again in %dms", delay);
-
-				++retries;
-
-				retryTimer->start(delay);
-				return;
-			}
-			else
-			{
-				errorMessage = "Failed to retrieve next link.";
-				doError();
-			}
-		}
-		else if(state == SendingGone)
-		{
-			log_debug("httpsession: failed to request gone link");
-			finished();
-		}
-		else
-		{
-			// Unexpected state
-			assert(0);
-		}
-	}
-
-	void timer_timeout()
-	{
-		if(instruct.holdMode == Instruct::ResponseHold)
-		{
-			// Send timeout response
-			respond(instruct.response.code, instruct.response.reason, instruct.response.headers, instruct.response.body);
-		}
-		else if(instruct.holdMode == Instruct::StreamHold)
-		{
-			writeBody(instruct.keepAliveData);
-
-			setupKeepAlive();
-
-			stats->addActivity(adata.statsRoute.toUtf8(), 1);
-		}
-	}
-
-	void retryTimer_timeout()
-	{
-		requestNextLink();
-	}
+    void cleanup() {
+        cancelActivities();
+
+        if (connectionStatsActive) {
+            connectionStatsActive = false;
+
+            ZhttpRequest::Rid rid = req->rid();
+            QByteArray cid = rid.first + ':' + rid.second;
+
+            stats->removeConnection(cid, false);
+        }
+    }
+
+    void cleanupOutReq() {
+        readyReadOutConnection.disconnect();
+        errorOutConnection.disconnect();
+        outReq.reset();
+
+        delete responseFilters;
+        responseFilters = 0;
+    }
+
+    void cancelAction() {
+        if (pendingAction) {
+            pendingAction->sessions.remove(q);
+            pendingAction = 0;
+        }
+    }
+
+    void cancelActivities() {
+        cleanupOutReq();
+        cancelAction();
+
+        publishQueue.clear();
+
+        timer->stop();
+        retryTimer->stop();
+
+        updateManager->unregisterSession(q);
+    }
+
+    void setupKeepAlive() {
+        if (instruct.keepAliveTimeout >= 0) {
+            int timeout = instruct.keepAliveTimeout * 1000;
+            timeout = qMax(
+                timeout - (int)(QRandomGenerator::global()->generate() % KEEPALIVE_RAND_MAX), 0);
+            timer->setSingleShot(true);
+            timer->start(timeout);
+        }
+    }
+
+    void adjustKeepAlive() {
+        // If idle mode, restart the timer. Else leave alone
+        if (timer && instruct.keepAliveMode == Instruct::Idle)
+            setupKeepAlive();
+    }
+
+    void prepareToClose() {
+        state = Closing;
+
+        cancelActivities();
+    }
+
+    void tryWriteFirstInstructResponse() {
+        int avail = req->writeBytesAvailable();
+        if (avail > 0) {
+            writeBody(firstInstructResponse.take(avail));
+
+            if (firstInstructResponse.isEmpty())
+                firstInstructResponseDone();
+        }
+    }
+
+    void firstInstructResponseDone() {
+        if (instruct.holdMode == Instruct::NoHold) {
+            // NoHold instruct MUST have had a link to make it this far
+            assert(!nextUri.isEmpty());
+
+            doUpdate();
+        } else // ResponseHold, StreamHold
+        {
+            prepareToSendQueueOrHold(true);
+        }
+    }
+
+    void doUpdate() {
+        pendingAction = 0;
+
+        if (instruct.holdMode == Instruct::ResponseHold) {
+            state = Pausing;
+
+            // Stop activity while pausing
+            timer->stop();
+
+            pausedConnection = req->paused.connect(boost::bind(&Private::req_paused, this));
+            req->pause();
+        } else {
+            state = Proxying;
+
+            requestNextLink();
+        }
+    }
+
+    void prepareToSendQueueOrHold(bool first = false) {
+        assert(instruct.holdMode != Instruct::NoHold);
+
+        if (instruct.holdMode == Instruct::StreamHold) {
+            // If prev ids used but not next link, error out
+            if (nextUri.isEmpty()) {
+                foreach (const Instruct::Channel &c, instruct.channels) {
+                    if (!c.prevId.isNull()) {
+                        errorMessage =
+                            QString("channel '%1' specifies prev-id, but no next link found")
+                                .arg(c.name);
+                        doError();
+                        return;
+                    }
+                }
+            }
+        }
+
+        QList<QString> channelsRemoved;
+        QHashIterator<QString, Instruct::Channel> it(channels);
+        while (it.hasNext()) {
+            it.next();
+            const QString &name = it.key();
+
+            if (adata.implicitChannels.contains(name))
+                continue;
+
+            bool found = false;
+            foreach (const Instruct::Channel &c, instruct.channels) {
+                if (adata.channelPrefix + c.name == name) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                channelsRemoved += name;
+                channels.remove(name);
+            }
+        }
+
+        QList<QString> channelsAdded;
+        foreach (const Instruct::Channel &c, instruct.channels) {
+            QString name = adata.channelPrefix + c.name;
+
+            if (!channels.contains(name)) {
+                channelsAdded += name;
+                channels.insert(name, c);
+            } else {
+                // Update channel properties
+                channels[name].prevId = c.prevId;
+                channels[name].filters = c.filters;
+            }
+        }
+
+        std::weak_ptr<Private> self = q->d;
+
+        foreach (const QString &channel, channelsRemoved) {
+            unsubscribeCallback.call({q, channel});
+
+            assert(!self.expired()); // Deleting here would leak
+                                     // subscriptions/connections
+        }
+
+        foreach (const QString &channel, channelsAdded) {
+            subscribeCallback.call({q, channel});
+
+            assert(!self.expired()); // Deleting here would leak
+                                     // subscriptions/connections
+        }
+
+        if (instruct.holdMode == Instruct::ResponseHold) {
+            state = Holding;
+
+            // Set timeout
+            if (instruct.timeout >= 0) {
+                timer->setSingleShot(true);
+                timer->start(instruct.timeout * 1000);
+            }
+        } else // StreamHold
+        {
+            // If conflict on first hold, immediately recover. We don't
+            // do this on subsequent holds because there may be queued
+            // messages available to resolve the conflict
+            if (first) {
+                bool conflict = false;
+                foreach (const Instruct::Channel &c, instruct.channels) {
+                    if (!c.prevId.isNull()) {
+                        QString name = adata.channelPrefix + c.name;
+
+                        QString lastId = publishLastIds->value(name);
+
+                        if (!lastId.isNull() && lastId != c.prevId) {
+                            log_debug("last ID inconsistency (got=%s, expected=%s), retrying",
+                                      qPrintable(c.prevId), qPrintable(lastId));
+                            publishLastIds->remove(name);
+                            conflict = true;
+
+                            // NOTE: don't exit loop here. We want to clear
+                            // the last ids of all conflicting channels
+                        }
+                    }
+                }
+
+                if (conflict) {
+                    // Update expects us to be in Holding state
+                    state = Holding;
+
+                    update(LowPriority);
+                    return;
+                }
+            }
+
+            // Drop any non-matching queued items
+            while (!publishQueue.isEmpty()) {
+                const QueuedItem &qi = publishQueue.first();
+                const PublishItem &item = qi.item;
+
+                if (!channels.contains(item.channel)) {
+                    // We don't care about this channel anymore
+                    publishQueue.removeFirst();
+                    continue;
+                }
+
+                Instruct::Channel &channel = channels[item.channel];
+
+                if (!channel.prevId.isNull() && channel.prevId != item.prevId) {
+                    // Item doesn't follow the hold
+                    publishQueue.removeFirst();
+                    continue;
+                }
+
+                break;
+            }
+
+            // If there are items to send, this will send them. If there are
+            // no items to send, this will end up changing state to Holding
+            sendQueue();
+        }
+    }
+
+    void sendQueue() {
+        state = SendingQueue;
+
+        processPublishQueue();
+    }
+
+    void processPublishQueue() {
+        assert(!inProcessPublishQueue);
+        inProcessPublishQueue = true;
+
+        while (state == SendingQueue && !publishQueue.isEmpty() && req->writeBytesAvailable() > 0 &&
+               !messageFilters) {
+            const QueuedItem &qi = publishQueue.first();
+            const PublishItem &item = qi.item;
+
+            if (!channels.contains(item.channel)) {
+                log_debug("httpsession: received publish for channel with no "
+                          "subscription, dropping");
+                publishQueue.removeFirst();
+                continue;
+            }
+
+            Instruct::Channel &channel = channels[item.channel];
+
+            if (!channel.prevId.isNull()) {
+                if (channel.prevId != item.prevId) {
+                    log_debug("last ID inconsistency (got=%s, expected=%s), retrying",
+                              qPrintable(item.prevId), qPrintable(channel.prevId));
+                    publishLastIds->remove(item.channel);
+
+                    publishQueue.clear();
+
+                    update(LowPriority);
+                    break;
+                }
+            }
+
+            const PublishFormat &f = item.format;
+
+            if (f.haveContentFilters) {
+                // Ensure content filters match
+                QStringList contentFilters;
+                foreach (const QString &f, channels[item.channel].filters) {
+                    if (Filter::targets(f) & Filter::MessageContent)
+                        contentFilters += f;
+                }
+                if (contentFilters != f.contentFilters) {
+                    publishQueue.removeFirst();
+
+                    if (adata.debug) {
+                        errorMessage =
+                            QString("content filter mismatch: subscription=%1 message=%2")
+                                .arg(contentFilters.join(","), f.contentFilters.join(","));
+                        doError();
+                        break;
+                    }
+
+                    continue;
+                }
+            }
+
+            QByteArray body;
+            if (f.type == PublishFormat::HttpResponse && f.haveBodyPatch)
+                body = applyBodyPatch(instruct.response.body, f.bodyPatch);
+            else
+                body = f.body;
+
+            messageFilters =
+                std::make_unique<Filter::MessageFilterStack>(channels[item.channel].filters);
+            messageFiltersFinishedConnection = messageFilters->finished.connect(
+                boost::bind(&Private::messageFiltersFinished, this, boost::placeholders::_1));
+
+            QHash<QString, QString> prevIds;
+            QHashIterator<QString, Instruct::Channel> it(channels);
+            while (it.hasNext()) {
+                it.next();
+                const Instruct::Channel &c = it.value();
+                prevIds[c.name] = c.prevId;
+            }
+
+            Filter::Context fc;
+            fc.prevIds = prevIds;
+            fc.subscriptionMeta = instruct.meta;
+            fc.publishMeta = item.meta;
+            fc.zhttpOut = outZhttp;
+            fc.currentUri = currentUri;
+            fc.route = adata.route;
+            fc.trusted = adata.trusted;
+            fc.limiter = filterLimiter;
+
+            // May call messageFiltersFinished immediately. If it does, queue
+            // processing will continue. Else, the loop will end and queue
+            // processing will resume after the filters finish
+            messageFilters->start(fc, body);
+        }
+
+        if (!messageFilters) {
+            // The state changed, the queue is empty, or the client buffer is full
+
+            if (state != SendingQueue || publishQueue.isEmpty()) {
+                // If the state changed or the queue is empty then we're done
+                sendQueueDone();
+            } else {
+                // Client buffer can only be full in stream mode
+                assert(instruct.holdMode == Instruct::StreamHold);
+
+                // NOTE: we can end up here multiple times in a single pass
+                // of the queue if the client buffer becomes full multiple
+                // times. So, whatever happens here should be idempotent and
+                // cheap.
+
+                // Turn off timers until we're able to send again
+                timer->stop();
+                updateManager->unregisterSession(q);
+            }
+        }
+
+        inProcessPublishQueue = false;
+    }
+
+    void sendQueueDone() {
+        // if the state changed during queue processing (e.g. to Closing),
+        // Then we want to leave the state alone and do nothing else
+        if (state != SendingQueue)
+            return;
+
+        state = Holding;
+
+        if (instruct.holdMode == Instruct::StreamHold) {
+            activeChannels.clear();
+
+            // Start keep alive timer, if it wasn't started already
+            if (!timer->isActive())
+                setupKeepAlive();
+
+            if (!nextUri.isEmpty() && instruct.nextLinkTimeout >= 0)
+                updateManager->registerSession(q, instruct.nextLinkTimeout, nextUri);
+        }
+
+        if (needUpdate)
+            update(needUpdatePriority);
+    }
+
+    void respond(int _code, const QByteArray &_reason, const HttpHeaders &_headers,
+                 const QByteArray &_body) {
+        prepareToClose();
+
+        int code = _code;
+        QByteArray reason = _reason;
+        HttpHeaders headers = _headers;
+        QByteArray body = _body;
+
+        headers.removeAll("Content-Length"); // This will be reset if needed
+
+        if (adata.autoCrossOrigin) {
+            if (!adata.jsonpCallback.isEmpty()) {
+                if (adata.jsonpExtendedResponse) {
+                    VariantMap result;
+                    result["code"] = code;
+                    result["reason"] = QString::fromUtf8(reason);
+
+                    // Need to compact headers into a map
+                    VariantMap vheaders;
+                    foreach (const HttpHeader &h, headers) {
+                        // Don't add the same header name twice. We'll collect all values
+                        // for a single header
+                        bool found = false;
+                        for (auto it = vheaders.constBegin(); it != vheaders.constEnd(); ++it) {
+                            const QString &name = it.key();
+
+                            QByteArray uname = name.toUtf8();
+                            if (qstricmp(uname.data(), h.first.data()) == 0) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (found)
+                            continue;
+
+                        QList<QByteArray> values = headers.getAll(h.first).asQByteArrayList();
+                        QString mergedValue;
+                        for (int n = 0; n < values.count(); ++n) {
+                            mergedValue += QString::fromUtf8(values[n]);
+                            if (n + 1 < values.count())
+                                mergedValue += ", ";
+                        }
+                        vheaders[h.first.asQByteArray()] = mergedValue;
+                    }
+                    result["headers"] = vheaders;
+
+                    result["body"] = QString::fromUtf8(body);
+
+                    QByteArray resultJson = QJsonDocument(QJsonObject::fromVariantMap(result))
+                                                .toJson(QJsonDocument::Compact);
+
+                    body = "/**/" + adata.jsonpCallback + '(' + resultJson + ");\n";
+                } else {
+                    if (body.endsWith("\r\n"))
+                        body.truncate(body.size() - 2);
+                    else if (body.endsWith("\n"))
+                        body.truncate(body.size() - 1);
+                    body = "/**/" + adata.jsonpCallback + '(' + body + ");\n";
+                }
+
+                headers.removeAll("Content-Type");
+                headers += HttpHeader("Content-Type", "application/javascript");
+                code = 200;
+                reason = "OK";
+            } else {
+                Cors::applyCorsHeaders(req->requestHeaders(), &headers);
+            }
+        }
+
+        incCounter(Stats::ClientHeaderBytesSent,
+                   ZhttpManager::estimateResponseHeaderBytes(code, reason, headers));
+
+        req->beginResponse(code, reason, headers);
+        writeBody(body);
+        req->endBody();
+    }
+
+    void respond(int code, const QByteArray &reason, const HttpHeaders &_headers,
+                 const QByteArray &body, const QList<QByteArray> &exposeHeaders) {
+        // Inherit headers from the timeout response
+        HttpHeaders headers = instruct.response.headers;
+        foreach (const HttpHeader &h, _headers)
+            headers.removeAll(h.first);
+        foreach (const HttpHeader &h, _headers)
+            headers += h;
+
+        // If Grip-Expose-Headers was provided in the push, apply now
+        if (!exposeHeaders.isEmpty()) {
+            for (int n = 0; n < headers.count(); ++n) {
+                const HttpHeader &h = headers[n];
+
+                bool found = false;
+                foreach (const QByteArray &e, exposeHeaders) {
+                    if (qstricmp(h.first.data(), e.data()) == 0) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found) {
+                    headers.removeAt(n);
+                    --n; // Adjust position
+                }
+            }
+        }
+
+        respond(code, reason, headers, body);
+    }
+
+    void doFinish(bool retry = false) {
+        cancelActivities();
+
+        ZhttpRequest::Rid rid = req->rid();
+        QByteArray cid = rid.first + ':' + rid.second;
+
+        std::weak_ptr<Private> self = q->d;
+
+        QHashIterator<QString, Instruct::Channel> it(channels);
+        while (it.hasNext()) {
+            it.next();
+            const QString &channel = it.key();
+
+            unsubscribeCallback.call({q, channel});
+
+            assert(!self.expired()); // Deleting here would leak
+                                     // subscriptions/connections
+        }
+
+        if (retry) {
+            // Refresh before remove, to ensure transition
+            stats->refreshConnection(cid);
+
+            connectionStatsActive = false;
+
+            int unreportedTime = stats->removeConnection(cid, true, adata.from);
+
+            ZhttpRequest::ServerState ss = req->serverState();
+
+            RetryRequestPacket rp;
+
+            RetryRequestPacket::Request rpreq;
+            rpreq.rid = rid;
+            rpreq.https = (req->requestUri().scheme() == "https");
+            rpreq.peerAddress = req->peerAddress();
+            rpreq.debug = adata.debug;
+            rpreq.autoCrossOrigin = adata.autoCrossOrigin;
+            rpreq.jsonpCallback = adata.jsonpCallback;
+            rpreq.jsonpExtendedResponse = adata.jsonpExtendedResponse;
+            if (!stats->connectionSendEnabled())
+                rpreq.unreportedTime = unreportedTime;
+            rpreq.inSeq = ss.inSeq;
+            rpreq.outSeq = ss.outSeq;
+            rpreq.outCredits = ss.outCredits;
+            rpreq.routerResp = ss.routerResp;
+            rpreq.userData = ss.userData;
+
+            rp.requests += rpreq;
+
+            rp.requestData = adata.requestData;
+
+            if (adata.haveInspectInfo) {
+                rp.haveInspectInfo = true;
+                rp.inspectInfo.doProxy = adata.inspectInfo.doProxy;
+                rp.inspectInfo.sharingKey = adata.inspectInfo.sharingKey;
+                rp.inspectInfo.sid = adata.inspectInfo.sid;
+                rp.inspectInfo.lastIds = adata.inspectInfo.lastIds;
+                rp.inspectInfo.userData = adata.inspectInfo.userData;
+            }
+
+            // If prev-id set on channels, set as inspect lastids so the proxy
+            // will pass as Grip-Last in the next request
+            QHashIterator<QString, Instruct::Channel> it(channels);
+            while (it.hasNext()) {
+                it.next();
+                const Instruct::Channel &c = it.value();
+
+                if (!c.prevId.isNull()) {
+                    if (!rp.haveInspectInfo) {
+                        rp.haveInspectInfo = true;
+                        rp.inspectInfo.doProxy = true;
+                    }
+
+                    rp.inspectInfo.lastIds.insert(c.name.toUtf8(), c.prevId.toUtf8());
+                }
+            }
+
+            rp.route = adata.route.toUtf8();
+            rp.retrySeq = stats->lastRetrySeq(adata.from);
+
+            retryToAddress = adata.from;
+            retryPacket = rp;
+        } else {
+            connectionStatsActive = false;
+
+            stats->removeConnection(cid, false);
+        }
+
+        if (!goneUri.isEmpty()) {
+            state = SendingGone;
+            prepareOutReq(goneUri);
+            outReq->start("POST", goneUri, HttpHeaders());
+            outReq->endBody();
+            return;
+        }
+
+        finished();
+    }
+
+    void finished() {
+        ZhttpRequest::Rid rid = req->rid();
+        QByteArray cid = rid.first + ':' + rid.second;
+
+        log_debug("httpsession: cleaning up %s", cid.data());
+        cleanup();
+
+        finishedCallback.call({q});
+    }
+
+    void prepareOutReq(const Url &destUri, bool autoShare = false) {
+        haveOutReqHeaders = false;
+        sentOutReqData = 0;
+
+        outReq.reset(outZhttp->createRequest());
+        readyReadOutConnection =
+            outReq->readyRead.connect(boost::bind(&Private::outReq_readyRead, this));
+        errorOutConnection = outReq->error.connect(boost::bind(&Private::outReq_error, this));
+
+        int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
+        int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
+
+        VariantHash passthroughData;
+
+        passthroughData["route"] = adata.route.toUtf8();
+
+        // If next link points to the same service as the current request,
+        // then we can assume the network would send the request back to
+        // us, so we can handle it internally. If the link points to a
+        // different service, then we can't make this assumption and need
+        // to make the request over the network. Note that such a request
+        // could still end up looping back to us
+        if (destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() &&
+            destPort == currentPort) {
+            // Tell the proxy that we prefer the request to be handled
+            // internally, using the same route
+            passthroughData["prefer-internal"] = true;
+        }
+
+        // Needed in case internal routing is not used
+        if (adata.trusted)
+            passthroughData["trusted"] = true;
+
+        // Share requests to the same URI
+        passthroughData["auto-share"] = autoShare;
+
+        outReq->setPassthroughData(passthroughData);
+    }
+
+    void requestNextLink() {
+        log_debug("httpsession: next: %s", qPrintable(nextUri.toString()));
+
+        if (!outZhttp) {
+            errorMessage = "Instruct contained link, but handler not configured for "
+                           "outbound requests.";
+            deferCall.defer([=] { doError(); });
+            return;
+        }
+
+        prepareOutReq(nextUri, true);
+
+        HttpHeaders headers;
+        foreach (const Instruct::Channel &c, channels.values()) {
+            if (!c.prevId.isNull())
+                headers +=
+                    HttpHeader("Grip-Last", c.name.toUtf8() + "; last-id=" + c.prevId.toUtf8());
+        }
+
+        outReq->start("GET", nextUri, headers);
+        outReq->endBody();
+    }
+
+    void tryProcessOutReq() {
+        if (outReq) {
+            if (!haveOutReqHeaders)
+                return;
+
+            if (outReq->responseCode() < 200 || outReq->responseCode() >= 300) {
+                outReq_error();
+                return;
+            }
+
+            if (state == Proxying) {
+                if (outReq->bytesAvailable() > 0) {
+                    // Stop keep alive timer only if we have to send data. If the
+                    // response body is empty, then the timer is left alone
+                    timer->stop();
+
+                    int avail = req->writeBytesAvailable();
+                    if (avail <= 0)
+                        return;
+
+                    QByteArray buf = outReq->readBody(avail);
+
+                    if (responseFilters) {
+                        buf = responseFilters->update(buf);
+                        if (buf.isNull()) {
+                            logRequestError(outReq->requestMethod(), outReq->requestUri(),
+                                            outReq->requestHeaders());
+
+                            errorMessage =
+                                QString("filter error: %1").arg(responseFilters->errorMessage());
+                            doError();
+                            return;
+                        }
+                    }
+
+                    writeBody(buf);
+
+                    sentOutReqData += buf.size();
+                }
+
+                if (outReq->bytesAvailable() == 0 && outReq->isFinished()) {
+                    if (responseFilters) {
+                        QByteArray buf = responseFilters->finalize();
+                        if (buf.isNull()) {
+                            logRequestError(outReq->requestMethod(), outReq->requestUri(),
+                                            outReq->requestHeaders());
+
+                            errorMessage =
+                                QString("filter error: %1").arg(responseFilters->errorMessage());
+                            doError();
+                            return;
+                        }
+
+                        delete responseFilters;
+                        responseFilters = 0;
+
+                        if (!buf.isEmpty()) {
+                            writeBody(buf);
+
+                            sentOutReqData += buf.size();
+                        }
+                    }
+
+                    HttpResponseData responseData;
+                    responseData.code = outReq->responseCode();
+                    responseData.reason = outReq->responseReason();
+                    responseData.headers = outReq->responseHeaders();
+
+                    logRequest(outReq->requestMethod(), outReq->requestUri(),
+                               outReq->requestHeaders(), responseData.code, sentOutReqData);
+
+                    retries = 0;
+
+                    cleanupOutReq();
+
+                    currentUri = nextUri;
+
+                    if (!instruct.nextLink.isEmpty())
+                        nextUri = currentUri.resolved(instruct.nextLink);
+                    else
+                        nextUri.clear();
+
+                    if (instruct.channels.count() > connectionSubscriptionMax) {
+                        instruct.channels = instruct.channels.mid(0, connectionSubscriptionMax);
+
+                        auto routeInfo = LogUtil::RouteInfo(adata.route, logLevel);
+                        LogUtil::logForRoute(routeInfo, "httpsession: too many subscriptions");
+                    }
+
+                    if (instruct.holdMode == Instruct::StreamHold) {
+                        if (instruct.keepAliveTimeout < 0)
+                            timer->stop();
+
+                        prepareToSendQueueOrHold();
+                    }
+                }
+            } else if (state == SendingGone) {
+                // Response should be empty
+                if (outReq->bytesAvailable() > 0) {
+                    outReq_error();
+                    return;
+                }
+
+                if (outReq->isFinished()) {
+                    logRequest(outReq->requestMethod(), outReq->requestUri(),
+                               outReq->requestHeaders(), outReq->responseCode(), 0);
+
+                    cleanupOutReq();
+
+                    finished();
+                    return;
+                }
+            } else {
+                // Unexpected state
+                assert(0);
+            }
+        }
+
+        if (state == Proxying && !outReq) {
+            if (!nextUri.isEmpty()) {
+                if (req->writeBytesAvailable() > 0)
+                    requestNextLink();
+            } else {
+                prepareToClose();
+
+                req->endBody();
+            }
+        }
+    }
+
+    void logRequest(const QString &method, const Url &uri, const HttpHeaders &headers, int code,
+                    int bodySize) {
+        LogUtil::RequestData rd;
+
+        // Only log route id if explicitly set
+        if (!adata.statsRoute.isEmpty())
+            rd.routeId = adata.route;
+
+        rd.status = LogUtil::Response;
+
+        rd.requestData.method = method;
+        rd.requestData.uri = uri;
+        rd.requestData.headers = headers;
+
+        rd.responseData.code = code;
+        rd.responseBodySize = bodySize;
+
+        LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
+    }
+
+    void logRequestError(const QString &method, const Url &uri, const HttpHeaders &headers) {
+        LogUtil::RequestData rd;
+
+        // Only log route id if explicitly set
+        if (!adata.statsRoute.isEmpty())
+            rd.routeId = adata.route;
+
+        rd.status = LogUtil::Error;
+
+        rd.requestData.method = method;
+        rd.requestData.uri = uri;
+        rd.requestData.headers = headers;
+
+        LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
+    }
+
+    void incCounter(Stats::Counter c, int count = 1) {
+        stats->incCounter(adata.statsRoute.toUtf8(), c, count);
+    }
+
+    void writeBody(const QByteArray &body) {
+        incCounter(Stats::ClientContentBytesSent, body.size());
+
+        req->writeBody(body);
+    }
+
+    void messageFiltersFinished(const Filter::MessageFilter::Result &result) {
+        QueuedItem qi = publishQueue.takeFirst();
+
+        messageFiltersFinishedConnection.disconnect();
+        messageFilters.reset();
+
+        if (!result.errorMessage.isNull()) {
+            if (adata.debug) {
+                errorMessage = QString("filter error: %1").arg(result.errorMessage);
+                doError();
+                return;
+            }
+        } else {
+            processItem(qi.item, result.sendAction, result.content, qi.exposeHeaders);
+        }
+
+        // If filters finished asynchronously then we need to resume processing
+        if (!inProcessPublishQueue)
+            processPublishQueue();
+    }
+
+    void processItem(const PublishItem &item, Filter::SendAction sendAction,
+                     const QByteArray &content, const QList<QByteArray> &exposeHeaders) {
+        const PublishFormat &f = item.format;
+
+        Instruct::Channel &channel = channels[item.channel];
+
+        if (!channel.prevId.isNull())
+            channel.prevId = item.id;
+
+        if (instruct.holdMode == Instruct::ResponseHold) {
+            if (sendAction == Filter::Drop)
+                return;
+
+            // NOTE: http-response mode doesn't support a close
+            // action since it's better to send a real response
+
+            if (f.action == PublishFormat::Send) {
+                respond(f.code, f.reason, f.headers, content, exposeHeaders);
+            } else if (f.action == PublishFormat::Hint) {
+                update(HighPriority);
+            }
+        } else if (instruct.holdMode == Instruct::StreamHold) {
+            if (sendAction == Filter::Drop)
+                return;
+
+            if (f.action == PublishFormat::Send) {
+                writeBody(content);
+
+                // Restart keep alive timer
+                adjustKeepAlive();
+
+                if (!nextUri.isEmpty() && instruct.nextLinkTimeout >= 0) {
+                    activeChannels += item.channel;
+                    if (activeChannels.count() == channels.count()) {
+                        activeChannels.clear();
+
+                        // All channels had activity. Reset the timeout
+                        updateManager->registerSession(q, instruct.nextLinkTimeout, nextUri, true);
+                    }
+                }
+            } else if (f.action == PublishFormat::Hint) {
+                // Clear queue since any items will be redundant
+                publishQueue.clear();
+
+                update(HighPriority);
+            } else if (f.action == PublishFormat::Close) {
+                prepareToClose();
+                req->endBody();
+            }
+        }
+    }
+
+    void doError() {
+        if (instruct.holdMode == Instruct::ResponseHold) {
+            QByteArray msg;
+
+            if (adata.debug)
+                msg = errorMessage.toUtf8();
+            else
+                msg = "Error while proxying to origin.";
+
+            HttpHeaders headers;
+            headers += HttpHeader("Content-Type", "text/plain");
+            respond(502, "Bad Gateway", headers, msg + '\n');
+        } else // StreamHold, NoHold
+        {
+            prepareToClose();
+
+            if (adata.debug)
+                writeBody("\n\n" + errorMessage.toUtf8() + '\n');
+
+            req->endBody();
+        }
+    }
+
+    void req_bytesWritten(int count) {
+        Q_UNUSED(count);
+
+        if (req->isFinished()) {
+            doFinish();
+            return;
+        }
+    }
+
+    void req_writeBytesChanged() {
+        if (state == SendingFirstInstructResponse) {
+            tryWriteFirstInstructResponse();
+        } else if (state == Proxying) {
+            tryProcessOutReq();
+        } else if (state == SendingQueue) {
+            // In this state, the writeBytesChanged signal is only
+            // interesting if it indicates write bytes are available
+
+            if (req->writeBytesAvailable() > 0)
+                processPublishQueue();
+        }
+    }
+
+    void req_error() { doFinish(); }
+
+    void req_paused() {
+        doFinish(true); // Finish for retry
+    }
+
+    void outReq_readyRead() {
+        if (!haveOutReqHeaders) {
+            haveOutReqHeaders = true;
+
+            if (state == Proxying) {
+                HttpResponseData responseData;
+                responseData.code = outReq->responseCode();
+                responseData.reason = outReq->responseReason();
+                responseData.headers = outReq->responseHeaders();
+
+                bool ok;
+                Instruct i = Instruct::fromResponse(responseData, &ok, &errorMessage);
+                if (!ok) {
+                    doError();
+                    return;
+                }
+
+                // Subsequent response must be non-hold or stream hold
+                if (i.holdMode != Instruct::NoHold && i.holdMode != Instruct::StreamHold) {
+                    errorMessage = "Next link returned non-stream hold.";
+                    doError();
+                    return;
+                }
+
+                // Accept the instruct as soon as it's available, so we can
+                // use its filters. If response processing ends up failing
+                // later on, the session will error out and the instruct
+                // won't be used for anything else
+                instruct = i;
+
+                // Apply ResponseContent filters of all channels
+                QStringList allFilters;
+                foreach (const Instruct::Channel &c, instruct.channels) {
+                    foreach (const QString &filter, c.filters) {
+                        if ((Filter::targets(filter) & Filter::ResponseContent) &&
+                            !allFilters.contains(filter))
+                            allFilters += filter;
+                    }
+                }
+
+                Filter::Context fc;
+                fc.subscriptionMeta = instruct.meta;
+
+                responseFilters = new FilterStack(fc, allFilters);
+            }
+        }
+
+        tryProcessOutReq();
+    }
+
+    void outReq_error() {
+        logRequestError(outReq->requestMethod(), outReq->requestUri(), outReq->requestHeaders());
+
+        cleanupOutReq();
+
+        if (state == Proxying) {
+            log_debug("httpsession: failed to retrieve next link");
+
+            // Can't retry if we started sending data
+
+            if (sentOutReqData <= 0 && retries < RETRY_MAX) {
+                int delay = RETRY_TIMEOUT;
+                for (int n = 0; n < retries; ++n)
+                    delay *= 2;
+                delay += QRandomGenerator::global()->generate() % RETRY_RAND_MAX;
+
+                log_debug("httpsession: trying again in %dms", delay);
+
+                ++retries;
+
+                retryTimer->start(delay);
+                return;
+            } else {
+                errorMessage = "Failed to retrieve next link.";
+                doError();
+            }
+        } else if (state == SendingGone) {
+            log_debug("httpsession: failed to request gone link");
+            finished();
+        } else {
+            // Unexpected state
+            assert(0);
+        }
+    }
+
+    void timer_timeout() {
+        if (instruct.holdMode == Instruct::ResponseHold) {
+            // Send timeout response
+            respond(instruct.response.code, instruct.response.reason, instruct.response.headers,
+                    instruct.response.body);
+        } else if (instruct.holdMode == Instruct::StreamHold) {
+            writeBody(instruct.keepAliveData);
+
+            setupKeepAlive();
+
+            stats->addActivity(adata.statsRoute.toUtf8(), 1);
+        }
+    }
+
+    void retryTimer_timeout() { requestNextLink(); }
 };
 
-HttpSession::HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *zhttpOut, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &updateManager, int connectionSubscriptionMax)
-{
-	d = std::make_shared<Private>(this, req, adata, instruct, zhttpOut, stats, updateLimiter, filterLimiter, publishLastIds, updateManager, connectionSubscriptionMax);
+HttpSession::HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata,
+                         const Instruct &instruct, ZhttpManager *zhttpOut, StatsManager *stats,
+                         RateLimiter *updateLimiter,
+                         const std::shared_ptr<RateLimiter> &filterLimiter,
+                         PublishLastIds *publishLastIds,
+                         const std::shared_ptr<HttpSessionUpdateManager> &updateManager,
+                         int connectionSubscriptionMax) {
+    d = std::make_shared<Private>(this, req, adata, instruct, zhttpOut, stats, updateLimiter,
+                                  filterLimiter, publishLastIds, updateManager,
+                                  connectionSubscriptionMax);
 }
 
 HttpSession::~HttpSession() = default;
 
-Instruct::HoldMode HttpSession::holdMode() const
-{
-	if(d->instruct.holdMode == Instruct::NoHold)
-	{
-		// NoHold is a temporary internal state for stream
-		return Instruct::StreamHold;
-	}
-	else
-		return d->instruct.holdMode;
+Instruct::HoldMode HttpSession::holdMode() const {
+    if (d->instruct.holdMode == Instruct::NoHold) {
+        // NoHold is a temporary internal state for stream
+        return Instruct::StreamHold;
+    } else
+        return d->instruct.holdMode;
 }
 
-ZhttpRequest::Rid HttpSession::rid() const
-{
-	return d->req->rid();
+ZhttpRequest::Rid HttpSession::rid() const { return d->req->rid(); }
+
+Url HttpSession::requestUri() const { return d->req->requestUri(); }
+
+bool HttpSession::isRetry() const { return d->adata.isRetry; }
+
+QString HttpSession::statsRoute() const { return d->adata.statsRoute; }
+
+QString HttpSession::sid() const { return d->adata.sid; }
+
+QHash<QString, Instruct::Channel> HttpSession::channels() const { return d->channels; }
+
+QHash<QString, QString> HttpSession::meta() const { return d->instruct.meta; }
+
+QByteArray HttpSession::retryToAddress() const { return d->retryToAddress; }
+
+RetryRequestPacket HttpSession::retryPacket() const { return d->retryPacket; }
+
+void HttpSession::start() { d->start(); }
+
+void HttpSession::update() { d->update(Private::LowPriority); }
+
+void HttpSession::publish(const PublishItem &item, const QList<QByteArray> &exposeHeaders) {
+    d->publish(item, exposeHeaders);
 }
 
-Url HttpSession::requestUri() const
-{
-	return d->req->requestUri();
+Callback<std::tuple<HttpSession *, const QString &>> &HttpSession::subscribeCallback() {
+    return d->subscribeCallback;
 }
 
-bool HttpSession::isRetry() const
-{
-	return d->adata.isRetry;
+Callback<std::tuple<HttpSession *, const QString &>> &HttpSession::unsubscribeCallback() {
+    return d->unsubscribeCallback;
 }
 
-QString HttpSession::statsRoute() const
-{
-	return d->adata.statsRoute;
-}
-
-QString HttpSession::sid() const
-{
-	return d->adata.sid;
-}
-
-QHash<QString, Instruct::Channel> HttpSession::channels() const
-{
-	return d->channels;
-}
-
-QHash<QString, QString> HttpSession::meta() const
-{
-	return d->instruct.meta;
-}
-
-QByteArray HttpSession::retryToAddress() const
-{
-	return d->retryToAddress;
-}
-
-RetryRequestPacket HttpSession::retryPacket() const
-{
-	return d->retryPacket;
-}
-
-void HttpSession::start()
-{
-	d->start();
-}
-
-void HttpSession::update()
-{
-	d->update(Private::LowPriority);
-}
-
-void HttpSession::publish(const PublishItem &item, const QList<QByteArray> &exposeHeaders)
-{
-	d->publish(item, exposeHeaders);
-}
-
-Callback<std::tuple<HttpSession *, const QString &>> & HttpSession::subscribeCallback()
-{
-	return d->subscribeCallback;
-}
-
-Callback<std::tuple<HttpSession *, const QString &>> & HttpSession::unsubscribeCallback()
-{
-	return d->unsubscribeCallback;
-}
-
-Callback<std::tuple<HttpSession *>> & HttpSession::finishedCallback()
-{
-	return d->finishedCallback;
-}
+Callback<std::tuple<HttpSession *>> &HttpSession::finishedCallback() { return d->finishedCallback; }

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -24,16 +24,16 @@
 #ifndef HTTPSESSION_H
 #define HTTPSESSION_H
 
-#include <boost/signals2.hpp>
+#include "callback.h"
+#include "clientsession.h"
+#include "filter.h"
+#include "inspectdata.h"
+#include "instruct.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
-#include "callback.h"
-#include "inspectdata.h"
-#include "zhttprequest.h"
-#include "instruct.h"
-#include "filter.h"
-#include "clientsession.h"
 #include "url.h"
+#include "zhttprequest.h"
+#include <boost/signals2.hpp>
 
 // Each session can have a bunch of timers:
 // incoming request
@@ -41,7 +41,8 @@
 // 2 additional timers
 // filter timers
 // a few more just in case
-#define TIMERS_PER_HTTPSESSION ((TIMERS_PER_ZHTTPREQUEST * 2) + 2 + TIMERS_PER_MESSAGEFILTERSTACK + 4)
+#define TIMERS_PER_HTTPSESSION                                                                     \
+    ((TIMERS_PER_ZHTTPREQUEST * 2) + 2 + TIMERS_PER_MESSAGEFILTERSTACK + 4)
 
 using Connection = boost::signals2::scoped_connection;
 
@@ -53,73 +54,74 @@ class PublishLastIds;
 class HttpSessionUpdateManager;
 class RetryRequestPacket;
 
-class HttpSession : public ClientSession
-{
+class HttpSession : public ClientSession {
 public:
-	class AcceptData
-	{
-	public:
-		QByteArray from;
-		QHostAddress logicalPeerAddress;
-		bool debug;
-		bool isRetry;
-		bool autoCrossOrigin;
-		QByteArray jsonpCallback;
-		bool jsonpExtendedResponse;
-		int unreportedTime;
-		HttpRequestData requestData;
-		QString route;
-		QString statsRoute;
-		QString channelPrefix;
-		int logLevel;
-		QSet<QString> implicitChannels;
-		bool trusted;
-		bool responseSent;
-		QString sid;
-		bool haveInspectInfo;
-		InspectData inspectInfo;
+    class AcceptData {
+    public:
+        QByteArray from;
+        QHostAddress logicalPeerAddress;
+        bool debug;
+        bool isRetry;
+        bool autoCrossOrigin;
+        QByteArray jsonpCallback;
+        bool jsonpExtendedResponse;
+        int unreportedTime;
+        HttpRequestData requestData;
+        QString route;
+        QString statsRoute;
+        QString channelPrefix;
+        int logLevel;
+        QSet<QString> implicitChannels;
+        bool trusted;
+        bool responseSent;
+        QString sid;
+        bool haveInspectInfo;
+        InspectData inspectInfo;
 
-		AcceptData() :
-			debug(false),
-			isRetry(false),
-			autoCrossOrigin(false),
-			jsonpExtendedResponse(false),
-			unreportedTime(-1),
-			logLevel(-1),
-			trusted(false),
-			responseSent(false),
-			haveInspectInfo(false)
-		{
-		}
-	};
+        AcceptData()
+            : debug(false),
+              isRetry(false),
+              autoCrossOrigin(false),
+              jsonpExtendedResponse(false),
+              unreportedTime(-1),
+              logLevel(-1),
+              trusted(false),
+              responseSent(false),
+              haveInspectInfo(false) {}
+    };
 
-	HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct, ZhttpManager *outZhttp, StatsManager *stats, RateLimiter *updateLimiter, const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds, const std::shared_ptr<HttpSessionUpdateManager> &updateManager, int connectionSubscriptionMax);
-	~HttpSession();
+    HttpSession(ZhttpRequest *req, const HttpSession::AcceptData &adata, const Instruct &instruct,
+                ZhttpManager *outZhttp, StatsManager *stats, RateLimiter *updateLimiter,
+                const std::shared_ptr<RateLimiter> &filterLimiter, PublishLastIds *publishLastIds,
+                const std::shared_ptr<HttpSessionUpdateManager> &updateManager,
+                int connectionSubscriptionMax);
+    ~HttpSession();
 
-	Instruct::HoldMode holdMode() const;
-	ZhttpRequest::Rid rid() const;
-	Url requestUri() const;
-	bool isRetry() const;
-	QString statsRoute() const;
-	QString sid() const;
-	QHash<QString, Instruct::Channel> channels() const;
-	QHash<QString, QString> meta() const;
-	QByteArray retryToAddress() const;
-	RetryRequestPacket retryPacket() const;
+    Instruct::HoldMode holdMode() const;
+    ZhttpRequest::Rid rid() const;
+    Url requestUri() const;
+    bool isRetry() const;
+    QString statsRoute() const;
+    QString sid() const;
+    QHash<QString, Instruct::Channel> channels() const;
+    QHash<QString, QString> meta() const;
+    QByteArray retryToAddress() const;
+    RetryRequestPacket retryPacket() const;
 
-	void start();
-	void update();
-	void publish(const PublishItem &item, const QList<QByteArray> &exposeHeaders = QList<QByteArray>());
+    void start();
+    void update();
+    void publish(const PublishItem &item,
+                 const QList<QByteArray> &exposeHeaders = QList<QByteArray>());
 
-	// NOTE: for performance reasons we use callbacks instead of signals/slots
-	Callback<std::tuple<HttpSession *, const QString &>> & subscribeCallback();
-	Callback<std::tuple<HttpSession *, const QString &>> & unsubscribeCallback();
-	Callback<std::tuple<HttpSession *>> & finishedCallback();
+    // NOTE: for performance reasons we use callbacks instead of signals/slots
+    Callback<std::tuple<HttpSession *, const QString &>> &subscribeCallback();
+    Callback<std::tuple<HttpSession *, const QString &>> &unsubscribeCallback();
+    Callback<std::tuple<HttpSession *>> &finishedCallback();
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/handler/httpsessionupdatemanager.cpp
+++ b/src/handler/httpsessionupdatemanager.cpp
@@ -23,158 +23,126 @@
 
 #include "httpsessionupdatemanager.h"
 
-#include "url.h"
-#include "timer.h"
 #include "defercall.h"
 #include "httpsession.h"
+#include "timer.h"
+#include "url.h"
 
-class HttpSessionUpdateManager::Private
-{
+class HttpSessionUpdateManager::Private {
 public:
-	class Bucket
-	{
-	public:
-		QPair<int, Url> key;
-		QSet<HttpSession*> sessions;
-		QSet<HttpSession*> deferredSessions;
-		std::unique_ptr<Timer> timer;
-	};
+    class Bucket {
+    public:
+        QPair<int, Url> key;
+        QSet<HttpSession *> sessions;
+        QSet<HttpSession *> deferredSessions;
+        std::unique_ptr<Timer> timer;
+    };
 
-	HttpSessionUpdateManager *q;
-	QHash<QPair<int, Url>, Bucket*> buckets;
-	QHash<Timer*, Bucket*> bucketsByTimer;
-	QHash<HttpSession*, Bucket*> bucketsBySession;
+    HttpSessionUpdateManager *q;
+    QHash<QPair<int, Url>, Bucket *> buckets;
+    QHash<Timer *, Bucket *> bucketsByTimer;
+    QHash<HttpSession *, Bucket *> bucketsBySession;
 
-	Private(HttpSessionUpdateManager *_q) :
-		q(_q)
-	{
-	}
+    Private(HttpSessionUpdateManager *_q) : q(_q) {}
 
-	~Private()
-	{
-		qDeleteAll(buckets);
-	}
+    ~Private() { qDeleteAll(buckets); }
 
-	void removeBucket(Bucket *bucket)
-	{
-		foreach(HttpSession *hs, bucket->sessions)
-			bucketsBySession.remove(hs);
+    void removeBucket(Bucket *bucket) {
+        foreach (HttpSession *hs, bucket->sessions)
+            bucketsBySession.remove(hs);
 
-		bucketsByTimer.remove(bucket->timer.get());
-		buckets.remove(bucket->key);
-		delete bucket;
-	}
+        bucketsByTimer.remove(bucket->timer.get());
+        buckets.remove(bucket->key);
+        delete bucket;
+    }
 
-	void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout)
-	{
-		Url tmp = uri;
-		tmp.setQuery(QString()); // Remove the query part
-		QPair<int, Url> key(timeout, tmp);
+    void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout) {
+        Url tmp = uri;
+        tmp.setQuery(QString()); // Remove the query part
+        QPair<int, Url> key(timeout, tmp);
 
-		Bucket *bucket = buckets.value(key);
-		if(bucket)
-		{
-			if(bucket->sessions.contains(hs))
-			{
-				if(resetTimeout)
-				{
-					// Flag for later processing
-					bucket->deferredSessions += hs;
-				}
-			}
-			else
-			{
-				// Move the session to this bucket
-				unregisterSession(hs);
-				bucket->sessions += hs;
-				bucketsBySession[hs] = bucket;
-			}
-		}
-		else
-		{
-			// Bucket doesn't exist. Make it and put this session in it
+        Bucket *bucket = buckets.value(key);
+        if (bucket) {
+            if (bucket->sessions.contains(hs)) {
+                if (resetTimeout) {
+                    // Flag for later processing
+                    bucket->deferredSessions += hs;
+                }
+            } else {
+                // Move the session to this bucket
+                unregisterSession(hs);
+                bucket->sessions += hs;
+                bucketsBySession[hs] = bucket;
+            }
+        } else {
+            // Bucket doesn't exist. Make it and put this session in it
 
-			unregisterSession(hs);
+            unregisterSession(hs);
 
-			bucket = new Bucket;
-			bucket->key = key;
-			bucket->sessions += hs;
-			bucket->timer = std::make_unique<Timer>();
-			bucket->timer->timeout.connect(boost::bind(&Private::timer_timeout, this, bucket->timer.get()));
+            bucket = new Bucket;
+            bucket->key = key;
+            bucket->sessions += hs;
+            bucket->timer = std::make_unique<Timer>();
+            bucket->timer->timeout.connect(
+                boost::bind(&Private::timer_timeout, this, bucket->timer.get()));
 
-			buckets[key] = bucket;
-			bucketsByTimer[bucket->timer.get()] = bucket;
-			bucketsBySession[hs] = bucket;
+            buckets[key] = bucket;
+            bucketsByTimer[bucket->timer.get()] = bucket;
+            bucketsBySession[hs] = bucket;
 
-			bucket->timer->start(timeout * 1000);
-		}
-	}
+            bucket->timer->start(timeout * 1000);
+        }
+    }
 
-	void unregisterSession(HttpSession *hs)
-	{
-		Bucket *bucket = bucketsBySession.value(hs);
-		if(!bucket)
-			return;
+    void unregisterSession(HttpSession *hs) {
+        Bucket *bucket = bucketsBySession.value(hs);
+        if (!bucket)
+            return;
 
-		bucket->sessions.remove(hs);
-		bucket->deferredSessions.remove(hs);
-		bucketsBySession.remove(hs);
+        bucket->sessions.remove(hs);
+        bucket->deferredSessions.remove(hs);
+        bucketsBySession.remove(hs);
 
-		if(bucket->sessions.isEmpty())
-			removeBucket(bucket);
-	}
+        if (bucket->sessions.isEmpty())
+            removeBucket(bucket);
+    }
 
 private:
-	void timer_timeout(Timer *timer)
-	{
-		Bucket *bucket = bucketsByTimer.value(timer);
-		if(!bucket)
-			return;
+    void timer_timeout(Timer *timer) {
+        Bucket *bucket = bucketsByTimer.value(timer);
+        if (!bucket)
+            return;
 
-		QSet<HttpSession*> sessions;
+        QSet<HttpSession *> sessions;
 
-		if(!bucket->deferredSessions.isEmpty())
-		{
-			foreach(HttpSession *hs, bucket->sessions)
-			{
-				if(!bucket->deferredSessions.contains(hs))
-				{
-					sessions += hs;
-					bucketsBySession.remove(hs);
-				}
-			}
+        if (!bucket->deferredSessions.isEmpty()) {
+            foreach (HttpSession *hs, bucket->sessions) {
+                if (!bucket->deferredSessions.contains(hs)) {
+                    sessions += hs;
+                    bucketsBySession.remove(hs);
+                }
+            }
 
-			bucket->sessions = bucket->deferredSessions;
-			bucket->deferredSessions.clear();
-			bucket->timer->start();
-		}
-		else
-		{
-			sessions = bucket->sessions;
-			removeBucket(bucket);
-		}
+            bucket->sessions = bucket->deferredSessions;
+            bucket->deferredSessions.clear();
+            bucket->timer->start();
+        } else {
+            sessions = bucket->sessions;
+            removeBucket(bucket);
+        }
 
-		foreach(HttpSession *hs, sessions)
-			hs->update();
-	}
+        foreach (HttpSession *hs, sessions)
+            hs->update();
+    }
 };
 
-HttpSessionUpdateManager::HttpSessionUpdateManager()
-{
-	d = new Private(this);
+HttpSessionUpdateManager::HttpSessionUpdateManager() { d = new Private(this); }
+
+HttpSessionUpdateManager::~HttpSessionUpdateManager() { delete d; }
+
+void HttpSessionUpdateManager::registerSession(HttpSession *hs, int timeout, const Url &uri,
+                                               bool resetTimeout) {
+    d->registerSession(hs, timeout, uri, resetTimeout);
 }
 
-HttpSessionUpdateManager::~HttpSessionUpdateManager()
-{
-	delete d;
-}
-
-void HttpSessionUpdateManager::registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout)
-{
-	d->registerSession(hs, timeout, uri, resetTimeout);
-}
-
-void HttpSessionUpdateManager::unregisterSession(HttpSession *hs)
-{
-	d->unregisterSession(hs);
-}
+void HttpSessionUpdateManager::unregisterSession(HttpSession *hs) { d->unregisterSession(hs); }

--- a/src/handler/httpsessionupdatemanager.h
+++ b/src/handler/httpsessionupdatemanager.h
@@ -29,20 +29,19 @@
 #define TIMERS_PER_UNIQUE_UPDATE_REGISTRATION 1
 class HttpSession;
 
-class HttpSessionUpdateManager
-{
+class HttpSessionUpdateManager {
 public:
-	HttpSessionUpdateManager();
-	~HttpSessionUpdateManager();
+    HttpSessionUpdateManager();
+    ~HttpSessionUpdateManager();
 
-	// No-op if session already registered and resetTimeout=false
-	void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout = false);
+    // No-op if session already registered and resetTimeout=false
+    void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout = false);
 
-	void unregisterSession(HttpSession *hs);
+    void unregisterSession(HttpSession *hs);
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/handler/idformat.cpp
+++ b/src/handler/idformat.cpp
@@ -22,134 +22,111 @@
 
 #include "idformat.h"
 
-#include <ctype.h>
 #include "format.h"
+#include <ctype.h>
 
 namespace IdFormat {
 
-class IdFormatHandler : public Format::Handler
-{
+class IdFormatHandler : public Format::Handler {
 public:
-	QHash<QString, QByteArray> vars;
+    QHash<QString, QByteArray> vars;
 
-	virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const
-	{
-		if(type != 's')
-		{
-			*error = QString("Unknown directive '%1'").arg(type);
-			return QByteArray();
-		}
+    virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const {
+        if (type != 's') {
+            *error = QString("Unknown directive '%1'").arg(type);
+            return QByteArray();
+        }
 
-		if(arg.isNull())
-		{
-			*error = QString("Directive 's' requires argument");
-			return QByteArray();
-		}
+        if (arg.isNull()) {
+            *error = QString("Directive 's' requires argument");
+            return QByteArray();
+        }
 
-		QByteArray value = vars.value(arg);
-		if(value.isNull())
-		{
-			*error = QString("No such variable '%1'").arg(QString::fromUtf8(arg));
-			return QByteArray();
-		}
+        QByteArray value = vars.value(arg);
+        if (value.isNull()) {
+            *error = QString("No such variable '%1'").arg(QString::fromUtf8(arg));
+            return QByteArray();
+        }
 
-		return value;
-	}
+        return value;
+    }
 };
 
-class ContentFormatHandler : public Format::Handler
-{
+class ContentFormatHandler : public Format::Handler {
 public:
-	QByteArray defaultId;
-	bool hex;
+    QByteArray defaultId;
+    bool hex;
 
-	ContentFormatHandler() :
-		hex(false)
-	{
-	}
+    ContentFormatHandler() : hex(false) {}
 
-	virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const
-	{
-		if(type != 'I')
-		{
-			*error = QString("Unknown directive '%1'").arg(type);
-			return QByteArray();
-		}
+    virtual QByteArray handle(char type, const QByteArray &arg, QString *error) const {
+        if (type != 'I') {
+            *error = QString("Unknown directive '%1'").arg(type);
+            return QByteArray();
+        }
 
-		QByteArray id;
-		if(!arg.isNull())
-		{
-			id = arg;
-		}
-		else
-		{
-			if(defaultId.isNull())
-			{
-				*error = QString("No ID specified and no default ID in context");
-				return QByteArray();
-			}
+        QByteArray id;
+        if (!arg.isNull()) {
+            id = arg;
+        } else {
+            if (defaultId.isNull()) {
+                *error = QString("No ID specified and no default ID in context");
+                return QByteArray();
+            }
 
-			id = defaultId;
-		}
+            id = defaultId;
+        }
 
-		if(hex)
-		{
-			id = id.toHex();
-		}
+        if (hex) {
+            id = id.toHex();
+        }
 
-		return id;
-	}
+        return id;
+    }
 };
 
-ContentRenderer::ContentRenderer(const QByteArray &defaultId, bool hex) :
-	defaultId_(defaultId),
-	hex_(hex)
-{
+ContentRenderer::ContentRenderer(const QByteArray &defaultId, bool hex)
+    : defaultId_(defaultId), hex_(hex) {}
+
+QByteArray ContentRenderer::update(const QByteArray &data) {
+    buf_ += data;
+
+    ContentFormatHandler handler;
+    handler.defaultId = defaultId_;
+    handler.hex = hex_;
+
+    int partialPos;
+
+    QByteArray ret = Format::process(buf_, &handler, &partialPos, &errorMessage_);
+    if (!ret.isNull()) {
+        buf_ = buf_.mid(partialPos);
+    }
+
+    return ret;
 }
 
-QByteArray ContentRenderer::update(const QByteArray &data)
-{
-	buf_ += data;
+QByteArray ContentRenderer::finalize() {
+    QByteArray data = buf_;
+    buf_.clear();
 
-	ContentFormatHandler handler;
-	handler.defaultId = defaultId_;
-	handler.hex = hex_;
-
-	int partialPos;
-
-	QByteArray ret = Format::process(buf_, &handler, &partialPos, &errorMessage_);
-	if(!ret.isNull())
-	{
-		buf_ = buf_.mid(partialPos);
-	}
-
-	return ret;
+    ContentFormatHandler handler;
+    handler.defaultId = defaultId_;
+    handler.hex = hex_;
+    return Format::process(data, &handler, 0, &errorMessage_);
 }
 
-QByteArray ContentRenderer::finalize()
-{
-	QByteArray data = buf_;
-	buf_.clear();
-
-	ContentFormatHandler handler;
-	handler.defaultId = defaultId_;
-	handler.hex = hex_;
-	return Format::process(data, &handler, 0, &errorMessage_);
+QByteArray ContentRenderer::process(const QByteArray &data) {
+    ContentFormatHandler handler;
+    handler.defaultId = defaultId_;
+    handler.hex = hex_;
+    return Format::process(data, &handler, 0, &errorMessage_);
 }
 
-QByteArray ContentRenderer::process(const QByteArray &data)
-{
-	ContentFormatHandler handler;
-	handler.defaultId = defaultId_;
-	handler.hex = hex_;
-	return Format::process(data, &handler, 0, &errorMessage_);
+QByteArray renderId(const QByteArray &data, const QHash<QString, QByteArray> &vars,
+                    QString *error) {
+    IdFormatHandler handler;
+    handler.vars = vars;
+    return Format::process(data, &handler, 0, error);
 }
 
-QByteArray renderId(const QByteArray &data, const QHash<QString, QByteArray> &vars, QString *error)
-{
-	IdFormatHandler handler;
-	handler.vars = vars;
-	return Format::process(data, &handler, 0, error);
-}
-
-}
+} // namespace IdFormat

--- a/src/handler/idformat.h
+++ b/src/handler/idformat.h
@@ -24,33 +24,33 @@
 #define IDFORMAT_H
 
 #include <QByteArray>
-#include <QString>
 #include <QHash>
+#include <QString>
 
 namespace IdFormat {
 
-class ContentRenderer
-{
+class ContentRenderer {
 public:
-	ContentRenderer(const QByteArray &defaultId, bool hex);
+    ContentRenderer(const QByteArray &defaultId, bool hex);
 
-	// Return null array on error
-	QByteArray update(const QByteArray &data);
-	QByteArray finalize();
+    // Return null array on error
+    QByteArray update(const QByteArray &data);
+    QByteArray finalize();
 
-	QString errorMessage() { return errorMessage_; }
+    QString errorMessage() { return errorMessage_; }
 
-	QByteArray process(const QByteArray &data);
+    QByteArray process(const QByteArray &data);
 
 private:
-	QByteArray defaultId_;
-	bool hex_;
-	QByteArray buf_;
-	QString errorMessage_;
+    QByteArray defaultId_;
+    bool hex_;
+    QByteArray buf_;
+    QString errorMessage_;
 };
 
-QByteArray renderId(const QByteArray &data, const QHash<QString, QByteArray> &vars, QString *error = 0);
+QByteArray renderId(const QByteArray &data, const QHash<QString, QByteArray> &vars,
+                    QString *error = 0);
 
-}
+} // namespace IdFormat
 
 #endif

--- a/src/handler/idformattest.cpp
+++ b/src/handler/idformattest.cpp
@@ -21,70 +21,67 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
 #include "idformat.h"
+#include "test.h"
 
-static void renderId()
-{
-	QHash<QString, QByteArray> vars;
-	QByteArray sformat = "This template has no directives.";
-	QByteArray ret = IdFormat::renderId(sformat, vars);
-	TEST_ASSERT_EQ(ret, QByteArray("This template has no directives."));
+static void renderId() {
+    QHash<QString, QByteArray> vars;
+    QByteArray sformat = "This template has no directives.";
+    QByteArray ret = IdFormat::renderId(sformat, vars);
+    TEST_ASSERT_EQ(ret, QByteArray("This template has no directives."));
 
-	vars["name"] = "Alice";
-	vars["food\\fruit(type)"] = "apples";
+    vars["name"] = "Alice";
+    vars["food\\fruit(type)"] = "apples";
 
-	sformat = "My name is %(name)s and I eat %(food\\\\fruit(type\\))s 10%% of the time.";
-	ret = IdFormat::renderId(sformat, vars);
-	TEST_ASSERT_EQ(ret, QByteArray("My name is Alice and I eat apples 10% of the time."));
+    sformat = "My name is %(name)s and I eat %(food\\\\fruit(type\\))s 10%% of "
+              "the time.";
+    ret = IdFormat::renderId(sformat, vars);
+    TEST_ASSERT_EQ(ret, QByteArray("My name is Alice and I eat apples 10% of the time."));
 }
 
-static void renderContent()
-{
-	QByteArray id = "C3PO";
-	QByteArray content = "This content has no directives.";
-	QByteArray ret = IdFormat::ContentRenderer(id, false).process(content);
-	TEST_ASSERT_EQ(ret, QByteArray("This content has no directives."));
+static void renderContent() {
+    QByteArray id = "C3PO";
+    QByteArray content = "This content has no directives.";
+    QByteArray ret = IdFormat::ContentRenderer(id, false).process(content);
+    TEST_ASSERT_EQ(ret, QByteArray("This content has no directives."));
 
-	content = "The ID is %I.";
-	ret = IdFormat::ContentRenderer(id, false).process(content);
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is C3PO."));
+    content = "The ID is %I.";
+    ret = IdFormat::ContentRenderer(id, false).process(content);
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is C3PO."));
 
-	ret = IdFormat::ContentRenderer(id, true).process(content);
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is 4333504f."));
+    ret = IdFormat::ContentRenderer(id, true).process(content);
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is 4333504f."));
 
-	content = "The ID is %(R2D2)I.";
-	ret = IdFormat::ContentRenderer(id, true).process(content);
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is 52324432."));
+    content = "The ID is %(R2D2)I.";
+    ret = IdFormat::ContentRenderer(id, true).process(content);
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is 52324432."));
 }
 
-static void renderContentIncremental()
-{
-	IdFormat::ContentRenderer cr(QByteArray(), true);
+static void renderContentIncremental() {
+    IdFormat::ContentRenderer cr(QByteArray(), true);
 
-	QByteArray ret = cr.update("The ID is %");
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
-	ret += cr.update("(");
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
-	ret += cr.update("R2D");
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
-	ret += cr.update("2");
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
-	ret += cr.update(")");
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
-	ret += cr.update("I.");
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is 52324432."));
+    QByteArray ret = cr.update("The ID is %");
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
+    ret += cr.update("(");
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
+    ret += cr.update("R2D");
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
+    ret += cr.update("2");
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
+    ret += cr.update(")");
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is "));
+    ret += cr.update("I.");
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is 52324432."));
 
-	ret += cr.finalize();
-	TEST_ASSERT(!ret.isNull());
-	TEST_ASSERT_EQ(ret, QByteArray("The ID is 52324432."));
+    ret += cr.finalize();
+    TEST_ASSERT(!ret.isNull());
+    TEST_ASSERT_EQ(ret, QByteArray("The ID is 52324432."));
 }
 
-extern "C" int idformat_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(renderId());
-	TEST_CATCH(renderContent());
-	TEST_CATCH(renderContentIncremental());
+extern "C" int idformat_test(ffi::TestException *out_ex) {
+    TEST_CATCH(renderId());
+    TEST_CATCH(renderContent());
+    TEST_CATCH(renderContentIncremental());
 
-	return 0;
+    return 0;
 }

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -23,13 +23,13 @@
 
 #include "instruct.h"
 
-#include <QJsonDocument>
-#include <QJsonObject>
+#include "filter.h"
 #include "qtcompat.h"
+#include "statusreasons.h"
 #include "variant.h"
 #include "variantutil.h"
-#include "statusreasons.h"
-#include "filter.h"
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #define DEFAULT_RESPONSE_TIMEOUT 55
 #define MINIMUM_RESPONSE_TIMEOUT 5
@@ -37,782 +37,663 @@
 
 using namespace VariantUtil;
 
-static int charToHex(char c)
-{
-	if(c >= '0' && c <= '9')
-		return c - '0';
-	else if(c >= 'a' && c <= 'f')
-		return c - 'a' + 10;
-	else if(c >= 'A' && c <= 'F')
-		return c - 'A' + 10;
-	else
-		return -1;
+static int charToHex(char c) {
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    else if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    else
+        return -1;
 }
-static QByteArray unescape(const QByteArray &in)
-{
-	QByteArray out;
+static QByteArray unescape(const QByteArray &in) {
+    QByteArray out;
 
-	for(int n = 0; n < in.length(); ++n)
-	{
-		if(in[n] == '\\')
-		{
-			if(n + 1 >= in.length())
-				return QByteArray();
+    for (int n = 0; n < in.length(); ++n) {
+        if (in[n] == '\\') {
+            if (n + 1 >= in.length())
+                return QByteArray();
 
-			++n;
+            ++n;
 
-			if(in[n] == '\\')
-			{
-				out += '\\';
-			}
-			else if(in[n] == 'r')
-			{
-				out += '\r';
-			}
-			else if(in[n] == 'n')
-			{
-				out += '\n';
-			}
-			else if(in[n] == 'x')
-			{
-				if(n + 2 >= in.length())
-					return QByteArray();
+            if (in[n] == '\\') {
+                out += '\\';
+            } else if (in[n] == 'r') {
+                out += '\r';
+            } else if (in[n] == 'n') {
+                out += '\n';
+            } else if (in[n] == 'x') {
+                if (n + 2 >= in.length())
+                    return QByteArray();
 
-				int hi = charToHex(in[n + 1]);
-				int lo = charToHex(in[n + 2]);
-				n += 2;
+                int hi = charToHex(in[n + 1]);
+                int lo = charToHex(in[n + 2]);
+                n += 2;
 
-				if(hi == -1 || lo == -1)
-					return QByteArray();
+                if (hi == -1 || lo == -1)
+                    return QByteArray();
 
-				unsigned int x = (hi << 4) + lo;
-				out += (char)x;
-			}
-		}
-		else
-			out += in[n];
-	}
+                unsigned int x = (hi << 4) + lo;
+                out += (char)x;
+            }
+        } else
+            out += in[n];
+    }
 
-	return out;
+    return out;
 }
 
-Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QString *errorMessage)
-{
-	HoldMode holdMode = NoHold;
-	QList<Channel> channels;
-	int timeout = -1;
-	QList<QByteArray> exposeHeaders;
-	KeepAliveMode keepAliveMode = NoKeepAlive;
-	QByteArray keepAliveData;
-	int keepAliveTimeout = -1;
-	QHash<QString, QString> meta;
-	HttpResponseData newResponse;
-
-	if(response.headers.contains("Grip-Hold"))
-	{
-		QByteArray gripHoldStr = response.headers.get("Grip-Hold").asQByteArray();
-		if(gripHoldStr == "response")
-		{
-			holdMode = ResponseHold;
-		}
-		else if(gripHoldStr == "stream")
-		{
-			holdMode = StreamHold;
-		}
-		else
-		{
-			setError(ok, errorMessage, "Grip-Hold must be set to either 'response' or 'stream'");
-			return Instruct();
-		}
-	}
-
-	QList<HttpHeaderParameters> gripChannels = response.headers.getAllAsParameters("Grip-Channel");
-	foreach(const HttpHeaderParameters &gripChannel, gripChannels)
-	{
-		if(gripChannel.isEmpty())
-		{
-			setError(ok, errorMessage, "failed to parse Grip-Channel");
-			return Instruct();
-		}
-
-		Channel c;
-		c.name = QString::fromUtf8(gripChannel[0].first.asQByteArray());
-		QByteArray param = gripChannel.get("prev-id").asQByteArray();
-		if(!param.isNull())
-			c.prevId = QString::fromUtf8(param);
-
-		for(int n = 1; n < gripChannel.count(); ++n)
-		{
-			const HttpHeaderParameter &param = gripChannel[n];
-			if(param.first == "filter")
-				c.filters += QString::fromUtf8(param.second.asQByteArray());
-		}
-
-		if(c.filters.count() > MESSAGEFILTERSTACK_SIZE_MAX)
-		{
-			setError(ok, errorMessage, QString("too many filters for channel '%1'").arg(c.name));
-			return Instruct();
-		}
-
-		channels += c;
-	}
-
-	if(response.headers.contains("Grip-Timeout"))
-	{
-		bool x;
-		timeout = response.headers.get("Grip-Timeout").asQByteArray().toInt(&x);
-		if(!x)
-		{
-			setError(ok, errorMessage, "failed to parse Grip-Timeout");
-			return Instruct();
-		}
-
-		if(timeout < 0)
-		{
-			setError(ok, errorMessage, "Grip-Timeout has invalid value");
-			return Instruct();
-		}
-	}
-
-	exposeHeaders = response.headers.getAll("Grip-Expose-Headers").asQByteArrayList();
-
-	HttpHeaderParameters keepAliveParams = response.headers.getAsParameters("Grip-Keep-Alive");
-	if(!keepAliveParams.isEmpty())
-	{
-		QByteArray val = keepAliveParams[0].first.asQByteArray();
-		if(val.isEmpty())
-		{
-			setError(ok, errorMessage, "Grip-Keep-Alive cannot be empty");
-			return Instruct();
-		}
-
-		QByteArray mode = keepAliveParams.get("mode").asQByteArray();
-		if(mode.isEmpty() || mode == "idle")
-		{
-			keepAliveMode = Idle;
-		}
-		else if(mode == "interval")
-		{
-			keepAliveMode = Interval;
-		}
-		else
-		{
-			setError(ok, errorMessage, QString("no such Grip-Keep-Alive mode '%1'").arg(QString::fromUtf8(mode)));
-			return Instruct();
-		}
-
-		if(keepAliveParams.contains("timeout"))
-		{
-			bool x;
-			keepAliveTimeout = keepAliveParams.get("timeout").asQByteArray().toInt(&x);
-			if(!x)
-			{
-				setError(ok, errorMessage, "failed to parse Grip-Keep-Alive timeout value");
-				return Instruct();
-			}
-
-			if(keepAliveTimeout < 0)
-			{
-				setError(ok, errorMessage, "Grip-Keep-Alive timeout has invalid value");
-				return Instruct();
-			}
-		}
-		else
-		{
-			keepAliveTimeout = DEFAULT_RESPONSE_TIMEOUT;
-		}
-
-		QByteArray format = keepAliveParams.get("format").asQByteArray();
-		if(format.isEmpty() || format == "raw")
-		{
-			keepAliveData = val;
-		}
-		else if(format == "cstring")
-		{
-			keepAliveData = unescape(val);
-			if(keepAliveData.isNull())
-			{
-				setError(ok, errorMessage, "failed to parse Grip-Keep-Alive cstring format");
-				return Instruct();
-			}
-		}
-		else if(format == "base64")
-		{
-			keepAliveData = QByteArray::fromBase64(val);
-		}
-		else
-		{
-			setError(ok, errorMessage, QString("no such Grip-Keep-Alive format '%1'").arg(QString::fromUtf8(format)));
-			return Instruct();
-		}
-	}
-
-	QList<HttpHeaderParameters> metaParams = response.headers.getAllAsParameters("Grip-Set-Meta", HttpHeaders::ParseAllParameters);
-	foreach(const HttpHeaderParameters &metaParam, metaParams)
-	{
-		if(metaParam.isEmpty())
-		{
-			setError(ok, errorMessage, "Grip-Set-Meta cannot be empty");
-			return Instruct();
-		}
-
-		QString key = QString::fromUtf8(metaParam[0].first.asQByteArray());
-		QString val = QString::fromUtf8(metaParam[0].second.asQByteArray());
-
-		meta[key] = val;
-	}
-
-	newResponse = response;
-
-	QByteArray statusHeader = response.headers.get("Grip-Status").asQByteArray();
-	if(!statusHeader.isEmpty())
-	{
-		QByteArray codeStr;
-		QByteArray reason;
-
-		int at = statusHeader.indexOf(' ');
-		if(at != -1)
-		{
-			codeStr = statusHeader.mid(0, at);
-			reason = statusHeader.mid(at + 1);
-		}
-		else
-		{
-			codeStr = statusHeader;
-		}
-
-		bool _ok;
-		newResponse.code = codeStr.toInt(&_ok);
-		if(!_ok || newResponse.code < 0 || newResponse.code > 999)
-		{
-			setError(ok, errorMessage, "Grip-Status contains invalid status code");
-			return Instruct();
-		}
-
-		newResponse.reason = reason;
-	}
-
-	Url nextLink;
-	int nextLinkTimeout = -1;
-	Url goneLink;
-	foreach(const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link"))
-	{
-		if(params.count() < 2)
-			continue;
-
-		QByteArray linkParam = params[0].first.asQByteArray();
-		if(linkParam.length() <= 2 || linkParam[0] != '<' || linkParam[linkParam.length() - 1] != '>')
-		{
-			setError(ok, errorMessage, "failed to parse Grip-Link value");
-			return Instruct();
-		}
-
-		Url link = Url::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
-		if(!link.isValid())
-		{
-			setError(ok, errorMessage, "Grip-Link contains invalid link");
-			return Instruct();
-		}
-
-		QByteArray rel = params.get("rel").asQByteArray();
-		if(rel == "next")
-		{
-			nextLink = link;
-
-			if(params.contains("timeout"))
-			{
-				bool x;
-				nextLinkTimeout = params.get("timeout").asQByteArray().toInt(&x);
-				if(!x)
-				{
-					setError(ok, errorMessage, "failed to parse Grip-Link timeout value");
-					return Instruct();
-				}
-
-				if(nextLinkTimeout < 0)
-				{
-					setError(ok, errorMessage, "Grip-Link timeout has invalid value");
-					return Instruct();
-				}
-			}
-			else
-			{
-				nextLinkTimeout = DEFAULT_NEXTLINK_TIMEOUT;
-			}
-		}
-		else if(rel == "gone")
-		{
-			goneLink = link;
-		}
-	}
-
-	newResponse.headers.clear();
-	foreach(const HttpHeader &h, response.headers)
-	{
-		// Strip out grip headers
-		if(qstrnicmp(h.first.data(), "Grip-", 5) == 0)
-			continue;
-
-		if(!exposeHeaders.isEmpty())
-		{
-			bool found = false;
-			foreach(const QByteArray &e, exposeHeaders)
-			{
-				if(qstricmp(e.data(), h.first.data()) == 0)
-				{
-					found = true;
-					break;
-				}
-			}
-
-			if(!found)
-				continue;
-		}
-
-		newResponse.headers += HttpHeader(h.first, h.second);
-	}
-
-	QByteArray contentType = response.headers.getAsFirstParameter("Content-Type").asQByteArray();
-	if(contentType == "application/grip-instruct")
-	{
-		if(response.code != 200)
-		{
-			setError(ok, errorMessage, "response code for application/grip-instruct content must be 200");
-			return Instruct();
-		}
-
-		QJsonParseError e;
-		QJsonDocument doc = QJsonDocument::fromJson(response.body, &e);
-		if(e.error != QJsonParseError::NoError)
-		{
-			setError(ok, errorMessage, "failed to parse application/grip-instruct content as JSON");
-			return Instruct();
-		}
-
-		if(!doc.isObject())
-		{
-			setError(ok, errorMessage, "instruct must be an object");
-			return Instruct();
-		}
-
-		VariantMap minstruct = doc.object().toVariantMap();
-
-		bool ok_;
-
-		if(minstruct.contains("hold"))
-		{
-			if(typeId(minstruct["hold"]) != VariantType::Map)
-			{
-				setError(ok, errorMessage, "instruct contains 'hold' with wrong type");
-				return Instruct();
-			}
-
-			QString pn = "hold";
-
-			Variant vhold = minstruct["hold"];
-
-			QString modeStr = getString(vhold, pn, "mode", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return Instruct();
-			}
-
-			if(!modeStr.isNull())
-			{
-				if(modeStr == "response")
-				{
-					holdMode = ResponseHold;
-				}
-				else if(modeStr == "stream")
-				{
-					holdMode = StreamHold;
-				}
-				else
-				{
-					setError(ok, errorMessage, "hold 'mode' must be set to either 'response' or 'stream'");
-					return Instruct();
-				}
-			}
-			else
-			{
-				holdMode = ResponseHold;
-			}
-
-			VariantList vchannels = getList(vhold, pn, "channels", true, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return Instruct();
-			}
-
-			for(const Variant &vchannel : vchannels)
-			{
-				QString cpn = "channel";
-				Channel c;
-
-				c.name = getString(vchannel, cpn, "name", true, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return Instruct();
-				}
-
-				c.prevId = getString(vchannel, cpn, "prev-id", false, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return Instruct();
-				}
-
-				VariantList vfilters = getList(vchannel, cpn, "filters", false, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return Instruct();
-				}
-
-				for(const Variant &vfilter : vfilters)
-				{
-					QString filter = getString(vfilter, &ok_);
-					if(!ok_)
-					{
-						setError(ok, errorMessage, "filters contains value with wrong type");
-						return Instruct();
-					}
-
-					c.filters += filter;
-				}
-
-				channels += c;
-			}
-
-			if(keyedObjectContains(vhold, "timeout"))
-			{
-				Variant vtimeout = keyedObjectGetValue(vhold, "timeout");
-				if(!canConvert(vtimeout, VariantType::Int))
-				{
-					setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(pn));
-					return Instruct();
-				}
-
-				timeout = vtimeout.toInt();
-
-				if(timeout < 0)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'timeout' with invalid value").arg(pn));
-					return Instruct();
-				}
-			}
-
-			Variant vka = getKeyedObject(vhold, pn, "keep-alive", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return Instruct();
-			}
-
-			if(isKeyedObject(vka))
-			{
-				QString kpn = "keep-alive";
-
-				if(keyedObjectContains(vka, "content-bin"))
-				{
-					QString contentBin = getString(vka, kpn, "content-bin", false, &ok_, errorMessage);
-					if(!ok_)
-					{
-						if(ok)
-							*ok = false;
-						return Instruct();
-					}
-
-					keepAliveData = QByteArray::fromBase64(contentBin.toUtf8());
-				}
-				else if(keyedObjectContains(vka, "content"))
-				{
-					Variant vcontent = keyedObjectGetValue(vka, "content");
-					if(typeId(vcontent) == VariantType::ByteArray)
-						keepAliveData = vcontent.toByteArray();
-					else if(typeId(vcontent) == VariantType::String)
-						keepAliveData = vcontent.toString().toUtf8();
-					else
-					{
-						setError(ok, errorMessage, QString("%1 contains 'content' with wrong type").arg(kpn));
-						return Instruct();
-					}
-				}
-
-				if(keyedObjectContains(vka, "timeout"))
-				{
-					Variant vtimeout = keyedObjectGetValue(vka, "timeout");
-					if(!canConvert(vtimeout, VariantType::Int))
-					{
-						setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(kpn));
-						return Instruct();
-					}
-
-					keepAliveTimeout = vtimeout.toInt();
-
-					if(keepAliveTimeout < 0)
-					{
-						setError(ok, errorMessage, QString("%1 contains 'timeout' with invalid value").arg(kpn));
-						return Instruct();
-					}
-				}
-				else
-				{
-					keepAliveTimeout = 55;
-				}
-			}
-
-			Variant vmeta = getKeyedObject(vhold, pn, "meta", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return Instruct();
-			}
-
-			if(vmeta.isValid())
-			{
-				if(typeId(vmeta) == VariantType::Hash)
-				{
-					VariantHash hmeta = vmeta.toHash();
-
-					for(auto it = hmeta.constBegin(); it != hmeta.constEnd(); ++it)
-					{
-						const QString &key = it.key();
-						const Variant &vval = it.value();
-
-						QString val = getString(vval, &ok_);
-						if(!ok_)
-						{
-							setError(ok, errorMessage, QString("'meta' contains '%1' with wrong type").arg(key));
-							return Instruct();
-						}
-
-						meta[key] = val;
-					}
-				}
-				else // Map
-				{
-					VariantMap mmeta = vmeta.toMap();
-
-					for(auto it = mmeta.constBegin(); it != mmeta.constEnd(); ++it)
-					{
-						const QString &key = it.key();
-						const Variant &vval = it.value();
-
-						QString val = getString(vval, &ok_);
-						if(!ok_)
-						{
-							setError(ok, errorMessage, QString("'meta' contains '%1' with wrong type").arg(key));
-							return Instruct();
-						}
-
-						meta[key] = val;
-					}
-				}
-			}
-		}
-
-		newResponse.headers.clear();
-		newResponse.body.clear();
-
-		if(minstruct.contains("response"))
-		{
-			if(typeId(minstruct["response"]) != VariantType::Map)
-			{
-				if(ok)
-					*ok = false;
-				return Instruct();
-			}
-
-			Variant in = minstruct["response"];
-
-			QString pn = "response";
-
-			if(keyedObjectContains(in, "code"))
-			{
-				Variant vcode = keyedObjectGetValue(in, "code");
-				if(!canConvert(vcode, VariantType::Int))
-				{
-					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
-					return Instruct();
-				}
-
-				newResponse.code = vcode.toInt();
-
-				if(newResponse.code < 0 || newResponse.code > 999)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'code' with invalid value").arg(pn));
-					return Instruct();
-				}
-
-				// If code was supplied in json instruct, then
-				// we need to clear the default reason
-				newResponse.reason.clear();
-			}
-
-			QString reasonStr = getString(in, pn, "reason", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return Instruct();
-			}
-
-			if(!reasonStr.isEmpty())
-				newResponse.reason = reasonStr.toUtf8();
-
-			if(keyedObjectContains(in, "headers"))
-			{
-				Variant vheaders = keyedObjectGetValue(in, "headers");
-				if(typeId(vheaders) == VariantType::List)
-				{
-					for(const Variant &vheader : vheaders.toList())
-					{
-						if(typeId(vheader) != VariantType::List)
-						{
-							setError(ok, errorMessage, "headers contains element with wrong type");
-							return Instruct();
-						}
-
-						VariantList lheader = vheader.toList();
-						if(lheader.count() != 2)
-						{
-							setError(ok, errorMessage, "headers contains list with wrong number of elements");
-							return Instruct();
-						}
-
-						QString name = getString(lheader[0], &ok_);
-						if(!ok_)
-						{
-							setError(ok, errorMessage, "header contains name element with wrong type");
-							return Instruct();
-						}
-
-						QString val = getString(lheader[1], &ok_);
-						if(!ok_)
-						{
-							setError(ok, errorMessage, "header contains value element with wrong type");
-							return Instruct();
-						}
-
-						newResponse.headers += HttpHeader(name.toUtf8(), val.toUtf8());
-					}
-				}
-				else if(isKeyedObject(vheaders))
-				{
-					if(typeId(vheaders) == VariantType::Hash)
-					{
-						VariantHash hheaders = vheaders.toHash();
-
-						for(auto it = hheaders.constBegin(); it != hheaders.constEnd(); ++it)
-						{
-							const QString &key = it.key();
-							const Variant &vval = it.value();
-
-							QString val = getString(vval, &ok_);
-							if(!ok_)
-							{
-								setError(ok, errorMessage, QString("headers contains '%1' with wrong type").arg(key));
-								return Instruct();
-							}
-
-							newResponse.headers += HttpHeader(key.toUtf8(), val.toUtf8());
-						}
-					}
-					else // Map
-					{
-						VariantMap mheaders = vheaders.toMap();
-
-						for(auto it = mheaders.constBegin(); it != mheaders.constEnd(); ++it)
-						{
-							const QString &key = it.key();
-							const Variant &vval = it.value();
-
-							QString val = getString(vval, &ok_);
-							if(!ok_)
-							{
-								setError(ok, errorMessage, QString("headers contains '%1' with wrong type").arg(key));
-								return Instruct();
-							}
-
-							newResponse.headers += HttpHeader(key.toUtf8(), val.toUtf8());
-						}
-					}
-				}
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'headers' with wrong type").arg(pn));
-					return Instruct();
-				}
-			}
-
-			if(keyedObjectContains(in, "body-bin"))
-			{
-				QString bodyBin = getString(in, pn, "body-bin", false, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return Instruct();
-				}
-
-				newResponse.body = QByteArray::fromBase64(bodyBin.toUtf8());
-			}
-			else if(keyedObjectContains(in, "body"))
-			{
-				Variant vcontent = keyedObjectGetValue(in, "body");
-				if(typeId(vcontent) == VariantType::ByteArray)
-					newResponse.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == VariantType::String)
-					newResponse.body = vcontent.toString().toUtf8();
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'body' with wrong type").arg(pn));
-					return Instruct();
-				}
-			}
-		}
-	}
-
-	if(newResponse.reason.isEmpty())
-		newResponse.reason = StatusReasons::getReason(newResponse.code);
-
-	if(timeout == -1)
-		timeout = DEFAULT_RESPONSE_TIMEOUT;
-
-	timeout = qMax(timeout, MINIMUM_RESPONSE_TIMEOUT);
-
-	if(keepAliveTimeout != -1)
-	{
-		if(keepAliveTimeout < 1)
-			keepAliveTimeout = 1;
-	}
-
-	Instruct i;
-	i.holdMode = holdMode;
-	i.channels = channels;
-	i.timeout = timeout;
-	i.exposeHeaders = exposeHeaders;
-	i.keepAliveMode = keepAliveMode;
-	i.keepAliveData = keepAliveData;
-	i.keepAliveTimeout = keepAliveTimeout;
-	i.meta = meta;
-	i.response = newResponse;
-	i.nextLink = nextLink;
-	i.nextLinkTimeout = nextLinkTimeout;
-	i.goneLink = goneLink;
-
-	if(ok)
-		*ok = true;
-	return i;
+Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QString *errorMessage) {
+    HoldMode holdMode = NoHold;
+    QList<Channel> channels;
+    int timeout = -1;
+    QList<QByteArray> exposeHeaders;
+    KeepAliveMode keepAliveMode = NoKeepAlive;
+    QByteArray keepAliveData;
+    int keepAliveTimeout = -1;
+    QHash<QString, QString> meta;
+    HttpResponseData newResponse;
+
+    if (response.headers.contains("Grip-Hold")) {
+        QByteArray gripHoldStr = response.headers.get("Grip-Hold").asQByteArray();
+        if (gripHoldStr == "response") {
+            holdMode = ResponseHold;
+        } else if (gripHoldStr == "stream") {
+            holdMode = StreamHold;
+        } else {
+            setError(ok, errorMessage, "Grip-Hold must be set to either 'response' or 'stream'");
+            return Instruct();
+        }
+    }
+
+    QList<HttpHeaderParameters> gripChannels = response.headers.getAllAsParameters("Grip-Channel");
+    foreach (const HttpHeaderParameters &gripChannel, gripChannels) {
+        if (gripChannel.isEmpty()) {
+            setError(ok, errorMessage, "failed to parse Grip-Channel");
+            return Instruct();
+        }
+
+        Channel c;
+        c.name = QString::fromUtf8(gripChannel[0].first.asQByteArray());
+        QByteArray param = gripChannel.get("prev-id").asQByteArray();
+        if (!param.isNull())
+            c.prevId = QString::fromUtf8(param);
+
+        for (int n = 1; n < gripChannel.count(); ++n) {
+            const HttpHeaderParameter &param = gripChannel[n];
+            if (param.first == "filter")
+                c.filters += QString::fromUtf8(param.second.asQByteArray());
+        }
+
+        if (c.filters.count() > MESSAGEFILTERSTACK_SIZE_MAX) {
+            setError(ok, errorMessage, QString("too many filters for channel '%1'").arg(c.name));
+            return Instruct();
+        }
+
+        channels += c;
+    }
+
+    if (response.headers.contains("Grip-Timeout")) {
+        bool x;
+        timeout = response.headers.get("Grip-Timeout").asQByteArray().toInt(&x);
+        if (!x) {
+            setError(ok, errorMessage, "failed to parse Grip-Timeout");
+            return Instruct();
+        }
+
+        if (timeout < 0) {
+            setError(ok, errorMessage, "Grip-Timeout has invalid value");
+            return Instruct();
+        }
+    }
+
+    exposeHeaders = response.headers.getAll("Grip-Expose-Headers").asQByteArrayList();
+
+    HttpHeaderParameters keepAliveParams = response.headers.getAsParameters("Grip-Keep-Alive");
+    if (!keepAliveParams.isEmpty()) {
+        QByteArray val = keepAliveParams[0].first.asQByteArray();
+        if (val.isEmpty()) {
+            setError(ok, errorMessage, "Grip-Keep-Alive cannot be empty");
+            return Instruct();
+        }
+
+        QByteArray mode = keepAliveParams.get("mode").asQByteArray();
+        if (mode.isEmpty() || mode == "idle") {
+            keepAliveMode = Idle;
+        } else if (mode == "interval") {
+            keepAliveMode = Interval;
+        } else {
+            setError(ok, errorMessage,
+                     QString("no such Grip-Keep-Alive mode '%1'").arg(QString::fromUtf8(mode)));
+            return Instruct();
+        }
+
+        if (keepAliveParams.contains("timeout")) {
+            bool x;
+            keepAliveTimeout = keepAliveParams.get("timeout").asQByteArray().toInt(&x);
+            if (!x) {
+                setError(ok, errorMessage, "failed to parse Grip-Keep-Alive timeout value");
+                return Instruct();
+            }
+
+            if (keepAliveTimeout < 0) {
+                setError(ok, errorMessage, "Grip-Keep-Alive timeout has invalid value");
+                return Instruct();
+            }
+        } else {
+            keepAliveTimeout = DEFAULT_RESPONSE_TIMEOUT;
+        }
+
+        QByteArray format = keepAliveParams.get("format").asQByteArray();
+        if (format.isEmpty() || format == "raw") {
+            keepAliveData = val;
+        } else if (format == "cstring") {
+            keepAliveData = unescape(val);
+            if (keepAliveData.isNull()) {
+                setError(ok, errorMessage, "failed to parse Grip-Keep-Alive cstring format");
+                return Instruct();
+            }
+        } else if (format == "base64") {
+            keepAliveData = QByteArray::fromBase64(val);
+        } else {
+            setError(ok, errorMessage,
+                     QString("no such Grip-Keep-Alive format '%1'").arg(QString::fromUtf8(format)));
+            return Instruct();
+        }
+    }
+
+    QList<HttpHeaderParameters> metaParams =
+        response.headers.getAllAsParameters("Grip-Set-Meta", HttpHeaders::ParseAllParameters);
+    foreach (const HttpHeaderParameters &metaParam, metaParams) {
+        if (metaParam.isEmpty()) {
+            setError(ok, errorMessage, "Grip-Set-Meta cannot be empty");
+            return Instruct();
+        }
+
+        QString key = QString::fromUtf8(metaParam[0].first.asQByteArray());
+        QString val = QString::fromUtf8(metaParam[0].second.asQByteArray());
+
+        meta[key] = val;
+    }
+
+    newResponse = response;
+
+    QByteArray statusHeader = response.headers.get("Grip-Status").asQByteArray();
+    if (!statusHeader.isEmpty()) {
+        QByteArray codeStr;
+        QByteArray reason;
+
+        int at = statusHeader.indexOf(' ');
+        if (at != -1) {
+            codeStr = statusHeader.mid(0, at);
+            reason = statusHeader.mid(at + 1);
+        } else {
+            codeStr = statusHeader;
+        }
+
+        bool _ok;
+        newResponse.code = codeStr.toInt(&_ok);
+        if (!_ok || newResponse.code < 0 || newResponse.code > 999) {
+            setError(ok, errorMessage, "Grip-Status contains invalid status code");
+            return Instruct();
+        }
+
+        newResponse.reason = reason;
+    }
+
+    Url nextLink;
+    int nextLinkTimeout = -1;
+    Url goneLink;
+    foreach (const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link")) {
+        if (params.count() < 2)
+            continue;
+
+        QByteArray linkParam = params[0].first.asQByteArray();
+        if (linkParam.length() <= 2 || linkParam[0] != '<' ||
+            linkParam[linkParam.length() - 1] != '>') {
+            setError(ok, errorMessage, "failed to parse Grip-Link value");
+            return Instruct();
+        }
+
+        Url link = Url::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
+        if (!link.isValid()) {
+            setError(ok, errorMessage, "Grip-Link contains invalid link");
+            return Instruct();
+        }
+
+        QByteArray rel = params.get("rel").asQByteArray();
+        if (rel == "next") {
+            nextLink = link;
+
+            if (params.contains("timeout")) {
+                bool x;
+                nextLinkTimeout = params.get("timeout").asQByteArray().toInt(&x);
+                if (!x) {
+                    setError(ok, errorMessage, "failed to parse Grip-Link timeout value");
+                    return Instruct();
+                }
+
+                if (nextLinkTimeout < 0) {
+                    setError(ok, errorMessage, "Grip-Link timeout has invalid value");
+                    return Instruct();
+                }
+            } else {
+                nextLinkTimeout = DEFAULT_NEXTLINK_TIMEOUT;
+            }
+        } else if (rel == "gone") {
+            goneLink = link;
+        }
+    }
+
+    newResponse.headers.clear();
+    foreach (const HttpHeader &h, response.headers) {
+        // Strip out grip headers
+        if (qstrnicmp(h.first.data(), "Grip-", 5) == 0)
+            continue;
+
+        if (!exposeHeaders.isEmpty()) {
+            bool found = false;
+            foreach (const QByteArray &e, exposeHeaders) {
+                if (qstricmp(e.data(), h.first.data()) == 0) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                continue;
+        }
+
+        newResponse.headers += HttpHeader(h.first, h.second);
+    }
+
+    QByteArray contentType = response.headers.getAsFirstParameter("Content-Type").asQByteArray();
+    if (contentType == "application/grip-instruct") {
+        if (response.code != 200) {
+            setError(ok, errorMessage,
+                     "response code for application/grip-instruct content must be 200");
+            return Instruct();
+        }
+
+        QJsonParseError e;
+        QJsonDocument doc = QJsonDocument::fromJson(response.body, &e);
+        if (e.error != QJsonParseError::NoError) {
+            setError(ok, errorMessage, "failed to parse application/grip-instruct content as JSON");
+            return Instruct();
+        }
+
+        if (!doc.isObject()) {
+            setError(ok, errorMessage, "instruct must be an object");
+            return Instruct();
+        }
+
+        VariantMap minstruct = doc.object().toVariantMap();
+
+        bool ok_;
+
+        if (minstruct.contains("hold")) {
+            if (typeId(minstruct["hold"]) != VariantType::Map) {
+                setError(ok, errorMessage, "instruct contains 'hold' with wrong type");
+                return Instruct();
+            }
+
+            QString pn = "hold";
+
+            Variant vhold = minstruct["hold"];
+
+            QString modeStr = getString(vhold, pn, "mode", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return Instruct();
+            }
+
+            if (!modeStr.isNull()) {
+                if (modeStr == "response") {
+                    holdMode = ResponseHold;
+                } else if (modeStr == "stream") {
+                    holdMode = StreamHold;
+                } else {
+                    setError(ok, errorMessage,
+                             "hold 'mode' must be set to either 'response' or 'stream'");
+                    return Instruct();
+                }
+            } else {
+                holdMode = ResponseHold;
+            }
+
+            VariantList vchannels = getList(vhold, pn, "channels", true, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return Instruct();
+            }
+
+            for (const Variant &vchannel : vchannels) {
+                QString cpn = "channel";
+                Channel c;
+
+                c.name = getString(vchannel, cpn, "name", true, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return Instruct();
+                }
+
+                c.prevId = getString(vchannel, cpn, "prev-id", false, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return Instruct();
+                }
+
+                VariantList vfilters = getList(vchannel, cpn, "filters", false, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return Instruct();
+                }
+
+                for (const Variant &vfilter : vfilters) {
+                    QString filter = getString(vfilter, &ok_);
+                    if (!ok_) {
+                        setError(ok, errorMessage, "filters contains value with wrong type");
+                        return Instruct();
+                    }
+
+                    c.filters += filter;
+                }
+
+                channels += c;
+            }
+
+            if (keyedObjectContains(vhold, "timeout")) {
+                Variant vtimeout = keyedObjectGetValue(vhold, "timeout");
+                if (!canConvert(vtimeout, VariantType::Int)) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'timeout' with wrong type").arg(pn));
+                    return Instruct();
+                }
+
+                timeout = vtimeout.toInt();
+
+                if (timeout < 0) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'timeout' with invalid value").arg(pn));
+                    return Instruct();
+                }
+            }
+
+            Variant vka = getKeyedObject(vhold, pn, "keep-alive", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return Instruct();
+            }
+
+            if (isKeyedObject(vka)) {
+                QString kpn = "keep-alive";
+
+                if (keyedObjectContains(vka, "content-bin")) {
+                    QString contentBin =
+                        getString(vka, kpn, "content-bin", false, &ok_, errorMessage);
+                    if (!ok_) {
+                        if (ok)
+                            *ok = false;
+                        return Instruct();
+                    }
+
+                    keepAliveData = QByteArray::fromBase64(contentBin.toUtf8());
+                } else if (keyedObjectContains(vka, "content")) {
+                    Variant vcontent = keyedObjectGetValue(vka, "content");
+                    if (typeId(vcontent) == VariantType::ByteArray)
+                        keepAliveData = vcontent.toByteArray();
+                    else if (typeId(vcontent) == VariantType::String)
+                        keepAliveData = vcontent.toString().toUtf8();
+                    else {
+                        setError(ok, errorMessage,
+                                 QString("%1 contains 'content' with wrong type").arg(kpn));
+                        return Instruct();
+                    }
+                }
+
+                if (keyedObjectContains(vka, "timeout")) {
+                    Variant vtimeout = keyedObjectGetValue(vka, "timeout");
+                    if (!canConvert(vtimeout, VariantType::Int)) {
+                        setError(ok, errorMessage,
+                                 QString("%1 contains 'timeout' with wrong type").arg(kpn));
+                        return Instruct();
+                    }
+
+                    keepAliveTimeout = vtimeout.toInt();
+
+                    if (keepAliveTimeout < 0) {
+                        setError(ok, errorMessage,
+                                 QString("%1 contains 'timeout' with invalid value").arg(kpn));
+                        return Instruct();
+                    }
+                } else {
+                    keepAliveTimeout = 55;
+                }
+            }
+
+            Variant vmeta = getKeyedObject(vhold, pn, "meta", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return Instruct();
+            }
+
+            if (vmeta.isValid()) {
+                if (typeId(vmeta) == VariantType::Hash) {
+                    VariantHash hmeta = vmeta.toHash();
+
+                    for (auto it = hmeta.constBegin(); it != hmeta.constEnd(); ++it) {
+                        const QString &key = it.key();
+                        const Variant &vval = it.value();
+
+                        QString val = getString(vval, &ok_);
+                        if (!ok_) {
+                            setError(ok, errorMessage,
+                                     QString("'meta' contains '%1' with wrong type").arg(key));
+                            return Instruct();
+                        }
+
+                        meta[key] = val;
+                    }
+                } else // Map
+                {
+                    VariantMap mmeta = vmeta.toMap();
+
+                    for (auto it = mmeta.constBegin(); it != mmeta.constEnd(); ++it) {
+                        const QString &key = it.key();
+                        const Variant &vval = it.value();
+
+                        QString val = getString(vval, &ok_);
+                        if (!ok_) {
+                            setError(ok, errorMessage,
+                                     QString("'meta' contains '%1' with wrong type").arg(key));
+                            return Instruct();
+                        }
+
+                        meta[key] = val;
+                    }
+                }
+            }
+        }
+
+        newResponse.headers.clear();
+        newResponse.body.clear();
+
+        if (minstruct.contains("response")) {
+            if (typeId(minstruct["response"]) != VariantType::Map) {
+                if (ok)
+                    *ok = false;
+                return Instruct();
+            }
+
+            Variant in = minstruct["response"];
+
+            QString pn = "response";
+
+            if (keyedObjectContains(in, "code")) {
+                Variant vcode = keyedObjectGetValue(in, "code");
+                if (!canConvert(vcode, VariantType::Int)) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'code' with wrong type").arg(pn));
+                    return Instruct();
+                }
+
+                newResponse.code = vcode.toInt();
+
+                if (newResponse.code < 0 || newResponse.code > 999) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'code' with invalid value").arg(pn));
+                    return Instruct();
+                }
+
+                // If code was supplied in json instruct, then
+                // we need to clear the default reason
+                newResponse.reason.clear();
+            }
+
+            QString reasonStr = getString(in, pn, "reason", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return Instruct();
+            }
+
+            if (!reasonStr.isEmpty())
+                newResponse.reason = reasonStr.toUtf8();
+
+            if (keyedObjectContains(in, "headers")) {
+                Variant vheaders = keyedObjectGetValue(in, "headers");
+                if (typeId(vheaders) == VariantType::List) {
+                    for (const Variant &vheader : vheaders.toList()) {
+                        if (typeId(vheader) != VariantType::List) {
+                            setError(ok, errorMessage, "headers contains element with wrong type");
+                            return Instruct();
+                        }
+
+                        VariantList lheader = vheader.toList();
+                        if (lheader.count() != 2) {
+                            setError(ok, errorMessage,
+                                     "headers contains list with wrong number of elements");
+                            return Instruct();
+                        }
+
+                        QString name = getString(lheader[0], &ok_);
+                        if (!ok_) {
+                            setError(ok, errorMessage,
+                                     "header contains name element with wrong type");
+                            return Instruct();
+                        }
+
+                        QString val = getString(lheader[1], &ok_);
+                        if (!ok_) {
+                            setError(ok, errorMessage,
+                                     "header contains value element with wrong type");
+                            return Instruct();
+                        }
+
+                        newResponse.headers += HttpHeader(name.toUtf8(), val.toUtf8());
+                    }
+                } else if (isKeyedObject(vheaders)) {
+                    if (typeId(vheaders) == VariantType::Hash) {
+                        VariantHash hheaders = vheaders.toHash();
+
+                        for (auto it = hheaders.constBegin(); it != hheaders.constEnd(); ++it) {
+                            const QString &key = it.key();
+                            const Variant &vval = it.value();
+
+                            QString val = getString(vval, &ok_);
+                            if (!ok_) {
+                                setError(ok, errorMessage,
+                                         QString("headers contains '%1' with wrong type").arg(key));
+                                return Instruct();
+                            }
+
+                            newResponse.headers += HttpHeader(key.toUtf8(), val.toUtf8());
+                        }
+                    } else // Map
+                    {
+                        VariantMap mheaders = vheaders.toMap();
+
+                        for (auto it = mheaders.constBegin(); it != mheaders.constEnd(); ++it) {
+                            const QString &key = it.key();
+                            const Variant &vval = it.value();
+
+                            QString val = getString(vval, &ok_);
+                            if (!ok_) {
+                                setError(ok, errorMessage,
+                                         QString("headers contains '%1' with wrong type").arg(key));
+                                return Instruct();
+                            }
+
+                            newResponse.headers += HttpHeader(key.toUtf8(), val.toUtf8());
+                        }
+                    }
+                } else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'headers' with wrong type").arg(pn));
+                    return Instruct();
+                }
+            }
+
+            if (keyedObjectContains(in, "body-bin")) {
+                QString bodyBin = getString(in, pn, "body-bin", false, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return Instruct();
+                }
+
+                newResponse.body = QByteArray::fromBase64(bodyBin.toUtf8());
+            } else if (keyedObjectContains(in, "body")) {
+                Variant vcontent = keyedObjectGetValue(in, "body");
+                if (typeId(vcontent) == VariantType::ByteArray)
+                    newResponse.body = vcontent.toByteArray();
+                else if (typeId(vcontent) == VariantType::String)
+                    newResponse.body = vcontent.toString().toUtf8();
+                else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'body' with wrong type").arg(pn));
+                    return Instruct();
+                }
+            }
+        }
+    }
+
+    if (newResponse.reason.isEmpty())
+        newResponse.reason = StatusReasons::getReason(newResponse.code);
+
+    if (timeout == -1)
+        timeout = DEFAULT_RESPONSE_TIMEOUT;
+
+    timeout = qMax(timeout, MINIMUM_RESPONSE_TIMEOUT);
+
+    if (keepAliveTimeout != -1) {
+        if (keepAliveTimeout < 1)
+            keepAliveTimeout = 1;
+    }
+
+    Instruct i;
+    i.holdMode = holdMode;
+    i.channels = channels;
+    i.timeout = timeout;
+    i.exposeHeaders = exposeHeaders;
+    i.keepAliveMode = keepAliveMode;
+    i.keepAliveData = keepAliveData;
+    i.keepAliveTimeout = keepAliveTimeout;
+    i.meta = meta;
+    i.response = newResponse;
+    i.nextLink = nextLink;
+    i.nextLinkTimeout = nextLinkTimeout;
+    i.goneLink = goneLink;
+
+    if (ok)
+        *ok = true;
+    return i;
 }

--- a/src/handler/instruct.h
+++ b/src/handler/instruct.h
@@ -23,62 +23,49 @@
 #ifndef INSTRUCT_H
 #define INSTRUCT_H
 
-#include <QString>
-#include <QStringList>
-#include <QByteArray>
-#include <QList>
-#include <QHash>
 #include "packet/httpresponsedata.h"
 #include "url.h"
+#include <QByteArray>
+#include <QHash>
+#include <QList>
+#include <QString>
+#include <QStringList>
 
-class Instruct
-{
+class Instruct {
 public:
-	enum HoldMode
-	{
-		NoHold,
-		ResponseHold,
-		StreamHold
-	};
+    enum HoldMode { NoHold, ResponseHold, StreamHold };
 
-	enum KeepAliveMode
-	{
-		NoKeepAlive,
-		Idle,
-		Interval
-	};
+    enum KeepAliveMode { NoKeepAlive, Idle, Interval };
 
-	class Channel
-	{
-	public:
-		QString name;
-		QString prevId;
-		QStringList filters;
-	};
+    class Channel {
+    public:
+        QString name;
+        QString prevId;
+        QStringList filters;
+    };
 
-	HoldMode holdMode;
-	QList<Channel> channels;
-	int timeout;
-	QList<QByteArray> exposeHeaders;
-	KeepAliveMode keepAliveMode;
-	QByteArray keepAliveData;
-	int keepAliveTimeout;
-	QHash<QString, QString> meta;
-	HttpResponseData response;
-	Url nextLink;
-	int nextLinkTimeout;
-	Url goneLink;
+    HoldMode holdMode;
+    QList<Channel> channels;
+    int timeout;
+    QList<QByteArray> exposeHeaders;
+    KeepAliveMode keepAliveMode;
+    QByteArray keepAliveData;
+    int keepAliveTimeout;
+    QHash<QString, QString> meta;
+    HttpResponseData response;
+    Url nextLink;
+    int nextLinkTimeout;
+    Url goneLink;
 
-	Instruct() :
-		holdMode(NoHold),
-		timeout(-1),
-		keepAliveMode(NoKeepAlive),
-		keepAliveTimeout(-1),
-		nextLinkTimeout(-1)
-	{
-	}
+    Instruct()
+        : holdMode(NoHold),
+          timeout(-1),
+          keepAliveMode(NoKeepAlive),
+          keepAliveTimeout(-1),
+          nextLinkTimeout(-1) {}
 
-	static Instruct fromResponse(const HttpResponseData &response, bool *ok = 0, QString *errorMessage = 0);
+    static Instruct fromResponse(const HttpResponseData &response, bool *ok = 0,
+                                 QString *errorMessage = 0);
 };
 
 #endif

--- a/src/handler/instructtest.cpp
+++ b/src/handler/instructtest.cpp
@@ -21,285 +21,293 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
+#include "instruct.h"
 #include "httpheaders.h"
 #include "packet/httpresponsedata.h"
-#include "instruct.h"
+#include "test.h"
 
-static void noHold()
-{
-	HttpResponseData data;
-	data.code = 200;
-	data.reason = "OK";
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Channel", "test");
-	data.body = "hello world";
+static void noHold() {
+    HttpResponseData data;
+    data.code = 200;
+    data.reason = "OK";
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Channel", "test");
+    data.body = "hello world";
 
-	Instruct i;
-	bool ok;
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
-	TEST_ASSERT_EQ(i.response.code, 200);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    Instruct i;
+    bool ok;
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+    TEST_ASSERT_EQ(i.response.code, 200);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 
-	data.headers += HttpHeader("Grip-Status", "404");
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
-	TEST_ASSERT_EQ(i.response.code, 404);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("Not Found"));
+    data.headers += HttpHeader("Grip-Status", "404");
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+    TEST_ASSERT_EQ(i.response.code, 404);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("Not Found"));
 
-	data.headers.removeAll("Grip-Status");
-	data.headers += HttpHeader("Grip-Status", "404 Nothing To See Here");
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
-	TEST_ASSERT_EQ(i.response.code, 404);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("Nothing To See Here"));
+    data.headers.removeAll("Grip-Status");
+    data.headers += HttpHeader("Grip-Status", "404 Nothing To See Here");
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+    TEST_ASSERT_EQ(i.response.code, 404);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("Nothing To See Here"));
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-	data.body = "{\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+    data.body = "{\"response\":{\"code\": "
+                "200,\"headers\":{\"Content-Type\":\"text/"
+                "plain\"},\"body\":\"hello world\"}}";
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
-	TEST_ASSERT_EQ(i.response.code, 200);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
+    TEST_ASSERT_EQ(i.response.code, 200);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
-static void responseHold()
-{
-	HttpResponseData data;
-	data.code = 200;
-	data.reason = "OK";
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "response");
-	data.headers += HttpHeader("Grip-Channel", "apple");
-	data.headers += HttpHeader("Grip-Channel", "banana, cherry");
-	data.headers += HttpHeader("Grip-Timeout", "120");
-	data.headers += HttpHeader("Grip-Set-Meta", "foo=bar, bar=baz");
-	data.body = "hello world";
+static void responseHold() {
+    HttpResponseData data;
+    data.code = 200;
+    data.reason = "OK";
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "response");
+    data.headers += HttpHeader("Grip-Channel", "apple");
+    data.headers += HttpHeader("Grip-Channel", "banana, cherry");
+    data.headers += HttpHeader("Grip-Timeout", "120");
+    data.headers += HttpHeader("Grip-Set-Meta", "foo=bar, bar=baz");
+    data.body = "hello world";
 
-	Instruct i;
-	bool ok;
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
-	TEST_ASSERT_EQ(i.channels.count(), 3);
-	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
-	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
-	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
-	TEST_ASSERT_EQ(i.timeout, 120);
-	TEST_ASSERT_EQ(i.meta.count(), 2);
-	TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
-	TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    Instruct i;
+    bool ok;
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+    TEST_ASSERT_EQ(i.channels.count(), 3);
+    TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+    TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+    TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+    TEST_ASSERT_EQ(i.timeout, 120);
+    TEST_ASSERT_EQ(i.meta.count(), 2);
+    TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
+    TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-	data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":\"test\"}],\"timeout\":120,\"meta\":{\"foo\":\"bar\",\"bar\":\"baz\"}},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+    data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":"
+                "\"test\"}],\"timeout\":120,\"meta\":{\"foo\":\"bar\",\"bar\":"
+                "\"baz\"}},\"response\":{\"code\": "
+                "200,\"headers\":{\"Content-Type\":\"text/"
+                "plain\"},\"body\":\"hello world\"}}";
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
-	TEST_ASSERT_EQ(i.channels.count(), 1);
-	TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
-	TEST_ASSERT_EQ(i.timeout, 120);
-	TEST_ASSERT_EQ(i.meta.count(), 2);
-	TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
-	TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
-	TEST_ASSERT_EQ(i.response.code, 200);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+    TEST_ASSERT_EQ(i.channels.count(), 1);
+    TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
+    TEST_ASSERT_EQ(i.timeout, 120);
+    TEST_ASSERT_EQ(i.meta.count(), 2);
+    TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
+    TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
+    TEST_ASSERT_EQ(i.response.code, 200);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
-static void responseHoldChannelParams()
-{
-	HttpResponseData data;
-	data.code = 200;
-	data.reason = "OK";
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "response");
-	data.headers += HttpHeader("Grip-Channel", "apple; prev-id=item1; filter=f1");
-	data.headers += HttpHeader("Grip-Channel", "banana; filter=f2, cherry; filter=f1; filter=f2");
-	data.body = "hello world";
+static void responseHoldChannelParams() {
+    HttpResponseData data;
+    data.code = 200;
+    data.reason = "OK";
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "response");
+    data.headers += HttpHeader("Grip-Channel", "apple; prev-id=item1; filter=f1");
+    data.headers += HttpHeader("Grip-Channel", "banana; filter=f2, cherry; filter=f1; filter=f2");
+    data.body = "hello world";
 
-	Instruct i;
-	bool ok;
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
-	TEST_ASSERT_EQ(i.channels.count(), 3);
-	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
-	TEST_ASSERT_EQ(i.channels[0].prevId, QString("item1"));
-	TEST_ASSERT_EQ(i.channels[0].filters.count(), 1);
-	TEST_ASSERT_EQ(i.channels[0].filters[0], QString("f1"));
-	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
-	TEST_ASSERT(i.channels[1].prevId.isNull());
-	TEST_ASSERT_EQ(i.channels[1].filters.count(), 1);
-	TEST_ASSERT_EQ(i.channels[1].filters[0], QString("f2"));
-	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
-	TEST_ASSERT(i.channels[2].prevId.isNull());
-	TEST_ASSERT_EQ(i.channels[2].filters.count(), 2);
-	TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
-	TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    Instruct i;
+    bool ok;
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+    TEST_ASSERT_EQ(i.channels.count(), 3);
+    TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+    TEST_ASSERT_EQ(i.channels[0].prevId, QString("item1"));
+    TEST_ASSERT_EQ(i.channels[0].filters.count(), 1);
+    TEST_ASSERT_EQ(i.channels[0].filters[0], QString("f1"));
+    TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+    TEST_ASSERT(i.channels[1].prevId.isNull());
+    TEST_ASSERT_EQ(i.channels[1].filters.count(), 1);
+    TEST_ASSERT_EQ(i.channels[1].filters[0], QString("f2"));
+    TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+    TEST_ASSERT(i.channels[2].prevId.isNull());
+    TEST_ASSERT_EQ(i.channels[2].filters.count(), 2);
+    TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
+    TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-	data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":\"apple\",\"prev-id\":\"item1\",\"filters\":[\"f1\"]},{\"name\":\"banana\",\"filters\":[\"f2\"]},{\"name\":\"cherry\",\"filters\":[\"f1\",\"f2\"]}]},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+    data.body = "{\"hold\":{\"mode\":\"response\",\"channels\":[{\"name\":"
+                "\"apple\",\"prev-id\":\"item1\",\"filters\":[\"f1\"]},{\"name\":"
+                "\"banana\",\"filters\":[\"f2\"]},{\"name\":\"cherry\","
+                "\"filters\":[\"f1\",\"f2\"]}]},\"response\":{\"code\": "
+                "200,\"headers\":{\"Content-Type\":\"text/"
+                "plain\"},\"body\":\"hello world\"}}";
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
-	TEST_ASSERT_EQ(i.channels.count(), 3);
-	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
-	TEST_ASSERT_EQ(i.channels[0].prevId, QString("item1"));
-	TEST_ASSERT_EQ(i.channels[0].filters.count(), 1);
-	TEST_ASSERT_EQ(i.channels[0].filters[0], QString("f1"));
-	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
-	TEST_ASSERT(i.channels[1].prevId.isNull());
-	TEST_ASSERT_EQ(i.channels[1].filters.count(), 1);
-	TEST_ASSERT_EQ(i.channels[1].filters[0], QString("f2"));
-	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
-	TEST_ASSERT(i.channels[2].prevId.isNull());
-	TEST_ASSERT_EQ(i.channels[2].filters.count(), 2);
-	TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
-	TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
-	TEST_ASSERT_EQ(i.response.code, 200);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::ResponseHold);
+    TEST_ASSERT_EQ(i.channels.count(), 3);
+    TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+    TEST_ASSERT_EQ(i.channels[0].prevId, QString("item1"));
+    TEST_ASSERT_EQ(i.channels[0].filters.count(), 1);
+    TEST_ASSERT_EQ(i.channels[0].filters[0], QString("f1"));
+    TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+    TEST_ASSERT(i.channels[1].prevId.isNull());
+    TEST_ASSERT_EQ(i.channels[1].filters.count(), 1);
+    TEST_ASSERT_EQ(i.channels[1].filters[0], QString("f2"));
+    TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+    TEST_ASSERT(i.channels[2].prevId.isNull());
+    TEST_ASSERT_EQ(i.channels[2].filters.count(), 2);
+    TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
+    TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
+    TEST_ASSERT_EQ(i.response.code, 200);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
-static void streamHold()
-{
-	HttpResponseData data;
-	data.code = 200;
-	data.reason = "OK";
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "stream");
-	data.headers += HttpHeader("Grip-Channel", "apple");
-	data.headers += HttpHeader("Grip-Channel", "banana, cherry");
-	data.body = "hello world";
+static void streamHold() {
+    HttpResponseData data;
+    data.code = 200;
+    data.reason = "OK";
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "stream");
+    data.headers += HttpHeader("Grip-Channel", "apple");
+    data.headers += HttpHeader("Grip-Channel", "banana, cherry");
+    data.body = "hello world";
 
-	Instruct i;
-	bool ok;
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.channels.count(), 3);
-	TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
-	TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
-	TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    Instruct i;
+    bool ok;
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.channels.count(), 3);
+    TEST_ASSERT_EQ(i.channels[0].name, QString("apple"));
+    TEST_ASSERT_EQ(i.channels[1].name, QString("banana"));
+    TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "application/grip-instruct");
-	data.body = "{\"hold\":{\"mode\":\"stream\",\"channels\":[{\"name\":\"test\"}]},\"response\":{\"code\": 200,\"headers\":{\"Content-Type\":\"text/plain\"},\"body\":\"hello world\"}}";
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "application/grip-instruct");
+    data.body = "{\"hold\":{\"mode\":\"stream\",\"channels\":[{\"name\":\"test\"}"
+                "]},\"response\":{\"code\": "
+                "200,\"headers\":{\"Content-Type\":\"text/"
+                "plain\"},\"body\":\"hello world\"}}";
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.channels.count(), 1);
-	TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
-	TEST_ASSERT_EQ(i.response.code, 200);
-	TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-	TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.channels.count(), 1);
+    TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
+    TEST_ASSERT_EQ(i.response.code, 200);
+    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
+    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
 }
 
-static void streamHoldKeepAlive()
-{
-	HttpResponseData data;
-	data.code = 200;
-	data.reason = "OK";
-	data.body = "hello world";
+static void streamHoldKeepAlive() {
+    HttpResponseData data;
+    data.code = 200;
+    data.reason = "OK";
+    data.body = "hello world";
 
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "stream");
-	data.headers += HttpHeader("Grip-Channel", "test");
-	Instruct i;
-	bool ok;
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::NoKeepAlive);
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "stream");
+    data.headers += HttpHeader("Grip-Channel", "test");
+    Instruct i;
+    bool ok;
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.keepAliveMode, Instruct::NoKeepAlive);
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "stream");
-	data.headers += HttpHeader("Grip-Channel", "test");
-	data.headers += HttpHeader("Grip-Keep-Alive", "ping1\\n; timeout=10");
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "stream");
+    data.headers += HttpHeader("Grip-Channel", "test");
+    data.headers += HttpHeader("Grip-Keep-Alive", "ping1\\n; timeout=10");
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
-	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping1\\n"));
-	TEST_ASSERT_EQ(i.keepAliveTimeout, 10);
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
+    TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping1\\n"));
+    TEST_ASSERT_EQ(i.keepAliveTimeout, 10);
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "stream");
-	data.headers += HttpHeader("Grip-Channel", "test");
-	data.headers += HttpHeader("Grip-Keep-Alive", "ping2\\n; format=cstring");
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "stream");
+    data.headers += HttpHeader("Grip-Channel", "test");
+    data.headers += HttpHeader("Grip-Keep-Alive", "ping2\\n; format=cstring");
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
-	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping2\n"));
-	TEST_ASSERT(i.keepAliveTimeout > 0);
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
+    TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping2\n"));
+    TEST_ASSERT(i.keepAliveTimeout > 0);
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "stream");
-	data.headers += HttpHeader("Grip-Channel", "test");
-	data.headers += HttpHeader("Grip-Keep-Alive", "cGluZzMK; format=base64");
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "stream");
+    data.headers += HttpHeader("Grip-Channel", "test");
+    data.headers += HttpHeader("Grip-Keep-Alive", "cGluZzMK; format=base64");
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
-	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping3\n"));
-	TEST_ASSERT(i.keepAliveTimeout > 0);
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Idle);
+    TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping3\n"));
+    TEST_ASSERT(i.keepAliveTimeout > 0);
 
-	data.headers.clear();
-	data.headers += HttpHeader("Content-Type", "text/plain");
-	data.headers += HttpHeader("Grip-Hold", "stream");
-	data.headers += HttpHeader("Grip-Channel", "test");
-	data.headers += HttpHeader("Grip-Keep-Alive", "ping4\\n; mode=interval");
+    data.headers.clear();
+    data.headers += HttpHeader("Content-Type", "text/plain");
+    data.headers += HttpHeader("Grip-Hold", "stream");
+    data.headers += HttpHeader("Grip-Channel", "test");
+    data.headers += HttpHeader("Grip-Keep-Alive", "ping4\\n; mode=interval");
 
-	i = Instruct::fromResponse(data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
-	TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Interval);
-	TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping4\\n"));
-	TEST_ASSERT(i.keepAliveTimeout > 0);
+    i = Instruct::fromResponse(data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.holdMode, Instruct::StreamHold);
+    TEST_ASSERT_EQ(i.keepAliveMode, Instruct::Interval);
+    TEST_ASSERT_EQ(i.keepAliveData, QByteArray("ping4\\n"));
+    TEST_ASSERT(i.keepAliveTimeout > 0);
 }
 
-extern "C" int instruct_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(noHold());
-	TEST_CATCH(responseHold());
-	TEST_CATCH(responseHoldChannelParams());
-	TEST_CATCH(streamHold());
-	TEST_CATCH(streamHoldKeepAlive());
+extern "C" int instruct_test(ffi::TestException *out_ex) {
+    TEST_CATCH(noHold());
+    TEST_CATCH(responseHold());
+    TEST_CATCH(responseHoldChannelParams());
+    TEST_CATCH(streamHold());
+    TEST_CATCH(streamHoldKeepAlive());
 
-	return 0;
+    return 0;
 }

--- a/src/handler/jsonpatch.cpp
+++ b/src/handler/jsonpatch.cpp
@@ -23,435 +23,365 @@
 
 #include "jsonpatch.h"
 
-#include <assert.h>
+#include "jsonpointer.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include "jsonpointer.h"
+#include <assert.h>
 
 namespace JsonPatch {
 
-static void setSuccess(bool *ok, QString *errorMessage)
-{
-	if(ok)
-		*ok = true;
-	if(errorMessage)
-		errorMessage->clear();
+static void setSuccess(bool *ok, QString *errorMessage) {
+    if (ok)
+        *ok = true;
+    if (errorMessage)
+        errorMessage->clear();
 }
 
-static void setError(bool *ok, QString *errorMessage, const QString &msg)
-{
-	if(ok)
-		*ok = false;
-	if(errorMessage)
-		*errorMessage = msg;
+static void setError(bool *ok, QString *errorMessage, const QString &msg) {
+    if (ok)
+        *ok = false;
+    if (errorMessage)
+        *errorMessage = msg;
 }
 
-static bool isKeyedObject(const Variant &in)
-{
-	return (typeId(in) == VariantType::Hash || typeId(in) == VariantType::Map);
+static bool isKeyedObject(const Variant &in) {
+    return (typeId(in) == VariantType::Hash || typeId(in) == VariantType::Map);
 }
 
-static bool keyedObjectContains(const Variant &in, const QString &name)
-{
-	if(typeId(in) == VariantType::Hash)
-		return in.toHash().contains(name);
-	else if(typeId(in) == VariantType::Map)
-		return in.toMap().contains(name);
-	else
-		return false;
+static bool keyedObjectContains(const Variant &in, const QString &name) {
+    if (typeId(in) == VariantType::Hash)
+        return in.toHash().contains(name);
+    else if (typeId(in) == VariantType::Map)
+        return in.toMap().contains(name);
+    else
+        return false;
 }
 
-static Variant keyedObjectGetValue(const Variant &in, const QString &name)
-{
-	if(typeId(in) == VariantType::Hash)
-		return in.toHash().value(name);
-	else if(typeId(in) == VariantType::Map)
-		return in.toMap().value(name);
-	else
-		return Variant();
+static Variant keyedObjectGetValue(const Variant &in, const QString &name) {
+    if (typeId(in) == VariantType::Hash)
+        return in.toHash().value(name);
+    else if (typeId(in) == VariantType::Map)
+        return in.toMap().value(name);
+    else
+        return Variant();
 }
 
-static Variant getChild(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0)
-{
-	if(!isKeyedObject(in))
-	{
-		QString pn = !parentName.isEmpty() ? parentName : QString("value");
-		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return Variant();
-	}
+static Variant getChild(const Variant &in, const QString &parentName, const QString &childName,
+                        bool required, bool *ok = 0, QString *errorMessage = 0) {
+    if (!isKeyedObject(in)) {
+        QString pn = !parentName.isEmpty() ? parentName : QString("value");
+        setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
+        return Variant();
+    }
 
-	QString pn = !parentName.isEmpty() ? parentName : QString("object");
+    QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	Variant v;
-	if(typeId(in) == VariantType::Hash)
-	{
-		VariantHash h = in.toHash();
+    Variant v;
+    if (typeId(in) == VariantType::Hash) {
+        VariantHash h = in.toHash();
 
-		if(!h.contains(childName))
-		{
-			if(required)
-				setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
-			else
-				setSuccess(ok, errorMessage);
+        if (!h.contains(childName)) {
+            if (required)
+                setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
+            else
+                setSuccess(ok, errorMessage);
 
-			return Variant();
-		}
+            return Variant();
+        }
 
-		v = h[childName];
-	}
-	else // Map
-	{
-		VariantMap m = in.toMap();
+        v = h[childName];
+    } else // Map
+    {
+        VariantMap m = in.toMap();
 
-		if(!m.contains(childName))
-		{
-			if(required)
-				setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
-			else
-				setSuccess(ok, errorMessage);
+        if (!m.contains(childName)) {
+            if (required)
+                setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
+            else
+                setSuccess(ok, errorMessage);
 
-			return Variant();
-		}
+            return Variant();
+        }
 
-		v = m[childName];
-	}
+        v = m[childName];
+    }
 
-	setSuccess(ok, errorMessage);
-	return v;
+    setSuccess(ok, errorMessage);
+    return v;
 }
 
-static QString getString(const Variant &in, bool *ok = 0)
-{
-	if(typeId(in) == VariantType::String)
-	{
-		if(ok)
-			*ok = true;
-		return in.toString();
-	}
-	else if(typeId(in) == VariantType::ByteArray)
-	{
-		if(ok)
-			*ok = true;
-		return QString::fromUtf8(in.toByteArray());
-	}
-	else
-	{
-		if(ok)
-			*ok = false;
-		return QString();
-	}
+static QString getString(const Variant &in, bool *ok = 0) {
+    if (typeId(in) == VariantType::String) {
+        if (ok)
+            *ok = true;
+        return in.toString();
+    } else if (typeId(in) == VariantType::ByteArray) {
+        if (ok)
+            *ok = true;
+        return QString::fromUtf8(in.toByteArray());
+    } else {
+        if (ok)
+            *ok = false;
+        return QString();
+    }
 }
 
-static QString getString(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0)
-{
-	bool ok_;
-	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return QString();
-	}
+static QString getString(const Variant &in, const QString &parentName, const QString &childName,
+                         bool required, bool *ok = 0, QString *errorMessage = 0) {
+    bool ok_;
+    Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return QString();
+    }
 
-	if(!v.isValid() && !required)
-	{
-		setSuccess(ok, errorMessage);
-		return QString();
-	}
+    if (!v.isValid() && !required) {
+        setSuccess(ok, errorMessage);
+        return QString();
+    }
 
-	QString pn = !parentName.isEmpty() ? parentName : QString("object");
+    QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	QString str = getString(v, &ok_);
-	if(!ok_)
-	{
-		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
-		return QString();
-	}
+    QString str = getString(v, &ok_);
+    if (!ok_) {
+        setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
+        return QString();
+    }
 
-	setSuccess(ok, errorMessage);
-	return str;
+    setSuccess(ok, errorMessage);
+    return str;
 }
 
 // Return true if item modified
-static bool convertToJsonStyleInPlace(Variant *in)
-{
-	// Hash -> Map
-	// ByteArray (UTF-8) -> String
+static bool convertToJsonStyleInPlace(Variant *in) {
+    // Hash -> Map
+    // ByteArray (UTF-8) -> String
 
-	bool changed = false;
+    bool changed = false;
 
-	VariantType::Type type = typeId(*in);
-	if(type == VariantType::Hash)
-	{
-		VariantMap vmap;
-		VariantHash vhash = in->toHash();
-		for(auto it = vhash.constBegin(); it != vhash.constEnd(); ++it)
-		{
-			Variant i = it.value();
-			convertToJsonStyleInPlace(&i);
-			vmap[it.key()] = i;
-		}
+    VariantType::Type type = typeId(*in);
+    if (type == VariantType::Hash) {
+        VariantMap vmap;
+        VariantHash vhash = in->toHash();
+        for (auto it = vhash.constBegin(); it != vhash.constEnd(); ++it) {
+            Variant i = it.value();
+            convertToJsonStyleInPlace(&i);
+            vmap[it.key()] = i;
+        }
 
-		*in = vmap;
-		changed = true;
-	}
-	else if(type == VariantType::List)
-	{
-		VariantList vlist = in->toList();
-		for(int n = 0; n < vlist.count(); ++n)
-		{
-			Variant i = vlist.at(n);
-			convertToJsonStyleInPlace(&i);
-			vlist[n] = i;
-		}
+        *in = vmap;
+        changed = true;
+    } else if (type == VariantType::List) {
+        VariantList vlist = in->toList();
+        for (int n = 0; n < vlist.count(); ++n) {
+            Variant i = vlist.at(n);
+            convertToJsonStyleInPlace(&i);
+            vlist[n] = i;
+        }
 
-		*in = vlist;
-		changed = true;
-	}
-	else if(type == VariantType::ByteArray)
-	{
-		*in = Variant(QString::fromUtf8(in->toByteArray()));
-		changed = true;
-	}
+        *in = vlist;
+        changed = true;
+    } else if (type == VariantType::ByteArray) {
+        *in = Variant(QString::fromUtf8(in->toByteArray()));
+        changed = true;
+    }
 
-	return changed;
+    return changed;
 }
 
-static Variant convertToJsonStyle(const Variant &in)
-{
-	Variant v = in;
-	convertToJsonStyleInPlace(&v);
-	return v;
+static Variant convertToJsonStyle(const Variant &in) {
+    Variant v = in;
+    convertToJsonStyleInPlace(&v);
+    return v;
 }
 
-static bool _compareJsonValues(const Variant &a, const Variant &b)
-{
-	if(typeId(a) == VariantType::Map && typeId(b) == VariantType::Map)
-	{
-		VariantMap am = a.toMap();
-		VariantMap bm = b.toMap();
+static bool _compareJsonValues(const Variant &a, const Variant &b) {
+    if (typeId(a) == VariantType::Map && typeId(b) == VariantType::Map) {
+        VariantMap am = a.toMap();
+        VariantMap bm = b.toMap();
 
-		if(am.count() != bm.count())
-			return false;
+        if (am.count() != bm.count())
+            return false;
 
-		for(auto it = am.constBegin(); it != am.constEnd(); ++it)
-		{
-			const QString &key = it.key();
-			const Variant &val = it.value();
+        for (auto it = am.constBegin(); it != am.constEnd(); ++it) {
+            const QString &key = it.key();
+            const Variant &val = it.value();
 
-			if(!bm.contains(key))
-				return false;
-			if(!_compareJsonValues(val, bm.value(key)))
-				return false;
-		}
+            if (!bm.contains(key))
+                return false;
+            if (!_compareJsonValues(val, bm.value(key)))
+                return false;
+        }
 
-		return true;
-	}
-	else if(typeId(a) == VariantType::List && typeId(b) == VariantType::List)
-	{
-		VariantList al = a.toList();
-		VariantList bl = b.toList();
+        return true;
+    } else if (typeId(a) == VariantType::List && typeId(b) == VariantType::List) {
+        VariantList al = a.toList();
+        VariantList bl = b.toList();
 
-		if(al.count() != bl.count())
-			return false;
+        if (al.count() != bl.count())
+            return false;
 
-		for(int n = 0; n < al.count(); ++n)
-		{
-			if(!_compareJsonValues(al[n], bl[n]))
-				return false;
-		}
+        for (int n = 0; n < al.count(); ++n) {
+            if (!_compareJsonValues(al[n], bl[n]))
+                return false;
+        }
 
-		return true;
-	}
-	else if(typeId(a) == VariantType::String && typeId(b) == VariantType::String)
-	{
-		return (a.toString() == b.toString());
-	}
-	else if(typeId(a) == VariantType::Bool && typeId(b) == VariantType::Bool)
-	{
-		return (a.toBool() == b.toBool());
-	}
-	else if(typeId(a) == VariantType::Invalid && typeId(b) == VariantType::Invalid)
-	{
-		return true;
-	}
-	else if(canConvert(a, VariantType::Int) && canConvert(b, VariantType::Int))
-	{
-		return (a.toInt() == b.toInt());
-	}
-	else
-		return false;
+        return true;
+    } else if (typeId(a) == VariantType::String && typeId(b) == VariantType::String) {
+        return (a.toString() == b.toString());
+    } else if (typeId(a) == VariantType::Bool && typeId(b) == VariantType::Bool) {
+        return (a.toBool() == b.toBool());
+    } else if (typeId(a) == VariantType::Invalid && typeId(b) == VariantType::Invalid) {
+        return true;
+    } else if (canConvert(a, VariantType::Int) && canConvert(b, VariantType::Int)) {
+        return (a.toInt() == b.toInt());
+    } else
+        return false;
 }
 
-static bool compareJsonValues(const Variant &a, const Variant &b)
-{
-	Variant ca = convertToJsonStyle(a);
-	Variant cb = convertToJsonStyle(b);
+static bool compareJsonValues(const Variant &a, const Variant &b) {
+    Variant ca = convertToJsonStyle(a);
+    Variant cb = convertToJsonStyle(b);
 
-	return _compareJsonValues(ca, cb);
+    return _compareJsonValues(ca, cb);
 }
 
-Variant patch(const Variant &data, const VariantList &ops, QString *errorMessage)
-{
-	Variant out = data;
+Variant patch(const Variant &data, const VariantList &ops, QString *errorMessage) {
+    Variant out = data;
 
-	for(const Variant &vop : ops)
-	{
-		if(!isKeyedObject(vop))
-		{
-			if(errorMessage)
-				*errorMessage = "invalid op";
-			return Variant();
-		}
+    for (const Variant &vop : ops) {
+        if (!isKeyedObject(vop)) {
+            if (errorMessage)
+                *errorMessage = "invalid op";
+            return Variant();
+        }
 
-		QString pn = "op";
+        QString pn = "op";
 
-		bool ok;
-		QString type = getString(vop, pn, "op", true, &ok, errorMessage);
-		if(!ok)
-			return Variant();
+        bool ok;
+        QString type = getString(vop, pn, "op", true, &ok, errorMessage);
+        if (!ok)
+            return Variant();
 
-		QString path = getString(vop, pn, "path", true, &ok, errorMessage);
-		if(!ok)
-			return Variant();
+        QString path = getString(vop, pn, "path", true, &ok, errorMessage);
+        if (!ok)
+            return Variant();
 
-		JsonPointer ptr;
+        JsonPointer ptr;
 
-		// For all ops except move, we can resolve the path now
-		if(type != "move")
-		{
-			ptr = JsonPointer::resolve(&out, path, errorMessage);
-			if(ptr.isNull())
-				return Variant();
-		}
+        // For all ops except move, we can resolve the path now
+        if (type != "move") {
+            ptr = JsonPointer::resolve(&out, path, errorMessage);
+            if (ptr.isNull())
+                return Variant();
+        }
 
-		if(type == "add")
-		{
-			if(!keyedObjectContains(vop, "value"))
-			{
-				if(errorMessage)
-					*errorMessage = "op does not contain 'value'";
-				return Variant();
-			}
+        if (type == "add") {
+            if (!keyedObjectContains(vop, "value")) {
+                if (errorMessage)
+                    *errorMessage = "op does not contain 'value'";
+                return Variant();
+            }
 
-			Variant value = keyedObjectGetValue(vop, "value");
-			ptr.setValue(value);
-		}
-		else if(type == "remove")
-		{
-			if(!ptr.exists())
-			{
-				if(errorMessage)
-					*errorMessage = "location does not exist";
-				return Variant();
-			}
+            Variant value = keyedObjectGetValue(vop, "value");
+            ptr.setValue(value);
+        } else if (type == "remove") {
+            if (!ptr.exists()) {
+                if (errorMessage)
+                    *errorMessage = "location does not exist";
+                return Variant();
+            }
 
-			if(!ptr.remove())
-				return Variant();
-		}
-		else if(type == "replace")
-		{
-			if(!keyedObjectContains(vop, "value"))
-			{
-				if(errorMessage)
-					*errorMessage = "op does not contain 'value'";
-				return Variant();
-			}
+            if (!ptr.remove())
+                return Variant();
+        } else if (type == "replace") {
+            if (!keyedObjectContains(vop, "value")) {
+                if (errorMessage)
+                    *errorMessage = "op does not contain 'value'";
+                return Variant();
+            }
 
-			Variant value = keyedObjectGetValue(vop, "value");
+            Variant value = keyedObjectGetValue(vop, "value");
 
-			if(!ptr.exists())
-			{
-				if(errorMessage)
-					*errorMessage = "location does not exist";
-				return Variant();
-			}
+            if (!ptr.exists()) {
+                if (errorMessage)
+                    *errorMessage = "location does not exist";
+                return Variant();
+            }
 
-			ptr.setValue(value);
-		}
-		else if(type == "move")
-		{
-			QString from = getString(vop, pn, "from", true, &ok, errorMessage);
-			if(!ok)
-				return Variant();
+            ptr.setValue(value);
+        } else if (type == "move") {
+            QString from = getString(vop, pn, "from", true, &ok, errorMessage);
+            if (!ok)
+                return Variant();
 
-			if(JsonPointer::isWithin(path, from))
-			{
-				if(errorMessage)
-					*errorMessage = "cannot move location into itself";
-				return Variant();
-			}
+            if (JsonPointer::isWithin(path, from)) {
+                if (errorMessage)
+                    *errorMessage = "cannot move location into itself";
+                return Variant();
+            }
 
-			JsonPointer fromPtr = JsonPointer::resolve(&out, from, errorMessage);
-			if(fromPtr.isNull())
-				return Variant();
+            JsonPointer fromPtr = JsonPointer::resolve(&out, from, errorMessage);
+            if (fromPtr.isNull())
+                return Variant();
 
-			if(!fromPtr.exists())
-			{
-				if(errorMessage)
-					*errorMessage = "location does not exist";
-				return Variant();
-			}
+            if (!fromPtr.exists()) {
+                if (errorMessage)
+                    *errorMessage = "location does not exist";
+                return Variant();
+            }
 
-			Variant value = fromPtr.take();
+            Variant value = fromPtr.take();
 
-			ptr = JsonPointer::resolve(&out, path, errorMessage);
-			if(ptr.isNull())
-				return Variant();
+            ptr = JsonPointer::resolve(&out, path, errorMessage);
+            if (ptr.isNull())
+                return Variant();
 
-			ptr.setValue(value);
-		}
-		else if(type == "copy")
-		{
-			QString from = getString(vop, pn, "from", true, &ok, errorMessage);
-			if(!ok)
-				return Variant();
+            ptr.setValue(value);
+        } else if (type == "copy") {
+            QString from = getString(vop, pn, "from", true, &ok, errorMessage);
+            if (!ok)
+                return Variant();
 
-			JsonPointer fromPtr = JsonPointer::resolve(&out, from, errorMessage);
-			if(fromPtr.isNull())
-				return Variant();
+            JsonPointer fromPtr = JsonPointer::resolve(&out, from, errorMessage);
+            if (fromPtr.isNull())
+                return Variant();
 
-			if(!fromPtr.exists())
-			{
-				if(errorMessage)
-					*errorMessage = "location does not exist";
-				return Variant();
-			}
+            if (!fromPtr.exists()) {
+                if (errorMessage)
+                    *errorMessage = "location does not exist";
+                return Variant();
+            }
 
-			ptr = JsonPointer::resolve(&out, path, errorMessage);
-			if(ptr.isNull())
-				return Variant();
+            ptr = JsonPointer::resolve(&out, path, errorMessage);
+            if (ptr.isNull())
+                return Variant();
 
-			ptr.setValue(fromPtr.value());
-		}
-		else if(type == "test")
-		{
-			if(!keyedObjectContains(vop, "value"))
-			{
-				if(errorMessage)
-					*errorMessage = "op does not contain 'value'";
-				return Variant();
-			}
+            ptr.setValue(fromPtr.value());
+        } else if (type == "test") {
+            if (!keyedObjectContains(vop, "value")) {
+                if (errorMessage)
+                    *errorMessage = "op does not contain 'value'";
+                return Variant();
+            }
 
-			Variant value = keyedObjectGetValue(vop, "value");
-			Variant cur = ptr.value();
+            Variant value = keyedObjectGetValue(vop, "value");
+            Variant cur = ptr.value();
 
-			if(!compareJsonValues(cur, value))
-			{
-				if(errorMessage)
-					*errorMessage = "tested values are not equal";
-				return Variant();
-			}
-		}
-		else
-		{
-			if(errorMessage)
-				*errorMessage = QString("unsupported op: %1").arg(type);
-			return Variant();
-		}
-	}
+            if (!compareJsonValues(cur, value)) {
+                if (errorMessage)
+                    *errorMessage = "tested values are not equal";
+                return Variant();
+            }
+        } else {
+            if (errorMessage)
+                *errorMessage = QString("unsupported op: %1").arg(type);
+            return Variant();
+        }
+    }
 
-	return out;
+    return out;
 }
 
-}
+} // namespace JsonPatch

--- a/src/handler/jsonpatchtest.cpp
+++ b/src/handler/jsonpatchtest.cpp
@@ -21,81 +21,79 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
-#include "qtcompat.h"
-#include "variant.h"
 #include "jsonpatch.h"
+#include "qtcompat.h"
+#include "test.h"
+#include "variant.h"
 
-static void patch()
-{
-	VariantMap data;
-	data["foo"] = "bar";
+static void patch() {
+    VariantMap data;
+    data["foo"] = "bar";
 
-	VariantMap op;
-	op["op"] = "test";
-	op["path"] = "/foo";
-	op["value"] = "bar";
-	QString msg;
-	Variant ret = JsonPatch::patch(data, VariantList() << op, &msg);
-	TEST_ASSERT(ret.isValid());
-	data = ret.toMap();
+    VariantMap op;
+    op["op"] = "test";
+    op["path"] = "/foo";
+    op["value"] = "bar";
+    QString msg;
+    Variant ret = JsonPatch::patch(data, VariantList() << op, &msg);
+    TEST_ASSERT(ret.isValid());
+    data = ret.toMap();
 
-	op.clear();
-	op["op"] = "add";
-	op["path"] = "/fruit";
-	op["value"] = VariantList() << "apple";
-	ret = JsonPatch::patch(data, VariantList() << op);
-	TEST_ASSERT(ret.isValid());
-	data = ret.toMap();
-	TEST_ASSERT_EQ(typeId(data["fruit"]), VariantType::List);
-	TEST_ASSERT_EQ(data["fruit"].toList()[0].toString(), QString("apple"));
+    op.clear();
+    op["op"] = "add";
+    op["path"] = "/fruit";
+    op["value"] = VariantList() << "apple";
+    ret = JsonPatch::patch(data, VariantList() << op);
+    TEST_ASSERT(ret.isValid());
+    data = ret.toMap();
+    TEST_ASSERT_EQ(typeId(data["fruit"]), VariantType::List);
+    TEST_ASSERT_EQ(data["fruit"].toList()[0].toString(), QString("apple"));
 
-	op.clear();
-	op["op"] = "copy";
-	op["from"] = "/foo";
-	op["path"] = "/fruit/-";
-	ret = JsonPatch::patch(data, VariantList() << op);
-	TEST_ASSERT(ret.isValid());
-	data = ret.toMap();
-	TEST_ASSERT_EQ(data["fruit"].toList()[1].toString(), QString("bar"));
+    op.clear();
+    op["op"] = "copy";
+    op["from"] = "/foo";
+    op["path"] = "/fruit/-";
+    ret = JsonPatch::patch(data, VariantList() << op);
+    TEST_ASSERT(ret.isValid());
+    data = ret.toMap();
+    TEST_ASSERT_EQ(data["fruit"].toList()[1].toString(), QString("bar"));
 
-	op.clear();
-	op["op"] = "replace";
-	op["path"] = "/fruit/1";
-	VariantMap bowl;
-	bowl["cherries"] = true;
-	bowl["grapes"] = 5;
-	op["value"] = bowl;
-	ret = JsonPatch::patch(data, VariantList() << op);
-	TEST_ASSERT(ret.isValid());
-	data = ret.toMap();
-	TEST_ASSERT_EQ(typeId(data["fruit"].toList()[1]), VariantType::Map);
-	TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("cherries").toBool(), true);
-	TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("grapes").toInt(), 5);
+    op.clear();
+    op["op"] = "replace";
+    op["path"] = "/fruit/1";
+    VariantMap bowl;
+    bowl["cherries"] = true;
+    bowl["grapes"] = 5;
+    op["value"] = bowl;
+    ret = JsonPatch::patch(data, VariantList() << op);
+    TEST_ASSERT(ret.isValid());
+    data = ret.toMap();
+    TEST_ASSERT_EQ(typeId(data["fruit"].toList()[1]), VariantType::Map);
+    TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("cherries").toBool(), true);
+    TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("grapes").toInt(), 5);
 
-	op.clear();
-	op["op"] = "remove";
-	op["path"] = "/fruit/1/cherries";
-	ret = JsonPatch::patch(data, VariantList() << op);
-	TEST_ASSERT(ret.isValid());
-	data = ret.toMap();
-	TEST_ASSERT(!data["fruit"].toList()[1].toMap().contains("cherries"));
-	TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("grapes").toInt(), 5);
+    op.clear();
+    op["op"] = "remove";
+    op["path"] = "/fruit/1/cherries";
+    ret = JsonPatch::patch(data, VariantList() << op);
+    TEST_ASSERT(ret.isValid());
+    data = ret.toMap();
+    TEST_ASSERT(!data["fruit"].toList()[1].toMap().contains("cherries"));
+    TEST_ASSERT_EQ(data["fruit"].toList()[1].toMap().value("grapes").toInt(), 5);
 
-	op.clear();
-	op["op"] = "move";
-	op["from"] = "/fruit/0";
-	op["path"] = "/foo";
-	ret = JsonPatch::patch(data, VariantList() << op);
-	TEST_ASSERT(ret.isValid());
-	data = ret.toMap();
-	TEST_ASSERT_EQ(data["foo"].toString(), QString("apple"));
-	TEST_ASSERT_EQ(data["fruit"].toList()[0].toMap().value("grapes").toInt(), 5);
+    op.clear();
+    op["op"] = "move";
+    op["from"] = "/fruit/0";
+    op["path"] = "/foo";
+    ret = JsonPatch::patch(data, VariantList() << op);
+    TEST_ASSERT(ret.isValid());
+    data = ret.toMap();
+    TEST_ASSERT_EQ(data["foo"].toString(), QString("apple"));
+    TEST_ASSERT_EQ(data["fruit"].toList()[0].toMap().value("grapes").toInt(), 5);
 }
 
-extern "C" int jsonpatch_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(patch());
+extern "C" int jsonpatch_test(ffi::TestException *out_ex) {
+    TEST_CATCH(patch());
 
-	return 0;
+    return 0;
 }

--- a/src/handler/jsonpointer.cpp
+++ b/src/handler/jsonpointer.cpp
@@ -23,541 +23,444 @@
 
 #include "jsonpointer.h"
 
-#include <assert.h>
-#include <QStringList>
 #include "qtcompat.h"
 #include "variant.h"
+#include <QStringList>
+#include <assert.h>
 
-JsonPointer::JsonPointer() :
-	isNull_(true)
-{
+JsonPointer::JsonPointer() : isNull_(true) {}
+
+Variant *JsonPointer::root() { return root_; }
+
+JsonPointer::ExecStatus JsonPointer::execute(const Variant *i, int refIndex, ConstFunc func,
+                                             void *data) const {
+    // If there are more refs after current ref, step into current
+    if (refIndex + 1 < refs_.count()) {
+        const Ref &ref = refs_[refIndex];
+
+        assert(ref.type != Ref::Self);
+
+        if (ref.type == Ref::Object) {
+            if (typeId(*i) == VariantType::Hash) {
+                VariantHash h = i->toHash();
+                if (!h.contains(ref.name))
+                    return ExecError;
+
+                return execute(&h[ref.name], refIndex + 1, func, data);
+            } else // Map
+            {
+                VariantMap m = i->toMap();
+                if (!m.contains(ref.name))
+                    return ExecError;
+
+                return execute(&m[ref.name], refIndex + 1, func, data);
+            }
+        } else // Array
+        {
+            VariantList l = i->toList();
+            if (ref.index < 0 || ref.index >= l.count())
+                return ExecError;
+
+            return execute(&l[ref.index], refIndex + 1, func, data);
+        }
+    }
+
+    // Ensure ref is correct type
+    const Ref &ref = refs_[refIndex];
+    if (ref.type == Ref::Object &&
+        (typeId(*i) != VariantType::Hash && typeId(*i) != VariantType::Map))
+        return ExecError;
+    else if (ref.type == Ref::Array && typeId(*i) != VariantType::List)
+        return ExecError;
+
+    func(i, refs_[refIndex], data);
+    return ExecContinue;
 }
 
-Variant *JsonPointer::root()
-{
-	return root_;
+JsonPointer::ExecStatus JsonPointer::execute(Variant *i, int refIndex, Func func, void *data) {
+    // If there are more refs after current ref, step into current
+    if (refIndex + 1 < refs_.count()) {
+        const Ref &ref = refs_[refIndex];
+        if (ref.type == Ref::Object) {
+            if (typeId(*i) == VariantType::Hash) {
+                VariantHash h = i->toHash();
+                if (!h.contains(ref.name))
+                    return ExecError;
+
+                ExecStatus ret = execute(&h[ref.name], refIndex + 1, func, data);
+                if (ret == ExecChanged)
+                    *i = h;
+                return ret;
+            } else // Map
+            {
+                VariantMap m = i->toMap();
+                if (!m.contains(ref.name))
+                    return ExecError;
+
+                ExecStatus ret = execute(&m[ref.name], refIndex + 1, func, data);
+                if (ret == ExecChanged)
+                    *i = m;
+                return ret;
+            }
+        } else if (ref.type == Ref::Array) {
+            VariantList l = i->toList();
+            if (ref.index < 0 || ref.index >= l.count())
+                return ExecError;
+
+            ExecStatus ret = execute(&l[ref.index], refIndex + 1, func, data);
+            if (ret == ExecChanged)
+                *i = l;
+            return ret;
+        }
+    }
+
+    // Ensure ref is correct type
+    const Ref &ref = refs_[refIndex];
+    if (ref.type == Ref::Object &&
+        (typeId(*i) != VariantType::Hash && typeId(*i) != VariantType::Map))
+        return ExecError;
+    else if (ref.type == Ref::Array && typeId(*i) != VariantType::List)
+        return ExecError;
+
+    if (func(i, refs_[refIndex], data))
+        return ExecChanged;
+    else
+        return ExecContinue;
 }
 
-JsonPointer::ExecStatus JsonPointer::execute(const Variant *i, int refIndex, ConstFunc func, void *data) const
-{
-	// If there are more refs after current ref, step into current
-	if(refIndex + 1 < refs_.count())
-	{
-		const Ref &ref = refs_[refIndex];
-
-		assert(ref.type != Ref::Self);
-
-		if(ref.type == Ref::Object)
-		{
-			if(typeId(*i) == VariantType::Hash)
-			{
-				VariantHash h = i->toHash();
-				if(!h.contains(ref.name))
-					return ExecError;
-
-				return execute(&h[ref.name], refIndex + 1, func, data);
-			}
-			else // Map
-			{
-				VariantMap m = i->toMap();
-				if(!m.contains(ref.name))
-					return ExecError;
-
-				return execute(&m[ref.name], refIndex + 1, func, data);
-			}
-		}
-		else // Array
-		{
-			VariantList l = i->toList();
-			if(ref.index < 0 || ref.index >= l.count())
-				return ExecError;
-
-			return execute(&l[ref.index], refIndex + 1, func, data);
-		}
-	}
-
-	// Ensure ref is correct type
-	const Ref &ref = refs_[refIndex];
-	if(ref.type == Ref::Object && (typeId(*i) != VariantType::Hash && typeId(*i) != VariantType::Map))
-		return ExecError;
-	else if(ref.type == Ref::Array && typeId(*i) != VariantType::List)
-		return ExecError;
-
-	func(i, refs_[refIndex], data);
-	return ExecContinue;
+bool JsonPointer::execute(ConstFunc func, void *data) const {
+    if (!refs_.isEmpty()) {
+        return (execute(root_, 0, func, data) != ExecError);
+    } else {
+        func(root_, Ref(), data);
+        return true;
+    }
 }
 
-JsonPointer::ExecStatus JsonPointer::execute(Variant *i, int refIndex, Func func, void *data)
-{
-	// If there are more refs after current ref, step into current
-	if(refIndex + 1 < refs_.count())
-	{
-		const Ref &ref = refs_[refIndex];
-		if(ref.type == Ref::Object)
-		{
-			if(typeId(*i) == VariantType::Hash)
-			{
-				VariantHash h = i->toHash();
-				if(!h.contains(ref.name))
-					return ExecError;
-
-				ExecStatus ret = execute(&h[ref.name], refIndex + 1, func, data);
-				if(ret == ExecChanged)
-					*i = h;
-				return ret;
-			}
-			else // Map
-			{
-				VariantMap m = i->toMap();
-				if(!m.contains(ref.name))
-					return ExecError;
-
-				ExecStatus ret = execute(&m[ref.name], refIndex + 1, func, data);
-				if(ret == ExecChanged)
-					*i = m;
-				return ret;
-			}
-		}
-		else if(ref.type == Ref::Array)
-		{
-			VariantList l = i->toList();
-			if(ref.index < 0 || ref.index >= l.count())
-				return ExecError;
-
-			ExecStatus ret = execute(&l[ref.index], refIndex + 1, func, data);
-			if(ret == ExecChanged)
-				*i = l;
-			return ret;
-		}
-	}
-
-	// Ensure ref is correct type
-	const Ref &ref = refs_[refIndex];
-	if(ref.type == Ref::Object && (typeId(*i) != VariantType::Hash && typeId(*i) != VariantType::Map))
-		return ExecError;
-	else if(ref.type == Ref::Array && typeId(*i) != VariantType::List)
-		return ExecError;
-
-	if(func(i, refs_[refIndex], data))
-		return ExecChanged;
-	else
-		return ExecContinue;
+bool JsonPointer::execute(Func func, void *data) {
+    if (!refs_.isEmpty()) {
+        return (execute(root_, 0, func, data) != ExecError);
+    } else {
+        func(root_, Ref(), data);
+        return true;
+    }
 }
 
-bool JsonPointer::execute(ConstFunc func, void *data) const
-{
-	if(!refs_.isEmpty())
-	{
-		return (execute(root_, 0, func, data) != ExecError);
-	}
-	else
-	{
-		func(root_, Ref(), data);
-		return true;
-	}
+static void existsFunc(const Variant *v, const JsonPointer::Ref &ref, void *data) {
+    Variant &ret = *((Variant *)data);
+
+    if (ref.type == JsonPointer::Ref::Self) {
+        ret = true;
+    } else if (ref.type == JsonPointer::Ref::Object) {
+        if (typeId(*v) == VariantType::Hash)
+            ret = v->toHash().contains(ref.name);
+        else // Map
+            ret = v->toMap().contains(ref.name);
+    } else // Array
+    {
+        VariantList l = v->toList();
+        ret = (ref.index >= 0 && ref.index < l.count());
+    }
 }
 
-bool JsonPointer::execute(Func func, void *data)
-{
-	if(!refs_.isEmpty())
-	{
-		return (execute(root_, 0, func, data) != ExecError);
-	}
-	else
-	{
-		func(root_, Ref(), data);
-		return true;
-	}
+bool JsonPointer::exists() const {
+    Variant ret;
+    if (execute(existsFunc, &ret))
+        return ret.toBool();
+    else
+        return false;
 }
 
-static void existsFunc(const Variant *v, const JsonPointer::Ref &ref, void *data)
-{
-	Variant &ret = *((Variant *)data);
+static void valueFunc(const Variant *v, const JsonPointer::Ref &ref, void *data) {
+    Variant &ret = *((Variant *)data);
 
-	if(ref.type == JsonPointer::Ref::Self)
-	{
-		ret = true;
-	}
-	else if(ref.type == JsonPointer::Ref::Object)
-	{
-		if(typeId(*v) == VariantType::Hash)
-			ret = v->toHash().contains(ref.name);
-		else // Map
-			ret = v->toMap().contains(ref.name);
-	}
-	else // Array
-	{
-		VariantList l = v->toList();
-		ret = (ref.index >= 0 && ref.index < l.count());
-	}
+    if (ref.type == JsonPointer::Ref::Self) {
+        ret = *v;
+    } else if (ref.type == JsonPointer::Ref::Object) {
+        if (typeId(*v) == VariantType::Hash)
+            ret = v->toHash().value(ref.name);
+        else // Map
+            ret = v->toMap().value(ref.name);
+    } else // Array
+    {
+        VariantList l = v->toList();
+        if (ref.index >= 0 && ref.index < l.count())
+            ret = l[ref.index];
+    }
 }
 
-bool JsonPointer::exists() const
-{
-	Variant ret;
-	if(execute(existsFunc, &ret))
-		return ret.toBool();
-	else
-		return false;
+Variant JsonPointer::value() const {
+    Variant ret;
+    if (execute(valueFunc, &ret))
+        return ret;
+    else
+        return Variant();
 }
 
-static void valueFunc(const Variant *v, const JsonPointer::Ref &ref, void *data)
-{
-	Variant &ret = *((Variant *)data);
+static bool removeFunc(Variant *v, const JsonPointer::Ref &ref, void *data) {
+    Variant &ret = *((Variant *)data);
 
-	if(ref.type == JsonPointer::Ref::Self)
-	{
-		ret = *v;
-	}
-	else if(ref.type == JsonPointer::Ref::Object)
-	{
-		if(typeId(*v) == VariantType::Hash)
-			ret = v->toHash().value(ref.name);
-		else // Map
-			ret = v->toMap().value(ref.name);
-	}
-	else // Array
-	{
-		VariantList l = v->toList();
-		if(ref.index >= 0 && ref.index < l.count())
-			ret = l[ref.index];
-	}
+    if (ref.type == JsonPointer::Ref::Self) {
+        ret = false;
+        return false; // Technically an error, since we can't remove the root
+    } else if (ref.type == JsonPointer::Ref::Object) {
+        if (typeId(*v) == VariantType::Hash) {
+            VariantHash h = v->toHash();
+            if (h.contains(ref.name)) {
+                ret = true;
+                h.remove(ref.name);
+                *v = h;
+                return true;
+            } else
+                return false;
+        } else // Map
+        {
+            VariantMap m = v->toMap();
+            if (m.contains(ref.name)) {
+                ret = true;
+                m.remove(ref.name);
+                *v = m;
+                return true;
+            } else
+                return false;
+        }
+    } else // Array
+    {
+        VariantList l = v->toList();
+        if (ref.index >= 0 && ref.index < l.count()) {
+            ret = true;
+            l.removeAt(ref.index);
+            *v = l;
+            return true;
+        } else
+            return false;
+    }
 }
 
-Variant JsonPointer::value() const
-{
-	Variant ret;
-	if(execute(valueFunc, &ret))
-		return ret;
-	else
-		return Variant();
+bool JsonPointer::remove() {
+    Variant ret;
+    if (execute(removeFunc, &ret))
+        return ret.toBool();
+    else
+        return false;
 }
 
-static bool removeFunc(Variant *v, const JsonPointer::Ref &ref, void *data)
-{
-	Variant &ret = *((Variant *)data);
+static bool takeFunc(Variant *v, const JsonPointer::Ref &ref, void *data) {
+    Variant &ret = *((Variant *)data);
 
-	if(ref.type == JsonPointer::Ref::Self)
-	{
-		ret = false;
-		return false; // Technically an error, since we can't remove the root
-	}
-	else if(ref.type == JsonPointer::Ref::Object)
-	{
-		if(typeId(*v) == VariantType::Hash)
-		{
-			VariantHash h = v->toHash();
-			if(h.contains(ref.name))
-			{
-				ret = true;
-				h.remove(ref.name);
-				*v = h;
-				return true;
-			}
-			else
-				return false;
-		}
-		else // Map
-		{
-			VariantMap m = v->toMap();
-			if(m.contains(ref.name))
-			{
-				ret = true;
-				m.remove(ref.name);
-				*v = m;
-				return true;
-			}
-			else
-				return false;
-		}
-	}
-	else // Array
-	{
-		VariantList l = v->toList();
-		if(ref.index >= 0 && ref.index < l.count())
-		{
-			ret = true;
-			l.removeAt(ref.index);
-			*v = l;
-			return true;
-		}
-		else
-			return false;
-	}
+    if (ref.type == JsonPointer::Ref::Self) {
+        ret = *v;
+        return false; // Technically an error, since we can't remove the root
+    } else if (ref.type == JsonPointer::Ref::Object) {
+        if (typeId(*v) == VariantType::Hash) {
+            VariantHash h = v->toHash();
+            if (h.contains(ref.name)) {
+                ret = h.value(ref.name);
+                h.remove(ref.name);
+                *v = h;
+                return true;
+            } else
+                return false;
+        } else // Map
+        {
+            VariantMap m = v->toMap();
+            if (m.contains(ref.name)) {
+                ret = m.value(ref.name);
+                m.remove(ref.name);
+                *v = m;
+                return true;
+            } else
+                return false;
+        }
+    } else // Array
+    {
+        VariantList l = v->toList();
+        if (ref.index >= 0 && ref.index < l.count()) {
+            ret = l[ref.index];
+            l.removeAt(ref.index);
+            *v = l;
+            return true;
+        } else
+            return false;
+    }
 }
 
-bool JsonPointer::remove()
-{
-	Variant ret;
-	if(execute(removeFunc, &ret))
-		return ret.toBool();
-	else
-		return false;
+Variant JsonPointer::take() {
+    Variant ret;
+    if (execute(takeFunc, &ret))
+        return ret;
+    else
+        return Variant();
 }
 
-static bool takeFunc(Variant *v, const JsonPointer::Ref &ref, void *data)
-{
-	Variant &ret = *((Variant *)data);
+static bool setValueFunc(Variant *v, const JsonPointer::Ref &ref, void *_data) {
+    QPair<Variant, Variant> &data = *((QPair<Variant, Variant> *)_data);
 
-	if(ref.type == JsonPointer::Ref::Self)
-	{
-		ret = *v;
-		return false; // Technically an error, since we can't remove the root
-	}
-	else if(ref.type == JsonPointer::Ref::Object)
-	{
-		if(typeId(*v) == VariantType::Hash)
-		{
-			VariantHash h = v->toHash();
-			if(h.contains(ref.name))
-			{
-				ret = h.value(ref.name);
-				h.remove(ref.name);
-				*v = h;
-				return true;
-			}
-			else
-				return false;
-		}
-		else // Map
-		{
-			VariantMap m = v->toMap();
-			if(m.contains(ref.name))
-			{
-				ret = m.value(ref.name);
-				m.remove(ref.name);
-				*v = m;
-				return true;
-			}
-			else
-				return false;
-		}
-	}
-	else // Array
-	{
-		VariantList l = v->toList();
-		if(ref.index >= 0 && ref.index < l.count())
-		{
-			ret = l[ref.index];
-			l.removeAt(ref.index);
-			*v = l;
-			return true;
-		}
-		else
-			return false;
-	}
+    if (ref.type == JsonPointer::Ref::Self) {
+        *v = data.first;
+        data.second = true;
+        return true;
+    } else if (ref.type == JsonPointer::Ref::Object) {
+        if (typeId(*v) == VariantType::Hash) {
+            VariantHash h = v->toHash();
+            h[ref.name] = data.first;
+            *v = h;
+            data.second = true;
+            return true;
+        } else // Map
+        {
+            VariantMap m = v->toMap();
+            m[ref.name] = data.first;
+            *v = m;
+            data.second = true;
+            return true;
+        }
+    } else // Array
+    {
+        VariantList l = v->toList();
+        if (ref.index == -1) {
+            // Append
+            l += data.first;
+            *v = l;
+            data.second = true;
+            return true;
+        } else if (ref.index >= 0 && ref.index < l.count()) {
+            l[ref.index] = data.first;
+            *v = l;
+            data.second = true;
+            return true;
+        } else
+            return false;
+    }
 }
 
-Variant JsonPointer::take()
-{
-	Variant ret;
-	if(execute(takeFunc, &ret))
-		return ret;
-	else
-		return Variant();
+bool JsonPointer::setValue(const Variant &value) {
+    QPair<Variant, Variant> data;
+    data.first = value;
+    if (execute(setValueFunc, &data))
+        return data.second.toBool();
+    else
+        return false;
 }
 
-static bool setValueFunc(Variant *v, const JsonPointer::Ref &ref, void *_data)
-{
-	QPair<Variant, Variant> &data = *((QPair<Variant, Variant> *)_data);
+bool JsonPointer::isWithin(const QString &bPointerStr, const QString &aPointerStr) {
+    if (!aPointerStr.startsWith('/') || !bPointerStr.startsWith('/') || aPointerStr == bPointerStr)
+        return false;
 
-	if(ref.type == JsonPointer::Ref::Self)
-	{
-		*v = data.first;
-		data.second = true;
-		return true;
-	}
-	else if(ref.type == JsonPointer::Ref::Object)
-	{
-		if(typeId(*v) == VariantType::Hash)
-		{
-			VariantHash h = v->toHash();
-			h[ref.name] = data.first;
-			*v = h;
-			data.second = true;
-			return true;
-		}
-		else // Map
-		{
-			VariantMap m = v->toMap();
-			m[ref.name] = data.first;
-			*v = m;
-			data.second = true;
-			return true;
-		}
-	}
-	else // Array
-	{
-		VariantList l = v->toList();
-		if(ref.index == -1)
-		{
-			// Append
-			l += data.first;
-			*v = l;
-			data.second = true;
-			return true;
-		}
-		else if(ref.index >= 0 && ref.index < l.count())
-		{
-			l[ref.index] = data.first;
-			*v = l;
-			data.second = true;
-			return true;
-		}
-		else
-			return false;
-	}
+    QStringList aParts = aPointerStr.split('/').mid(1);
+    QStringList bParts = bPointerStr.split('/').mid(1);
+
+    if (aParts.count() >= bParts.count())
+        return false;
+
+    for (int n = 0; n < aParts.count(); ++n) {
+        if (aParts[n] != bParts[n])
+            return false;
+    }
+
+    return true;
 }
 
-bool JsonPointer::setValue(const Variant &value)
-{
-	QPair<Variant, Variant> data;
-	data.first = value;
-	if(execute(setValueFunc, &data))
-		return data.second.toBool();
-	else
-		return false;
-}
+JsonPointer JsonPointer::resolve(Variant *data, const QString &pointerStr, QString *errorMessage) {
+    if (!pointerStr.startsWith('/')) {
+        if (errorMessage)
+            *errorMessage = "pointer must start with /";
+        return JsonPointer();
+    }
 
-bool JsonPointer::isWithin(const QString &bPointerStr, const QString &aPointerStr)
-{
-	if(!aPointerStr.startsWith('/') || !bPointerStr.startsWith('/') || aPointerStr == bPointerStr)
-		return false;
+    JsonPointer ptr;
+    ptr.isNull_ = false;
+    ptr.root_ = data;
 
-	QStringList aParts = aPointerStr.split('/').mid(1);
-	QStringList bParts = bPointerStr.split('/').mid(1);
+    // Root
+    if (pointerStr.length() == 1)
+        return ptr;
 
-	if(aParts.count() >= bParts.count())
-		return false;
+    Variant i = *ptr.root_;
+    QStringList parts = pointerStr.split('/').mid(1);
+    foreach (const QString &part, parts) {
+        if (part.isEmpty()) {
+            if (errorMessage)
+                *errorMessage = "reference cannot be empty";
+            return JsonPointer();
+        }
 
-	for(int n = 0; n < aParts.count(); ++n)
-	{
-		if(aParts[n] != bParts[n])
-			return false;
-	}
+        QString p = part;
+        p.replace("~1", "/");
+        p.replace("~0", "~");
 
-	return true;
-}
+        // Validate and step into previous reference, if any
+        if (!ptr.refs_.isEmpty()) {
+            const Ref &prevRef = ptr.refs_[ptr.refs_.count() - 1];
 
-JsonPointer JsonPointer::resolve(Variant *data, const QString &pointerStr, QString *errorMessage)
-{
-	if(!pointerStr.startsWith('/'))
-	{
-		if(errorMessage)
-			*errorMessage = "pointer must start with /";
-		return JsonPointer();
-	}
+            if (prevRef.type == Ref::Object) {
+                assert(typeId(i) == VariantType::Hash || typeId(i) == VariantType::Map);
 
-	JsonPointer ptr;
-	ptr.isNull_ = false;
-	ptr.root_ = data;
+                if (typeId(i) == VariantType::Hash) {
+                    VariantHash h = i.toHash();
+                    if (!h.contains(prevRef.name)) {
+                        if (errorMessage)
+                            *errorMessage = QString("cannot step into undefined reference: key=%1")
+                                                .arg(prevRef.name);
+                        return JsonPointer();
+                    }
 
-	// Root
-	if(pointerStr.length() == 1)
-		return ptr;
+                    i = h[prevRef.name];
+                } else // Map
+                {
+                    VariantMap m = i.toMap();
+                    if (!m.contains(prevRef.name)) {
+                        if (errorMessage)
+                            *errorMessage = QString("cannot step into undefined reference: key=%1")
+                                                .arg(prevRef.name);
+                        return JsonPointer();
+                    }
 
-	Variant i = *ptr.root_;
-	QStringList parts = pointerStr.split('/').mid(1);
-	foreach(const QString &part, parts)
-	{
-		if(part.isEmpty())
-		{
-			if(errorMessage)
-				*errorMessage = "reference cannot be empty";
-			return JsonPointer();
-		}
+                    i = m[prevRef.name];
+                }
+            } else // Array
+            {
+                VariantList l = i.toList();
+                if (prevRef.index < 0 || prevRef.index >= l.count()) {
+                    if (errorMessage)
+                        *errorMessage = QString("cannot step into undefined reference: index=%1")
+                                            .arg(prevRef.index);
+                    return JsonPointer();
+                }
 
-		QString p = part;
-		p.replace("~1", "/");
-		p.replace("~0", "~");
+                i = l[prevRef.index];
+            }
+        }
 
-		// Validate and step into previous reference, if any
-		if(!ptr.refs_.isEmpty())
-		{
-			const Ref &prevRef = ptr.refs_[ptr.refs_.count() - 1];
+        if (typeId(i) == VariantType::Hash || typeId(i) == VariantType::Map) {
+            ptr.refs_ += Ref(p);
+        } else if (typeId(i) == VariantType::List) {
+            VariantList l = i.toList();
+            if (p == "-") {
+                ptr.refs_ += Ref(-1);
+            } else {
+                bool ok;
+                int index = p.toInt(&ok);
+                if (!ok) {
+                    if (errorMessage)
+                        *errorMessage = "index must be an integer";
+                    return JsonPointer();
+                }
 
-			if(prevRef.type == Ref::Object)
-			{
-				assert(typeId(i) == VariantType::Hash || typeId(i) == VariantType::Map);
+                if (index < 0 || index >= l.count()) {
+                    if (errorMessage)
+                        *errorMessage = "index out of range";
+                    return JsonPointer();
+                }
 
-				if(typeId(i) == VariantType::Hash)
-				{
-					VariantHash h = i.toHash();
-					if(!h.contains(prevRef.name))
-					{
-						if(errorMessage)
-							*errorMessage = QString("cannot step into undefined reference: key=%1").arg(prevRef.name);
-						return JsonPointer();
-					}
+                ptr.refs_ += Ref(index);
+            }
+        } else {
+            if (errorMessage)
+                *errorMessage = "non-container value cannot have child reference";
+            return JsonPointer();
+        }
+    }
 
-					i = h[prevRef.name];
-				}
-				else // Map
-				{
-					VariantMap m = i.toMap();
-					if(!m.contains(prevRef.name))
-					{
-						if(errorMessage)
-							*errorMessage = QString("cannot step into undefined reference: key=%1").arg(prevRef.name);
-						return JsonPointer();
-					}
-
-					i = m[prevRef.name];
-				}
-			}
-			else // Array
-			{
-				VariantList l = i.toList();
-				if(prevRef.index < 0 || prevRef.index >= l.count())
-				{
-					if(errorMessage)
-						*errorMessage = QString("cannot step into undefined reference: index=%1").arg(prevRef.index);
-					return JsonPointer();
-				}
-
-				i = l[prevRef.index];
-			}
-		}
-
-		if(typeId(i) == VariantType::Hash || typeId(i) == VariantType::Map)
-		{
-			ptr.refs_ += Ref(p);
-		}
-		else if(typeId(i) == VariantType::List)
-		{
-			VariantList l = i.toList();
-			if(p == "-")
-			{
-				ptr.refs_ += Ref(-1);
-			}
-			else
-			{
-				bool ok;
-				int index = p.toInt(&ok);
-				if(!ok)
-				{
-					if(errorMessage)
-						*errorMessage = "index must be an integer";
-					return JsonPointer();
-				}
-
-				if(index < 0 || index >= l.count())
-				{
-					if(errorMessage)
-						*errorMessage = "index out of range";
-					return JsonPointer();
-				}
-
-				ptr.refs_ += Ref(index);
-			}
-		}
-		else
-		{
-			if(errorMessage)
-				*errorMessage = "non-container value cannot have child reference";
-			return JsonPointer();
-		}
-	}
-
-	return ptr;
+    return ptr;
 }

--- a/src/handler/jsonpointer.h
+++ b/src/handler/jsonpointer.h
@@ -23,82 +23,61 @@
 #ifndef JSONPOINTER_H
 #define JSONPOINTER_H
 
+#include "variant.h"
 #include <QString>
 #include <QVarLengthArray>
-#include "variant.h"
 
-class JsonPointer
-{
+class JsonPointer {
 public:
-	class Ref
-	{
-	public:
-		enum Type
-		{
-			Self, // Used for root
-			Object,
-			Array
-		};
+    class Ref {
+    public:
+        enum Type {
+            Self, // Used for root
+            Object,
+            Array
+        };
 
-		Type type;
-		QString name;
-		int index;
+        Type type;
+        QString name;
+        int index;
 
-		Ref() :
-			type(Self),
-			index(-1)
-		{
-		}
+        Ref() : type(Self), index(-1) {}
 
-		Ref(const QString &_name) :
-			type(Object),
-			name(_name),
-			index(-1)
-		{
-		}
+        Ref(const QString &_name) : type(Object), name(_name), index(-1) {}
 
-		Ref(int _index) :
-			type(Array),
-			index(_index)
-		{
-		}
-	};
+        Ref(int _index) : type(Array), index(_index) {}
+    };
 
-	typedef void (*ConstFunc)(const Variant *v, const Ref &ref, void *data);
+    typedef void (*ConstFunc)(const Variant *v, const Ref &ref, void *data);
 
-	// Return true if data was modified
-	typedef bool (*Func)(Variant *v, const Ref &ref, void *data);
+    // Return true if data was modified
+    typedef bool (*Func)(Variant *v, const Ref &ref, void *data);
 
-	JsonPointer();
+    JsonPointer();
 
-	inline bool isNull() const { return isNull_; }
+    inline bool isNull() const { return isNull_; }
 
-	Variant *root();
-	bool execute(ConstFunc func, void *data) const;
-	bool execute(Func func, void *data);
-	bool exists() const;
-	Variant value() const;
-	Variant take();
-	bool remove();
-	bool setValue(const Variant &value);
+    Variant *root();
+    bool execute(ConstFunc func, void *data) const;
+    bool execute(Func func, void *data);
+    bool exists() const;
+    Variant value() const;
+    Variant take();
+    bool remove();
+    bool setValue(const Variant &value);
 
-	static bool isWithin(const QString &bPointerStr, const QString &aPointerStr);
-	static JsonPointer resolve(Variant *data, const QString &pointerStr, QString *errorMessage = 0);
+    static bool isWithin(const QString &bPointerStr, const QString &aPointerStr);
+    static JsonPointer resolve(Variant *data, const QString &pointerStr, QString *errorMessage = 0);
 
 private:
-	enum ExecStatus
-	{
-		ExecError,
-		ExecContinue,
-		ExecChanged
-	};
+    enum ExecStatus { ExecError, ExecContinue, ExecChanged };
 
-	bool isNull_;
-	Variant *root_;
-	QVarLengthArray<Ref, 16> refs_;
+    bool isNull_;
+    Variant *root_;
+    QVarLengthArray<Ref, 16> refs_;
 
-	ExecStatus execute(const Variant *i, int refIndex, ConstFunc func, void *data) const;
-	ExecStatus execute(Variant *i, int refIndex, Func func, void *data);
+    ExecStatus execute(const Variant *i, int refIndex, ConstFunc func, void *data) const;
+    ExecStatus execute(Variant *i, int refIndex, Func func, void *data);
 };
 
 #endif

--- a/src/handler/lastids.h
+++ b/src/handler/lastids.h
@@ -24,8 +24,8 @@
 #define LASTIDS_H
 
 #include <QHash>
-#include <QString>
 #include <QMetaType>
+#include <QString>
 
 typedef QHash<QString, QString> LastIds;
 Q_DECLARE_METATYPE(LastIds);

--- a/src/handler/publishformat.cpp
+++ b/src/handler/publishformat.cpp
@@ -24,462 +24,404 @@
 #include "publishformat.h"
 
 #include "qtcompat.h"
+#include "statusreasons.h"
 #include "variant.h"
 #include "variantutil.h"
-#include "statusreasons.h"
 
 using namespace VariantUtil;
 
-PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok, QString *errorMessage)
-{
-	QString pn;
-	if(type == HttpResponse)
-		pn = "'http-response'";
-	else if(type == HttpStream)
-		pn = "'http-stream'";
-	else // WebSocketMessage
-		pn = "'ws-message'";
+PublishFormat PublishFormat::fromVariant(Type type, const Variant &in, bool *ok,
+                                         QString *errorMessage) {
+    QString pn;
+    if (type == HttpResponse)
+        pn = "'http-response'";
+    else if (type == HttpStream)
+        pn = "'http-stream'";
+    else // WebSocketMessage
+        pn = "'ws-message'";
 
-	if(!isKeyedObject(in))
-	{
-		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return PublishFormat();
-	}
+    if (!isKeyedObject(in)) {
+        setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
+        return PublishFormat();
+    }
 
-	PublishFormat out(type);
-	bool ok_;
+    PublishFormat out(type);
+    bool ok_;
 
-	QString action = getString(in, pn, "action", false, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return PublishFormat();
-	}
+    QString action = getString(in, pn, "action", false, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return PublishFormat();
+    }
 
-	if(action == "hint")
-	{
-		out.action = Hint;
-	}
-	else if(action == "close")
-	{
-		out.action = Close;
-	}
-	else if(action == "refresh")
-	{
-		out.action = Refresh;
-	}
-	else if(action.isNull() || action == "send") // Default
-	{
-		out.action = Send;
-	}
-	else
-	{
-		if(ok)
-			*ok = false;
-		return PublishFormat();
-	}
+    if (action == "hint") {
+        out.action = Hint;
+    } else if (action == "close") {
+        out.action = Close;
+    } else if (action == "refresh") {
+        out.action = Refresh;
+    } else if (action.isNull() || action == "send") // Default
+    {
+        out.action = Send;
+    } else {
+        if (ok)
+            *ok = false;
+        return PublishFormat();
+    }
 
-	if(type == HttpResponse)
-	{
-		if(out.action == Send)
-		{
-			if(keyedObjectContains(in, "code"))
-			{
-				Variant vcode = keyedObjectGetValue(in, "code");
-				if(!canConvert(vcode, VariantType::Int))
-				{
-					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
-					return PublishFormat();
-				}
+    if (type == HttpResponse) {
+        if (out.action == Send) {
+            if (keyedObjectContains(in, "code")) {
+                Variant vcode = keyedObjectGetValue(in, "code");
+                if (!canConvert(vcode, VariantType::Int)) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'code' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
 
-				out.code = vcode.toInt();
+                out.code = vcode.toInt();
 
-				if(out.code < 0 || out.code > 999)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'code' with invalid value").arg(pn));
-					return PublishFormat();
-				}
-			}
-			else
-				out.code = 200;
+                if (out.code < 0 || out.code > 999) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'code' with invalid value").arg(pn));
+                    return PublishFormat();
+                }
+            } else
+                out.code = 200;
 
-			QString reasonStr = getString(in, pn, "reason", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return PublishFormat();
-			}
+            QString reasonStr = getString(in, pn, "reason", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return PublishFormat();
+            }
 
-			if(!reasonStr.isEmpty())
-				out.reason = reasonStr.toUtf8();
-			else
-				out.reason = StatusReasons::getReason(out.code);
+            if (!reasonStr.isEmpty())
+                out.reason = reasonStr.toUtf8();
+            else
+                out.reason = StatusReasons::getReason(out.code);
 
-			if(keyedObjectContains(in, "headers"))
-			{
-				Variant vheaders = keyedObjectGetValue(in, "headers");
-				if(typeId(vheaders) == VariantType::List)
-				{
-					for(const Variant &vheader : vheaders.toList())
-					{
-						if(typeId(vheader) != VariantType::List)
-						{
-							setError(ok, errorMessage, "headers contains element with wrong type");
-							return PublishFormat();
-						}
+            if (keyedObjectContains(in, "headers")) {
+                Variant vheaders = keyedObjectGetValue(in, "headers");
+                if (typeId(vheaders) == VariantType::List) {
+                    for (const Variant &vheader : vheaders.toList()) {
+                        if (typeId(vheader) != VariantType::List) {
+                            setError(ok, errorMessage, "headers contains element with wrong type");
+                            return PublishFormat();
+                        }
 
-						VariantList lheader = vheader.toList();
-						if(lheader.count() != 2)
-						{
-							setError(ok, errorMessage, "headers contains list with wrong number of elements");
-							return PublishFormat();
-						}
+                        VariantList lheader = vheader.toList();
+                        if (lheader.count() != 2) {
+                            setError(ok, errorMessage,
+                                     "headers contains list with wrong number of elements");
+                            return PublishFormat();
+                        }
 
-						QString name = getString(lheader[0], &ok_);
-						if(!ok_)
-						{
-							setError(ok, errorMessage, "header contains name element with wrong type");
-							return PublishFormat();
-						}
+                        QString name = getString(lheader[0], &ok_);
+                        if (!ok_) {
+                            setError(ok, errorMessage,
+                                     "header contains name element with wrong type");
+                            return PublishFormat();
+                        }
 
-						QString val = getString(lheader[1], &ok_);
-						if(!ok_)
-						{
-							setError(ok, errorMessage, "header contains value element with wrong type");
-							return PublishFormat();
-						}
+                        QString val = getString(lheader[1], &ok_);
+                        if (!ok_) {
+                            setError(ok, errorMessage,
+                                     "header contains value element with wrong type");
+                            return PublishFormat();
+                        }
 
-						out.headers += HttpHeader(name.toUtf8(), val.toUtf8());
-					}
-				}
-				else if(isKeyedObject(vheaders))
-				{
-					if(typeId(vheaders) == VariantType::Hash)
-					{
-						VariantHash hheaders = vheaders.toHash();
+                        out.headers += HttpHeader(name.toUtf8(), val.toUtf8());
+                    }
+                } else if (isKeyedObject(vheaders)) {
+                    if (typeId(vheaders) == VariantType::Hash) {
+                        VariantHash hheaders = vheaders.toHash();
 
-						for(auto it = hheaders.constBegin(); it != hheaders.constEnd(); ++it)
-						{
-							const QString &key = it.key();
-							const Variant &vval = it.value();
+                        for (auto it = hheaders.constBegin(); it != hheaders.constEnd(); ++it) {
+                            const QString &key = it.key();
+                            const Variant &vval = it.value();
 
-							QString val = getString(vval, &ok_);
-							if(!ok_)
-							{
-								setError(ok, errorMessage, QString("headers contains '%1' with wrong type").arg(key));
-								return PublishFormat();
-							}
+                            QString val = getString(vval, &ok_);
+                            if (!ok_) {
+                                setError(ok, errorMessage,
+                                         QString("headers contains '%1' with wrong type").arg(key));
+                                return PublishFormat();
+                            }
 
-							out.headers += HttpHeader(key.toUtf8(), val.toUtf8());
-						}
-					}
-					else // Map
-					{
-						VariantMap mheaders = vheaders.toMap();
+                            out.headers += HttpHeader(key.toUtf8(), val.toUtf8());
+                        }
+                    } else // Map
+                    {
+                        VariantMap mheaders = vheaders.toMap();
 
-						for(auto it = mheaders.constBegin(); it != mheaders.constEnd(); ++it)
-						{
-							const QString &key = it.key();
-							const Variant &vval = it.value();
+                        for (auto it = mheaders.constBegin(); it != mheaders.constEnd(); ++it) {
+                            const QString &key = it.key();
+                            const Variant &vval = it.value();
 
-							QString val = getString(vval, &ok_);
-							if(!ok_)
-							{
-								setError(ok, errorMessage, QString("headers contains '%1' with wrong type").arg(key));
-								return PublishFormat();
-							}
+                            QString val = getString(vval, &ok_);
+                            if (!ok_) {
+                                setError(ok, errorMessage,
+                                         QString("headers contains '%1' with wrong type").arg(key));
+                                return PublishFormat();
+                            }
 
-							out.headers += HttpHeader(key.toUtf8(), val.toUtf8());
-						}
-					}
-				}
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'headers' with wrong type").arg(pn));
-					return PublishFormat();
-				}
-			}
+                            out.headers += HttpHeader(key.toUtf8(), val.toUtf8());
+                        }
+                    }
+                } else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'headers' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
+            }
 
-			if(keyedObjectContains(in, "content-filters"))
-			{
-				Variant vfilters = keyedObjectGetValue(in, "content-filters");
-				if(typeId(vfilters) != VariantType::List)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
-					return PublishFormat();
-				}
+            if (keyedObjectContains(in, "content-filters")) {
+                Variant vfilters = keyedObjectGetValue(in, "content-filters");
+                if (typeId(vfilters) != VariantType::List) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content-filters' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
 
-				QStringList filters;
-				for(const Variant &vfilter : vfilters.toList())
-				{
-					QString filter = getString(vfilter, &ok_);
-					if(!ok_)
-					{
-						setError(ok, errorMessage, "content-filters contains element with wrong type");
-						return PublishFormat();
-					}
+                QStringList filters;
+                for (const Variant &vfilter : vfilters.toList()) {
+                    QString filter = getString(vfilter, &ok_);
+                    if (!ok_) {
+                        setError(ok, errorMessage,
+                                 "content-filters contains element with wrong type");
+                        return PublishFormat();
+                    }
 
-					filters += filter;
-				}
+                    filters += filter;
+                }
 
-				out.haveContentFilters = true;
-				out.contentFilters = filters;
-			}
+                out.haveContentFilters = true;
+                out.contentFilters = filters;
+            }
 
-			if(typeId(in) == VariantType::Map && keyedObjectContains(in, "body-bin")) // JSON input
-			{
-				QString bodyBin = getString(in, pn, "body-bin", false, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return PublishFormat();
-				}
+            if (typeId(in) == VariantType::Map && keyedObjectContains(in, "body-bin")) // JSON input
+            {
+                QString bodyBin = getString(in, pn, "body-bin", false, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return PublishFormat();
+                }
 
-				out.body = QByteArray::fromBase64(bodyBin.toUtf8());
-			}
-			else if(keyedObjectContains(in, "body"))
-			{
-				Variant vcontent = keyedObjectGetValue(in, "body");
-				if(typeId(vcontent) == VariantType::ByteArray)
-					out.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == VariantType::String)
-					out.body = vcontent.toString().toUtf8();
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'body' with wrong type").arg(pn));
-					return PublishFormat();
-				}
-			}
-			else if(keyedObjectContains(in, "body-patch"))
-			{
-				out.bodyPatch = getList(in, pn, "body-patch", false, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return PublishFormat();
-				}
+                out.body = QByteArray::fromBase64(bodyBin.toUtf8());
+            } else if (keyedObjectContains(in, "body")) {
+                Variant vcontent = keyedObjectGetValue(in, "body");
+                if (typeId(vcontent) == VariantType::ByteArray)
+                    out.body = vcontent.toByteArray();
+                else if (typeId(vcontent) == VariantType::String)
+                    out.body = vcontent.toString().toUtf8();
+                else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'body' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
+            } else if (keyedObjectContains(in, "body-patch")) {
+                out.bodyPatch = getList(in, pn, "body-patch", false, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return PublishFormat();
+                }
 
-				out.haveBodyPatch = true;
-			}
-			else
-			{
-				if(typeId(in) == VariantType::Map) // JSON input
-					setError(ok, errorMessage, QString("%1 does not contain 'body', 'body-bin', or 'body-patch'").arg(pn));
-				else
-					setError(ok, errorMessage, QString("%1 does not contain 'body' or 'body-patch'").arg(pn));
-				return PublishFormat();
-			}
-		}
-	}
-	else if(type == HttpStream)
-	{
-		if(out.action == Send)
-		{
-			if(keyedObjectContains(in, "content-filters"))
-			{
-				Variant vfilters = keyedObjectGetValue(in, "content-filters");
-				if(typeId(vfilters) != VariantType::List)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
-					return PublishFormat();
-				}
+                out.haveBodyPatch = true;
+            } else {
+                if (typeId(in) == VariantType::Map) // JSON input
+                    setError(
+                        ok, errorMessage,
+                        QString("%1 does not contain 'body', 'body-bin', or 'body-patch'").arg(pn));
+                else
+                    setError(ok, errorMessage,
+                             QString("%1 does not contain 'body' or 'body-patch'").arg(pn));
+                return PublishFormat();
+            }
+        }
+    } else if (type == HttpStream) {
+        if (out.action == Send) {
+            if (keyedObjectContains(in, "content-filters")) {
+                Variant vfilters = keyedObjectGetValue(in, "content-filters");
+                if (typeId(vfilters) != VariantType::List) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content-filters' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
 
-				QStringList filters;
-				for(const Variant &vfilter : vfilters.toList())
-				{
-					QString filter = getString(vfilter, &ok_);
-					if(!ok_)
-					{
-						setError(ok, errorMessage, "content-filters contains element with wrong type");
-						return PublishFormat();
-					}
+                QStringList filters;
+                for (const Variant &vfilter : vfilters.toList()) {
+                    QString filter = getString(vfilter, &ok_);
+                    if (!ok_) {
+                        setError(ok, errorMessage,
+                                 "content-filters contains element with wrong type");
+                        return PublishFormat();
+                    }
 
-					filters += filter;
-				}
+                    filters += filter;
+                }
 
-				out.haveContentFilters = true;
-				out.contentFilters = filters;
-			}
+                out.haveContentFilters = true;
+                out.contentFilters = filters;
+            }
 
-			if(typeId(in) == VariantType::Map && keyedObjectContains(in, "content-bin")) // JSON input
-			{
-				QString contentBin = getString(in, pn, "content-bin", false, &ok_, errorMessage);
-				if(!ok_)
-				{
-					if(ok)
-						*ok = false;
-					return PublishFormat();
-				}
+            if (typeId(in) == VariantType::Map &&
+                keyedObjectContains(in, "content-bin")) // JSON input
+            {
+                QString contentBin = getString(in, pn, "content-bin", false, &ok_, errorMessage);
+                if (!ok_) {
+                    if (ok)
+                        *ok = false;
+                    return PublishFormat();
+                }
 
-				out.body = QByteArray::fromBase64(contentBin.toUtf8());
-			}
-			else if(keyedObjectContains(in, "content"))
-			{
-				Variant vcontent = keyedObjectGetValue(in, "content");
-				if(typeId(vcontent) == VariantType::ByteArray)
-					out.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == VariantType::String)
-					out.body = vcontent.toString().toUtf8();
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content' with wrong type").arg(pn));
-					return PublishFormat();
-				}
-			}
-			else
-			{
-				if(typeId(in) == VariantType::Map) // JSON input
-					setError(ok, errorMessage, QString("%1 does not contain 'content' or 'content-bin'").arg(pn));
-				else
-					setError(ok, errorMessage, QString("%1 does not contain 'content'").arg(pn));
-				return PublishFormat();
-			}
-		}
-	}
-	else if(type == WebSocketMessage)
-	{
-		if(out.action == Send)
-		{
-			QString typeStr = getString(in, pn, "type", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return PublishFormat();
-			}
+                out.body = QByteArray::fromBase64(contentBin.toUtf8());
+            } else if (keyedObjectContains(in, "content")) {
+                Variant vcontent = keyedObjectGetValue(in, "content");
+                if (typeId(vcontent) == VariantType::ByteArray)
+                    out.body = vcontent.toByteArray();
+                else if (typeId(vcontent) == VariantType::String)
+                    out.body = vcontent.toString().toUtf8();
+                else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
+            } else {
+                if (typeId(in) == VariantType::Map) // JSON input
+                    setError(ok, errorMessage,
+                             QString("%1 does not contain 'content' or 'content-bin'").arg(pn));
+                else
+                    setError(ok, errorMessage, QString("%1 does not contain 'content'").arg(pn));
+                return PublishFormat();
+            }
+        }
+    } else if (type == WebSocketMessage) {
+        if (out.action == Send) {
+            QString typeStr = getString(in, pn, "type", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return PublishFormat();
+            }
 
-			if(!typeStr.isNull())
-			{
-				if(typeStr == "text")
-					out.messageType = Text;
-				else if(typeStr == "binary")
-					out.messageType = Binary;
-				else if(typeStr == "ping")
-					out.messageType = Ping;
-				else if(typeStr == "pong")
-					out.messageType = Pong;
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'type' with unknown value").arg(pn));
-					return PublishFormat();
-				}
-			}
+            if (!typeStr.isNull()) {
+                if (typeStr == "text")
+                    out.messageType = Text;
+                else if (typeStr == "binary")
+                    out.messageType = Binary;
+                else if (typeStr == "ping")
+                    out.messageType = Ping;
+                else if (typeStr == "pong")
+                    out.messageType = Pong;
+                else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'type' with unknown value").arg(pn));
+                    return PublishFormat();
+                }
+            }
 
-			if(keyedObjectContains(in, "content-filters"))
-			{
-				Variant vfilters = keyedObjectGetValue(in, "content-filters");
-				if(typeId(vfilters) != VariantType::List)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content-filters' with wrong type").arg(pn));
-					return PublishFormat();
-				}
+            if (keyedObjectContains(in, "content-filters")) {
+                Variant vfilters = keyedObjectGetValue(in, "content-filters");
+                if (typeId(vfilters) != VariantType::List) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content-filters' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
 
-				QStringList filters;
-				for(const Variant &vfilter : vfilters.toList())
-				{
-					QString filter = getString(vfilter, &ok_);
-					if(!ok_)
-					{
-						setError(ok, errorMessage, "content-filters contains element with wrong type");
-						return PublishFormat();
-					}
+                QStringList filters;
+                for (const Variant &vfilter : vfilters.toList()) {
+                    QString filter = getString(vfilter, &ok_);
+                    if (!ok_) {
+                        setError(ok, errorMessage,
+                                 "content-filters contains element with wrong type");
+                        return PublishFormat();
+                    }
 
-					filters += filter;
-				}
+                    filters += filter;
+                }
 
-				out.haveContentFilters = true;
-				out.contentFilters = filters;
-			}
+                out.haveContentFilters = true;
+                out.contentFilters = filters;
+            }
 
-			if(keyedObjectContains(in, "content-bin"))
-			{
-				Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
+            if (keyedObjectContains(in, "content-bin")) {
+                Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
 
-				if(typeId(in) == VariantType::Map) // JSON input
-				{
-					if(typeId(vcontentBin) != VariantType::String)
-					{
-						setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
-						return PublishFormat();
-					}
+                if (typeId(in) == VariantType::Map) // JSON input
+                {
+                    if (typeId(vcontentBin) != VariantType::String) {
+                        setError(ok, errorMessage,
+                                 QString("%1 contains 'content-bin' with wrong type").arg(pn));
+                        return PublishFormat();
+                    }
 
-					out.body = QByteArray::fromBase64(vcontentBin.toString().toUtf8());
-				}
-				else
-				{
-					if(typeId(vcontentBin) != VariantType::ByteArray)
-					{
-						setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
-						return PublishFormat();
-					}
+                    out.body = QByteArray::fromBase64(vcontentBin.toString().toUtf8());
+                } else {
+                    if (typeId(vcontentBin) != VariantType::ByteArray) {
+                        setError(ok, errorMessage,
+                                 QString("%1 contains 'content-bin' with wrong type").arg(pn));
+                        return PublishFormat();
+                    }
 
-					out.body = vcontentBin.toByteArray();
-				}
+                    out.body = vcontentBin.toByteArray();
+                }
 
-				if(((int)out.messageType) == -1)
-					out.messageType = Binary;
-			}
-			else if(keyedObjectContains(in, "content"))
-			{
-				Variant vcontent = keyedObjectGetValue(in, "content");
-				if(typeId(vcontent) == VariantType::ByteArray)
-					out.body = vcontent.toByteArray();
-				else if(typeId(vcontent) == VariantType::String)
-					out.body = vcontent.toString().toUtf8();
-				else
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content' with wrong type").arg(pn));
-					return PublishFormat();
-				}
+                if (((int)out.messageType) == -1)
+                    out.messageType = Binary;
+            } else if (keyedObjectContains(in, "content")) {
+                Variant vcontent = keyedObjectGetValue(in, "content");
+                if (typeId(vcontent) == VariantType::ByteArray)
+                    out.body = vcontent.toByteArray();
+                else if (typeId(vcontent) == VariantType::String)
+                    out.body = vcontent.toString().toUtf8();
+                else {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
 
-				if(((int)out.messageType) == -1)
-					out.messageType = Text;
-			}
-			else if(out.messageType == Text || out.messageType == Binary || ((int)out.messageType) == -1)
-			{
-				setError(ok, errorMessage, QString("%1 does not contain 'content' or 'content-bin'").arg(pn));
-				return PublishFormat();
-			}
-		}
-		else if(out.action == Close)
-		{
-			if(keyedObjectContains(in, "code"))
-			{
-				Variant vcode = keyedObjectGetValue(in, "code");
-				if(!canConvert(vcode, VariantType::Int))
-				{
-					setError(ok, errorMessage, QString("%1 contains 'code' with wrong type").arg(pn));
-					return PublishFormat();
-				}
+                if (((int)out.messageType) == -1)
+                    out.messageType = Text;
+            } else if (out.messageType == Text || out.messageType == Binary ||
+                       ((int)out.messageType) == -1) {
+                setError(ok, errorMessage,
+                         QString("%1 does not contain 'content' or 'content-bin'").arg(pn));
+                return PublishFormat();
+            }
+        } else if (out.action == Close) {
+            if (keyedObjectContains(in, "code")) {
+                Variant vcode = keyedObjectGetValue(in, "code");
+                if (!canConvert(vcode, VariantType::Int)) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'code' with wrong type").arg(pn));
+                    return PublishFormat();
+                }
 
-				out.code = vcode.toInt();
+                out.code = vcode.toInt();
 
-				if(out.code < 0)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'code' with invalid value").arg(pn));
-					return PublishFormat();
-				}
-			}
+                if (out.code < 0) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'code' with invalid value").arg(pn));
+                    return PublishFormat();
+                }
+            }
 
-			QString reasonStr = getString(in, pn, "reason", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return PublishFormat();
-			}
+            QString reasonStr = getString(in, pn, "reason", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return PublishFormat();
+            }
 
-			if(!reasonStr.isEmpty())
-				out.reason = reasonStr.toUtf8();
-		}
+            if (!reasonStr.isEmpty())
+                out.reason = reasonStr.toUtf8();
+        }
+    }
 
-	}
-
-	if(ok)
-		*ok = true;
-	return out;
+    if (ok)
+        *ok = true;
+    return out;
 }

--- a/src/handler/publishformat.h
+++ b/src/handler/publishformat.h
@@ -23,70 +23,49 @@
 #ifndef PUBLISHFORMAT_H
 #define PUBLISHFORMAT_H
 
+#include "httpheaders.h"
+#include "variant.h"
 #include <QByteArray>
 #include <QString>
-#include "variant.h"
-#include "httpheaders.h"
 
-class PublishFormat
-{
+class PublishFormat {
 public:
-	enum Type
-	{
-		HttpResponse,
-		HttpStream,
-		WebSocketMessage
-	};
+    enum Type { HttpResponse, HttpStream, WebSocketMessage };
 
-	enum Action
-	{
-		Send,
-		Hint,
-		Refresh,
-		Close
-	};
+    enum Action { Send, Hint, Refresh, Close };
 
-	enum MessageType
-	{
-		Text,
-		Binary,
-		Ping,
-		Pong
-	};
+    enum MessageType { Text, Binary, Ping, Pong };
 
-	Type type;
-	Action action; // Response/stream/ws
-	int code; // Response/ws
-	QByteArray reason; // Response/ws
-	HttpHeaders headers; // Response
-	QByteArray body; // Response/stream/ws
-	bool haveBodyPatch; // Response
-	VariantList bodyPatch; // Response
-	MessageType messageType; // Ws
-	bool haveContentFilters;
-	QStringList contentFilters; // Response/stream/ws
+    Type type;
+    Action action;           // Response/stream/ws
+    int code;                // Response/ws
+    QByteArray reason;       // Response/ws
+    HttpHeaders headers;     // Response
+    QByteArray body;         // Response/stream/ws
+    bool haveBodyPatch;      // Response
+    VariantList bodyPatch;   // Response
+    MessageType messageType; // Ws
+    bool haveContentFilters;
+    QStringList contentFilters; // Response/stream/ws
 
-	PublishFormat() :
-		type((Type)-1),
-		action(Send),
-		code(-1),
-		haveBodyPatch(false),
-		messageType((MessageType)-1),
-		haveContentFilters(false)
-	{
-	}
+    PublishFormat()
+        : type((Type)-1),
+          action(Send),
+          code(-1),
+          haveBodyPatch(false),
+          messageType((MessageType)-1),
+          haveContentFilters(false) {}
 
-	PublishFormat(Type _type) :
-		type(_type),
-		action(Send),
-		code(-1),
-		haveBodyPatch(false),
-		messageType((MessageType)-1),
-		haveContentFilters(false)
-	{
-	}
+    PublishFormat(Type _type)
+        : type(_type),
+          action(Send),
+          code(-1),
+          haveBodyPatch(false),
+          messageType((MessageType)-1),
+          haveContentFilters(false) {}
 
-	static PublishFormat fromVariant(Type type, const Variant &in, bool *ok = 0, QString *errorMessage = 0);
+    static PublishFormat fromVariant(Type type, const Variant &in, bool *ok = 0,
+                                     QString *errorMessage = 0);
 };
 
 #endif

--- a/src/handler/publishformattest.cpp
+++ b/src/handler/publishformattest.cpp
@@ -21,113 +21,110 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "publishformat.h"
 #include "test.h"
 #include "variant.h"
-#include "publishformat.h"
 
-static void responseFormat()
-{
-	VariantHash data;
-	data["code"] = 200;
-	data["reason"] = QByteArray("OK");
-	data["headers"] = VariantList() << Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
-	data["body"] = QByteArray("hello world");
+static void responseFormat() {
+    VariantHash data;
+    data["code"] = 200;
+    data["reason"] = QByteArray("OK");
+    data["headers"] = VariantList() << Variant(VariantList() << QByteArray("Content-Type")
+                                                             << QByteArray("text/plain"));
+    data["body"] = QByteArray("hello world");
 
-	bool ok;
-	PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpResponse, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(f.code, 200);
-	TEST_ASSERT_EQ(f.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(f.headers.count(), 1);
-	TEST_ASSERT_EQ(f.headers[0].first, CowByteArray("Content-Type"));
-	TEST_ASSERT_EQ(f.headers[0].second, CowByteArray("text/plain"));
-	TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
+    bool ok;
+    PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpResponse, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(f.code, 200);
+    TEST_ASSERT_EQ(f.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(f.headers.count(), 1);
+    TEST_ASSERT_EQ(f.headers[0].first, CowByteArray("Content-Type"));
+    TEST_ASSERT_EQ(f.headers[0].second, CowByteArray("text/plain"));
+    TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
 
-	data.clear();
-	data["body"] = QByteArray("other fields implied");
+    data.clear();
+    data["body"] = QByteArray("other fields implied");
 
-	f = PublishFormat::fromVariant(PublishFormat::HttpResponse, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(f.code, 200);
-	TEST_ASSERT_EQ(f.reason, QByteArray("OK"));
-	TEST_ASSERT_EQ(f.headers.count(), 0);
-	TEST_ASSERT_EQ(f.body, QByteArray("other fields implied"));
+    f = PublishFormat::fromVariant(PublishFormat::HttpResponse, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(f.code, 200);
+    TEST_ASSERT_EQ(f.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(f.headers.count(), 0);
+    TEST_ASSERT_EQ(f.body, QByteArray("other fields implied"));
 }
 
-static void streamFormat()
-{
-	VariantHash data;
-	data["content"] = QByteArray("hello world");
+static void streamFormat() {
+    VariantHash data;
+    data["content"] = QByteArray("hello world");
 
-	bool ok;
-	PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpStream, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Send);
-	TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
+    bool ok;
+    PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpStream, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Send);
+    TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
 
-	data.clear();
-	data["action"] = QByteArray("close");
+    data.clear();
+    data["action"] = QByteArray("close");
 
-	f = PublishFormat::fromVariant(PublishFormat::HttpStream, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Close);
-	TEST_ASSERT(f.body.isEmpty());
+    f = PublishFormat::fromVariant(PublishFormat::HttpStream, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Close);
+    TEST_ASSERT(f.body.isEmpty());
 }
 
-static void webSocketMessageFormat()
-{
-	VariantHash data;
-	data["content"] = QByteArray("hello world");
+static void webSocketMessageFormat() {
+    VariantHash data;
+    data["content"] = QByteArray("hello world");
 
-	bool ok;
-	PublishFormat f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Send);
-	TEST_ASSERT_EQ(f.messageType, PublishFormat::Text);
-	TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
+    bool ok;
+    PublishFormat f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Send);
+    TEST_ASSERT_EQ(f.messageType, PublishFormat::Text);
+    TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
 
-	data.clear();
-	data["type"] = "binary";
-	data["content"] = QByteArray("hello world");
+    data.clear();
+    data["type"] = "binary";
+    data["content"] = QByteArray("hello world");
 
-	f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Send);
-	TEST_ASSERT_EQ(f.messageType, PublishFormat::Binary);
-	TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
+    f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Send);
+    TEST_ASSERT_EQ(f.messageType, PublishFormat::Binary);
+    TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
 
-	data.clear();
-	data["content-bin"] = QByteArray("hello world");
+    data.clear();
+    data["content-bin"] = QByteArray("hello world");
 
-	f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Send);
-	TEST_ASSERT_EQ(f.messageType, PublishFormat::Binary);
-	TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
+    f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Send);
+    TEST_ASSERT_EQ(f.messageType, PublishFormat::Binary);
+    TEST_ASSERT_EQ(f.body, QByteArray("hello world"));
 
-	data.clear();
-	data["action"] = "close";
+    data.clear();
+    data["action"] = "close";
 
-	f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Close);
-	TEST_ASSERT_EQ(f.code, -1);
+    f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Close);
+    TEST_ASSERT_EQ(f.code, -1);
 
-	data.clear();
-	data["action"] = "close";
-	data["code"] = 1001;
+    data.clear();
+    data["action"] = "close";
+    data["code"] = 1001;
 
-	f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT(f.action == PublishFormat::Close);
-	TEST_ASSERT_EQ(f.code, 1001);
+    f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, data, &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT(f.action == PublishFormat::Close);
+    TEST_ASSERT_EQ(f.code, 1001);
 }
 
-extern "C" int publishformat_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(responseFormat());
-	TEST_CATCH(streamFormat());
-	TEST_CATCH(webSocketMessageFormat());
+extern "C" int publishformat_test(ffi::TestException *out_ex) {
+    TEST_CATCH(responseFormat());
+    TEST_CATCH(streamFormat());
+    TEST_CATCH(webSocketMessageFormat());
 
-	return 0;
+    return 0;
 }

--- a/src/handler/publishitem.cpp
+++ b/src/handler/publishitem.cpp
@@ -29,200 +29,179 @@
 
 using namespace VariantUtil;
 
-PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channel, bool *ok, QString *errorMessage)
-{
-	QString pn = "publish item object";
+PublishItem PublishItem::fromVariant(const Variant &vitem, const QString &channel, bool *ok,
+                                     QString *errorMessage) {
+    QString pn = "publish item object";
 
-	if(!isKeyedObject(vitem))
-	{
-		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return PublishItem();
-	}
+    if (!isKeyedObject(vitem)) {
+        setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
+        return PublishItem();
+    }
 
-	PublishItem item;
-	bool ok_;
+    PublishItem item;
+    bool ok_;
 
-	if(!channel.isEmpty())
-	{
-		item.channel = channel;
-	}
-	else
-	{
-		item.channel = getString(vitem, pn, "channel", true, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return PublishItem();
-		}
-	}
+    if (!channel.isEmpty()) {
+        item.channel = channel;
+    } else {
+        item.channel = getString(vitem, pn, "channel", true, &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return PublishItem();
+        }
+    }
 
-	item.id = getString(vitem, pn, "id", false, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return PublishItem();
-	}
+    item.id = getString(vitem, pn, "id", false, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return PublishItem();
+    }
 
-	item.prevId = getString(vitem, pn, "prev-id", false, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return PublishItem();
-	}
+    item.prevId = getString(vitem, pn, "prev-id", false, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return PublishItem();
+    }
 
-	Variant vformats = getKeyedObject(vitem, pn, "formats", false, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return PublishItem();
-	}
+    Variant vformats = getKeyedObject(vitem, pn, "formats", false, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return PublishItem();
+    }
 
-	if(!vformats.isValid())
-	{
-		vformats = createSameKeyedObject(vitem);
+    if (!vformats.isValid()) {
+        vformats = createSameKeyedObject(vitem);
 
-		Variant v = keyedObjectGetValue(vitem, "http-response");
-		if(v.isValid())
-			keyedObjectInsert(&vformats, "http-response", v);
+        Variant v = keyedObjectGetValue(vitem, "http-response");
+        if (v.isValid())
+            keyedObjectInsert(&vformats, "http-response", v);
 
-		v = keyedObjectGetValue(vitem, "http-stream");
-		if(v.isValid())
-			keyedObjectInsert(&vformats, "http-stream", v);
+        v = keyedObjectGetValue(vitem, "http-stream");
+        if (v.isValid())
+            keyedObjectInsert(&vformats, "http-stream", v);
 
-		v = keyedObjectGetValue(vitem, "ws-message");
-		if(v.isValid())
-			keyedObjectInsert(&vformats, "ws-message", v);
-	}
+        v = keyedObjectGetValue(vitem, "ws-message");
+        if (v.isValid())
+            keyedObjectInsert(&vformats, "ws-message", v);
+    }
 
-	if(keyedObjectIsEmpty(vformats))
-	{
-		setError(ok, errorMessage, "no formats specified");
-		return PublishItem();
-	}
+    if (keyedObjectIsEmpty(vformats)) {
+        setError(ok, errorMessage, "no formats specified");
+        return PublishItem();
+    }
 
-	if(keyedObjectContains(vformats, "http-response"))
-	{
-		PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpResponse, keyedObjectGetValue(vformats, "http-response"), &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return PublishItem();
-		}
+    if (keyedObjectContains(vformats, "http-response")) {
+        PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpResponse,
+                                                     keyedObjectGetValue(vformats, "http-response"),
+                                                     &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return PublishItem();
+        }
 
-		item.formats.insert(f.type, f);
-	}
+        item.formats.insert(f.type, f);
+    }
 
-	if(keyedObjectContains(vformats, "http-stream"))
-	{
-		PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpStream, keyedObjectGetValue(vformats, "http-stream"), &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return PublishItem();
-		}
+    if (keyedObjectContains(vformats, "http-stream")) {
+        PublishFormat f = PublishFormat::fromVariant(PublishFormat::HttpStream,
+                                                     keyedObjectGetValue(vformats, "http-stream"),
+                                                     &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return PublishItem();
+        }
 
-		item.formats.insert(f.type, f);
-	}
+        item.formats.insert(f.type, f);
+    }
 
-	if(keyedObjectContains(vformats, "ws-message"))
-	{
-		PublishFormat f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage, keyedObjectGetValue(vformats, "ws-message"), &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return PublishItem();
-		}
+    if (keyedObjectContains(vformats, "ws-message")) {
+        PublishFormat f = PublishFormat::fromVariant(PublishFormat::WebSocketMessage,
+                                                     keyedObjectGetValue(vformats, "ws-message"),
+                                                     &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return PublishItem();
+        }
 
-		item.formats.insert(f.type, f);
-	}
+        item.formats.insert(f.type, f);
+    }
 
-	Variant vmeta = getKeyedObject(vitem, pn, "meta", false, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return PublishItem();
-	}
+    Variant vmeta = getKeyedObject(vitem, pn, "meta", false, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return PublishItem();
+    }
 
-	if(vmeta.isValid())
-	{
-		if(typeId(vmeta) == VariantType::Hash)
-		{
-			VariantHash hmeta = vmeta.toHash();
+    if (vmeta.isValid()) {
+        if (typeId(vmeta) == VariantType::Hash) {
+            VariantHash hmeta = vmeta.toHash();
 
-			for(auto it = hmeta.constBegin(); it != hmeta.constEnd(); ++it)
-			{
-				const QString &key = it.key();
-				const Variant &vval = it.value();
+            for (auto it = hmeta.constBegin(); it != hmeta.constEnd(); ++it) {
+                const QString &key = it.key();
+                const Variant &vval = it.value();
 
-				QString val = getString(vval, &ok_);
-				if(!ok_)
-				{
-					setError(ok, errorMessage, QString("'meta' contains '%1' with wrong type").arg(key));
-					return PublishItem();
-				}
+                QString val = getString(vval, &ok_);
+                if (!ok_) {
+                    setError(ok, errorMessage,
+                             QString("'meta' contains '%1' with wrong type").arg(key));
+                    return PublishItem();
+                }
 
-				item.meta[key] = val;
-			}
-		}
-		else // Map
-		{
-			VariantMap mmeta = vmeta.toMap();
+                item.meta[key] = val;
+            }
+        } else // Map
+        {
+            VariantMap mmeta = vmeta.toMap();
 
-			for(auto it = mmeta.constBegin(); it != mmeta.constEnd(); ++it)
-			{
-				const QString &key = it.key();
-				const Variant &vval = it.value();
+            for (auto it = mmeta.constBegin(); it != mmeta.constEnd(); ++it) {
+                const QString &key = it.key();
+                const Variant &vval = it.value();
 
-				QString val = getString(vval, &ok_);
-				if(!ok_)
-				{
-					setError(ok, errorMessage, QString("'meta' contains '%1' with wrong type").arg(key));
-					return PublishItem();
-				}
+                QString val = getString(vval, &ok_);
+                if (!ok_) {
+                    setError(ok, errorMessage,
+                             QString("'meta' contains '%1' with wrong type").arg(key));
+                    return PublishItem();
+                }
 
-				item.meta[key] = val;
-			}
-		}
-	}
+                item.meta[key] = val;
+            }
+        }
+    }
 
-	if(keyedObjectContains(vitem, "size"))
-	{
-		Variant vsize = keyedObjectGetValue(vitem, "size");
-		if(!canConvert(vsize, VariantType::Int))
-		{
-			setError(ok, errorMessage, QString("%1 contains 'size' with wrong type").arg(pn));
-			return PublishItem();
-		}
+    if (keyedObjectContains(vitem, "size")) {
+        Variant vsize = keyedObjectGetValue(vitem, "size");
+        if (!canConvert(vsize, VariantType::Int)) {
+            setError(ok, errorMessage, QString("%1 contains 'size' with wrong type").arg(pn));
+            return PublishItem();
+        }
 
-		item.size = vsize.toInt();
+        item.size = vsize.toInt();
 
-		if(item.size < 0)
-		{
-			setError(ok, errorMessage, QString("%1 contains 'size' with invalid value").arg(pn));
-			return PublishItem();
-		}
-	}
+        if (item.size < 0) {
+            setError(ok, errorMessage, QString("%1 contains 'size' with invalid value").arg(pn));
+            return PublishItem();
+        }
+    }
 
-	if(keyedObjectContains(vitem, "no-seq"))
-	{
-		Variant vnoSeq = keyedObjectGetValue(vitem, "no-seq");
-		if(typeId(vnoSeq) != VariantType::Bool)
-		{
-			setError(ok, errorMessage, QString("%1 contains 'no-seq' with wrong type").arg(pn));
-			return PublishItem();
-		}
+    if (keyedObjectContains(vitem, "no-seq")) {
+        Variant vnoSeq = keyedObjectGetValue(vitem, "no-seq");
+        if (typeId(vnoSeq) != VariantType::Bool) {
+            setError(ok, errorMessage, QString("%1 contains 'no-seq' with wrong type").arg(pn));
+            return PublishItem();
+        }
 
-		item.noSeq = vnoSeq.toBool();
-	}
+        item.noSeq = vnoSeq.toBool();
+    }
 
-	setSuccess(ok, errorMessage);
-	return item;
+    setSuccess(ok, errorMessage);
+    return item;
 }

--- a/src/handler/publishitem.h
+++ b/src/handler/publishitem.h
@@ -23,31 +23,27 @@
 #ifndef PUBLISHITEM_H
 #define PUBLISHITEM_H
 
-#include <QString>
-#include <QHash>
-#include "variant.h"
 #include "publishformat.h"
+#include "variant.h"
+#include <QHash>
+#include <QString>
 
-class PublishItem
-{
+class PublishItem {
 public:
-	QString channel;
-	QString id;
-	QString prevId;
-	QHash<PublishFormat::Type, PublishFormat> formats;
-	QHash<QString, QString> meta;
-	int size;
-	bool noSeq;
+    QString channel;
+    QString id;
+    QString prevId;
+    QHash<PublishFormat::Type, PublishFormat> formats;
+    QHash<QString, QString> meta;
+    int size;
+    bool noSeq;
 
-	PublishFormat format; // For single format items
+    PublishFormat format; // For single format items
 
-	PublishItem() :
-		size(-1),
-		noSeq(false)
-	{
-	}
+    PublishItem() : size(-1), noSeq(false) {}
 
-	static PublishItem fromVariant(const Variant &vitem, const QString &channel = QString(), bool *ok = 0, QString *errorMessage = 0);
+    static PublishItem fromVariant(const Variant &vitem, const QString &channel = QString(),
+                                   bool *ok = 0, QString *errorMessage = 0);
 };
 
 #endif

--- a/src/handler/publishitemtest.cpp
+++ b/src/handler/publishitemtest.cpp
@@ -21,79 +21,76 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
-#include "publishformat.h"
 #include "publishitem.h"
+#include "publishformat.h"
+#include "test.h"
 #include "variant.h"
 
-static void parseItem()
-{
-	VariantHash meta;
-	meta["foo"] = QByteArray("bar");
-	meta["bar"] = QByteArray("baz");
+static void parseItem() {
+    VariantHash meta;
+    meta["foo"] = QByteArray("bar");
+    meta["bar"] = QByteArray("baz");
 
-	VariantHash hs;
-	hs["content"] = QByteArray("hello world");
+    VariantHash hs;
+    hs["content"] = QByteArray("hello world");
 
-	VariantHash formats;
-	formats["http-stream"] = hs;
+    VariantHash formats;
+    formats["http-stream"] = hs;
 
-	VariantHash data;
-	data["channel"] = QByteArray("apple");
-	data["id"] = QByteArray("item1");
-	data["prev-id"] = QByteArray("item0");
-	data["meta"] = meta;
-	data["formats"] = formats;
+    VariantHash data;
+    data["channel"] = QByteArray("apple");
+    data["id"] = QByteArray("item1");
+    data["prev-id"] = QByteArray("item0");
+    data["meta"] = meta;
+    data["formats"] = formats;
 
-	bool ok;
-	PublishItem i = PublishItem::fromVariant(data, QString(), &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.channel, QString("apple"));
-	TEST_ASSERT_EQ(i.id, QString("item1"));
-	TEST_ASSERT_EQ(i.prevId, QString("item0"));
-	TEST_ASSERT_EQ(i.meta.count(), 2);
-	TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
-	TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
-	TEST_ASSERT(i.formats.contains(PublishFormat::HttpStream));
-	TEST_ASSERT_EQ(i.formats.value(PublishFormat::HttpStream).body, QByteArray("hello world"));
+    bool ok;
+    PublishItem i = PublishItem::fromVariant(data, QString(), &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.channel, QString("apple"));
+    TEST_ASSERT_EQ(i.id, QString("item1"));
+    TEST_ASSERT_EQ(i.prevId, QString("item0"));
+    TEST_ASSERT_EQ(i.meta.count(), 2);
+    TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
+    TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
+    TEST_ASSERT(i.formats.contains(PublishFormat::HttpStream));
+    TEST_ASSERT_EQ(i.formats.value(PublishFormat::HttpStream).body, QByteArray("hello world"));
 }
 
-static void parseItemJsonStyle()
-{
-	VariantMap meta;
-	meta["foo"] = QString("bar");
-	meta["bar"] = QString("baz");
+static void parseItemJsonStyle() {
+    VariantMap meta;
+    meta["foo"] = QString("bar");
+    meta["bar"] = QString("baz");
 
-	VariantMap hs;
-	hs["content"] = QString("hello world");
+    VariantMap hs;
+    hs["content"] = QString("hello world");
 
-	VariantMap formats;
-	formats["http-stream"] = hs;
+    VariantMap formats;
+    formats["http-stream"] = hs;
 
-	VariantMap data;
-	data["channel"] = QString("apple");
-	data["id"] = QString("item1");
-	data["prev-id"] = QString("item0");
-	data["meta"] = meta;
-	data["formats"] = formats;
+    VariantMap data;
+    data["channel"] = QString("apple");
+    data["id"] = QString("item1");
+    data["prev-id"] = QString("item0");
+    data["meta"] = meta;
+    data["formats"] = formats;
 
-	bool ok;
-	PublishItem i = PublishItem::fromVariant(data, QString(), &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(i.channel, QString("apple"));
-	TEST_ASSERT_EQ(i.id, QString("item1"));
-	TEST_ASSERT_EQ(i.prevId, QString("item0"));
-	TEST_ASSERT_EQ(i.meta.count(), 2);
-	TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
-	TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
-	TEST_ASSERT(i.formats.contains(PublishFormat::HttpStream));
-	TEST_ASSERT_EQ(i.formats.value(PublishFormat::HttpStream).body, QByteArray("hello world"));
+    bool ok;
+    PublishItem i = PublishItem::fromVariant(data, QString(), &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(i.channel, QString("apple"));
+    TEST_ASSERT_EQ(i.id, QString("item1"));
+    TEST_ASSERT_EQ(i.prevId, QString("item0"));
+    TEST_ASSERT_EQ(i.meta.count(), 2);
+    TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
+    TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
+    TEST_ASSERT(i.formats.contains(PublishFormat::HttpStream));
+    TEST_ASSERT_EQ(i.formats.value(PublishFormat::HttpStream).body, QByteArray("hello world"));
 }
 
-extern "C" int publishitem_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(parseItem());
-	TEST_CATCH(parseItemJsonStyle());
+extern "C" int publishitem_test(ffi::TestException *out_ex) {
+    TEST_CATCH(parseItem());
+    TEST_CATCH(parseItemJsonStyle());
 
-	return 0;
+    return 0;
 }

--- a/src/handler/publishlastids.cpp
+++ b/src/handler/publishlastids.cpp
@@ -24,62 +24,48 @@
 
 #include <assert.h>
 
-PublishLastIds::PublishLastIds(int maxCapacity) :
-	maxCapacity_(maxCapacity)
-{
+PublishLastIds::PublishLastIds(int maxCapacity) : maxCapacity_(maxCapacity) {}
+
+void PublishLastIds::set(const QString &channel, const QString &id) {
+    QDateTime now = QDateTime::currentDateTimeUtc();
+
+    if (table_.contains(channel)) {
+        Item &i = table_[channel];
+        recentlyUsed_.remove(TimeStringPair(i.time, channel));
+        i.id = id;
+        i.time = now;
+        recentlyUsed_.insert(TimeStringPair(i.time, channel), i);
+    } else {
+        while (!table_.isEmpty() && table_.count() >= maxCapacity_) {
+            // Remove oldest
+            QMutableMapIterator<TimeStringPair, Item> it(recentlyUsed_);
+            assert(it.hasNext());
+            it.next();
+            QString channel = it.value().channel;
+            it.remove();
+            table_.remove(channel);
+        }
+
+        Item i;
+        i.channel = channel;
+        i.id = id;
+        i.time = now;
+        table_.insert(channel, i);
+        recentlyUsed_.insert(TimeStringPair(i.time, channel), i);
+    }
 }
 
-void PublishLastIds::set(const QString &channel, const QString &id)
-{
-	QDateTime now = QDateTime::currentDateTimeUtc();
-
-	if(table_.contains(channel))
-	{
-		Item &i = table_[channel];
-		recentlyUsed_.remove(TimeStringPair(i.time, channel));
-		i.id = id;
-		i.time = now;
-		recentlyUsed_.insert(TimeStringPair(i.time, channel), i);
-	}
-	else
-	{
-		while(!table_.isEmpty() && table_.count() >= maxCapacity_)
-		{
-			// Remove oldest
-			QMutableMapIterator<TimeStringPair, Item> it(recentlyUsed_);
-			assert(it.hasNext());
-			it.next();
-			QString channel = it.value().channel;
-			it.remove();
-			table_.remove(channel);
-		}
-
-		Item i;
-		i.channel = channel;
-		i.id = id;
-		i.time = now;
-		table_.insert(channel, i);
-		recentlyUsed_.insert(TimeStringPair(i.time, channel), i);
-	}
+void PublishLastIds::remove(const QString &channel) {
+    if (table_.contains(channel)) {
+        Item &i = table_[channel];
+        recentlyUsed_.remove(TimeStringPair(i.time, channel));
+        table_.remove(channel);
+    }
 }
 
-void PublishLastIds::remove(const QString &channel)
-{
-	if(table_.contains(channel))
-	{
-		Item &i = table_[channel];
-		recentlyUsed_.remove(TimeStringPair(i.time, channel));
-		table_.remove(channel);
-	}
+void PublishLastIds::clear() {
+    recentlyUsed_.clear();
+    table_.clear();
 }
 
-void PublishLastIds::clear()
-{
-	recentlyUsed_.clear();
-	table_.clear();
-}
-
-QString PublishLastIds::value(const QString &channel)
-{
-	return table_.value(channel).id;
-}
+QString PublishLastIds::value(const QString &channel) { return table_.value(channel).id; }

--- a/src/handler/publishlastids.h
+++ b/src/handler/publishlastids.h
@@ -23,35 +23,33 @@
 #ifndef PUBLISHLASTIDS_H
 #define PUBLISHLASTIDS_H
 
-#include <QString>
 #include <QDateTime>
-#include <QMap>
 #include <QHash>
+#include <QMap>
+#include <QString>
 
 // Cache with LRU expiration
-class PublishLastIds
-{
+class PublishLastIds {
 public:
-	PublishLastIds(int maxCapacity);
-	void set(const QString &channel, const QString &id);
-	void remove(const QString &channel);
-	void clear();
-	QString value(const QString &channel);
+    PublishLastIds(int maxCapacity);
+    void set(const QString &channel, const QString &id);
+    void remove(const QString &channel);
+    void clear();
+    QString value(const QString &channel);
 
 private:
-	typedef QPair<QDateTime, QString> TimeStringPair;
+    typedef QPair<QDateTime, QString> TimeStringPair;
 
-	class Item
-	{
-	public:
-		QString channel;
-		QString id;
-		QDateTime time;
-	};
+    class Item {
+    public:
+        QString channel;
+        QString id;
+        QDateTime time;
+    };
 
-	QHash<QString, Item> table_;
-	QMap<TimeStringPair, Item> recentlyUsed_;
-	int maxCapacity_;
+    QHash<QString, Item> table_;
+    QMap<TimeStringPair, Item> recentlyUsed_;
+    int maxCapacity_;
 };
 
 #endif

--- a/src/handler/ratelimiter.cpp
+++ b/src/handler/ratelimiter.cpp
@@ -23,309 +23,238 @@
 
 #include "ratelimiter.h"
 
+#include "defercall.h"
+#include "timer.h"
 #include <QList>
 #include <QMap>
-#include "timer.h"
-#include "defercall.h"
 
 #define MIN_BATCH_INTERVAL 25
 
-class RateLimiter::Private
-{
+class RateLimiter::Private {
 public:
-	class ActionItem
-	{
-	public:
-		Action *action;
-		int weight;
+    class ActionItem {
+    public:
+        Action *action;
+        int weight;
 
-		ActionItem(Action *_action = 0, int _weight = 0) :
-			action(_action),
-			weight(_weight)
-		{
-		}
-	};
+        ActionItem(Action *_action = 0, int _weight = 0) : action(_action), weight(_weight) {}
+    };
 
-	class Bucket
-	{
-	public:
-		QList<ActionItem> actions;
-		int weight;
-		int debt;
+    class Bucket {
+    public:
+        QList<ActionItem> actions;
+        int weight;
+        int debt;
 
-		Bucket() :
-			weight(0),
-			debt(0)
-		{
-		}
+        Bucket() : weight(0), debt(0) {}
 
-		~Bucket()
-		{
-			foreach(const ActionItem &i, actions)
-				delete i.action;
-		}
-	};
+        ~Bucket() {
+            foreach (const ActionItem &i, actions)
+                delete i.action;
+        }
+    };
 
-	RateLimiter *q;
-	int rate;
-	int hwm;
-	bool batchWaitEnabled;
-	QMap<QString, Bucket> buckets;
-	QString lastKey;
-	std::unique_ptr<Timer> timer;
-	bool firstPass;
-	int batchInterval;
-	int batchSize;
-	bool lastBatchEmpty;
+    RateLimiter *q;
+    int rate;
+    int hwm;
+    bool batchWaitEnabled;
+    QMap<QString, Bucket> buckets;
+    QString lastKey;
+    std::unique_ptr<Timer> timer;
+    bool firstPass;
+    int batchInterval;
+    int batchSize;
+    bool lastBatchEmpty;
 
-	Private(RateLimiter *_q) :
-		q(_q),
-		rate(-1),
-		hwm(-1),
-		batchWaitEnabled(false),
-		batchInterval(-1),
-		batchSize(-1),
-		lastBatchEmpty(false)
-	{
-		timer = std::make_unique<Timer>();
-		timer->timeout.connect(boost::bind(&Private::timeout, this));
-	}
+    Private(RateLimiter *_q)
+        : q(_q),
+          rate(-1),
+          hwm(-1),
+          batchWaitEnabled(false),
+          batchInterval(-1),
+          batchSize(-1),
+          lastBatchEmpty(false) {
+        timer = std::make_unique<Timer>();
+        timer->timeout.connect(boost::bind(&Private::timeout, this));
+    }
 
-	void setRate(int actionsPerSecond)
-	{
-		if(actionsPerSecond > 0)
-		{
-			rate = actionsPerSecond;
+    void setRate(int actionsPerSecond) {
+        if (actionsPerSecond > 0) {
+            rate = actionsPerSecond;
 
-			if(rate >= 1000 / MIN_BATCH_INTERVAL)
-			{
-				batchInterval = MIN_BATCH_INTERVAL;
-				batchSize = (rate * batchInterval + 999) / 1000;
-			}
-			else
-			{
-				batchInterval = 1000 / rate;
-				batchSize = 1;
-			}
-		}
-		else
-		{
-			rate = -1;
-			batchInterval = -1;
-			batchSize = -1;
-		}
+            if (rate >= 1000 / MIN_BATCH_INTERVAL) {
+                batchInterval = MIN_BATCH_INTERVAL;
+                batchSize = (rate * batchInterval + 999) / 1000;
+            } else {
+                batchInterval = 1000 / rate;
+                batchSize = 1;
+            }
+        } else {
+            rate = -1;
+            batchInterval = -1;
+            batchSize = -1;
+        }
 
-		setup();
-	}
+        setup();
+    }
 
-	bool addAction(const QString &key, int weight, Action *action)
-	{
-		Bucket &bucket = buckets[key];
-		if(hwm > 0 && bucket.weight + weight > hwm)
-			return false;
+    bool addAction(const QString &key, int weight, Action *action) {
+        Bucket &bucket = buckets[key];
+        if (hwm > 0 && bucket.weight + weight > hwm)
+            return false;
 
-		bucket.actions += ActionItem(action, weight);
-		bucket.weight += weight;
+        bucket.actions += ActionItem(action, weight);
+        bucket.weight += weight;
 
-		setup();
-		return true;
-	}
+        setup();
+        return true;
+    }
 
 private:
-	void setup()
-	{
-		if(rate > 0)
-		{
-			if(!buckets.isEmpty() || !lastBatchEmpty)
-			{
-				if(timer->isActive())
-				{
-					// After the first pass, switch to batch interval
-					if(!firstPass)
-						timer->setInterval(batchInterval);
-				}
-				else
-				{
-					// Process first batch
-					firstPass = true;
+    void setup() {
+        if (rate > 0) {
+            if (!buckets.isEmpty() || !lastBatchEmpty) {
+                if (timer->isActive()) {
+                    // After the first pass, switch to batch interval
+                    if (!firstPass)
+                        timer->setInterval(batchInterval);
+                } else {
+                    // Process first batch
+                    firstPass = true;
 
-					if(batchWaitEnabled)
-					{
-						// If wait enabled, collect for awhile before processing
-						timer->start(batchInterval);
-					}
-					else
-					{
-						// If wait not enabled, process immediately
-						timer->start(0);
-					}
-				}
-			}
-			else
-			{
-				if(lastBatchEmpty)
-				{
-					// If we processed nothing on this pass, stop timer
-					lastBatchEmpty = false;
-					timer->stop();
-				}
-			}
-		}
-		else
-		{
-			if(!buckets.isEmpty())
-			{
-				if(timer->isActive())
-				{
-					// Ensure we're on fastest interval
-					timer->setInterval(0);
-				}
-				else
-				{
-					// Process first batch right away
-					firstPass = true;
-					timer->start(0);
-				}
-			}
-			else
-			{
-				timer->stop();
-			}
-		}
-	}
+                    if (batchWaitEnabled) {
+                        // If wait enabled, collect for awhile before processing
+                        timer->start(batchInterval);
+                    } else {
+                        // If wait not enabled, process immediately
+                        timer->start(0);
+                    }
+                }
+            } else {
+                if (lastBatchEmpty) {
+                    // If we processed nothing on this pass, stop timer
+                    lastBatchEmpty = false;
+                    timer->stop();
+                }
+            }
+        } else {
+            if (!buckets.isEmpty()) {
+                if (timer->isActive()) {
+                    // Ensure we're on fastest interval
+                    timer->setInterval(0);
+                } else {
+                    // Process first batch right away
+                    firstPass = true;
+                    timer->start(0);
+                }
+            } else {
+                timer->stop();
+            }
+        }
+    }
 
-	// Return false if self destroyed
-	bool processBatch()
-	{
-		if(buckets.isEmpty())
-		{
-			lastBatchEmpty = true;
-			return true;
-		}
+    // Return false if self destroyed
+    bool processBatch() {
+        if (buckets.isEmpty()) {
+            lastBatchEmpty = true;
+            return true;
+        }
 
-		lastBatchEmpty = false;
+        lastBatchEmpty = false;
 
-		QMap<QString, Bucket>::iterator it;
+        QMap<QString, Bucket>::iterator it;
 
-		if(!lastKey.isNull())
-		{
-			it = buckets.find(lastKey);
+        if (!lastKey.isNull()) {
+            it = buckets.find(lastKey);
 
-			if(it == buckets.end())
-				it = buckets.begin();
-		}
-		else
-		{
-			it = buckets.begin();
-		}
+            if (it == buckets.end())
+                it = buckets.begin();
+        } else {
+            it = buckets.begin();
+        }
 
-		std::weak_ptr<Private> self = q->d;
+        std::weak_ptr<Private> self = q->d;
 
-		int processed = 0;
-		while((batchSize < 1 || processed < batchSize) && it != buckets.end())
-		{
-			Bucket &bucket = it.value();
+        int processed = 0;
+        while ((batchSize < 1 || processed < batchSize) && it != buckets.end()) {
+            Bucket &bucket = it.value();
 
-			QString key = it.key();
+            QString key = it.key();
 
-			if(bucket.debt <= 0)
-			{
-				ActionItem ai = bucket.actions.takeFirst();
-				Action *action = ai.action;
-				int weight = ai.weight;
+            if (bucket.debt <= 0) {
+                ActionItem ai = bucket.actions.takeFirst();
+                Action *action = ai.action;
+                int weight = ai.weight;
 
-				bucket.weight -= weight;
+                bucket.weight -= weight;
 
-				bool ret = action->execute();
-				delete action;
+                bool ret = action->execute();
+                delete action;
 
-				if(self.expired())
-					return false;
+                if (self.expired())
+                    return false;
 
-				if(ret)
-				{
-					if(weight > 1)
-						processed += weight;
-					else
-						++processed;
+                if (ret) {
+                    if (weight > 1)
+                        processed += weight;
+                    else
+                        ++processed;
 
-					if(batchSize >= 1 && processed > batchSize)
-					{
-						bucket.debt += processed - batchSize;
-					}
-				}
-			}
-			else
-			{
-				--bucket.debt;
-				++processed;
-			}
+                    if (batchSize >= 1 && processed > batchSize) {
+                        bucket.debt += processed - batchSize;
+                    }
+                }
+            } else {
+                --bucket.debt;
+                ++processed;
+            }
 
-			if(bucket.actions.isEmpty() && bucket.debt <= 0)
-			{
-				lastKey = key;
-				it = buckets.erase(it);
-			}
-			else
-			{
-				++it;
-				if(it == buckets.end())
-					it = buckets.begin();
-			}
-		}
+            if (bucket.actions.isEmpty() && bucket.debt <= 0) {
+                lastKey = key;
+                it = buckets.erase(it);
+            } else {
+                ++it;
+                if (it == buckets.end())
+                    it = buckets.begin();
+            }
+        }
 
-		if(it != buckets.end())
-			lastKey = it.key();
+        if (it != buckets.end())
+            lastKey = it.key();
 
-		return true;
-	}
+        return true;
+    }
 
-	void timeout()
-	{
-		if(!processBatch())
-			return;
+    void timeout() {
+        if (!processBatch())
+            return;
 
-		firstPass = false;
+        firstPass = false;
 
-		setup();
-	}
+        setup();
+    }
 };
 
-RateLimiter::RateLimiter()
-{
-	d = std::make_shared<Private>(this);
-}
+RateLimiter::RateLimiter() { d = std::make_shared<Private>(this); }
 
 RateLimiter::~RateLimiter() = default;
 
-void RateLimiter::setRate(int actionsPerSecond)
-{
-	d->setRate(actionsPerSecond);
+void RateLimiter::setRate(int actionsPerSecond) { d->setRate(actionsPerSecond); }
+
+void RateLimiter::setHwm(int hwm) { d->hwm = hwm; }
+
+void RateLimiter::setBatchWaitEnabled(bool on) { d->batchWaitEnabled = on; }
+
+bool RateLimiter::addAction(const QString &key, Action *action, int weight) {
+    return d->addAction(key, weight, action);
 }
 
-void RateLimiter::setHwm(int hwm)
-{
-	d->hwm = hwm;
-}
+RateLimiter::Action *RateLimiter::lastAction(const QString &key) const {
+    if (d->buckets.contains(key)) {
+        const Private::Bucket &bucket = d->buckets[key];
+        if (!bucket.actions.isEmpty())
+            return bucket.actions.last().action;
+    }
 
-void RateLimiter::setBatchWaitEnabled(bool on)
-{
-	d->batchWaitEnabled = on;
-}
-
-bool RateLimiter::addAction(const QString &key, Action *action, int weight)
-{
-	return d->addAction(key, weight, action);
-}
-
-RateLimiter::Action *RateLimiter::lastAction(const QString &key) const
-{
-	if(d->buckets.contains(key))
-	{
-		const Private::Bucket &bucket = d->buckets[key];
-		if(!bucket.actions.isEmpty())
-			return bucket.actions.last().action;
-	}
-
-	return 0;
+    return 0;
 }

--- a/src/handler/ratelimiter.h
+++ b/src/handler/ratelimiter.h
@@ -28,30 +28,28 @@
 
 class QString;
 
-class RateLimiter
-{
+class RateLimiter {
 public:
-	class Action
-	{
-	public:
-		virtual ~Action() {}
+    class Action {
+    public:
+        virtual ~Action() {}
 
-		virtual bool execute() = 0;
-	};
+        virtual bool execute() = 0;
+    };
 
-	RateLimiter();
-	~RateLimiter();
+    RateLimiter();
+    ~RateLimiter();
 
-	void setRate(int actionsPerSecond);
-	void setHwm(int hwm);
-	void setBatchWaitEnabled(bool on);
+    void setRate(int actionsPerSecond);
+    void setHwm(int hwm);
+    void setBatchWaitEnabled(bool on);
 
-	bool addAction(const QString &key, Action *action, int weight = 1);
-	Action *lastAction(const QString &key) const;
+    bool addAction(const QString &key, Action *action, int weight = 1);
+    Action *lastAction(const QString &key) const;
 
 private:
-	class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/handler/refreshworker.cpp
+++ b/src/handler/refreshworker.cpp
@@ -23,86 +23,71 @@
 
 #include "refreshworker.h"
 
-#include "qtcompat.h"
-#include "zrpcrequest.h"
 #include "controlrequest.h"
+#include "qtcompat.h"
 #include "statsmanager.h"
-#include "wssession.h"
 #include "variant.h"
+#include "wssession.h"
+#include "zrpcrequest.h"
 
-RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel) :
-	ignoreErrors_(false),
-	proxyControlClient_(proxyControlClient),
-	req_(req)
-{
-	VariantHash args = req_->args();
+RefreshWorker::RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient,
+                             QHash<QString, QSet<WsSession *>> *wsSessionsByChannel)
+    : ignoreErrors_(false), proxyControlClient_(proxyControlClient), req_(req) {
+    VariantHash args = req_->args();
 
-	if(args.contains("cid"))
-	{
-		if(typeId(args["cid"]) != VariantType::ByteArray)
-		{
-			respondError("bad-request");
-			return;
-		}
+    if (args.contains("cid")) {
+        if (typeId(args["cid"]) != VariantType::ByteArray) {
+            respondError("bad-request");
+            return;
+        }
 
-		cids_ += QString::fromUtf8(args["cid"].toByteArray());
+        cids_ += QString::fromUtf8(args["cid"].toByteArray());
 
-		refreshNextCid();
-	}
-	else if(args.contains("channel"))
-	{
-		if(typeId(args["channel"]) != VariantType::ByteArray)
-		{
-			respondError("bad-request");
-			return;
-		}
+        refreshNextCid();
+    } else if (args.contains("channel")) {
+        if (typeId(args["channel"]) != VariantType::ByteArray) {
+            respondError("bad-request");
+            return;
+        }
 
-		QString channel = QString::fromUtf8(args["channel"].toByteArray());
+        QString channel = QString::fromUtf8(args["channel"].toByteArray());
 
-		QSet<WsSession*> wsbc = wsSessionsByChannel->value(channel);
-		foreach(WsSession *s, wsbc)
-		{
-			cids_ += s->cid;
-		}
+        QSet<WsSession *> wsbc = wsSessionsByChannel->value(channel);
+        foreach (WsSession *s, wsbc) {
+            cids_ += s->cid;
+        }
 
-		ignoreErrors_ = true;
+        ignoreErrors_ = true;
 
-		refreshNextCid();
-	}
-	else
-	{
-		respondError("bad-request");
-		return;
-	}
+        refreshNextCid();
+    } else {
+        respondError("bad-request");
+        return;
+    }
 }
 
-void RefreshWorker::respondError(const QByteArray &condition)
-{
-	req_->respondError(condition);
-	setFinished(true);
+void RefreshWorker::respondError(const QByteArray &condition) {
+    req_->respondError(condition);
+    setFinished(true);
 }
 
-void RefreshWorker::refreshNextCid()
-{
-	if(cids_.isEmpty())
-	{
-		req_->respond();
-		setFinished(true);
-		return;
-	}
+void RefreshWorker::refreshNextCid() {
+    if (cids_.isEmpty()) {
+        req_->respond();
+        setFinished(true);
+        return;
+    }
 
-	refresh_ = std::unique_ptr<Deferred>(ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8()));
-	finishedConnection_ = refresh_->finished.connect(boost::bind(&RefreshWorker::proxyRefresh_finished, this, boost::placeholders::_1));
+    refresh_ = std::unique_ptr<Deferred>(
+        ControlRequest::refresh(proxyControlClient_, cids_.takeFirst().toUtf8()));
+    finishedConnection_ = refresh_->finished.connect(
+        boost::bind(&RefreshWorker::proxyRefresh_finished, this, boost::placeholders::_1));
 }
 
-void RefreshWorker::proxyRefresh_finished(const DeferredResult &result)
-{
-	if(result.success || ignoreErrors_)
-	{
-		refreshNextCid();
-	}
-	else
-	{
-		respondError(result.value.toByteArray());
-	}
+void RefreshWorker::proxyRefresh_finished(const DeferredResult &result) {
+    if (result.success || ignoreErrors_) {
+        refreshNextCid();
+    } else {
+        respondError(result.value.toByteArray());
+    }
 }

--- a/src/handler/refreshworker.h
+++ b/src/handler/refreshworker.h
@@ -24,12 +24,12 @@
 #ifndef REFRESHWORKER_H
 #define REFRESHWORKER_H
 
+#include "deferred.h"
+#include "zrpcrequest.h"
 #include <QByteArray>
 #include <QHash>
 #include <QSet>
 #include <boost/signals2.hpp>
-#include "deferred.h"
-#include "zrpcrequest.h"
 
 using Connection = boost::signals2::scoped_connection;
 
@@ -37,22 +37,22 @@ class ZrpcManager;
 class StatsManager;
 class WsSession;
 
-class RefreshWorker : public Deferred
-{
+class RefreshWorker : public Deferred {
 public:
-	RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient, QHash<QString, QSet<WsSession*> > *wsSessionsByChannel);
+    RefreshWorker(ZrpcRequest *req, ZrpcManager *proxyControlClient,
+                  QHash<QString, QSet<WsSession *>> *wsSessionsByChannel);
 
 private:
-	QStringList cids_;
-	bool ignoreErrors_;
-	ZrpcManager *proxyControlClient_;
-	std::unique_ptr<ZrpcRequest> req_;
-	std::unique_ptr<Deferred> refresh_;
-	Connection finishedConnection_;
+    QStringList cids_;
+    bool ignoreErrors_;
+    ZrpcManager *proxyControlClient_;
+    std::unique_ptr<ZrpcRequest> req_;
+    std::unique_ptr<Deferred> refresh_;
+    Connection finishedConnection_;
 
-	void refreshNextCid();
-	void respondError(const QByteArray &condition);
-	void proxyRefresh_finished(const DeferredResult &result);
+    void refreshNextCid();
+    void respondError(const QByteArray &condition);
+    void proxyRefresh_finished(const DeferredResult &result);
 };
 
 #endif

--- a/src/handler/requeststate.cpp
+++ b/src/handler/requeststate.cpp
@@ -26,136 +26,124 @@
 #include "qtcompat.h"
 #include "variant.h"
 
-RequestState RequestState::fromVariant(const Variant &in)
-{
-	if(typeId(in) != VariantType::Hash)
-		return RequestState();
+RequestState RequestState::fromVariant(const Variant &in) {
+    if (typeId(in) != VariantType::Hash)
+        return RequestState();
 
-	VariantHash r = in.toHash();
-	RequestState rs;
+    VariantHash r = in.toHash();
+    RequestState rs;
 
-	if(!r.contains("rid") || typeId(r["rid"]) != VariantType::Hash)
-		return RequestState();
+    if (!r.contains("rid") || typeId(r["rid"]) != VariantType::Hash)
+        return RequestState();
 
-	VariantHash vrid = r["rid"].toHash();
+    VariantHash vrid = r["rid"].toHash();
 
-	if(!vrid.contains("sender") || typeId(vrid["sender"]) != VariantType::ByteArray)
-		return RequestState();
+    if (!vrid.contains("sender") || typeId(vrid["sender"]) != VariantType::ByteArray)
+        return RequestState();
 
-	if(!vrid.contains("id") || typeId(vrid["id"]) != VariantType::ByteArray)
-		return RequestState();
+    if (!vrid.contains("id") || typeId(vrid["id"]) != VariantType::ByteArray)
+        return RequestState();
 
-	rs.rid = ZhttpRequest::Rid(vrid["sender"].toByteArray(), vrid["id"].toByteArray());
+    rs.rid = ZhttpRequest::Rid(vrid["sender"].toByteArray(), vrid["id"].toByteArray());
 
-	if(!r.contains("in-seq") || !canConvert(r["in-seq"], VariantType::Int))
-		return RequestState();
+    if (!r.contains("in-seq") || !canConvert(r["in-seq"], VariantType::Int))
+        return RequestState();
 
-	rs.inSeq = r["in-seq"].toInt();
+    rs.inSeq = r["in-seq"].toInt();
 
-	if(!r.contains("out-seq") || !canConvert(r["out-seq"], VariantType::Int))
-		return RequestState();
+    if (!r.contains("out-seq") || !canConvert(r["out-seq"], VariantType::Int))
+        return RequestState();
 
-	rs.outSeq = r["out-seq"].toInt();
+    rs.outSeq = r["out-seq"].toInt();
 
-	if(!r.contains("out-credits") || !canConvert(r["out-credits"], VariantType::Int))
-		return RequestState();
+    if (!r.contains("out-credits") || !canConvert(r["out-credits"], VariantType::Int))
+        return RequestState();
 
-	rs.outCredits = r["out-credits"].toInt();
+    rs.outCredits = r["out-credits"].toInt();
 
-	if(r.contains("router-resp"))
-	{
-		if(typeId(r["router-resp"]) != VariantType::Bool)
-			return RequestState();
+    if (r.contains("router-resp")) {
+        if (typeId(r["router-resp"]) != VariantType::Bool)
+            return RequestState();
 
-		rs.routerResp = r["router-resp"].toBool();
-	}
+        rs.routerResp = r["router-resp"].toBool();
+    }
 
-	if(r.contains("response-code"))
-	{
-		if(!canConvert(r["response-code"], VariantType::Int))
-			return RequestState();
+    if (r.contains("response-code")) {
+        if (!canConvert(r["response-code"], VariantType::Int))
+            return RequestState();
 
-		rs.responseCode = r["response-code"].toInt();
-	}
+        rs.responseCode = r["response-code"].toInt();
+    }
 
-	if(r.contains("peer-address"))
-	{
-		if(typeId(r["peer-address"]) != VariantType::ByteArray)
-			return RequestState();
+    if (r.contains("peer-address")) {
+        if (typeId(r["peer-address"]) != VariantType::ByteArray)
+            return RequestState();
 
-		if(!rs.peerAddress.setAddress(QString::fromUtf8(r["peer-address"].toByteArray())))
-			return RequestState();
-	}
+        if (!rs.peerAddress.setAddress(QString::fromUtf8(r["peer-address"].toByteArray())))
+            return RequestState();
+    }
 
-	if(r.contains("logical-peer-address"))
-	{
-		if(typeId(r["logical-peer-address"]) != VariantType::ByteArray)
-			return RequestState();
+    if (r.contains("logical-peer-address")) {
+        if (typeId(r["logical-peer-address"]) != VariantType::ByteArray)
+            return RequestState();
 
-		if(!rs.logicalPeerAddress.setAddress(QString::fromUtf8(r["logical-peer-address"].toByteArray())))
-			return RequestState();
-	}
+        if (!rs.logicalPeerAddress.setAddress(
+                QString::fromUtf8(r["logical-peer-address"].toByteArray())))
+            return RequestState();
+    }
 
-	if(r.contains("https"))
-	{
-		if(typeId(r["https"]) != VariantType::Bool)
-			return RequestState();
+    if (r.contains("https")) {
+        if (typeId(r["https"]) != VariantType::Bool)
+            return RequestState();
 
-		rs.isHttps = r["https"].toBool();
-	}
+        rs.isHttps = r["https"].toBool();
+    }
 
-	if(r.contains("debug"))
-	{
-		if(typeId(r["debug"]) != VariantType::Bool)
-			return RequestState();
+    if (r.contains("debug")) {
+        if (typeId(r["debug"]) != VariantType::Bool)
+            return RequestState();
 
-		rs.debug = r["debug"].toBool();
-	}
+        rs.debug = r["debug"].toBool();
+    }
 
-	if(r.contains("is-retry"))
-	{
-		if(typeId(r["is-retry"]) != VariantType::Bool)
-			return RequestState();
+    if (r.contains("is-retry")) {
+        if (typeId(r["is-retry"]) != VariantType::Bool)
+            return RequestState();
 
-		rs.isRetry = r["is-retry"].toBool();
-	}
+        rs.isRetry = r["is-retry"].toBool();
+    }
 
-	if(r.contains("auto-cross-origin"))
-	{
-		if(typeId(r["auto-cross-origin"]) != VariantType::Bool)
-			return RequestState();
+    if (r.contains("auto-cross-origin")) {
+        if (typeId(r["auto-cross-origin"]) != VariantType::Bool)
+            return RequestState();
 
-		rs.autoCrossOrigin = r["auto-cross-origin"].toBool();
-	}
+        rs.autoCrossOrigin = r["auto-cross-origin"].toBool();
+    }
 
-	if(r.contains("jsonp-callback"))
-	{
-		if(typeId(r["jsonp-callback"]) != VariantType::ByteArray)
-			return RequestState();
+    if (r.contains("jsonp-callback")) {
+        if (typeId(r["jsonp-callback"]) != VariantType::ByteArray)
+            return RequestState();
 
-		rs.jsonpCallback = r["jsonp-callback"].toByteArray();
-	}
+        rs.jsonpCallback = r["jsonp-callback"].toByteArray();
+    }
 
-	if(r.contains("jsonp-extended-response"))
-	{
-		if(typeId(r["jsonp-extended-response"]) != VariantType::Bool)
-			return RequestState();
+    if (r.contains("jsonp-extended-response")) {
+        if (typeId(r["jsonp-extended-response"]) != VariantType::Bool)
+            return RequestState();
 
-		rs.jsonpExtendedResponse = r["jsonp-extended-response"].toBool();
-	}
+        rs.jsonpExtendedResponse = r["jsonp-extended-response"].toBool();
+    }
 
-	if(r.contains("unreported-time"))
-	{
-		if(!canConvert(r["unreported-time"], VariantType::Int))
-			return RequestState();
+    if (r.contains("unreported-time")) {
+        if (!canConvert(r["unreported-time"], VariantType::Int))
+            return RequestState();
 
-		rs.unreportedTime = r["unreported-time"].toInt();
-	}
+        rs.unreportedTime = r["unreported-time"].toInt();
+    }
 
-	if(r.contains("user-data"))
-	{
-		rs.userData = r["user-data"];
-	}
+    if (r.contains("user-data")) {
+        rs.userData = r["user-data"];
+    }
 
-	return rs;
+    return rs;
 }

--- a/src/handler/requeststate.h
+++ b/src/handler/requeststate.h
@@ -24,47 +24,44 @@
 #ifndef REQUESTSTATE_H
 #define REQUESTSTATE_H
 
-#include <QByteArray>
 #include "variant.h"
-#include <QHostAddress>
 #include "zhttprequest.h"
+#include <QByteArray>
+#include <QHostAddress>
 
-class RequestState
-{
+class RequestState {
 public:
-	ZhttpRequest::Rid rid;
-	int responseCode;
-	int inSeq;
-	int outSeq;
-	int outCredits;
-	bool routerResp;
-	QHostAddress peerAddress;
-	QHostAddress logicalPeerAddress;
-	bool isHttps;
-	bool debug;
-	bool isRetry;
-	bool autoCrossOrigin;
-	QByteArray jsonpCallback;
-	bool jsonpExtendedResponse;
-	int unreportedTime;
-	Variant userData;
+    ZhttpRequest::Rid rid;
+    int responseCode;
+    int inSeq;
+    int outSeq;
+    int outCredits;
+    bool routerResp;
+    QHostAddress peerAddress;
+    QHostAddress logicalPeerAddress;
+    bool isHttps;
+    bool debug;
+    bool isRetry;
+    bool autoCrossOrigin;
+    QByteArray jsonpCallback;
+    bool jsonpExtendedResponse;
+    int unreportedTime;
+    Variant userData;
 
-	RequestState() :
-		responseCode(-1),
-		inSeq(0),
-		outSeq(0),
-		outCredits(0),
-		routerResp(false),
-		isHttps(false),
-		debug(false),
-		isRetry(false),
-		autoCrossOrigin(false),
-		jsonpExtendedResponse(false),
-		unreportedTime(-1)
-	{
-	}
+    RequestState()
+        : responseCode(-1),
+          inSeq(0),
+          outSeq(0),
+          outCredits(0),
+          routerResp(false),
+          isHttps(false),
+          debug(false),
+          isRetry(false),
+          autoCrossOrigin(false),
+          jsonpExtendedResponse(false),
+          unreportedTime(-1) {}
 
-	static RequestState fromVariant(const Variant &in);
+    static RequestState fromVariant(const Variant &in);
 };
 
 #endif

--- a/src/handler/sequencer.cpp
+++ b/src/handler/sequencer.cpp
@@ -23,267 +23,226 @@
 
 #include "sequencer.h"
 
-#include <QDateTime>
-#include "log.h"
-#include "timer.h"
 #include "defercall.h"
+#include "log.h"
 #include "publishitem.h"
 #include "publishlastids.h"
+#include "timer.h"
+#include <QDateTime>
 
 #define CHANNEL_PENDING_MAX 100
 #define DEFAULT_PENDING_EXPIRE 5000
 #define EXPIRE_INTERVAL 1000
 
-class Sequencer::Private
-{
+class Sequencer::Private {
 public:
-	class PendingItem
-	{
-	public:
-		int64_t time;
-		PublishItem item;
-	};
+    class PendingItem {
+    public:
+        int64_t time;
+        PublishItem item;
+    };
 
-	class ChannelPendingItems
-	{
-	public:
-		QHash<QString, PendingItem*> itemsByPrevId;
+    class ChannelPendingItems {
+    public:
+        QHash<QString, PendingItem *> itemsByPrevId;
 
-		~ChannelPendingItems()
-		{
-			qDeleteAll(itemsByPrevId);
-		}
-	};
+        ~ChannelPendingItems() { qDeleteAll(itemsByPrevId); }
+    };
 
-	class CachedId
-	{
-	public:
-		int64_t expireTime;
-		QString channel;
-		QString id;
-	};
+    class CachedId {
+    public:
+        int64_t expireTime;
+        QString channel;
+        QString id;
+    };
 
-	Sequencer *q;
-	PublishLastIds *lastIds;
-	QHash<QString, ChannelPendingItems> pendingItemsByChannel;
-	QMap<QPair<int64_t, PendingItem*>, PendingItem*> pendingItemsByTime;
-	std::unique_ptr<Timer> expireTimer;
-	int pendingExpireMSecs;
-	int idCacheTtl;
-	QHash<QPair<QString, QString>, CachedId*> idCacheById;
-	QMap<QPair<int64_t, CachedId*>, CachedId*> idCacheByExpireTime;
+    Sequencer *q;
+    PublishLastIds *lastIds;
+    QHash<QString, ChannelPendingItems> pendingItemsByChannel;
+    QMap<QPair<int64_t, PendingItem *>, PendingItem *> pendingItemsByTime;
+    std::unique_ptr<Timer> expireTimer;
+    int pendingExpireMSecs;
+    int idCacheTtl;
+    QHash<QPair<QString, QString>, CachedId *> idCacheById;
+    QMap<QPair<int64_t, CachedId *>, CachedId *> idCacheByExpireTime;
 
-	Private(Sequencer *_q, PublishLastIds *_publishLastIds) :
-		q(_q),
-		lastIds(_publishLastIds),
-		pendingExpireMSecs(DEFAULT_PENDING_EXPIRE),
-		idCacheTtl(-1)
-	{
-		expireTimer = std::make_unique<Timer>();
-		expireTimer->timeout.connect(boost::bind(&Private::expireTimer_timeout, this));
-	}
+    Private(Sequencer *_q, PublishLastIds *_publishLastIds)
+        : q(_q),
+          lastIds(_publishLastIds),
+          pendingExpireMSecs(DEFAULT_PENDING_EXPIRE),
+          idCacheTtl(-1) {
+        expireTimer = std::make_unique<Timer>();
+        expireTimer->timeout.connect(boost::bind(&Private::expireTimer_timeout, this));
+    }
 
-	~Private()
-	{
-		qDeleteAll(idCacheById);
-	}
+    ~Private() { qDeleteAll(idCacheById); }
 
-	void addItem(const PublishItem &item, bool seq)
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
+    void addItem(const PublishItem &item, bool seq) {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
 
-		while(!idCacheByExpireTime.isEmpty())
-		{
-			QMap<QPair<int64_t, CachedId*>, CachedId*>::iterator it = idCacheByExpireTime.begin();
-			CachedId *i = it.value();
+        while (!idCacheByExpireTime.isEmpty()) {
+            QMap<QPair<int64_t, CachedId *>, CachedId *>::iterator it = idCacheByExpireTime.begin();
+            CachedId *i = it.value();
 
-			if(i->expireTime > now)
-				break;
+            if (i->expireTime > now)
+                break;
 
-			idCacheById.remove(QPair<QString, QString>(i->channel, i->id));
-			idCacheByExpireTime.erase(it);
-			delete i;
-		}
+            idCacheById.remove(QPair<QString, QString>(i->channel, i->id));
+            idCacheByExpireTime.erase(it);
+            delete i;
+        }
 
-		if(!item.id.isNull() && idCacheTtl > 0)
-		{
-			QPair<QString, QString> idKey(item.channel, item.id);
-			if(idCacheById.contains(idKey))
-			{
-				// We've seen this ID recently, drop the message
-				return;
-			}
+        if (!item.id.isNull() && idCacheTtl > 0) {
+            QPair<QString, QString> idKey(item.channel, item.id);
+            if (idCacheById.contains(idKey)) {
+                // We've seen this ID recently, drop the message
+                return;
+            }
 
-			CachedId *i = new CachedId;
-			i->expireTime = now + (idCacheTtl * 1000);
-			i->channel = item.channel;
-			i->id = item.id;
-			idCacheById.insert(idKey, i);
-			idCacheByExpireTime.insert(QPair<int64_t, CachedId*>(i->expireTime, i), i);
-		}
+            CachedId *i = new CachedId;
+            i->expireTime = now + (idCacheTtl * 1000);
+            i->channel = item.channel;
+            i->id = item.id;
+            idCacheById.insert(idKey, i);
+            idCacheByExpireTime.insert(QPair<int64_t, CachedId *>(i->expireTime, i), i);
+        }
 
-		if(!seq)
-		{
-			q->itemReady(item);
-			return;
-		}
+        if (!seq) {
+            q->itemReady(item);
+            return;
+        }
 
-		QString lastId = lastIds->value(item.channel);
+        QString lastId = lastIds->value(item.channel);
 
-		if(!lastId.isNull() && !item.prevId.isNull() && lastId != item.prevId)
-		{
-			ChannelPendingItems &channelPendingItems = pendingItemsByChannel[item.channel];
+        if (!lastId.isNull() && !item.prevId.isNull() && lastId != item.prevId) {
+            ChannelPendingItems &channelPendingItems = pendingItemsByChannel[item.channel];
 
-			if(channelPendingItems.itemsByPrevId.contains(item.prevId))
-			{
-				log_debug("sequencer: already have item for channel [%s] depending on prev-id [%s], dropping", qPrintable(item.channel), qPrintable(item.prevId));
-				return;
-			}
+            if (channelPendingItems.itemsByPrevId.contains(item.prevId)) {
+                log_debug("sequencer: already have item for channel [%s] depending on "
+                          "prev-id [%s], dropping",
+                          qPrintable(item.channel), qPrintable(item.prevId));
+                return;
+            }
 
-			if(channelPendingItems.itemsByPrevId.count() >= CHANNEL_PENDING_MAX)
-			{
-				log_debug("sequencer: too many pending items for channel [%s], dropping", qPrintable(item.channel));
-				return;
-			}
+            if (channelPendingItems.itemsByPrevId.count() >= CHANNEL_PENDING_MAX) {
+                log_debug("sequencer: too many pending items for channel [%s], dropping",
+                          qPrintable(item.channel));
+                return;
+            }
 
-			PendingItem *i = new PendingItem;
-			i->time = now;
-			i->item = item;
+            PendingItem *i = new PendingItem;
+            i->time = now;
+            i->item = item;
 
-			channelPendingItems.itemsByPrevId.insert(item.prevId, i);
-			pendingItemsByTime.insert(QPair<int64_t, PendingItem*>(i->time, i), i);
+            channelPendingItems.itemsByPrevId.insert(item.prevId, i);
+            pendingItemsByTime.insert(QPair<int64_t, PendingItem *>(i->time, i), i);
 
-			if(!expireTimer->isActive())
-				expireTimer->start(EXPIRE_INTERVAL);
-			return;
-		}
+            if (!expireTimer->isActive())
+                expireTimer->start(EXPIRE_INTERVAL);
+            return;
+        }
 
-		sendItem(item);
-	}
+        sendItem(item);
+    }
 
-	void clear(const QString &channel)
-	{
-		if(!pendingItemsByChannel.contains(channel))
-			return;
+    void clear(const QString &channel) {
+        if (!pendingItemsByChannel.contains(channel))
+            return;
 
-		ChannelPendingItems &channelPendingItems = pendingItemsByChannel[channel];
-		QHashIterator<QString, PendingItem*> it(channelPendingItems.itemsByPrevId);
-		while(it.hasNext())
-		{
-			it.next();
-			PendingItem *i = it.value();
+        ChannelPendingItems &channelPendingItems = pendingItemsByChannel[channel];
+        QHashIterator<QString, PendingItem *> it(channelPendingItems.itemsByPrevId);
+        while (it.hasNext()) {
+            it.next();
+            PendingItem *i = it.value();
 
-			pendingItemsByTime.remove(QPair<int64_t, PendingItem*>(i->time, i));
-		}
+            pendingItemsByTime.remove(QPair<int64_t, PendingItem *>(i->time, i));
+        }
 
-		pendingItemsByChannel.remove(channel);
-	}
+        pendingItemsByChannel.remove(channel);
+    }
 
-	void sendItem(const PublishItem &item)
-	{
-		if(!item.id.isNull())
-			lastIds->set(item.channel, item.id);
-		else
-			lastIds->remove(item.channel);
+    void sendItem(const PublishItem &item) {
+        if (!item.id.isNull())
+            lastIds->set(item.channel, item.id);
+        else
+            lastIds->remove(item.channel);
 
-		q->itemReady(item);
+        q->itemReady(item);
 
-		if(pendingItemsByChannel.contains(item.channel))
-		{
-			ChannelPendingItems &channelPendingItems = pendingItemsByChannel[item.channel];
-			QString id = item.id;
+        if (pendingItemsByChannel.contains(item.channel)) {
+            ChannelPendingItems &channelPendingItems = pendingItemsByChannel[item.channel];
+            QString id = item.id;
 
-			while(!id.isNull() && !channelPendingItems.itemsByPrevId.isEmpty())
-			{
-				PendingItem *i = channelPendingItems.itemsByPrevId.value(id);
-				if(!i)
-					break;
+            while (!id.isNull() && !channelPendingItems.itemsByPrevId.isEmpty()) {
+                PendingItem *i = channelPendingItems.itemsByPrevId.value(id);
+                if (!i)
+                    break;
 
-				PublishItem pitem = i->item;
-				channelPendingItems.itemsByPrevId.remove(i->item.prevId);
-				pendingItemsByTime.remove(QPair<int64_t, PendingItem*>(i->time, i));
-				delete i;
+                PublishItem pitem = i->item;
+                channelPendingItems.itemsByPrevId.remove(i->item.prevId);
+                pendingItemsByTime.remove(QPair<int64_t, PendingItem *>(i->time, i));
+                delete i;
 
-				if(!pitem.id.isNull())
-					lastIds->set(pitem.channel, pitem.id);
-				else
-					lastIds->remove(pitem.channel);
+                if (!pitem.id.isNull())
+                    lastIds->set(pitem.channel, pitem.id);
+                else
+                    lastIds->remove(pitem.channel);
 
-				q->itemReady(pitem);
+                q->itemReady(pitem);
 
-				id = pitem.id;
-			}
+                id = pitem.id;
+            }
 
-			if(channelPendingItems.itemsByPrevId.isEmpty())
-			{
-				pendingItemsByChannel.remove(item.channel);
+            if (channelPendingItems.itemsByPrevId.isEmpty()) {
+                pendingItemsByChannel.remove(item.channel);
 
-				if(pendingItemsByChannel.isEmpty())
-					expireTimer->stop();
-			}
-		}
-	}
+                if (pendingItemsByChannel.isEmpty())
+                    expireTimer->stop();
+            }
+        }
+    }
 
-	void expireTimer_timeout()
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
-		int64_t threshold = now - pendingExpireMSecs;
+    void expireTimer_timeout() {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t threshold = now - pendingExpireMSecs;
 
-		while(!pendingItemsByTime.isEmpty())
-		{
-			QMap<QPair<int64_t, PendingItem*>, PendingItem*>::iterator it = pendingItemsByTime.begin();
-			PendingItem *i = it.value();
+        while (!pendingItemsByTime.isEmpty()) {
+            QMap<QPair<int64_t, PendingItem *>, PendingItem *>::iterator it =
+                pendingItemsByTime.begin();
+            PendingItem *i = it.value();
 
-			if(i->time > threshold)
-				break;
+            if (i->time > threshold)
+                break;
 
-			log_debug("timing out item channel=[%s] id=[%s]", qPrintable(i->item.channel), qPrintable(i->item.id));
+            log_debug("timing out item channel=[%s] id=[%s]", qPrintable(i->item.channel),
+                      qPrintable(i->item.id));
 
-			PublishItem item = i->item;
-			ChannelPendingItems &channelPendingItems = pendingItemsByChannel[i->item.channel];
-			channelPendingItems.itemsByPrevId.remove(i->item.prevId);
-			pendingItemsByTime.erase(it);
-			delete i;
+            PublishItem item = i->item;
+            ChannelPendingItems &channelPendingItems = pendingItemsByChannel[i->item.channel];
+            channelPendingItems.itemsByPrevId.remove(i->item.prevId);
+            pendingItemsByTime.erase(it);
+            delete i;
 
-			if(channelPendingItems.itemsByPrevId.isEmpty())
-			{
-				pendingItemsByChannel.remove(item.channel);
+            if (channelPendingItems.itemsByPrevId.isEmpty()) {
+                pendingItemsByChannel.remove(item.channel);
 
-				if(pendingItemsByChannel.isEmpty())
-					expireTimer->stop();
-			}
+                if (pendingItemsByChannel.isEmpty())
+                    expireTimer->stop();
+            }
 
-			sendItem(item);
-		}
-	}
+            sendItem(item);
+        }
+    }
 };
 
-Sequencer::Sequencer(PublishLastIds *publishLastIds)
-{
-	d = new Private(this, publishLastIds);
-}
+Sequencer::Sequencer(PublishLastIds *publishLastIds) { d = new Private(this, publishLastIds); }
 
-Sequencer::~Sequencer()
-{
-	delete d;
-}
+Sequencer::~Sequencer() { delete d; }
 
-void Sequencer::setWaitMax(int msecs)
-{
-	d->pendingExpireMSecs = msecs;
-}
+void Sequencer::setWaitMax(int msecs) { d->pendingExpireMSecs = msecs; }
 
-void Sequencer::setIdCacheTtl(int secs)
-{
-	d->idCacheTtl = secs;
-}
+void Sequencer::setIdCacheTtl(int secs) { d->idCacheTtl = secs; }
 
-void Sequencer::addItem(const PublishItem &item, bool seq)
-{
-	d->addItem(item, seq);
-}
+void Sequencer::addItem(const PublishItem &item, bool seq) { d->addItem(item, seq); }
 
-void Sequencer::clearPendingForChannel(const QString &channel)
-{
-	d->clear(channel);
-}
+void Sequencer::clearPendingForChannel(const QString &channel) { d->clear(channel); }

--- a/src/handler/sequencer.h
+++ b/src/handler/sequencer.h
@@ -31,27 +31,26 @@ class QString;
 class PublishLastIds;
 class PublishItem;
 
-class Sequencer
-{
+class Sequencer {
 public:
-	Sequencer(PublishLastIds *publishLastIds);
-	~Sequencer();
+    Sequencer(PublishLastIds *publishLastIds);
+    ~Sequencer();
 
-	void setWaitMax(int msecs);
-	void setIdCacheTtl(int secs);
+    void setWaitMax(int msecs);
+    void setIdCacheTtl(int secs);
 
-	// Seq = false means ID cache handling only
-	// note: may emit signals
-	void addItem(const PublishItem &item, bool seq = true);
+    // Seq = false means ID cache handling only
+    // note: may emit signals
+    void addItem(const PublishItem &item, bool seq = true);
 
-	void clearPendingForChannel(const QString &channel);
+    void clearPendingForChannel(const QString &channel);
 
-	boost::signals2::signal<void(const PublishItem&)> itemReady;
+    boost::signals2::signal<void(const PublishItem &)> itemReady;
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 };
 
 #endif

--- a/src/handler/sessionrequest.cpp
+++ b/src/handler/sessionrequest.cpp
@@ -23,315 +23,269 @@
 
 #include "sessionrequest.h"
 
+#include "deferred.h"
+#include "detectrule.h"
 #include "qtcompat.h"
 #include "variant.h"
 #include "zrpcmanager.h"
 #include "zrpcrequest.h"
-#include "deferred.h"
-#include "detectrule.h"
 
 namespace SessionRequest {
 
-class DetectRulesSet : public Deferred
-{
+class DetectRulesSet : public Deferred {
 public:
-	DetectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
-	{
-		req = std::make_unique<ZrpcRequest>(stateClient);
-		finishedConnection = req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this));
+    DetectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules) {
+        req = std::make_unique<ZrpcRequest>(stateClient);
+        finishedConnection =
+            req->finished.connect(boost::bind(&DetectRulesSet::req_finished, this));
 
-		VariantList rlist;
-		foreach(const DetectRule &rule, rules)
-		{
-			VariantHash i;
-			i["domain"] = rule.domain.toUtf8();
-			i["path-prefix"] = rule.pathPrefix;
-			i["sid-ptr"] = rule.sidPtr.toUtf8();
-			if(!rule.jsonParam.isEmpty())
-				i["json-param"] = rule.jsonParam.toUtf8();
-			rlist += i;
-		}
+        VariantList rlist;
+        foreach (const DetectRule &rule, rules) {
+            VariantHash i;
+            i["domain"] = rule.domain.toUtf8();
+            i["path-prefix"] = rule.pathPrefix;
+            i["sid-ptr"] = rule.sidPtr.toUtf8();
+            if (!rule.jsonParam.isEmpty())
+                i["json-param"] = rule.jsonParam.toUtf8();
+            rlist += i;
+        }
 
-		VariantHash args;
-		args["rules"] = rlist;
-		req->start("session-detect-rules-set", args);
-	}
+        VariantHash args;
+        args["rules"] = rlist;
+        req->start("session-detect-rules-set", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-		{
-			setFinished(true);
-		}
-		else
-		{
-			setFinished(false, req->errorCondition());
-		}
-	}
+    void req_finished() {
+        if (req->success()) {
+            setFinished(true);
+        } else {
+            setFinished(false, req->errorCondition());
+        }
+    }
 };
 
-class DetectRulesGet : public Deferred
-{
+class DetectRulesGet : public Deferred {
 public:
-	DetectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
-	{
-		req = std::make_unique<ZrpcRequest>(stateClient);
-		finishedConnection = req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this));
+    DetectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path) {
+        req = std::make_unique<ZrpcRequest>(stateClient);
+        finishedConnection =
+            req->finished.connect(boost::bind(&DetectRulesGet::req_finished, this));
 
-		VariantHash args;
-		args["domain"] = domain.toUtf8();
-		args["path"] = path;
-		req->start("session-detect-rules-get", args);
-	}
+        VariantHash args;
+        args["domain"] = domain.toUtf8();
+        args["path"] = path;
+        req->start("session-detect-rules-get", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-		{
-			Variant vresult = req->result();
-			if(typeId(vresult) != VariantType::List)
-			{
-				setFinished(false);
-				return;
-			}
+    void req_finished() {
+        if (req->success()) {
+            Variant vresult = req->result();
+            if (typeId(vresult) != VariantType::List) {
+                setFinished(false);
+                return;
+            }
 
-			VariantList result = vresult.toList();
+            VariantList result = vresult.toList();
 
-			QList<DetectRule> rules;
-			for(const Variant &vr : result)
-			{
-				if(typeId(vr) != VariantType::Hash)
-				{
-					setFinished(false);
-					return;
-				}
+            QList<DetectRule> rules;
+            for (const Variant &vr : result) {
+                if (typeId(vr) != VariantType::Hash) {
+                    setFinished(false);
+                    return;
+                }
 
-				VariantHash r = vr.toHash();
+                VariantHash r = vr.toHash();
 
-				DetectRule rule;
+                DetectRule rule;
 
-				if(!r.contains("domain") || typeId(r["domain"]) != VariantType::ByteArray)
-				{
-					setFinished(false);
-					return;
-				}
+                if (!r.contains("domain") || typeId(r["domain"]) != VariantType::ByteArray) {
+                    setFinished(false);
+                    return;
+                }
 
-				rule.domain = QString::fromUtf8(r["domain"].toByteArray());
+                rule.domain = QString::fromUtf8(r["domain"].toByteArray());
 
-				if(!r.contains("path-prefix") || typeId(r["path-prefix"]) != VariantType::ByteArray)
-				{
-					setFinished(false);
-					return;
-				}
+                if (!r.contains("path-prefix") ||
+                    typeId(r["path-prefix"]) != VariantType::ByteArray) {
+                    setFinished(false);
+                    return;
+                }
 
-				rule.pathPrefix = r["path-prefix"].toByteArray();
+                rule.pathPrefix = r["path-prefix"].toByteArray();
 
-				if(!r.contains("sid-ptr") || typeId(r["sid-ptr"]) != VariantType::ByteArray)
-				{
-					setFinished(false);
-					return;
-				}
+                if (!r.contains("sid-ptr") || typeId(r["sid-ptr"]) != VariantType::ByteArray) {
+                    setFinished(false);
+                    return;
+                }
 
-				rule.sidPtr = QString::fromUtf8(r["sid-ptr"].toByteArray());
+                rule.sidPtr = QString::fromUtf8(r["sid-ptr"].toByteArray());
 
-				if(r.contains("json-param"))
-				{
-					if(typeId(r["json-param"]) != VariantType::ByteArray)
-					{
-						setFinished(false);
-						return;
-					}
+                if (r.contains("json-param")) {
+                    if (typeId(r["json-param"]) != VariantType::ByteArray) {
+                        setFinished(false);
+                        return;
+                    }
 
-					rule.jsonParam = QString::fromUtf8(r["json-param"].toByteArray());
-				}
+                    rule.jsonParam = QString::fromUtf8(r["json-param"].toByteArray());
+                }
 
-				rules += rule;
-			}
+                rules += rule;
+            }
 
-			setFinished(true, Variant::fromValue<DetectRuleList>(rules));
-		}
-		else
-		{
-			setFinished(false, req->errorCondition());
-		}
-	}
+            setFinished(true, Variant::fromValue<DetectRuleList>(rules));
+        } else {
+            setFinished(false, req->errorCondition());
+        }
+    }
 };
 
-class CreateOrUpdate : public Deferred
-{
+class CreateOrUpdate : public Deferred {
 public:
-	CreateOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
-	{
-		req = std::make_unique<ZrpcRequest>(stateClient);
-		finishedConnection = req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this));
+    CreateOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds) {
+        req = std::make_unique<ZrpcRequest>(stateClient);
+        finishedConnection =
+            req->finished.connect(boost::bind(&CreateOrUpdate::req_finished, this));
 
-		VariantHash args;
+        VariantHash args;
 
-		args["sid"] = sid.toUtf8();
+        args["sid"] = sid.toUtf8();
 
-		VariantHash vlastIds;
-		QHashIterator<QString, QString> it(lastIds);
-		while(it.hasNext())
-		{
-			it.next();
-			vlastIds.insert(it.key(), it.value().toUtf8());
-		}
-		args["last-ids"] = vlastIds;
+        VariantHash vlastIds;
+        QHashIterator<QString, QString> it(lastIds);
+        while (it.hasNext()) {
+            it.next();
+            vlastIds.insert(it.key(), it.value().toUtf8());
+        }
+        args["last-ids"] = vlastIds;
 
-		req->start("session-create-or-update", args);
-	}
+        req->start("session-create-or-update", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-		{
-			setFinished(true);
-		}
-		else
-		{
-			setFinished(false, req->errorCondition());
-		}
-	}
+    void req_finished() {
+        if (req->success()) {
+            setFinished(true);
+        } else {
+            setFinished(false, req->errorCondition());
+        }
+    }
 };
 
-class UpdateMany : public Deferred
-{
+class UpdateMany : public Deferred {
 public:
-	UpdateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
-	{
-		req = std::make_unique<ZrpcRequest>(stateClient);
-		finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this));
+    UpdateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds) {
+        req = std::make_unique<ZrpcRequest>(stateClient);
+        finishedConnection = req->finished.connect(boost::bind(&UpdateMany::req_finished, this));
 
-		VariantHash vsidLastIds;
+        VariantHash vsidLastIds;
 
-		QHashIterator<QString, LastIds> it(sidLastIds);
-		while(it.hasNext())
-		{
-			it.next();
-			const QString &sid = it.key();
-			const LastIds &lastIds = it.value();
+        QHashIterator<QString, LastIds> it(sidLastIds);
+        while (it.hasNext()) {
+            it.next();
+            const QString &sid = it.key();
+            const LastIds &lastIds = it.value();
 
-			VariantHash vlastIds;
+            VariantHash vlastIds;
 
-			QHashIterator<QString, QString> it(lastIds);
-			while(it.hasNext())
-			{
-				it.next();
-				vlastIds.insert(it.key(), it.value().toUtf8());
-			}
+            QHashIterator<QString, QString> it(lastIds);
+            while (it.hasNext()) {
+                it.next();
+                vlastIds.insert(it.key(), it.value().toUtf8());
+            }
 
-			vsidLastIds.insert(sid, vlastIds);
-		}
+            vsidLastIds.insert(sid, vlastIds);
+        }
 
-		VariantHash args;
-		args["sid-last-ids"] = vsidLastIds;
-		req->start("session-update-many", args);
-	}
+        VariantHash args;
+        args["sid-last-ids"] = vsidLastIds;
+        req->start("session-update-many", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-		{
-			setFinished(true);
-		}
-		else
-		{
-			setFinished(false, req->errorCondition());
-		}
-	}
+    void req_finished() {
+        if (req->success()) {
+            setFinished(true);
+        } else {
+            setFinished(false, req->errorCondition());
+        }
+    }
 };
 
-class GetLastIds : public Deferred
-{
+class GetLastIds : public Deferred {
 public:
-	GetLastIds(ZrpcManager *stateClient, const QString &sid)
-	{
-		req = std::make_unique<ZrpcRequest>(stateClient);
-		finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this));
+    GetLastIds(ZrpcManager *stateClient, const QString &sid) {
+        req = std::make_unique<ZrpcRequest>(stateClient);
+        finishedConnection = req->finished.connect(boost::bind(&GetLastIds::req_finished, this));
 
-		VariantHash args;
-		args["sid"] = sid.toUtf8();
-		req->start("session-get-last-ids", args);
-	}
+        VariantHash args;
+        args["sid"] = sid.toUtf8();
+        req->start("session-get-last-ids", args);
+    }
 
 private:
-	std::unique_ptr<ZrpcRequest> req;
-	Connection finishedConnection;
+    std::unique_ptr<ZrpcRequest> req;
+    Connection finishedConnection;
 
-	void req_finished()
-	{
-		if(req->success())
-		{
-			Variant vresult = req->result();
-			if(typeId(vresult) != VariantType::Hash)
-			{
-				setFinished(false);
-				return;
-			}
+    void req_finished() {
+        if (req->success()) {
+            Variant vresult = req->result();
+            if (typeId(vresult) != VariantType::Hash) {
+                setFinished(false);
+                return;
+            }
 
-			VariantHash result = vresult.toHash();
+            VariantHash result = vresult.toHash();
 
-			QHash<QString, QString> out;
-			for(auto it = result.constBegin(); it != result.constEnd(); ++it)
-			{
-				const Variant &i = it.value();
-				if(typeId(i) != VariantType::ByteArray)
-				{
-					setFinished(false);
-					return;
-				}
+            QHash<QString, QString> out;
+            for (auto it = result.constBegin(); it != result.constEnd(); ++it) {
+                const Variant &i = it.value();
+                if (typeId(i) != VariantType::ByteArray) {
+                    setFinished(false);
+                    return;
+                }
 
-				out.insert(it.key(), QString::fromUtf8(i.toByteArray()));
-			}
+                out.insert(it.key(), QString::fromUtf8(i.toByteArray()));
+            }
 
-			setFinished(true, Variant::fromValue<LastIds>(out));
-		}
-		else
-		{
-			setFinished(false, req->errorCondition());
-		}
-	}
+            setFinished(true, Variant::fromValue<LastIds>(out));
+        } else {
+            setFinished(false, req->errorCondition());
+        }
+    }
 };
 
-Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules)
-{
-	return new DetectRulesSet(stateClient, rules);
+Deferred *detectRulesSet(ZrpcManager *stateClient, const QList<DetectRule> &rules) {
+    return new DetectRulesSet(stateClient, rules);
 }
 
-Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path)
-{
-	return new DetectRulesGet(stateClient, domain, path);
+Deferred *detectRulesGet(ZrpcManager *stateClient, const QString &domain, const QByteArray &path) {
+    return new DetectRulesGet(stateClient, domain, path);
 }
 
-Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds)
-{
-	return new CreateOrUpdate(stateClient, sid, lastIds);
+Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const LastIds &lastIds) {
+    return new CreateOrUpdate(stateClient, sid, lastIds);
 }
 
-Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds)
-{
-	return new UpdateMany(stateClient, sidLastIds);
+Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds) {
+    return new UpdateMany(stateClient, sidLastIds);
 }
 
-Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid)
-{
-	return new GetLastIds(stateClient, sid);
+Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid) {
+    return new GetLastIds(stateClient, sid);
 }
 
-}
+} // namespace SessionRequest

--- a/src/handler/sessionrequest.h
+++ b/src/handler/sessionrequest.h
@@ -24,10 +24,10 @@
 #ifndef SESSIONREQUEST_H
 #define SESSIONREQUEST_H
 
-#include <QString>
-#include <QList>
-#include <QHash>
 #include "lastids.h"
+#include <QHash>
+#include <QList>
+#include <QString>
 #include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
@@ -44,6 +44,6 @@ Deferred *createOrUpdate(ZrpcManager *stateClient, const QString &sid, const Las
 Deferred *updateMany(ZrpcManager *stateClient, const QHash<QString, LastIds> &sidLastIds);
 Deferred *getLastIds(ZrpcManager *stateClient, const QString &sid);
 
-}
+} // namespace SessionRequest
 
 #endif

--- a/src/handler/variantutil.cpp
+++ b/src/handler/variantutil.cpp
@@ -28,299 +28,259 @@
 
 namespace VariantUtil {
 
-void setSuccess(bool *ok, QString *errorMessage)
-{
-	if(ok)
-		*ok = true;
-	if(errorMessage)
-		errorMessage->clear();
+void setSuccess(bool *ok, QString *errorMessage) {
+    if (ok)
+        *ok = true;
+    if (errorMessage)
+        errorMessage->clear();
 }
 
-void setError(bool *ok, QString *errorMessage, const QString &msg)
-{
-	if(ok)
-		*ok = false;
-	if(errorMessage)
-		*errorMessage = msg;
+void setError(bool *ok, QString *errorMessage, const QString &msg) {
+    if (ok)
+        *ok = false;
+    if (errorMessage)
+        *errorMessage = msg;
 }
 
-bool isKeyedObject(const Variant &in)
-{
-	return (typeId(in) == VariantType::Hash || typeId(in) == VariantType::Map);
+bool isKeyedObject(const Variant &in) {
+    return (typeId(in) == VariantType::Hash || typeId(in) == VariantType::Map);
 }
 
-Variant createSameKeyedObject(const Variant &in)
-{
-	if(typeId(in) == VariantType::Hash)
-		return VariantHash();
-	else if(typeId(in) == VariantType::Map)
-		return VariantMap();
-	else
-		return Variant();
+Variant createSameKeyedObject(const Variant &in) {
+    if (typeId(in) == VariantType::Hash)
+        return VariantHash();
+    else if (typeId(in) == VariantType::Map)
+        return VariantMap();
+    else
+        return Variant();
 }
 
-bool keyedObjectIsEmpty(const Variant &in)
-{
-	if(typeId(in) == VariantType::Hash)
-		return in.toHash().isEmpty();
-	else if(typeId(in) == VariantType::Map)
-		return in.toMap().isEmpty();
-	else
-		return true;
+bool keyedObjectIsEmpty(const Variant &in) {
+    if (typeId(in) == VariantType::Hash)
+        return in.toHash().isEmpty();
+    else if (typeId(in) == VariantType::Map)
+        return in.toMap().isEmpty();
+    else
+        return true;
 }
 
-bool keyedObjectContains(const Variant &in, const QString &name)
-{
-	if(typeId(in) == VariantType::Hash)
-		return in.toHash().contains(name);
-	else if(typeId(in) == VariantType::Map)
-		return in.toMap().contains(name);
-	else
-		return false;
+bool keyedObjectContains(const Variant &in, const QString &name) {
+    if (typeId(in) == VariantType::Hash)
+        return in.toHash().contains(name);
+    else if (typeId(in) == VariantType::Map)
+        return in.toMap().contains(name);
+    else
+        return false;
 }
 
-Variant keyedObjectGetValue(const Variant &in, const QString &name)
-{
-	if(typeId(in) == VariantType::Hash)
-		return in.toHash().value(name);
-	else if(typeId(in) == VariantType::Map)
-		return in.toMap().value(name);
-	else
-		return Variant();
+Variant keyedObjectGetValue(const Variant &in, const QString &name) {
+    if (typeId(in) == VariantType::Hash)
+        return in.toHash().value(name);
+    else if (typeId(in) == VariantType::Map)
+        return in.toMap().value(name);
+    else
+        return Variant();
 }
 
-void keyedObjectInsert(Variant *in, const QString &name, const Variant &value)
-{
-	if(typeId(*in) == VariantType::Hash)
-	{
-		VariantHash h = in->toHash();
-		h.insert(name, value);
-		*in = h;
-	}
-	else if(typeId(*in) == VariantType::Map)
-	{
-		VariantMap h = in->toMap();
-		h.insert(name, value);
-		*in = h;
-	}
+void keyedObjectInsert(Variant *in, const QString &name, const Variant &value) {
+    if (typeId(*in) == VariantType::Hash) {
+        VariantHash h = in->toHash();
+        h.insert(name, value);
+        *in = h;
+    } else if (typeId(*in) == VariantType::Map) {
+        VariantMap h = in->toMap();
+        h.insert(name, value);
+        *in = h;
+    }
 }
 
-Variant getChild(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
-{
-	if(!isKeyedObject(in))
-	{
-		QString pn = !parentName.isEmpty() ? parentName : QString("value");
-		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return Variant();
-	}
+Variant getChild(const Variant &in, const QString &parentName, const QString &childName,
+                 bool required, bool *ok, QString *errorMessage) {
+    if (!isKeyedObject(in)) {
+        QString pn = !parentName.isEmpty() ? parentName : QString("value");
+        setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
+        return Variant();
+    }
 
-	QString pn = !parentName.isEmpty() ? parentName : QString("object");
+    QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	Variant v;
-	if(typeId(in) == VariantType::Hash)
-	{
-		VariantHash h = in.toHash();
+    Variant v;
+    if (typeId(in) == VariantType::Hash) {
+        VariantHash h = in.toHash();
 
-		if(!h.contains(childName))
-		{
-			if(required)
-				setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
-			else
-				setSuccess(ok, errorMessage);
+        if (!h.contains(childName)) {
+            if (required)
+                setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
+            else
+                setSuccess(ok, errorMessage);
 
-			return Variant();
-		}
+            return Variant();
+        }
 
-		v = h[childName];
-	}
-	else // Map
-	{
-		VariantMap m = in.toMap();
+        v = h[childName];
+    } else // Map
+    {
+        VariantMap m = in.toMap();
 
-		if(!m.contains(childName))
-		{
-			if(required)
-				setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
-			else
-				setSuccess(ok, errorMessage);
+        if (!m.contains(childName)) {
+            if (required)
+                setError(ok, errorMessage, QString("%1 does not contain '%2'").arg(pn, childName));
+            else
+                setSuccess(ok, errorMessage);
 
-			return Variant();
-		}
+            return Variant();
+        }
 
-		v = m[childName];
-	}
+        v = m[childName];
+    }
 
-	setSuccess(ok, errorMessage);
-	return v;
+    setSuccess(ok, errorMessage);
+    return v;
 }
 
-Variant getKeyedObject(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
-{
-	bool ok_;
-	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return Variant();
-	}
+Variant getKeyedObject(const Variant &in, const QString &parentName, const QString &childName,
+                       bool required, bool *ok, QString *errorMessage) {
+    bool ok_;
+    Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return Variant();
+    }
 
-	if(!v.isValid() && !required)
-	{
-		setSuccess(ok, errorMessage);
-		return Variant();
-	}
+    if (!v.isValid() && !required) {
+        setSuccess(ok, errorMessage);
+        return Variant();
+    }
 
-	QString pn = !parentName.isEmpty() ? parentName : QString("object");
+    QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	if(!isKeyedObject(v))
-	{
-		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
-		return Variant();
-	}
+    if (!isKeyedObject(v)) {
+        setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
+        return Variant();
+    }
 
-	setSuccess(ok, errorMessage);
-	return v;
+    setSuccess(ok, errorMessage);
+    return v;
 }
 
-VariantList getList(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
-{
-	bool ok_;
-	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return VariantList();
-	}
+VariantList getList(const Variant &in, const QString &parentName, const QString &childName,
+                    bool required, bool *ok, QString *errorMessage) {
+    bool ok_;
+    Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return VariantList();
+    }
 
-	if(!v.isValid() && !required)
-	{
-		setSuccess(ok, errorMessage);
-		return VariantList();
-	}
+    if (!v.isValid() && !required) {
+        setSuccess(ok, errorMessage);
+        return VariantList();
+    }
 
-	QString pn = !parentName.isEmpty() ? parentName : QString("object");
+    QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	if(typeId(v) != VariantType::List)
-	{
-		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
-		return VariantList();
-	}
+    if (typeId(v) != VariantType::List) {
+        setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
+        return VariantList();
+    }
 
-	setSuccess(ok, errorMessage);
-	return v.toList();
+    setSuccess(ok, errorMessage);
+    return v.toList();
 }
 
-QString getString(const Variant &in, bool *ok)
-{
-	if(typeId(in) == VariantType::String)
-	{
-		if(ok)
-			*ok = true;
-		return in.toString();
-	}
-	else if(typeId(in) == VariantType::ByteArray)
-	{
-		QByteArray buf = in.toByteArray();
-		if(ok)
-			*ok = true;
-		if(!buf.isNull())
-			return QString::fromUtf8(buf);
-		else
-			return QString();
-	}
-	else
-	{
-		if(ok)
-			*ok = false;
-		return QString();
-	}
+QString getString(const Variant &in, bool *ok) {
+    if (typeId(in) == VariantType::String) {
+        if (ok)
+            *ok = true;
+        return in.toString();
+    } else if (typeId(in) == VariantType::ByteArray) {
+        QByteArray buf = in.toByteArray();
+        if (ok)
+            *ok = true;
+        if (!buf.isNull())
+            return QString::fromUtf8(buf);
+        else
+            return QString();
+    } else {
+        if (ok)
+            *ok = false;
+        return QString();
+    }
 }
 
-QString getString(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok, QString *errorMessage)
-{
-	bool ok_;
-	Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return QString();
-	}
+QString getString(const Variant &in, const QString &parentName, const QString &childName,
+                  bool required, bool *ok, QString *errorMessage) {
+    bool ok_;
+    Variant v = getChild(in, parentName, childName, required, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return QString();
+    }
 
-	if(!v.isValid() && !required)
-	{
-		setSuccess(ok, errorMessage);
-		return QString();
-	}
+    if (!v.isValid() && !required) {
+        setSuccess(ok, errorMessage);
+        return QString();
+    }
 
-	QString pn = !parentName.isEmpty() ? parentName : QString("object");
+    QString pn = !parentName.isEmpty() ? parentName : QString("object");
 
-	QString str = getString(v, &ok_);
-	if(!ok_)
-	{
-		setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
-		return QString();
-	}
+    QString str = getString(v, &ok_);
+    if (!ok_) {
+        setError(ok, errorMessage, QString("%1 contains '%2' with wrong type").arg(pn, childName));
+        return QString();
+    }
 
-	setSuccess(ok, errorMessage);
-	return str;
+    setSuccess(ok, errorMessage);
+    return str;
 }
 
-bool convertToJsonStyleInPlace(Variant *in)
-{
-	// Hash -> Map
-	// ByteArray (UTF-8) -> String
+bool convertToJsonStyleInPlace(Variant *in) {
+    // Hash -> Map
+    // ByteArray (UTF-8) -> String
 
-	bool changed = false;
+    bool changed = false;
 
-	VariantType::Type type = typeId(*in);
-	if(type == VariantType::Hash)
-	{
-		VariantMap vmap;
-		VariantHash vhash = in->toHash();
-		for(auto it = vhash.constBegin(); it != vhash.constEnd(); ++it)
-		{
-			Variant i = it.value();
-			convertToJsonStyleInPlace(&i);
-			vmap[it.key()] = i;
-		}
+    VariantType::Type type = typeId(*in);
+    if (type == VariantType::Hash) {
+        VariantMap vmap;
+        VariantHash vhash = in->toHash();
+        for (auto it = vhash.constBegin(); it != vhash.constEnd(); ++it) {
+            Variant i = it.value();
+            convertToJsonStyleInPlace(&i);
+            vmap[it.key()] = i;
+        }
 
-		*in = vmap;
-		changed = true;
-	}
-	else if(type == VariantType::List)
-	{
-		VariantList vlist = in->toList();
-		for(int n = 0; n < vlist.count(); ++n)
-		{
-			Variant i = vlist.at(n);
-			convertToJsonStyleInPlace(&i);
-			vlist[n] = i;
-		}
+        *in = vmap;
+        changed = true;
+    } else if (type == VariantType::List) {
+        VariantList vlist = in->toList();
+        for (int n = 0; n < vlist.count(); ++n) {
+            Variant i = vlist.at(n);
+            convertToJsonStyleInPlace(&i);
+            vlist[n] = i;
+        }
 
-		*in = vlist;
-		changed = true;
-	}
-	else if(type == VariantType::ByteArray)
-	{
-		QByteArray buf = in->toByteArray();
-		if(!buf.isNull())
-			*in = QString::fromUtf8(buf);
-		else
-			*in = QString();
-		changed = true;
-	}
+        *in = vlist;
+        changed = true;
+    } else if (type == VariantType::ByteArray) {
+        QByteArray buf = in->toByteArray();
+        if (!buf.isNull())
+            *in = QString::fromUtf8(buf);
+        else
+            *in = QString();
+        changed = true;
+    }
 
-	return changed;
+    return changed;
 }
 
-Variant convertToJsonStyle(const Variant &in)
-{
-	Variant v = in;
-	convertToJsonStyleInPlace(&v);
-	return v;
+Variant convertToJsonStyle(const Variant &in) {
+    Variant v = in;
+    convertToJsonStyleInPlace(&v);
+    return v;
 }
 
-}
+} // namespace VariantUtil

--- a/src/handler/variantutil.h
+++ b/src/handler/variantutil.h
@@ -37,17 +37,21 @@ bool keyedObjectContains(const Variant &in, const QString &name);
 Variant keyedObjectGetValue(const Variant &in, const QString &name);
 void keyedObjectInsert(Variant *in, const QString &name, const Variant &value);
 
-Variant getChild(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
-Variant getKeyedObject(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
-VariantList getList(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
+Variant getChild(const Variant &in, const QString &parentName, const QString &childName,
+                 bool required, bool *ok = 0, QString *errorMessage = 0);
+Variant getKeyedObject(const Variant &in, const QString &parentName, const QString &childName,
+                       bool required, bool *ok = 0, QString *errorMessage = 0);
+VariantList getList(const Variant &in, const QString &parentName, const QString &childName,
+                    bool required, bool *ok = 0, QString *errorMessage = 0);
 QString getString(const Variant &in, bool *ok = 0);
-QString getString(const Variant &in, const QString &parentName, const QString &childName, bool required, bool *ok = 0, QString *errorMessage = 0);
+QString getString(const Variant &in, const QString &parentName, const QString &childName,
+                  bool required, bool *ok = 0, QString *errorMessage = 0);
 
 // Return true if item modified
 bool convertToJsonStyleInPlace(Variant *in);
 
 Variant convertToJsonStyle(const Variant &in);
 
-}
+} // namespace VariantUtil
 
 #endif

--- a/src/handler/wscontrolmessage.cpp
+++ b/src/handler/wscontrolmessage.cpp
@@ -29,236 +29,202 @@
 
 using namespace VariantUtil;
 
-WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QString *errorMessage)
-{
-	QString pn = "grip control packet";
+WsControlMessage WsControlMessage::fromVariant(const Variant &in, bool *ok, QString *errorMessage) {
+    QString pn = "grip control packet";
 
-	if(!isKeyedObject(in))
-	{
-		setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
-		return WsControlMessage();
-	}
+    if (!isKeyedObject(in)) {
+        setError(ok, errorMessage, QString("%1 is not an object").arg(pn));
+        return WsControlMessage();
+    }
 
-	pn = "grip control object";
+    pn = "grip control object";
 
-	WsControlMessage out;
+    WsControlMessage out;
 
-	bool ok_;
-	QString type = getString(in, pn, "type", true, &ok_, errorMessage);
-	if(!ok_)
-	{
-		if(ok)
-			*ok = false;
-		return WsControlMessage();
-	}
+    bool ok_;
+    QString type = getString(in, pn, "type", true, &ok_, errorMessage);
+    if (!ok_) {
+        if (ok)
+            *ok = false;
+        return WsControlMessage();
+    }
 
-	if(type == "subscribe")
-		out.type = Subscribe;
-	else if(type == "unsubscribe")
-		out.type = Unsubscribe;
-	else if(type == "detach")
-		out.type = Detach;
-	else if(type == "session")
-		out.type = Session;
-	else if(type == "set-meta")
-		out.type = SetMeta;
-	else if(type == "keep-alive")
-		out.type = KeepAlive;
-	else if(type == "send-delayed")
-		out.type = SendDelayed;
-	else if(type == "flush-delayed")
-		out.type = FlushDelayed;
-	else
-	{
-		setError(ok, errorMessage, QString("'type' contains unknown value: %1").arg(type));
-		return WsControlMessage();
-	}
+    if (type == "subscribe")
+        out.type = Subscribe;
+    else if (type == "unsubscribe")
+        out.type = Unsubscribe;
+    else if (type == "detach")
+        out.type = Detach;
+    else if (type == "session")
+        out.type = Session;
+    else if (type == "set-meta")
+        out.type = SetMeta;
+    else if (type == "keep-alive")
+        out.type = KeepAlive;
+    else if (type == "send-delayed")
+        out.type = SendDelayed;
+    else if (type == "flush-delayed")
+        out.type = FlushDelayed;
+    else {
+        setError(ok, errorMessage, QString("'type' contains unknown value: %1").arg(type));
+        return WsControlMessage();
+    }
 
-	if(out.type == Subscribe || out.type == Unsubscribe)
-	{
-		out.channel = getString(in, pn, "channel", true, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return WsControlMessage();
-		}
+    if (out.type == Subscribe || out.type == Unsubscribe) {
+        out.channel = getString(in, pn, "channel", true, &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return WsControlMessage();
+        }
 
-		if(out.channel.isEmpty())
-		{
-			setError(ok, errorMessage, QString("%1 contains 'channel' with invalid value").arg(pn));
-			return WsControlMessage();
-		}
+        if (out.channel.isEmpty()) {
+            setError(ok, errorMessage, QString("%1 contains 'channel' with invalid value").arg(pn));
+            return WsControlMessage();
+        }
 
-		if(out.type == Subscribe)
-		{
-			VariantList vfilters = getList(in, pn, "filters", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return WsControlMessage();
-			}
+        if (out.type == Subscribe) {
+            VariantList vfilters = getList(in, pn, "filters", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return WsControlMessage();
+            }
 
-			for(const Variant &vfilter : vfilters)
-			{
-				QString filter = getString(vfilter, &ok_);
-				if(!ok_)
-				{
-					setError(ok, errorMessage, "filters contains value with wrong type");
-					return WsControlMessage();
-				}
+            for (const Variant &vfilter : vfilters) {
+                QString filter = getString(vfilter, &ok_);
+                if (!ok_) {
+                    setError(ok, errorMessage, "filters contains value with wrong type");
+                    return WsControlMessage();
+                }
 
-				out.filters += filter;
-			}
-		}
-	}
-	else if(out.type == Session)
-	{
-		out.sessionId = getString(in, pn, "id", false, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return WsControlMessage();
-		}
-	}
-	else if(out.type == SetMeta)
-	{
-		out.metaName = getString(in, pn, "name", true, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return WsControlMessage();
-		}
+                out.filters += filter;
+            }
+        }
+    } else if (out.type == Session) {
+        out.sessionId = getString(in, pn, "id", false, &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return WsControlMessage();
+        }
+    } else if (out.type == SetMeta) {
+        out.metaName = getString(in, pn, "name", true, &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return WsControlMessage();
+        }
 
-		if(out.metaName.isEmpty())
-		{
-			setError(ok, errorMessage, QString("%1 contains 'name' with invalid value").arg(pn));
-			return WsControlMessage();
-		}
+        if (out.metaName.isEmpty()) {
+            setError(ok, errorMessage, QString("%1 contains 'name' with invalid value").arg(pn));
+            return WsControlMessage();
+        }
 
-		out.metaValue = getString(in, pn, "value", false, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return WsControlMessage();
-		}
-	}
-	else if(out.type == KeepAlive || out.type == SendDelayed)
-	{
-		QString typeStr = getString(in, pn, "message-type", false, &ok_, errorMessage);
-		if(!ok_)
-		{
-			if(ok)
-				*ok = false;
-			return WsControlMessage();
-		}
+        out.metaValue = getString(in, pn, "value", false, &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return WsControlMessage();
+        }
+    } else if (out.type == KeepAlive || out.type == SendDelayed) {
+        QString typeStr = getString(in, pn, "message-type", false, &ok_, errorMessage);
+        if (!ok_) {
+            if (ok)
+                *ok = false;
+            return WsControlMessage();
+        }
 
-		if(!typeStr.isNull())
-		{
-			if(typeStr == "text")
-				out.messageType = Text;
-			else if(typeStr == "binary")
-				out.messageType = Binary;
-			else if(typeStr == "ping")
-				out.messageType = Ping;
-			else if(typeStr == "pong")
-				out.messageType = Pong;
-			else
-			{
-				setError(ok, errorMessage, QString("%1 contains 'message-type' with unknown value").arg(pn));
-				return WsControlMessage();
-			}
-		}
-		else
-		{
-			// Default
-			out.messageType = Text;
-		}
+        if (!typeStr.isNull()) {
+            if (typeStr == "text")
+                out.messageType = Text;
+            else if (typeStr == "binary")
+                out.messageType = Binary;
+            else if (typeStr == "ping")
+                out.messageType = Ping;
+            else if (typeStr == "pong")
+                out.messageType = Pong;
+            else {
+                setError(ok, errorMessage,
+                         QString("%1 contains 'message-type' with unknown value").arg(pn));
+                return WsControlMessage();
+            }
+        } else {
+            // Default
+            out.messageType = Text;
+        }
 
-		if(keyedObjectContains(in, "content-bin"))
-		{
-			Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
+        if (keyedObjectContains(in, "content-bin")) {
+            Variant vcontentBin = keyedObjectGetValue(in, "content-bin");
 
-			if(typeId(in) == VariantType::Map) // JSON input
-			{
-				if(typeId(vcontentBin) != VariantType::String)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
-					return WsControlMessage();
-				}
+            if (typeId(in) == VariantType::Map) // JSON input
+            {
+                if (typeId(vcontentBin) != VariantType::String) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content-bin' with wrong type").arg(pn));
+                    return WsControlMessage();
+                }
 
-				out.content = QByteArray::fromBase64(vcontentBin.toString().toUtf8());
-			}
-			else
-			{
-				if(typeId(vcontentBin) != VariantType::ByteArray)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'content-bin' with wrong type").arg(pn));
-					return WsControlMessage();
-				}
+                out.content = QByteArray::fromBase64(vcontentBin.toString().toUtf8());
+            } else {
+                if (typeId(vcontentBin) != VariantType::ByteArray) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'content-bin' with wrong type").arg(pn));
+                    return WsControlMessage();
+                }
 
-				out.content = vcontentBin.toByteArray();
-			}
+                out.content = vcontentBin.toByteArray();
+            }
 
-			if(((int)out.messageType) == -1)
-				out.messageType = Binary;
-		}
-		else if(keyedObjectContains(in, "content"))
-		{
-			Variant vcontent = keyedObjectGetValue(in, "content");
-			if(typeId(vcontent) == VariantType::ByteArray)
-				out.content = vcontent.toByteArray();
-			else if(typeId(vcontent) == VariantType::String)
-				out.content = vcontent.toString().toUtf8();
-			else
-			{
-				setError(ok, errorMessage, QString("%1 contains 'content' with wrong type").arg(pn));
-				return WsControlMessage();
-			}
+            if (((int)out.messageType) == -1)
+                out.messageType = Binary;
+        } else if (keyedObjectContains(in, "content")) {
+            Variant vcontent = keyedObjectGetValue(in, "content");
+            if (typeId(vcontent) == VariantType::ByteArray)
+                out.content = vcontent.toByteArray();
+            else if (typeId(vcontent) == VariantType::String)
+                out.content = vcontent.toString().toUtf8();
+            else {
+                setError(ok, errorMessage,
+                         QString("%1 contains 'content' with wrong type").arg(pn));
+                return WsControlMessage();
+            }
 
-			if(((int)out.messageType) == -1)
-				out.messageType = Text;
-		}
+            if (((int)out.messageType) == -1)
+                out.messageType = Text;
+        }
 
-		if(!out.content.isNull())
-		{
-			if(keyedObjectContains(in, "timeout"))
-			{
-				Variant vtimeout = keyedObjectGetValue(in, "timeout");
-				if(!canConvert(vtimeout, VariantType::Int))
-				{
-					setError(ok, errorMessage, QString("%1 contains 'timeout' with wrong type").arg(pn));
-					return WsControlMessage();
-				}
+        if (!out.content.isNull()) {
+            if (keyedObjectContains(in, "timeout")) {
+                Variant vtimeout = keyedObjectGetValue(in, "timeout");
+                if (!canConvert(vtimeout, VariantType::Int)) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'timeout' with wrong type").arg(pn));
+                    return WsControlMessage();
+                }
 
-				out.timeout = vtimeout.toInt();
+                out.timeout = vtimeout.toInt();
 
-				if(out.timeout < 0)
-				{
-					setError(ok, errorMessage, QString("%1 contains 'timeout' with invalid value").arg(pn));
-					return WsControlMessage();
-				}
-			}
-		}
+                if (out.timeout < 0) {
+                    setError(ok, errorMessage,
+                             QString("%1 contains 'timeout' with invalid value").arg(pn));
+                    return WsControlMessage();
+                }
+            }
+        }
 
-		if(out.type == KeepAlive)
-		{
-			QString mode = getString(in, pn, "mode", false, &ok_, errorMessage);
-			if(!ok_)
-			{
-				if(ok)
-					*ok = false;
-				return WsControlMessage();
-			}
+        if (out.type == KeepAlive) {
+            QString mode = getString(in, pn, "mode", false, &ok_, errorMessage);
+            if (!ok_) {
+                if (ok)
+                    *ok = false;
+                return WsControlMessage();
+            }
 
-			if(!mode.isNull())
-				out.keepAliveMode = mode.toUtf8();
-		}
-	}
+            if (!mode.isNull())
+                out.keepAliveMode = mode.toUtf8();
+        }
+    }
 
-	return out;
+    return out;
 }

--- a/src/handler/wscontrolmessage.h
+++ b/src/handler/wscontrolmessage.h
@@ -23,52 +23,39 @@
 #ifndef WSCONTROLMESSAGE_H
 #define WSCONTROLMESSAGE_H
 
+#include "variant.h"
 #include <QString>
 #include <QStringList>
-#include "variant.h"
 
-class WsControlMessage
-{
+class WsControlMessage {
 public:
-	enum Type
-	{
-		Subscribe,
-		Unsubscribe,
-		Detach,
-		Session,
-		SetMeta,
-		KeepAlive,
-		SendDelayed,
-		FlushDelayed
-	};
+    enum Type {
+        Subscribe,
+        Unsubscribe,
+        Detach,
+        Session,
+        SetMeta,
+        KeepAlive,
+        SendDelayed,
+        FlushDelayed
+    };
 
-	enum MessageType
-	{
-		Text,
-		Binary,
-		Ping,
-		Pong
-	};
+    enum MessageType { Text, Binary, Ping, Pong };
 
-	Type type;
-	QString channel;
-	QStringList filters;
-	QString sessionId;
-	QString metaName;
-	QString metaValue;
-	MessageType messageType;
-	QByteArray content;
-	int timeout;
-	QByteArray keepAliveMode;
+    Type type;
+    QString channel;
+    QStringList filters;
+    QString sessionId;
+    QString metaName;
+    QString metaValue;
+    MessageType messageType;
+    QByteArray content;
+    int timeout;
+    QByteArray keepAliveMode;
 
-	WsControlMessage() :
-		type((Type)-1),
-		messageType((MessageType)-1),
-		timeout(-1)
-	{
-	}
+    WsControlMessage() : type((Type)-1), messageType((MessageType)-1), timeout(-1) {}
 
-	static WsControlMessage fromVariant(const Variant &in, bool *ok = 0, QString *errorMessage = 0);
+    static WsControlMessage fromVariant(const Variant &in, bool *ok = 0, QString *errorMessage = 0);
 };
 
 #endif

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -23,298 +23,274 @@
 
 #include "wssession.h"
 
-#include <QDateTime>
-#include "log.h"
-#include "timer.h"
 #include "defercall.h"
 #include "filter.h"
-#include "publishitem.h"
+#include "log.h"
 #include "publishformat.h"
+#include "publishitem.h"
+#include "timer.h"
+#include <QDateTime>
 
 #define WSCONTROL_REQUEST_TIMEOUT 8000
 
-WsSession::WsSession() :
-	nextReqId(0),
-	debug(false),
-	logLevel(LOG_LEVEL_DEBUG),
-	targetTrusted(false),
-	ttl(0),
-	inProcessPublishQueue(false),
-	closed(false)
-{
-	expireTimer = std::make_unique<Timer>();
-	expireTimer->setSingleShot(true);
-	expireTimer->timeout.connect(boost::bind(&WsSession::expireTimer_timeout, this));
+WsSession::WsSession()
+    : nextReqId(0),
+      debug(false),
+      logLevel(LOG_LEVEL_DEBUG),
+      targetTrusted(false),
+      ttl(0),
+      inProcessPublishQueue(false),
+      closed(false) {
+    expireTimer = std::make_unique<Timer>();
+    expireTimer->setSingleShot(true);
+    expireTimer->timeout.connect(boost::bind(&WsSession::expireTimer_timeout, this));
 
-	delayedTimer = std::make_unique<Timer>();
-	delayedTimer->setSingleShot(true);
-	delayedTimer->timeout.connect(boost::bind(&WsSession::delayedTimer_timeout, this));
+    delayedTimer = std::make_unique<Timer>();
+    delayedTimer->setSingleShot(true);
+    delayedTimer->timeout.connect(boost::bind(&WsSession::delayedTimer_timeout, this));
 
-	requestTimer = std::make_unique<Timer>();
-	requestTimer->setSingleShot(true);
-	requestTimer->timeout.connect(boost::bind(&WsSession::requestTimer_timeout, this));
+    requestTimer = std::make_unique<Timer>();
+    requestTimer->setSingleShot(true);
+    requestTimer->timeout.connect(boost::bind(&WsSession::requestTimer_timeout, this));
 }
 
 WsSession::~WsSession() = default;
 
-void WsSession::refreshExpiration()
-{
-	expireTimer->start(ttl * 1000);
+void WsSession::refreshExpiration() { expireTimer->start(ttl * 1000); }
+
+void WsSession::flushDelayed() {
+    if (delayedTimer->isActive()) {
+        delayedTimer->stop();
+        delayedTimer_timeout();
+    }
 }
 
-void WsSession::flushDelayed()
-{
-	if(delayedTimer->isActive())
-	{
-		delayedTimer->stop();
-		delayedTimer_timeout();
-	}
+void WsSession::sendDelayed(const QByteArray &type, const QByteArray &message, int timeout) {
+    flushDelayed();
+
+    delayedType = type;
+    delayedMessage = message;
+    delayedTimer->start(timeout * 1000);
 }
 
-void WsSession::sendDelayed(const QByteArray &type, const QByteArray &message, int timeout)
-{
-	flushDelayed();
-
-	delayedType = type;
-	delayedMessage = message;
-	delayedTimer->start(timeout * 1000);
+void WsSession::ack(int reqId) {
+    if (pendingRequests.contains(reqId)) {
+        pendingRequests.remove(reqId);
+        setupRequestTimer();
+    }
 }
 
-void WsSession::ack(int reqId)
-{
-	if(pendingRequests.contains(reqId))
-	{
-		pendingRequests.remove(reqId);
-		setupRequestTimer();
-	}
+void WsSession::publish(const PublishItem &item) {
+    const PublishFormat &f = item.format;
+
+    if (f.type != PublishFormat::WebSocketMessage)
+        return;
+
+    publishQueue += item;
+
+    if (!inProcessPublishQueue)
+        processPublishQueue();
 }
 
-void WsSession::publish(const PublishItem &item)
-{
-	const PublishFormat &f = item.format;
+void WsSession::processPublishQueue() {
+    assert(!inProcessPublishQueue);
+    inProcessPublishQueue = true;
 
-	if(f.type != PublishFormat::WebSocketMessage)
-		return;
+    while (!closed && !publishQueue.isEmpty() && !filters) {
+        const PublishItem &item = publishQueue.first();
+        const PublishFormat &f = item.format;
 
-	publishQueue += item;
+        if (f.haveContentFilters) {
+            // Ensure content filters match
+            QStringList contentFilters;
+            foreach (const QString &f, channels[item.channel].filters) {
+                if (Filter::targets(f) & Filter::MessageContent)
+                    contentFilters += f;
+            }
+            if (contentFilters != f.contentFilters) {
+                publishQueue.removeFirst();
 
-	if(!inProcessPublishQueue)
-		processPublishQueue();
+                if (debug) {
+                    QString errorMessage =
+                        QString("content filter mismatch: subscription=%1 message=%2")
+                            .arg(contentFilters.join(","), f.contentFilters.join(","));
+                    sendCloseError(errorMessage);
+                    break;
+                }
+
+                continue;
+            }
+        }
+
+        filters = std::make_unique<Filter::MessageFilterStack>(channels[item.channel].filters);
+        filtersFinishedConnection = filters->finished.connect(
+            boost::bind(&WsSession::filtersFinished, this, boost::placeholders::_1));
+
+        // Websocket sessions currently don't support previous IDs on
+        // subscriptions, but we still need to populate the channel names in
+        // in the filter context even if all the values will be null
+        QHash<QString, QString> prevIds;
+        QHashIterator<QString, Instruct::Channel> it(channels);
+        while (it.hasNext()) {
+            it.next();
+            const Instruct::Channel &c = it.value();
+            prevIds[c.name] = c.prevId;
+        }
+
+        Filter::Context fc;
+        fc.prevIds = prevIds;
+        fc.subscriptionMeta = meta;
+        fc.publishMeta = item.meta;
+        fc.zhttpOut = zhttpOut;
+        fc.currentUri = requestData.uri;
+        fc.route = route;
+        fc.trusted = targetTrusted;
+        fc.limiter = filterLimiter;
+
+        // May call filtersFinished immediately. If it does, queue processing
+        // will continue. Else, the loop will end and queue processing will
+        // resume after the filters finish
+        filters->start(fc, f.body);
+    }
+
+    inProcessPublishQueue = false;
 }
 
-void WsSession::processPublishQueue()
-{
-	assert(!inProcessPublishQueue);
-	inProcessPublishQueue = true;
+void WsSession::filtersFinished(const Filter::MessageFilter::Result &result) {
+    PublishItem item = publishQueue.takeFirst();
 
-	while(!closed && !publishQueue.isEmpty() && !filters)
-	{
-		const PublishItem &item = publishQueue.first();
-		const PublishFormat &f = item.format;
+    filtersFinishedConnection.disconnect();
+    filters.reset();
 
-		if(f.haveContentFilters)
-		{
-			// Ensure content filters match
-			QStringList contentFilters;
-			foreach(const QString &f, channels[item.channel].filters)
-			{
-				if(Filter::targets(f) & Filter::MessageContent)
-					contentFilters += f;
-			}
-			if(contentFilters != f.contentFilters)
-			{
-				publishQueue.removeFirst();
+    if (!result.errorMessage.isNull()) {
+        if (debug) {
+            QString errorMessage = QString("filter error: %1").arg(result.errorMessage);
+            sendCloseError(errorMessage);
+            return;
+        }
+    } else {
+        afterFilters(item, result.sendAction, result.content);
+    }
 
-				if(debug)
-				{
-					QString errorMessage = QString("content filter mismatch: subscription=%1 message=%2").arg(contentFilters.join(","), f.contentFilters.join(","));
-					sendCloseError(errorMessage);
-					break;
-				}
-
-				continue;
-			}
-		}
-
-		filters = std::make_unique<Filter::MessageFilterStack>(channels[item.channel].filters);
-		filtersFinishedConnection = filters->finished.connect(boost::bind(&WsSession::filtersFinished, this, boost::placeholders::_1));
-
-		// Websocket sessions currently don't support previous IDs on
-		// subscriptions, but we still need to populate the channel names in
-		// in the filter context even if all the values will be null
-		QHash<QString, QString> prevIds;
-		QHashIterator<QString, Instruct::Channel> it(channels);
-		while(it.hasNext())
-		{
-			it.next();
-			const Instruct::Channel &c = it.value();
-			prevIds[c.name] = c.prevId;
-		}
-
-		Filter::Context fc;
-		fc.prevIds = prevIds;
-		fc.subscriptionMeta = meta;
-		fc.publishMeta = item.meta;
-		fc.zhttpOut = zhttpOut;
-		fc.currentUri = requestData.uri;
-		fc.route = route;
-		fc.trusted = targetTrusted;
-		fc.limiter = filterLimiter;
-
-		// May call filtersFinished immediately. If it does, queue processing
-		// will continue. Else, the loop will end and queue processing will
-		// resume after the filters finish
-		filters->start(fc, f.body);
-	}
-
-	inProcessPublishQueue = false;
+    // If filters finished asynchronously then we need to resume processing
+    if (!inProcessPublishQueue)
+        processPublishQueue();
 }
 
-void WsSession::filtersFinished(const Filter::MessageFilter::Result &result)
-{
-	PublishItem item = publishQueue.takeFirst();
+void WsSession::afterFilters(const PublishItem &item, Filter::SendAction sendAction,
+                             const QByteArray &content) {
+    if (sendAction == Filter::Drop)
+        return;
 
-	filtersFinishedConnection.disconnect();
-	filters.reset();
+    const PublishFormat &f = item.format;
 
-	if(!result.errorMessage.isNull())
-	{
-		if(debug)
-		{
-			QString errorMessage = QString("filter error: %1").arg(result.errorMessage);
-			sendCloseError(errorMessage);
-			return;
-		}
-	}
-	else
-	{
-		afterFilters(item, result.sendAction, result.content);
-	}
+    // TODO: hint support for websockets?
+    if (f.action != PublishFormat::Send && f.action != PublishFormat::Close &&
+        f.action != PublishFormat::Refresh)
+        return;
 
-	// If filters finished asynchronously then we need to resume processing
-	if(!inProcessPublishQueue)
-		processPublishQueue();
+    WsControlPacket::Item i;
+    i.cid = cid.toUtf8();
+
+    if (f.action == PublishFormat::Send) {
+        i.type = WsControlPacket::Item::Send;
+
+        switch (f.messageType) {
+        case PublishFormat::Text:
+            i.contentType = "text";
+            break;
+        case PublishFormat::Binary:
+            i.contentType = "binary";
+            break;
+        case PublishFormat::Ping:
+            i.contentType = "ping";
+            break;
+        case PublishFormat::Pong:
+            i.contentType = "pong";
+            break;
+        default:
+            return; // Unrecognized type, skip
+        }
+
+        i.message = content;
+    } else if (f.action == PublishFormat::Close) {
+        closed = true;
+
+        i.type = WsControlPacket::Item::Close;
+        i.code = f.code;
+        i.reason = f.reason;
+    } else if (f.action == PublishFormat::Refresh) {
+        i.type = WsControlPacket::Item::Refresh;
+    }
+
+    send(i);
 }
 
-void WsSession::afterFilters(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content)
-{
-	if(sendAction == Filter::Drop)
-		return;
+void WsSession::sendCloseError(const QString &message) {
+    closed = true;
 
-	const PublishFormat &f = item.format;
+    WsControlPacket::Item i;
+    i.cid = cid.toUtf8();
+    i.type = WsControlPacket::Item::Close;
+    i.code = 1011;
 
-	// TODO: hint support for websockets?
-	if(f.action != PublishFormat::Send && f.action != PublishFormat::Close && f.action != PublishFormat::Refresh)
-		return;
+    if (debug)
+        i.reason = message.toUtf8();
 
-	WsControlPacket::Item i;
-	i.cid = cid.toUtf8();
-
-	if(f.action == PublishFormat::Send)
-	{
-		i.type = WsControlPacket::Item::Send;
-
-		switch(f.messageType)
-		{
-			case PublishFormat::Text:   i.contentType = "text"; break;
-			case PublishFormat::Binary: i.contentType = "binary"; break;
-			case PublishFormat::Ping:   i.contentType = "ping"; break;
-			case PublishFormat::Pong:   i.contentType = "pong"; break;
-			default: return; // Unrecognized type, skip
-		}
-
-		i.message = content;
-	}
-	else if(f.action == PublishFormat::Close)
-	{
-		closed = true;
-
-		i.type = WsControlPacket::Item::Close;
-		i.code = f.code;
-		i.reason = f.reason;
-	}
-	else if(f.action == PublishFormat::Refresh)
-	{
-		i.type = WsControlPacket::Item::Refresh;
-	}
-
-	send(i);
+    send(i);
 }
 
-void WsSession::sendCloseError(const QString &message)
-{
-	closed = true;
+void WsSession::setupRequestTimer() {
+    if (!pendingRequests.isEmpty()) {
+        // Find next expiring request
+        int64_t lowestTime = -1;
+        QHashIterator<int, int64_t> it(pendingRequests);
+        while (it.hasNext()) {
+            it.next();
+            int64_t time = it.value();
 
-	WsControlPacket::Item i;
-	i.cid = cid.toUtf8();
-	i.type = WsControlPacket::Item::Close;
-	i.code = 1011;
+            if (lowestTime == -1 || time < lowestTime)
+                lowestTime = time;
+        }
 
-	if(debug)
-		i.reason = message.toUtf8();
+        int until = int(lowestTime - QDateTime::currentMSecsSinceEpoch());
 
-	send(i);
+        requestTimer->start(qMax(until, 0));
+    } else {
+        requestTimer->stop();
+    }
 }
 
-void WsSession::setupRequestTimer()
-{
-	if(!pendingRequests.isEmpty())
-	{
-		// Find next expiring request
-		int64_t lowestTime = -1;
-		QHashIterator<int, int64_t> it(pendingRequests);
-		while(it.hasNext())
-		{
-			it.next();
-			int64_t time = it.value();
+void WsSession::expireTimer_timeout() {
+    log_debug("timing out ws session: %s", qPrintable(cid));
 
-			if(lowestTime == -1 || time < lowestTime)
-				lowestTime = time;
-		}
-
-		int until = int(lowestTime - QDateTime::currentMSecsSinceEpoch());
-
-		requestTimer->start(qMax(until, 0));
-	}
-	else
-	{
-		requestTimer->stop();
-	}
+    expired();
 }
 
-void WsSession::expireTimer_timeout()
-{
-	log_debug("timing out ws session: %s", qPrintable(cid));
+void WsSession::delayedTimer_timeout() {
+    int reqId = nextReqId++;
 
-	expired();
+    QByteArray message = delayedMessage;
+    delayedMessage.clear();
+
+    pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + WSCONTROL_REQUEST_TIMEOUT;
+    setupRequestTimer();
+
+    WsControlPacket::Item i;
+    i.cid = cid.toUtf8();
+    i.requestId = QByteArray::number(reqId);
+    i.type = WsControlPacket::Item::Send;
+    i.contentType = delayedType;
+    i.message = message;
+    i.queue = true;
+
+    send(i);
 }
 
-void WsSession::delayedTimer_timeout()
-{
-	int reqId = nextReqId++;
+void WsSession::requestTimer_timeout() {
+    // On error, destroy any other pending requests
+    pendingRequests.clear();
+    setupRequestTimer();
 
-	QByteArray message = delayedMessage;
-	delayedMessage.clear();
-
-	pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + WSCONTROL_REQUEST_TIMEOUT;
-	setupRequestTimer();
-
-	WsControlPacket::Item i;
-	i.cid = cid.toUtf8();
-	i.requestId = QByteArray::number(reqId);
-	i.type = WsControlPacket::Item::Send;
-	i.contentType = delayedType;
-	i.message = message;
-	i.queue = true;
-
-	send(i);
-}
-
-void WsSession::requestTimer_timeout()
-{
-	// On error, destroy any other pending requests
-	pendingRequests.clear();
-	setupRequestTimer();
-
-	error();
+    error();
 }

--- a/src/handler/wssession.h
+++ b/src/handler/wssession.h
@@ -24,15 +24,15 @@
 #ifndef WSSESSION_H
 #define WSSESSION_H
 
-#include <QHash>
-#include <QSet>
-#include <boost/signals2.hpp>
+#include "clientsession.h"
+#include "filter.h"
+#include "instruct.h"
 #include "packet/httprequestdata.h"
 #include "packet/wscontrolpacket.h"
 #include "ratelimiter.h"
-#include "instruct.h"
-#include "filter.h"
-#include "clientsession.h"
+#include <QHash>
+#include <QSet>
+#include <boost/signals2.hpp>
 
 // Each session can have a bunch of timers:
 // 3 misc timers
@@ -46,62 +46,62 @@ class Timer;
 class ZhttpManager;
 class PublishItem;
 
-class WsSession : public ClientSession
-{
+class WsSession : public ClientSession {
 public:
-	QByteArray peer;
-	QString cid;
-	int nextReqId;
-	bool debug;
-	QString channelPrefix;
-	int logLevel;
-	HttpRequestData requestData;
-	QString route;
-	QString statsRoute;
-	bool targetTrusted;
-	QString sid;
-	QHash<QString, QString> meta;
-	QHash<QString, Instruct::Channel> channels;
-	QSet<QString> implicitChannels;
-	int ttl;
-	QByteArray keepAliveType;
-	QByteArray keepAliveMessage;
-	QByteArray delayedType;
-	QByteArray delayedMessage;
-	QHash<int, int64_t> pendingRequests;
-	std::unique_ptr<Timer> expireTimer;
-	std::unique_ptr<Timer> delayedTimer;
-	std::unique_ptr<Timer> requestTimer;
-	QList<PublishItem> publishQueue;
-	ZhttpManager *zhttpOut;
-	std::shared_ptr<RateLimiter> filterLimiter;
-	std::unique_ptr<Filter::MessageFilter> filters;
-	Connection filtersFinishedConnection;
-	bool inProcessPublishQueue;
-	bool closed;
+    QByteArray peer;
+    QString cid;
+    int nextReqId;
+    bool debug;
+    QString channelPrefix;
+    int logLevel;
+    HttpRequestData requestData;
+    QString route;
+    QString statsRoute;
+    bool targetTrusted;
+    QString sid;
+    QHash<QString, QString> meta;
+    QHash<QString, Instruct::Channel> channels;
+    QSet<QString> implicitChannels;
+    int ttl;
+    QByteArray keepAliveType;
+    QByteArray keepAliveMessage;
+    QByteArray delayedType;
+    QByteArray delayedMessage;
+    QHash<int, int64_t> pendingRequests;
+    std::unique_ptr<Timer> expireTimer;
+    std::unique_ptr<Timer> delayedTimer;
+    std::unique_ptr<Timer> requestTimer;
+    QList<PublishItem> publishQueue;
+    ZhttpManager *zhttpOut;
+    std::shared_ptr<RateLimiter> filterLimiter;
+    std::unique_ptr<Filter::MessageFilter> filters;
+    Connection filtersFinishedConnection;
+    bool inProcessPublishQueue;
+    bool closed;
 
-	WsSession();
-	~WsSession();
+    WsSession();
+    ~WsSession();
 
-	void refreshExpiration();
-	void flushDelayed();
-	void sendDelayed(const QByteArray &type, const QByteArray &message, int timeout);
-	void ack(int reqId);
-	void publish(const PublishItem &item);
-	void sendCloseError(const QString &message);
+    void refreshExpiration();
+    void flushDelayed();
+    void sendDelayed(const QByteArray &type, const QByteArray &message, int timeout);
+    void ack(int reqId);
+    void publish(const PublishItem &item);
+    void sendCloseError(const QString &message);
 
-	boost::signals2::signal<void(const WsControlPacket::Item&)> send;
-	Signal expired;
-	Signal error;
+    boost::signals2::signal<void(const WsControlPacket::Item &)> send;
+    Signal expired;
+    Signal error;
 
 private:
-	void processPublishQueue();
-	void filtersFinished(const Filter::MessageFilter::Result &result);
-	void afterFilters(const PublishItem &item, Filter::SendAction sendAction, const QByteArray &content);
-	void setupRequestTimer();
-	void expireTimer_timeout();
-	void delayedTimer_timeout();
-	void requestTimer_timeout();
+    void processPublishQueue();
+    void filtersFinished(const Filter::MessageFilter::Result &result);
+    void afterFilters(const PublishItem &item, Filter::SendAction sendAction,
+                      const QByteArray &content);
+    void setupRequestTimer();
+    void expireTimer_timeout();
+    void delayedTimer_timeout();
+    void requestTimer_timeout();
 };
 
 #endif

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -23,33 +23,33 @@
 
 #include "m2adapterapp.h"
 
-#include <assert.h>
-#include <QCoreApplication>
-#include <QCommandLineParser>
-#include <QPair>
-#include <QHash>
-#include <QDateTime>
-#include <QElapsedTimer>
-#include <QTimer>
-#include <QDir>
-#include <QSettings>
-#include "cowstring.h"
+#include "bufferlist.h"
+#include "config.h"
 #include "cowbytearray.h"
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "qtcompat.h"
-#include "variant.h"
-#include "processquit.h"
-#include "tnetstring.h"
+#include "cowstring.h"
+#include "layertracker.h"
+#include "log.h"
+#include "logutil.h"
 #include "m2requestpacket.h"
 #include "m2responsepacket.h"
+#include "processquit.h"
+#include "qtcompat.h"
+#include "tnetstring.h"
+#include "variant.h"
 #include "zhttprequestpacket.h"
 #include "zhttpresponsepacket.h"
-#include "bufferlist.h"
-#include "log.h"
-#include "layertracker.h"
-#include "logutil.h"
-#include "config.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QPair>
+#include <QSettings>
+#include <QTimer>
+#include <assert.h>
 
 #define DEFAULT_HWM 101000
 #define STATUS_INTERVAL 250
@@ -78,2820 +78,2507 @@
 // This doesn't have to match the peer, but we'll set a reasonable number
 #define ZHTTP_IDS_MAX 128
 
-//#define CONTROL_PORT_DEBUG
+// #define CONTROL_PORT_DEBUG
 
-static void trimlist(QStringList *list)
-{
-	for(int n = 0; n < list->count(); ++n)
-	{
-		if((*list)[n].isEmpty())
-		{
-			list->removeAt(n);
-			--n; // Adjust position
-		}
-	}
+static void trimlist(QStringList *list) {
+    for (int n = 0; n < list->count(); ++n) {
+        if ((*list)[n].isEmpty()) {
+            list->removeAt(n);
+            --n; // Adjust position
+        }
+    }
 }
 
-static bool validateHost(const QByteArray &in)
-{
-	for(int n = 0; n < in.size(); ++n)
-	{
-		if(in[n] == '/')
-			return false;
-	}
+static bool validateHost(const QByteArray &in) {
+    for (int n = 0; n < in.size(); ++n) {
+        if (in[n] == '/')
+            return false;
+    }
 
-	return true;
+    return true;
 }
 
-static QByteArray createResponseHeader(int code, const QByteArray &reason, const HttpHeaders &headers)
-{
-	QByteArray out = "HTTP/1.1 " + QByteArray::number(code) + ' ' + reason + "\r\n";
-	foreach(const HttpHeader &h, headers)
-		out += (h.first + ": " + h.second + "\r\n").asQByteArray();
-	out += "\r\n";
-	return out;
+static QByteArray createResponseHeader(int code, const QByteArray &reason,
+                                       const HttpHeaders &headers) {
+    QByteArray out = "HTTP/1.1 " + QByteArray::number(code) + ' ' + reason + "\r\n";
+    foreach (const HttpHeader &h, headers)
+        out += (h.first + ": " + h.second + "\r\n").asQByteArray();
+    out += "\r\n";
+    return out;
 }
 
-static QByteArray makeChunkHeader(int size)
-{
-	return QByteArray::number(size, 16).toUpper() + "\r\n";
+static QByteArray makeChunkHeader(int size) {
+    return QByteArray::number(size, 16).toUpper() + "\r\n";
 }
 
-static QByteArray makeChunkFooter()
-{
-	return "\r\n";
+static QByteArray makeChunkFooter() { return "\r\n"; }
+
+static bool isErrorPacket(const ZhttpResponsePacket &packet) {
+    return (packet.type == ZhttpResponsePacket::Error ||
+            packet.type == ZhttpResponsePacket::Cancel);
 }
 
-static bool isErrorPacket(const ZhttpResponsePacket &packet)
-{
-	return (packet.type == ZhttpResponsePacket::Error || packet.type == ZhttpResponsePacket::Cancel);
+static void writeBigEndian(char *dest, quint64 value, int bytes) {
+    for (int n = 0; n < bytes; ++n)
+        dest[n] = (char)((value >> ((bytes - 1 - n) * 8)) & 0xff);
 }
 
-static void writeBigEndian(char *dest, quint64 value, int bytes)
-{
-	for(int n = 0; n < bytes; ++n)
-		dest[n] = (char)((value >> ((bytes - 1 - n) * 8)) & 0xff);
+static QByteArray makeWsHeader(bool fin, int opcode, quint64 size) {
+    quint8 b1 = 0;
+    if (fin)
+        b1 |= 0x80;
+    b1 |= (opcode & 0x0f);
+
+    if (size < 126) {
+        QByteArray out(2, 0);
+        out[0] = (char)b1;
+        out[1] = (char)size;
+        return out;
+    } else if (size < 65536) {
+        QByteArray out(4, 0);
+        out[0] = (char)b1;
+        out[1] = (char)126;
+        writeBigEndian(out.data() + 2, size, 2);
+        return out;
+    } else {
+        QByteArray out(10, 0);
+        out[0] = (char)b1;
+        out[1] = (char)127;
+        writeBigEndian(out.data() + 2, size, 8);
+        return out;
+    }
 }
 
-static QByteArray makeWsHeader(bool fin, int opcode, quint64 size)
-{
-	quint8 b1 = 0;
-	if(fin)
-		b1 |= 0x80;
-	b1 |= (opcode & 0x0f);
-
-	if(size < 126)
-	{
-		QByteArray out(2, 0);
-		out[0] = (char)b1;
-		out[1] = (char)size;
-		return out;
-	}
-	else if(size < 65536)
-	{
-		QByteArray out(4, 0);
-		out[0] = (char)b1;
-		out[1] = (char)126;
-		writeBigEndian(out.data() + 2, size, 2);
-		return out;
-	}
-	else
-	{
-		QByteArray out(10, 0);
-		out[0] = (char)b1;
-		out[1] = (char)127;
-		writeBigEndian(out.data() + 2, size, 8);
-		return out;
-	}
-}
-
-enum CommandLineParseResult
-{
-	CommandLineOk,
-	CommandLineError,
-	CommandLineVersionRequested,
-	CommandLineHelpRequested
+enum CommandLineParseResult {
+    CommandLineOk,
+    CommandLineError,
+    CommandLineVersionRequested,
+    CommandLineHelpRequested
 };
 
-class ArgsData
-{
+class ArgsData {
 public:
-	QString configFile;
-	QString logFile;
-	int logLevel;
+    QString configFile;
+    QString logFile;
+    int logLevel;
 
-	ArgsData() :
-		logLevel(-1)
-	{
-	}
+    ArgsData() : logLevel(-1) {}
 };
 
-static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, ArgsData *args, QString *errorMessage)
-{
-	parser->setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
-	const QCommandLineOption configFileOption("config", "Config file.", "file");
-	parser->addOption(configFileOption);
-	const QCommandLineOption logFileOption("logfile", "File to log to.", "file");
-	parser->addOption(logFileOption);
-	const QCommandLineOption logLevelOption("loglevel", "Log level (default: 2).", "x");
-	parser->addOption(logLevelOption);
-	const QCommandLineOption verboseOption("verbose", "Verbose output. Same as --loglevel=3.");
-	parser->addOption(verboseOption);
-	const QCommandLineOption helpOption = parser->addHelpOption();
-	const QCommandLineOption versionOption = parser->addVersionOption();
+static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, ArgsData *args,
+                                               QString *errorMessage) {
+    parser->setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    const QCommandLineOption configFileOption("config", "Config file.", "file");
+    parser->addOption(configFileOption);
+    const QCommandLineOption logFileOption("logfile", "File to log to.", "file");
+    parser->addOption(logFileOption);
+    const QCommandLineOption logLevelOption("loglevel", "Log level (default: 2).", "x");
+    parser->addOption(logLevelOption);
+    const QCommandLineOption verboseOption("verbose", "Verbose output. Same as --loglevel=3.");
+    parser->addOption(verboseOption);
+    const QCommandLineOption helpOption = parser->addHelpOption();
+    const QCommandLineOption versionOption = parser->addVersionOption();
 
-	if(!parser->parse(QCoreApplication::arguments()))
-	{
-		*errorMessage = parser->errorText();
-		return CommandLineError;
-	}
+    if (!parser->parse(QCoreApplication::arguments())) {
+        *errorMessage = parser->errorText();
+        return CommandLineError;
+    }
 
-	if(parser->isSet(versionOption))
-		return CommandLineVersionRequested;
+    if (parser->isSet(versionOption))
+        return CommandLineVersionRequested;
 
-	if(parser->isSet(helpOption))
-		return CommandLineHelpRequested;
+    if (parser->isSet(helpOption))
+        return CommandLineHelpRequested;
 
-	if(parser->isSet(configFileOption))
-		args->configFile = parser->value(configFileOption);
+    if (parser->isSet(configFileOption))
+        args->configFile = parser->value(configFileOption);
 
-	if(parser->isSet(logFileOption))
-		args->logFile = parser->value(logFileOption);
+    if (parser->isSet(logFileOption))
+        args->logFile = parser->value(logFileOption);
 
-	if(parser->isSet(logLevelOption))
-	{
-		bool ok;
-		int x = parser->value(logLevelOption).toInt(&ok);
-		if(!ok || x < 0)
-		{
-			*errorMessage = "error: loglevel must be greater than or equal to 0";
-			return CommandLineError;
-		}
+    if (parser->isSet(logLevelOption)) {
+        bool ok;
+        int x = parser->value(logLevelOption).toInt(&ok);
+        if (!ok || x < 0) {
+            *errorMessage = "error: loglevel must be greater than or equal to 0";
+            return CommandLineError;
+        }
 
-		args->logLevel = x;
-	}
+        args->logLevel = x;
+    }
 
-	if(parser->isSet(verboseOption))
-		args->logLevel = 3;
+    if (parser->isSet(verboseOption))
+        args->logLevel = 3;
 
-	return CommandLineOk;
+    return CommandLineOk;
 }
 
-class M2AdapterApp::Private : public QObject
-{
-	Q_OBJECT
+class M2AdapterApp::Private : public QObject {
+    Q_OBJECT
 
 public:
-	enum Mode
-	{
-		Http,
-		WebSocket
-	};
-
-	class ControlPort
-	{
-	public:
-		enum State
-		{
-			Disabled,
-			Idle,
-			ExpectingResponse
-		};
-
-		ZmqSocket *sock;
-		State state;
-		bool works;
-		int reqStartTime;
-
-		ControlPort() :
-			sock(0),
-			state(Disabled),
-			works(false),
-			reqStartTime(-1)
-		{
-		}
-	};
-
-	// Can be used for either m2 or zhttp
-	typedef QPair<QByteArray, QByteArray> Rid;
-
-	class Session;
-
-	class M2PendingOutItem
-	{
-	public:
-		enum Type
-		{
-			Headers,
-			Response,
-			Frame,
-			Close
-		};
-
-		Type type;
-		BufferList data;
-		bool chunked;
-		int contentSize;
-
-		M2PendingOutItem(Type _type) :
-			type(_type),
-			chunked(false),
-			contentSize(0)
-		{
-		}
-	};
-
-	class M2Connection
-	{
-	public:
-		int identIndex;
-		QByteArray id;
-		int confirmedBytesWritten;
-		int packetsPending; // Count of packets sent to m2 not yet ack'd
-		Session *session;
-		bool isNew;
-		bool continuation;
-		LayerTracker bodyTracker;
-		LayerTracker packetTracker;
-		QList<M2PendingOutItem> pendingOutItems; // Packets yet to send
-		bool flowControl;
-		bool waitForAllWritten;
-		bool outCreditsEnabled;
-		int outCredits;
-		quint64 subIdBase;
-		qint64 lastRefresh;
-		int refreshBucket;
-
-		M2Connection() :
-			confirmedBytesWritten(0),
-			packetsPending(0),
-			session(0),
-			isNew(false),
-			continuation(false),
-			flowControl(false),
-			waitForAllWritten(false),
-			outCreditsEnabled(false),
-			outCredits(0),
-			subIdBase(0)
-		{
-		}
-
-		bool canWrite() const
-		{
-			if(!flowControl)
-				return true;
-
-			if(outCreditsEnabled)
-			{
-				if(outCredits > 0)
-					return true;
-			}
-			else
-			{
-				// If we aren't using outCredits, then limit pending packets
-				// to hardcoded m2 value
-				if(packetsPending < M2_PENDING_MAX)
-					return true;
-			}
-
-			return false;
-		}
-	};
-
-	class Session
-	{
-	public:
-		Mode mode;
-		qint64 lastActive;
-		QByteArray errorCondition;
-		QByteArray acceptToken; // For websocket
-		bool downClosed; // For websocket
-		bool upClosed; // For websockets
-		QString method;
-		bool responseHeadersOnly; // HEAD, 204, 304
-		qint64 lastRefresh;
-		int refreshBucket;
-		bool pendingCancel;
-
-		// M2 stuff
-		M2Connection *conn;
-		bool persistent;
-		bool allowChunked;
-		bool respondKeepAlive;
-		bool respondClose;
-		bool chunked;
-		int readCount;
-		BufferList pendingIn;
-		QList<ZhttpRequestPacket> pendingInPackets;
-		bool inFinished;
-
-		// Zhttp stuff
-		QByteArray id;
-		QByteArray zhttpAddress;
-		bool sentResponseHeader;
-		int outSeq;
-		int inSeq;
-		int pendingInCredits;
-		bool inHandoff;
-		bool multi;
-
-		Session() :
-			lastActive(-1),
-			downClosed(false),
-			upClosed(false),
-			responseHeadersOnly(false),
-			lastRefresh(-1),
-			pendingCancel(false),
-			persistent(false),
-			allowChunked(false),
-			respondKeepAlive(false),
-			respondClose(false),
-			chunked(false),
-			readCount(0),
-			inFinished(false),
-			sentResponseHeader(false),
-			outSeq(0),
-			inSeq(0),
-			pendingInCredits(0),
-			inHandoff(false),
-			multi(false)
-		{
-		}
-	};
-
-	M2AdapterApp *q;
-	ArgsData args;
-	QByteArray zhttpInstanceId;
-	QByteArray zwsInstanceId;
-	std::unique_ptr<ZmqSocket> m2_in_sock;
-	std::unique_ptr<ZmqSocket> m2_out_sock;
-	std::unique_ptr<ZmqSocket> zhttp_in_sock;
-	std::unique_ptr<ZmqSocket> zhttp_out_sock;
-	std::unique_ptr<ZmqSocket> zhttp_out_stream_sock;
-	std::unique_ptr<ZmqSocket> zws_in_sock;
-	std::unique_ptr<ZmqSocket> zws_out_sock;
-	std::unique_ptr<ZmqSocket> zws_out_stream_sock;
-	std::unique_ptr<ZmqValve> m2_in_valve;
-	std::unique_ptr<ZmqValve> zhttp_in_valve;
-	std::unique_ptr<ZmqValve> zws_in_valve;
-	QList<QByteArray> m2_send_idents;
-	QHash<Rid, M2Connection*> m2ConnectionsByRid;
-	QHash<Rid, Session*> sessionsByM2Rid;
-	QHash<Rid, Session*> sessionsByZhttpRid;
-	QHash<Rid, Session*> sessionsByZwsRid;
-	QMap<QPair<qint64, M2Connection*>, M2Connection*> m2ConnectionsByLastRefresh;
-	QSet<M2Connection*> m2ConnectionRefreshBuckets[M2_REFRESH_BUCKETS];
-	int currentM2RefreshBucket;
-	QMap<QPair<qint64, Session*>, Session*> sessionsByLastRefresh;
-	QSet<Session*> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
-	int currentSessionRefreshBucket;
-	QMap<QPair<qint64, Session*>, Session*> sessionsByLastActive;
-	int zhttpCancelMeter;
-	QSet<Session*> sessionsToCancel;
-	int m2_client_buffer;
-	int maxSessions;
-	int zhttpConnectPort;
-	int zwsConnectPort;
-	bool ignorePolicies;
-	QList<ControlPort> controlPorts;
-	QElapsedTimer time;
-	QTimer *statusTimer;
-	QTimer *refreshTimer;
-	Connection quitConnection;
-	Connection hupConnection;
-	map<ZmqSocket*, Connection> rrConnection;
-	Connection m2InValveConnection;
-	Connection zhttpInValveConnection;
-	Connection zwsInValveConnection;
-
-	Private(M2AdapterApp *_q) :
-		QObject(_q),
-		q(_q),
-		currentM2RefreshBucket(0),
-		currentSessionRefreshBucket(0),
-		zhttpCancelMeter(0)
-	{
-		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::doQuit, this));
-		hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&M2AdapterApp::Private::reload, this));
-
-		statusTimer = new QTimer(this);
-		connect(statusTimer, &QTimer::timeout, this, &Private::status_timeout);
-
-		refreshTimer = new QTimer(this);
-		connect(refreshTimer, &QTimer::timeout, this, &Private::refresh_timeout);
-
-		time.start();
-	}
-
-	~Private()
-	{
-		qDeleteAll(sessionsByZhttpRid);
-		qDeleteAll(sessionsByZwsRid);
-		qDeleteAll(m2ConnectionsByRid);
-
-		for(int n = 0; n < controlPorts.count(); ++n)
-		{
-			ControlPort &c = controlPorts[n];
-			delete c.sock;
-			c.sock = 0;
-		}
-	}
-
-	void start()
-	{
-		QCoreApplication::setApplicationName("m2adapter");
-		QCoreApplication::setApplicationVersion(Config::get().version);
-
-		QCommandLineParser parser;
-		parser.setApplicationDescription("Mongrel2 <-> ZHTTP adapter.");
-
-		QString errorMessage;
-		switch(parseCommandLine(&parser, &args, &errorMessage))
-		{
-			case CommandLineOk:
-				break;
-			case CommandLineError:
-				fprintf(stderr, "%s\n\n%s", qPrintable(errorMessage), qPrintable(parser.helpText()));
-				q->quit(1);
-				return;
-			case CommandLineVersionRequested:
-				printf("%s %s\n", qPrintable(QCoreApplication::applicationName()),
-					qPrintable(QCoreApplication::applicationVersion()));
-				q->quit(0);
-				return;
-			case CommandLineHelpRequested:
-				parser.showHelp();
-				Q_UNREACHABLE();
-		}
-
-		if(!init())
-		{
-			q->quit(1);
-			return;
-		}
-
-		m2_in_valve->open();
-
-		if(zhttp_in_valve)
-			zhttp_in_valve->open();
-		if(zws_in_valve)
-			zws_in_valve->open();
-
-		statusTimer->setInterval(STATUS_INTERVAL);
-
-		refreshTimer->setInterval(REFRESH_INTERVAL);
-		refreshTimer->start();
-
-		log_info("started");
-	}
-
-	bool init()
-	{
-		if(args.logLevel != -1)
-			log_setOutputLevel(args.logLevel);
-		else
-			log_setOutputLevel(LOG_LEVEL_INFO);
-
-		if(!args.logFile.isEmpty())
-		{
-			if(!log_setFile(args.logFile))
-			{
-				log_error("failed to open log file: %s", qPrintable(args.logFile));
-				return false;
-			}
-		}
-
-		log_info("starting...");
-
-		QString configFile = args.configFile;
-		if(configFile.isEmpty())
-			configFile = QDir(Config::get().configDir).filePath("m2adapter.conf");
-
-		// QSettings doesn't inform us if the config file doesn't exist, so do that ourselves
-		{
-			QFile file(configFile);
-			if(!file.open(QIODevice::ReadOnly))
-			{
-				log_error("failed to open %s, and --config not passed", qPrintable(configFile));
-				return false;
-			}
-		}
-
-		QSettings settings(configFile, QSettings::IniFormat);
-
-		QStringList m2_in_specs = settings.value("m2_in_specs").toStringList();
-		trimlist(&m2_in_specs);
-		QStringList m2_out_specs = settings.value("m2_out_specs").toStringList();
-		trimlist(&m2_out_specs);
-		QStringList str_m2_send_idents = settings.value("m2_send_idents").toStringList();
-		trimlist(&str_m2_send_idents);
-		QStringList m2_control_specs = settings.value("m2_control_specs").toStringList();
-		trimlist(&m2_control_specs);
-
-		bool zhttp_connect = settings.value("zhttp_connect").toBool();
-		QStringList zhttp_in_specs = settings.value("zhttp_in_specs").toStringList();
-		trimlist(&zhttp_in_specs);
-		QStringList zhttp_out_specs = settings.value("zhttp_out_specs").toStringList();
-		trimlist(&zhttp_out_specs);
-		QStringList zhttp_out_stream_specs = settings.value("zhttp_out_stream_specs").toStringList();
-		trimlist(&zhttp_out_stream_specs);
-
-		bool zws_connect = settings.value("zws_connect").toBool();
-		QStringList zws_in_specs = settings.value("zws_in_specs").toStringList();
-		trimlist(&zws_in_specs);
-		QStringList zws_out_specs = settings.value("zws_out_specs").toStringList();
-		trimlist(&zws_out_specs);
-		QStringList zws_out_stream_specs = settings.value("zws_out_stream_specs").toStringList();
-		trimlist(&zws_out_stream_specs);	
-
-		zhttpConnectPort = settings.value("zhttp_connect_port", -1).toInt();
-		zwsConnectPort = settings.value("zws_connect_port", -1).toInt();
-		ignorePolicies = settings.value("ignore_policies").toBool();
-		m2_client_buffer = settings.value("m2_client_buffer").toInt();
-		if(m2_client_buffer <= 0)
-			m2_client_buffer = 200000;
-
-		maxSessions = settings.value("max_open_requests", -1).toInt();
-
-		m2_send_idents.clear();
-		foreach(const QString &s, str_m2_send_idents)
-			m2_send_idents += s.toUtf8();
-
-		if(m2_in_specs.isEmpty() || m2_out_specs.isEmpty() || m2_control_specs.isEmpty())
-		{
-			log_error("must set m2_in_specs, m2_out_specs, and m2_control_specs");
-			return false;
-		}
-
-		if(m2_send_idents.count() != m2_control_specs.count())
-		{
-			log_error("m2_control_specs must have the same count as m2_send_idents");
-			return false;
-		}
-
-		if((!zhttp_in_specs.isEmpty() || !zhttp_out_specs.isEmpty() || !zhttp_out_stream_specs.isEmpty()) && (zhttp_in_specs.isEmpty() || zhttp_out_specs.isEmpty() || zhttp_out_stream_specs.isEmpty()))
-		{
-			log_error("if zhttp is used, must set all of zhttp_in_specs, zhttp_out_specs, and zhttp_out_stream_specs");
-			return false;
-		}
-
-		if((!zws_in_specs.isEmpty() || !zws_out_specs.isEmpty() || !zws_out_stream_specs.isEmpty()) && (zws_in_specs.isEmpty() || zws_out_specs.isEmpty() || zws_out_stream_specs.isEmpty()))
-		{
-			log_error("if zws is used, must set all of zws_in_specs, zws_out_specs, and zws_out_stream_specs");
-			return false;
-		}
-
-		if(zhttp_in_specs.isEmpty() || zws_in_specs.isEmpty())
-		{
-			log_error("must set zhttp_* and/or zws_* specs");
-			return false;
-		}
-
-		QByteArray pidStr = QByteArray::number(QCoreApplication::applicationPid());
-		zhttpInstanceId = "m2zhttp_" + pidStr;
-		zwsInstanceId = "m2zws_" + pidStr;
-
-		m2_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
-		m2_in_sock->setHwm(DEFAULT_HWM);
-		foreach(const QString &spec, m2_in_specs)
-		{
-			log_info("m2_in connect %s", qPrintable(spec));
-			m2_in_sock->connectToAddress(spec);
-		}
-
-		m2_in_valve = std::make_unique<ZmqValve>(m2_in_sock.get());
-		m2InValveConnection = m2_in_valve->readyRead.connect(boost::bind(&Private::m2_in_readyRead, this, boost::placeholders::_1));
-
-		m2_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
-		m2_out_sock->setShutdownWaitTime(0);
-		m2_out_sock->setHwm(DEFAULT_HWM);
-		m2_out_sock->setWriteQueueEnabled(false);
-		foreach(const QString &spec, m2_out_specs)
-		{
-			log_info("m2_out connect %s", qPrintable(spec));
-			m2_out_sock->connectToAddress(spec);
-		}
-
-		for(int n = 0; n < m2_control_specs.count(); ++n)
-		{
-			const QString &spec = m2_control_specs[n];
-
-			ZmqSocket *sock = new ZmqSocket(ZmqSocket::Dealer);
-			sock->setShutdownWaitTime(0);
-			sock->setHwm(1); // Queue up 1 outstanding request at most
-			sock->setWriteQueueEnabled(false);
-			rrConnection[sock] = sock->readyRead.connect(boost::bind(&Private::m2_control_readyRead, this, sock));
-
-			log_info("m2_control connect %s:%s", m2_send_idents[n].data(), qPrintable(spec));
-			sock->connectToAddress(spec);
-
-			ControlPort controlPort;
-			controlPort.sock = sock;
-			controlPorts += controlPort;
-		}
-
-		if(!zhttp_in_specs.isEmpty())
-		{
-			zhttp_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-			zhttp_in_sock->setHwm(DEFAULT_HWM);
-			zhttp_in_sock->setShutdownWaitTime(0);
-			zhttp_in_sock->subscribe(zhttpInstanceId + ' ');
-			if(zhttp_connect)
-			{
-				foreach(const QString &spec, zhttp_in_specs)
-				{
-					log_info("zhttp_in connect %s", qPrintable(spec));
-					zhttp_in_sock->connectToAddress(spec);
-				}
-			}
-			else
-			{
-				log_info("zhttp_in bind %s", qPrintable(zhttp_in_specs[0]));
-				if(!zhttp_in_sock->bind(zhttp_in_specs[0]))
-				{
-					log_error("unable to bind to zhttp_in spec: %s", qPrintable(zhttp_in_specs[0]));
-					return false;
-				}
-			}
-
-			zhttp_in_valve = std::make_unique<ZmqValve>(zhttp_in_sock.get());
-			zhttpInValveConnection = zhttp_in_valve->readyRead.connect(boost::bind(&Private::zhttp_in_readyRead, this, boost::placeholders::_1));
-
-			zhttp_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
-			zhttp_out_sock->setShutdownWaitTime(0);
-			zhttp_out_sock->setHwm(DEFAULT_HWM);
-			if(zhttp_connect)
-			{
-				foreach(const QString &spec, zhttp_out_specs)
-				{
-					log_info("zhttp_out connect %s", qPrintable(spec));
-					zhttp_out_sock->connectToAddress(spec);
-				}
-			}
-			else
-			{
-				log_info("zhttp_out bind %s", qPrintable(zhttp_out_specs[0]));
-				if(!zhttp_out_sock->bind(zhttp_out_specs[0]))
-				{
-					log_error("unable to bind to zhttp_out spec: %s", qPrintable(zhttp_out_specs[0]));
-					return false;
-				}
-			}
-
-			zhttp_out_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-			zhttp_out_stream_sock->setShutdownWaitTime(0);
-			zhttp_out_stream_sock->setHwm(DEFAULT_HWM);
-			if(zhttp_connect)
-			{
-				foreach(const QString &spec, zhttp_out_stream_specs)
-				{
-					log_info("zhttp_out_stream connect %s", qPrintable(spec));
-					zhttp_out_stream_sock->connectToAddress(spec);
-				}
-			}
-			else
-			{
-				log_info("zhttp_out_stream bind %s", qPrintable(zhttp_out_stream_specs[0]));
-				if(!zhttp_out_stream_sock->bind(zhttp_out_stream_specs[0]))
-				{
-					log_error("unable to bind to zhttp_out_stream spec: %s", qPrintable(zhttp_out_stream_specs[0]));
-					return false;
-				}
-			}
-		}
-
-		if(!zws_in_specs.isEmpty())
-		{
-			zws_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-			zws_in_sock->setHwm(DEFAULT_HWM);
-			zws_in_sock->subscribe(zwsInstanceId + ' ');
-			if(zws_connect)
-			{
-				foreach(const QString &spec, zws_in_specs)
-				{
-					log_info("zws_in connect %s", qPrintable(spec));
-					zws_in_sock->connectToAddress(spec);
-				}
-			}
-			else
-			{
-				log_info("zws_in bind %s", qPrintable(zws_in_specs[0]));
-				if(!zws_in_sock->bind(zws_in_specs[0]))
-				{
-					log_error("unable to bind to zws_in spec: %s", qPrintable(zws_in_specs[0]));
-					return false;
-				}
-			}
-
-			zws_in_valve = std::make_unique<ZmqValve>(zws_in_sock.get());
-			zwsInValveConnection = zws_in_valve->readyRead.connect(boost::bind(&Private::zws_in_readyRead, this, boost::placeholders::_1));
-
-			zws_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
-			zws_out_sock->setShutdownWaitTime(0);
-			zws_out_sock->setHwm(DEFAULT_HWM);
-			if(zws_connect)
-			{
-				foreach(const QString &spec, zws_out_specs)
-				{
-					log_info("zws_out connect %s", qPrintable(spec));
-					zws_out_sock->connectToAddress(spec);
-				}
-			}
-			else
-			{
-				log_info("zws_out bind %s", qPrintable(zws_out_specs[0]));
-				if(!zws_out_sock->bind(zws_out_specs[0]))
-				{
-					log_error("unable to bind to zws_out spec: %s", qPrintable(zws_out_specs[0]));
-					return false;
-				}
-			}
-
-			zws_out_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-			zws_out_stream_sock->setShutdownWaitTime(0);
-			zws_out_stream_sock->setHwm(DEFAULT_HWM);
-			if(zws_connect)
-			{
-				foreach(const QString &spec, zws_out_stream_specs)
-				{
-					log_info("zws_out_stream connect %s", qPrintable(spec));
-					zws_out_stream_sock->connectToAddress(spec);
-				}
-			}
-			else
-			{
-				log_info("zws_out_stream bind %s", qPrintable(zws_out_stream_specs[0]));
-				if(!zws_out_stream_sock->bind(zws_out_stream_specs[0]))
-				{
-					log_error("unable to bind to zws_out_stream spec: %s", qPrintable(zws_out_stream_specs[0]));
-					return false;
-				}
-			}
-		}
-
-		return true;
-	}
-
-	void removeConnection(M2Connection *conn)
-	{
-		m2ConnectionRefreshBuckets[conn->refreshBucket].remove(conn);
-		m2ConnectionsByLastRefresh.remove(QPair<qint64, M2Connection*>(conn->lastRefresh, conn));
-		m2ConnectionsByRid.remove(Rid(m2_send_idents[conn->identIndex], conn->id));
-	}
-
-	void unlinkConnection(Session *s)
-	{
-		if(s->conn)
-		{
-			s->conn->session = 0; // Unlink the M2Connection so that it may be reused
-			if(s->conn->packetsPending > 0 || !s->conn->pendingOutItems.isEmpty())
-				s->conn->waitForAllWritten = true;
-			sessionsByM2Rid.remove(Rid(m2_send_idents[s->conn->identIndex], s->conn->id));
-			s->conn = 0;
-		}
-	}
-
-	int smallestM2RefreshBucket()
-	{
-		int best = -1;
-		int bestSize = 0;
-
-		for(int n = 0; n < M2_REFRESH_BUCKETS; ++n)
-		{
-			if(best == -1 || m2ConnectionRefreshBuckets[n].count() < bestSize)
-			{
-				best = n;
-				bestSize = m2ConnectionRefreshBuckets[n].count();
-			}
-		}
-
-		return best;
-	}
-
-	int smallestSessionRefreshBucket()
-	{
-		int best = -1;
-		int bestSize = 0;
-
-		for(int n = 0; n < ZHTTP_REFRESH_BUCKETS; ++n)
-		{
-			if(best == -1 || sessionRefreshBuckets[n].count() < bestSize)
-			{
-				best = n;
-				bestSize = sessionRefreshBuckets[n].count();
-			}
-		}
-
-		return best;
-	}
-
-	void removeSession(Session *s)
-	{
-		unlinkConnection(s);
-
-		sessionsToCancel -= s;
-
-		if(s->lastRefresh >= 0)
-		{
-			QPair<qint64, Session*> k(s->lastRefresh, s);
-			if(sessionsByLastRefresh.contains(k))
-			{
-				sessionRefreshBuckets[s->refreshBucket].remove(s);
-				sessionsByLastRefresh.remove(k);
-			}
-		}
-
-		sessionsByLastActive.remove(QPair<qint64, Session*>(s->lastActive, s));
-
-		if(s->mode == Http)
-			sessionsByZhttpRid.remove(Rid(zhttpInstanceId, s->id));
-		else // WebSocket
-			sessionsByZwsRid.remove(Rid(zwsInstanceId, s->id));
-	}
-
-	void destroySession(Session *s)
-	{
-		removeSession(s);
-		delete s;
-	}
-
-	void queueCancelSession(Session *s)
-	{
-		assert(!s->zhttpAddress.isEmpty());
-
-		unlinkConnection(s);
-
-		s->pendingCancel = true;
-		sessionsToCancel += s;
-	}
-
-	void destroySessionAndErrorConnection(Session *s)
-	{
-		M2Connection *conn = s->conn;
-		destroySession(s);
-		if(conn)
-			m2_writeErrorClose(conn);
-	}
-
-	void m2_out_write(const M2ResponsePacket &packet)
-	{
-		QByteArray buf = packet.toByteArray();
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logByteArray(LOG_LEVEL_DEBUG, buf, "m2: OUT");
-
-		m2_out_sock->write(QList<QByteArray>() << buf);
-	}
-
-	void m2_control_write(int index, const QByteArray &cmd, const VariantHash &args)
-	{
-		VariantList vlist;
-		vlist += cmd;
-		vlist += args;
-
-		QByteArray buf = TnetString::fromVariant(vlist);
+    enum Mode { Http, WebSocket };
+
+    class ControlPort {
+    public:
+        enum State { Disabled, Idle, ExpectingResponse };
+
+        ZmqSocket *sock;
+        State state;
+        bool works;
+        int reqStartTime;
+
+        ControlPort() : sock(0), state(Disabled), works(false), reqStartTime(-1) {}
+    };
+
+    // Can be used for either m2 or zhttp
+    typedef QPair<QByteArray, QByteArray> Rid;
+
+    class Session;
+
+    class M2PendingOutItem {
+    public:
+        enum Type { Headers, Response, Frame, Close };
+
+        Type type;
+        BufferList data;
+        bool chunked;
+        int contentSize;
+
+        M2PendingOutItem(Type _type) : type(_type), chunked(false), contentSize(0) {}
+    };
+
+    class M2Connection {
+    public:
+        int identIndex;
+        QByteArray id;
+        int confirmedBytesWritten;
+        int packetsPending; // Count of packets sent to m2 not yet ack'd
+        Session *session;
+        bool isNew;
+        bool continuation;
+        LayerTracker bodyTracker;
+        LayerTracker packetTracker;
+        QList<M2PendingOutItem> pendingOutItems; // Packets yet to send
+        bool flowControl;
+        bool waitForAllWritten;
+        bool outCreditsEnabled;
+        int outCredits;
+        quint64 subIdBase;
+        qint64 lastRefresh;
+        int refreshBucket;
+
+        M2Connection()
+            : confirmedBytesWritten(0),
+              packetsPending(0),
+              session(0),
+              isNew(false),
+              continuation(false),
+              flowControl(false),
+              waitForAllWritten(false),
+              outCreditsEnabled(false),
+              outCredits(0),
+              subIdBase(0) {}
+
+        bool canWrite() const {
+            if (!flowControl)
+                return true;
+
+            if (outCreditsEnabled) {
+                if (outCredits > 0)
+                    return true;
+            } else {
+                // If we aren't using outCredits, then limit pending packets
+                // to hardcoded m2 value
+                if (packetsPending < M2_PENDING_MAX)
+                    return true;
+            }
+
+            return false;
+        }
+    };
+
+    class Session {
+    public:
+        Mode mode;
+        qint64 lastActive;
+        QByteArray errorCondition;
+        QByteArray acceptToken; // For websocket
+        bool downClosed;        // For websocket
+        bool upClosed;          // For websockets
+        QString method;
+        bool responseHeadersOnly; // HEAD, 204, 304
+        qint64 lastRefresh;
+        int refreshBucket;
+        bool pendingCancel;
+
+        // M2 stuff
+        M2Connection *conn;
+        bool persistent;
+        bool allowChunked;
+        bool respondKeepAlive;
+        bool respondClose;
+        bool chunked;
+        int readCount;
+        BufferList pendingIn;
+        QList<ZhttpRequestPacket> pendingInPackets;
+        bool inFinished;
+
+        // Zhttp stuff
+        QByteArray id;
+        QByteArray zhttpAddress;
+        bool sentResponseHeader;
+        int outSeq;
+        int inSeq;
+        int pendingInCredits;
+        bool inHandoff;
+        bool multi;
+
+        Session()
+            : lastActive(-1),
+              downClosed(false),
+              upClosed(false),
+              responseHeadersOnly(false),
+              lastRefresh(-1),
+              pendingCancel(false),
+              persistent(false),
+              allowChunked(false),
+              respondKeepAlive(false),
+              respondClose(false),
+              chunked(false),
+              readCount(0),
+              inFinished(false),
+              sentResponseHeader(false),
+              outSeq(0),
+              inSeq(0),
+              pendingInCredits(0),
+              inHandoff(false),
+              multi(false) {}
+    };
+
+    M2AdapterApp *q;
+    ArgsData args;
+    QByteArray zhttpInstanceId;
+    QByteArray zwsInstanceId;
+    std::unique_ptr<ZmqSocket> m2_in_sock;
+    std::unique_ptr<ZmqSocket> m2_out_sock;
+    std::unique_ptr<ZmqSocket> zhttp_in_sock;
+    std::unique_ptr<ZmqSocket> zhttp_out_sock;
+    std::unique_ptr<ZmqSocket> zhttp_out_stream_sock;
+    std::unique_ptr<ZmqSocket> zws_in_sock;
+    std::unique_ptr<ZmqSocket> zws_out_sock;
+    std::unique_ptr<ZmqSocket> zws_out_stream_sock;
+    std::unique_ptr<ZmqValve> m2_in_valve;
+    std::unique_ptr<ZmqValve> zhttp_in_valve;
+    std::unique_ptr<ZmqValve> zws_in_valve;
+    QList<QByteArray> m2_send_idents;
+    QHash<Rid, M2Connection *> m2ConnectionsByRid;
+    QHash<Rid, Session *> sessionsByM2Rid;
+    QHash<Rid, Session *> sessionsByZhttpRid;
+    QHash<Rid, Session *> sessionsByZwsRid;
+    QMap<QPair<qint64, M2Connection *>, M2Connection *> m2ConnectionsByLastRefresh;
+    QSet<M2Connection *> m2ConnectionRefreshBuckets[M2_REFRESH_BUCKETS];
+    int currentM2RefreshBucket;
+    QMap<QPair<qint64, Session *>, Session *> sessionsByLastRefresh;
+    QSet<Session *> sessionRefreshBuckets[ZHTTP_REFRESH_BUCKETS];
+    int currentSessionRefreshBucket;
+    QMap<QPair<qint64, Session *>, Session *> sessionsByLastActive;
+    int zhttpCancelMeter;
+    QSet<Session *> sessionsToCancel;
+    int m2_client_buffer;
+    int maxSessions;
+    int zhttpConnectPort;
+    int zwsConnectPort;
+    bool ignorePolicies;
+    QList<ControlPort> controlPorts;
+    QElapsedTimer time;
+    QTimer *statusTimer;
+    QTimer *refreshTimer;
+    Connection quitConnection;
+    Connection hupConnection;
+    map<ZmqSocket *, Connection> rrConnection;
+    Connection m2InValveConnection;
+    Connection zhttpInValveConnection;
+    Connection zwsInValveConnection;
+
+    Private(M2AdapterApp *_q)
+        : QObject(_q),
+          q(_q),
+          currentM2RefreshBucket(0),
+          currentSessionRefreshBucket(0),
+          zhttpCancelMeter(0) {
+        quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::doQuit, this));
+        hupConnection =
+            ProcessQuit::instance()->hup.connect(boost::bind(&M2AdapterApp::Private::reload, this));
+
+        statusTimer = new QTimer(this);
+        connect(statusTimer, &QTimer::timeout, this, &Private::status_timeout);
+
+        refreshTimer = new QTimer(this);
+        connect(refreshTimer, &QTimer::timeout, this, &Private::refresh_timeout);
+
+        time.start();
+    }
+
+    ~Private() {
+        qDeleteAll(sessionsByZhttpRid);
+        qDeleteAll(sessionsByZwsRid);
+        qDeleteAll(m2ConnectionsByRid);
+
+        for (int n = 0; n < controlPorts.count(); ++n) {
+            ControlPort &c = controlPorts[n];
+            delete c.sock;
+            c.sock = 0;
+        }
+    }
+
+    void start() {
+        QCoreApplication::setApplicationName("m2adapter");
+        QCoreApplication::setApplicationVersion(Config::get().version);
+
+        QCommandLineParser parser;
+        parser.setApplicationDescription("Mongrel2 <-> ZHTTP adapter.");
+
+        QString errorMessage;
+        switch (parseCommandLine(&parser, &args, &errorMessage)) {
+        case CommandLineOk:
+            break;
+        case CommandLineError:
+            fprintf(stderr, "%s\n\n%s", qPrintable(errorMessage), qPrintable(parser.helpText()));
+            q->quit(1);
+            return;
+        case CommandLineVersionRequested:
+            printf("%s %s\n", qPrintable(QCoreApplication::applicationName()),
+                   qPrintable(QCoreApplication::applicationVersion()));
+            q->quit(0);
+            return;
+        case CommandLineHelpRequested:
+            parser.showHelp();
+            Q_UNREACHABLE();
+        }
+
+        if (!init()) {
+            q->quit(1);
+            return;
+        }
+
+        m2_in_valve->open();
+
+        if (zhttp_in_valve)
+            zhttp_in_valve->open();
+        if (zws_in_valve)
+            zws_in_valve->open();
+
+        statusTimer->setInterval(STATUS_INTERVAL);
+
+        refreshTimer->setInterval(REFRESH_INTERVAL);
+        refreshTimer->start();
+
+        log_info("started");
+    }
+
+    bool init() {
+        if (args.logLevel != -1)
+            log_setOutputLevel(args.logLevel);
+        else
+            log_setOutputLevel(LOG_LEVEL_INFO);
+
+        if (!args.logFile.isEmpty()) {
+            if (!log_setFile(args.logFile)) {
+                log_error("failed to open log file: %s", qPrintable(args.logFile));
+                return false;
+            }
+        }
+
+        log_info("starting...");
+
+        QString configFile = args.configFile;
+        if (configFile.isEmpty())
+            configFile = QDir(Config::get().configDir).filePath("m2adapter.conf");
+
+        // QSettings doesn't inform us if the config file doesn't exist, so do that
+        // ourselves
+        {
+            QFile file(configFile);
+            if (!file.open(QIODevice::ReadOnly)) {
+                log_error("failed to open %s, and --config not passed", qPrintable(configFile));
+                return false;
+            }
+        }
+
+        QSettings settings(configFile, QSettings::IniFormat);
+
+        QStringList m2_in_specs = settings.value("m2_in_specs").toStringList();
+        trimlist(&m2_in_specs);
+        QStringList m2_out_specs = settings.value("m2_out_specs").toStringList();
+        trimlist(&m2_out_specs);
+        QStringList str_m2_send_idents = settings.value("m2_send_idents").toStringList();
+        trimlist(&str_m2_send_idents);
+        QStringList m2_control_specs = settings.value("m2_control_specs").toStringList();
+        trimlist(&m2_control_specs);
+
+        bool zhttp_connect = settings.value("zhttp_connect").toBool();
+        QStringList zhttp_in_specs = settings.value("zhttp_in_specs").toStringList();
+        trimlist(&zhttp_in_specs);
+        QStringList zhttp_out_specs = settings.value("zhttp_out_specs").toStringList();
+        trimlist(&zhttp_out_specs);
+        QStringList zhttp_out_stream_specs =
+            settings.value("zhttp_out_stream_specs").toStringList();
+        trimlist(&zhttp_out_stream_specs);
+
+        bool zws_connect = settings.value("zws_connect").toBool();
+        QStringList zws_in_specs = settings.value("zws_in_specs").toStringList();
+        trimlist(&zws_in_specs);
+        QStringList zws_out_specs = settings.value("zws_out_specs").toStringList();
+        trimlist(&zws_out_specs);
+        QStringList zws_out_stream_specs = settings.value("zws_out_stream_specs").toStringList();
+        trimlist(&zws_out_stream_specs);
+
+        zhttpConnectPort = settings.value("zhttp_connect_port", -1).toInt();
+        zwsConnectPort = settings.value("zws_connect_port", -1).toInt();
+        ignorePolicies = settings.value("ignore_policies").toBool();
+        m2_client_buffer = settings.value("m2_client_buffer").toInt();
+        if (m2_client_buffer <= 0)
+            m2_client_buffer = 200000;
+
+        maxSessions = settings.value("max_open_requests", -1).toInt();
+
+        m2_send_idents.clear();
+        foreach (const QString &s, str_m2_send_idents)
+            m2_send_idents += s.toUtf8();
+
+        if (m2_in_specs.isEmpty() || m2_out_specs.isEmpty() || m2_control_specs.isEmpty()) {
+            log_error("must set m2_in_specs, m2_out_specs, and m2_control_specs");
+            return false;
+        }
+
+        if (m2_send_idents.count() != m2_control_specs.count()) {
+            log_error("m2_control_specs must have the same count as m2_send_idents");
+            return false;
+        }
+
+        if ((!zhttp_in_specs.isEmpty() || !zhttp_out_specs.isEmpty() ||
+             !zhttp_out_stream_specs.isEmpty()) &&
+            (zhttp_in_specs.isEmpty() || zhttp_out_specs.isEmpty() ||
+             zhttp_out_stream_specs.isEmpty())) {
+            log_error("if zhttp is used, must set all of zhttp_in_specs, "
+                      "zhttp_out_specs, and zhttp_out_stream_specs");
+            return false;
+        }
+
+        if ((!zws_in_specs.isEmpty() || !zws_out_specs.isEmpty() ||
+             !zws_out_stream_specs.isEmpty()) &&
+            (zws_in_specs.isEmpty() || zws_out_specs.isEmpty() || zws_out_stream_specs.isEmpty())) {
+            log_error("if zws is used, must set all of zws_in_specs, zws_out_specs, "
+                      "and zws_out_stream_specs");
+            return false;
+        }
+
+        if (zhttp_in_specs.isEmpty() || zws_in_specs.isEmpty()) {
+            log_error("must set zhttp_* and/or zws_* specs");
+            return false;
+        }
+
+        QByteArray pidStr = QByteArray::number(QCoreApplication::applicationPid());
+        zhttpInstanceId = "m2zhttp_" + pidStr;
+        zwsInstanceId = "m2zws_" + pidStr;
+
+        m2_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+        m2_in_sock->setHwm(DEFAULT_HWM);
+        foreach (const QString &spec, m2_in_specs) {
+            log_info("m2_in connect %s", qPrintable(spec));
+            m2_in_sock->connectToAddress(spec);
+        }
+
+        m2_in_valve = std::make_unique<ZmqValve>(m2_in_sock.get());
+        m2InValveConnection = m2_in_valve->readyRead.connect(
+            boost::bind(&Private::m2_in_readyRead, this, boost::placeholders::_1));
+
+        m2_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
+        m2_out_sock->setShutdownWaitTime(0);
+        m2_out_sock->setHwm(DEFAULT_HWM);
+        m2_out_sock->setWriteQueueEnabled(false);
+        foreach (const QString &spec, m2_out_specs) {
+            log_info("m2_out connect %s", qPrintable(spec));
+            m2_out_sock->connectToAddress(spec);
+        }
+
+        for (int n = 0; n < m2_control_specs.count(); ++n) {
+            const QString &spec = m2_control_specs[n];
+
+            ZmqSocket *sock = new ZmqSocket(ZmqSocket::Dealer);
+            sock->setShutdownWaitTime(0);
+            sock->setHwm(1); // Queue up 1 outstanding request at most
+            sock->setWriteQueueEnabled(false);
+            rrConnection[sock] =
+                sock->readyRead.connect(boost::bind(&Private::m2_control_readyRead, this, sock));
+
+            log_info("m2_control connect %s:%s", m2_send_idents[n].data(), qPrintable(spec));
+            sock->connectToAddress(spec);
+
+            ControlPort controlPort;
+            controlPort.sock = sock;
+            controlPorts += controlPort;
+        }
+
+        if (!zhttp_in_specs.isEmpty()) {
+            zhttp_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+            zhttp_in_sock->setHwm(DEFAULT_HWM);
+            zhttp_in_sock->setShutdownWaitTime(0);
+            zhttp_in_sock->subscribe(zhttpInstanceId + ' ');
+            if (zhttp_connect) {
+                foreach (const QString &spec, zhttp_in_specs) {
+                    log_info("zhttp_in connect %s", qPrintable(spec));
+                    zhttp_in_sock->connectToAddress(spec);
+                }
+            } else {
+                log_info("zhttp_in bind %s", qPrintable(zhttp_in_specs[0]));
+                if (!zhttp_in_sock->bind(zhttp_in_specs[0])) {
+                    log_error("unable to bind to zhttp_in spec: %s", qPrintable(zhttp_in_specs[0]));
+                    return false;
+                }
+            }
+
+            zhttp_in_valve = std::make_unique<ZmqValve>(zhttp_in_sock.get());
+            zhttpInValveConnection = zhttp_in_valve->readyRead.connect(
+                boost::bind(&Private::zhttp_in_readyRead, this, boost::placeholders::_1));
+
+            zhttp_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
+            zhttp_out_sock->setShutdownWaitTime(0);
+            zhttp_out_sock->setHwm(DEFAULT_HWM);
+            if (zhttp_connect) {
+                foreach (const QString &spec, zhttp_out_specs) {
+                    log_info("zhttp_out connect %s", qPrintable(spec));
+                    zhttp_out_sock->connectToAddress(spec);
+                }
+            } else {
+                log_info("zhttp_out bind %s", qPrintable(zhttp_out_specs[0]));
+                if (!zhttp_out_sock->bind(zhttp_out_specs[0])) {
+                    log_error("unable to bind to zhttp_out spec: %s",
+                              qPrintable(zhttp_out_specs[0]));
+                    return false;
+                }
+            }
+
+            zhttp_out_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+            zhttp_out_stream_sock->setShutdownWaitTime(0);
+            zhttp_out_stream_sock->setHwm(DEFAULT_HWM);
+            if (zhttp_connect) {
+                foreach (const QString &spec, zhttp_out_stream_specs) {
+                    log_info("zhttp_out_stream connect %s", qPrintable(spec));
+                    zhttp_out_stream_sock->connectToAddress(spec);
+                }
+            } else {
+                log_info("zhttp_out_stream bind %s", qPrintable(zhttp_out_stream_specs[0]));
+                if (!zhttp_out_stream_sock->bind(zhttp_out_stream_specs[0])) {
+                    log_error("unable to bind to zhttp_out_stream spec: %s",
+                              qPrintable(zhttp_out_stream_specs[0]));
+                    return false;
+                }
+            }
+        }
+
+        if (!zws_in_specs.isEmpty()) {
+            zws_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+            zws_in_sock->setHwm(DEFAULT_HWM);
+            zws_in_sock->subscribe(zwsInstanceId + ' ');
+            if (zws_connect) {
+                foreach (const QString &spec, zws_in_specs) {
+                    log_info("zws_in connect %s", qPrintable(spec));
+                    zws_in_sock->connectToAddress(spec);
+                }
+            } else {
+                log_info("zws_in bind %s", qPrintable(zws_in_specs[0]));
+                if (!zws_in_sock->bind(zws_in_specs[0])) {
+                    log_error("unable to bind to zws_in spec: %s", qPrintable(zws_in_specs[0]));
+                    return false;
+                }
+            }
+
+            zws_in_valve = std::make_unique<ZmqValve>(zws_in_sock.get());
+            zwsInValveConnection = zws_in_valve->readyRead.connect(
+                boost::bind(&Private::zws_in_readyRead, this, boost::placeholders::_1));
+
+            zws_out_sock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
+            zws_out_sock->setShutdownWaitTime(0);
+            zws_out_sock->setHwm(DEFAULT_HWM);
+            if (zws_connect) {
+                foreach (const QString &spec, zws_out_specs) {
+                    log_info("zws_out connect %s", qPrintable(spec));
+                    zws_out_sock->connectToAddress(spec);
+                }
+            } else {
+                log_info("zws_out bind %s", qPrintable(zws_out_specs[0]));
+                if (!zws_out_sock->bind(zws_out_specs[0])) {
+                    log_error("unable to bind to zws_out spec: %s", qPrintable(zws_out_specs[0]));
+                    return false;
+                }
+            }
+
+            zws_out_stream_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+            zws_out_stream_sock->setShutdownWaitTime(0);
+            zws_out_stream_sock->setHwm(DEFAULT_HWM);
+            if (zws_connect) {
+                foreach (const QString &spec, zws_out_stream_specs) {
+                    log_info("zws_out_stream connect %s", qPrintable(spec));
+                    zws_out_stream_sock->connectToAddress(spec);
+                }
+            } else {
+                log_info("zws_out_stream bind %s", qPrintable(zws_out_stream_specs[0]));
+                if (!zws_out_stream_sock->bind(zws_out_stream_specs[0])) {
+                    log_error("unable to bind to zws_out_stream spec: %s",
+                              qPrintable(zws_out_stream_specs[0]));
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    void removeConnection(M2Connection *conn) {
+        m2ConnectionRefreshBuckets[conn->refreshBucket].remove(conn);
+        m2ConnectionsByLastRefresh.remove(QPair<qint64, M2Connection *>(conn->lastRefresh, conn));
+        m2ConnectionsByRid.remove(Rid(m2_send_idents[conn->identIndex], conn->id));
+    }
+
+    void unlinkConnection(Session *s) {
+        if (s->conn) {
+            s->conn->session = 0; // Unlink the M2Connection so that it may be reused
+            if (s->conn->packetsPending > 0 || !s->conn->pendingOutItems.isEmpty())
+                s->conn->waitForAllWritten = true;
+            sessionsByM2Rid.remove(Rid(m2_send_idents[s->conn->identIndex], s->conn->id));
+            s->conn = 0;
+        }
+    }
+
+    int smallestM2RefreshBucket() {
+        int best = -1;
+        int bestSize = 0;
+
+        for (int n = 0; n < M2_REFRESH_BUCKETS; ++n) {
+            if (best == -1 || m2ConnectionRefreshBuckets[n].count() < bestSize) {
+                best = n;
+                bestSize = m2ConnectionRefreshBuckets[n].count();
+            }
+        }
+
+        return best;
+    }
+
+    int smallestSessionRefreshBucket() {
+        int best = -1;
+        int bestSize = 0;
+
+        for (int n = 0; n < ZHTTP_REFRESH_BUCKETS; ++n) {
+            if (best == -1 || sessionRefreshBuckets[n].count() < bestSize) {
+                best = n;
+                bestSize = sessionRefreshBuckets[n].count();
+            }
+        }
+
+        return best;
+    }
+
+    void removeSession(Session *s) {
+        unlinkConnection(s);
+
+        sessionsToCancel -= s;
+
+        if (s->lastRefresh >= 0) {
+            QPair<qint64, Session *> k(s->lastRefresh, s);
+            if (sessionsByLastRefresh.contains(k)) {
+                sessionRefreshBuckets[s->refreshBucket].remove(s);
+                sessionsByLastRefresh.remove(k);
+            }
+        }
+
+        sessionsByLastActive.remove(QPair<qint64, Session *>(s->lastActive, s));
+
+        if (s->mode == Http)
+            sessionsByZhttpRid.remove(Rid(zhttpInstanceId, s->id));
+        else // WebSocket
+            sessionsByZwsRid.remove(Rid(zwsInstanceId, s->id));
+    }
+
+    void destroySession(Session *s) {
+        removeSession(s);
+        delete s;
+    }
+
+    void queueCancelSession(Session *s) {
+        assert(!s->zhttpAddress.isEmpty());
+
+        unlinkConnection(s);
+
+        s->pendingCancel = true;
+        sessionsToCancel += s;
+    }
+
+    void destroySessionAndErrorConnection(Session *s) {
+        M2Connection *conn = s->conn;
+        destroySession(s);
+        if (conn)
+            m2_writeErrorClose(conn);
+    }
+
+    void m2_out_write(const M2ResponsePacket &packet) {
+        QByteArray buf = packet.toByteArray();
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logByteArray(LOG_LEVEL_DEBUG, buf, "m2: OUT");
+
+        m2_out_sock->write(QList<QByteArray>() << buf);
+    }
+
+    void m2_control_write(int index, const QByteArray &cmd, const VariantHash &args) {
+        VariantList vlist;
+        vlist += cmd;
+        vlist += args;
+
+        QByteArray buf = TnetString::fromVariant(vlist);
 
 #ifdef CONTROL_PORT_DEBUG
-		log_debug("m2: OUT control %s %s", m2_send_idents[index].data(), buf.data());
+        log_debug("m2: OUT control %s %s", m2_send_idents[index].data(), buf.data());
 #endif
 
-		QList<QByteArray> message;
-		message += QByteArray();
-		message += buf;
-		controlPorts[index].sock->write(message);
-	}
+        QList<QByteArray> message;
+        message += QByteArray();
+        message += buf;
+        controlPorts[index].sock->write(message);
+    }
 
-	void m2_writeCtl(M2Connection *conn, const Variant &args)
-	{
-		M2ResponsePacket mresp;
-		mresp.sender = m2_send_idents[conn->identIndex];
-		mresp.id = "X " + conn->id;
-		VariantList parts;
-		parts += QByteArray("ctl");
-		parts += args;
-		mresp.data = TnetString::fromVariant(parts);
-		m2_out_write(mresp);
-	}
+    void m2_writeCtl(M2Connection *conn, const Variant &args) {
+        M2ResponsePacket mresp;
+        mresp.sender = m2_send_idents[conn->identIndex];
+        mresp.id = "X " + conn->id;
+        VariantList parts;
+        parts += QByteArray("ctl");
+        parts += args;
+        mresp.data = TnetString::fromVariant(parts);
+        m2_out_write(mresp);
+    }
 
-	void m2_writeCtlMany(const QByteArray &sender, const QList<QByteArray> &connIds, const Variant &args)
-	{
-		assert(!connIds.isEmpty());
+    void m2_writeCtlMany(const QByteArray &sender, const QList<QByteArray> &connIds,
+                         const Variant &args) {
+        assert(!connIds.isEmpty());
 
-		M2ResponsePacket mresp;
-		mresp.sender = sender;
-		mresp.id = "X";
-		foreach(const QByteArray &id, connIds)
-			mresp.id += " " + id;
-		VariantList parts;
-		parts += QByteArray("ctl");
-		parts += args;
-		mresp.data = TnetString::fromVariant(parts);
-		m2_out_write(mresp);
-	}
+        M2ResponsePacket mresp;
+        mresp.sender = sender;
+        mresp.id = "X";
+        foreach (const QByteArray &id, connIds)
+            mresp.id += " " + id;
+        VariantList parts;
+        parts += QByteArray("ctl");
+        parts += args;
+        mresp.data = TnetString::fromVariant(parts);
+        m2_out_write(mresp);
+    }
 
-	void m2_writeCtlCancel(const QByteArray &sender, const QByteArray &id)
-	{
-		M2ResponsePacket mresp;
-		mresp.sender = sender;
-		mresp.id = "X " + id;
-		VariantHash args;
-		args["cancel"] = true;
-		VariantList parts;
-		parts += QByteArray("ctl");
-		parts += args;
-		mresp.data = TnetString::fromVariant(parts);
-		m2_out_write(mresp);
-	}
+    void m2_writeCtlCancel(const QByteArray &sender, const QByteArray &id) {
+        M2ResponsePacket mresp;
+        mresp.sender = sender;
+        mresp.id = "X " + id;
+        VariantHash args;
+        args["cancel"] = true;
+        VariantList parts;
+        parts += QByteArray("ctl");
+        parts += args;
+        mresp.data = TnetString::fromVariant(parts);
+        m2_out_write(mresp);
+    }
 
-	void m2_writeCtlCancel(M2Connection *conn)
-	{
-		m2_writeCtlCancel(m2_send_idents[conn->identIndex], conn->id);
-		removeConnection(conn);
-		delete conn;
-	}
+    void m2_writeCtlCancel(M2Connection *conn) {
+        m2_writeCtlCancel(m2_send_idents[conn->identIndex], conn->id);
+        removeConnection(conn);
+        delete conn;
+    }
 
-	// contentSize = packet.data.size() - framing overhead
-	void m2_writeData(M2Connection *conn, const M2ResponsePacket &packet, int contentSize)
-	{
-		if(conn->outCreditsEnabled)
-			conn->outCredits -= packet.data.size();
+    // contentSize = packet.data.size() - framing overhead
+    void m2_writeData(M2Connection *conn, const M2ResponsePacket &packet, int contentSize) {
+        if (conn->outCreditsEnabled)
+            conn->outCredits -= packet.data.size();
 
-		conn->bodyTracker.addPlain(contentSize);
-		conn->bodyTracker.specifyEncoded(packet.data.size(), contentSize);
+        conn->bodyTracker.addPlain(contentSize);
+        conn->bodyTracker.specifyEncoded(packet.data.size(), contentSize);
 
-		++(conn->packetsPending);
-		conn->packetTracker.addPlain(1);
-		conn->packetTracker.specifyEncoded(packet.data.size(), 1);
+        ++(conn->packetsPending);
+        conn->packetTracker.addPlain(1);
+        conn->packetTracker.specifyEncoded(packet.data.size(), 1);
 
-		m2_out_write(packet);
-	}
+        m2_out_write(packet);
+    }
 
-	void m2_queueHeaders(M2Connection *conn, const QByteArray &headerData)
-	{
-		// Only try writing if this item would be next
-		bool tryWrite = conn->pendingOutItems.isEmpty();
+    void m2_queueHeaders(M2Connection *conn, const QByteArray &headerData) {
+        // Only try writing if this item would be next
+        bool tryWrite = conn->pendingOutItems.isEmpty();
 
-		M2PendingOutItem item(M2PendingOutItem::Headers);
-		item.data += headerData;
-		conn->pendingOutItems += item;
+        M2PendingOutItem item(M2PendingOutItem::Headers);
+        item.data += headerData;
+        conn->pendingOutItems += item;
 
-		if(tryWrite)
-			m2_tryWriteQueued(conn);
-	}
+        if (tryWrite)
+            m2_tryWriteQueued(conn);
+    }
 
-	void m2_queueResponse(M2Connection *conn, const QByteArray &data, bool chunked)
-	{
-		// Skip if the result would send no bytes
-		if(data.isEmpty() && !chunked)
-			return;
+    void m2_queueResponse(M2Connection *conn, const QByteArray &data, bool chunked) {
+        // Skip if the result would send no bytes
+        if (data.isEmpty() && !chunked)
+            return;
 
-		// Only try writing if this item would be next
-		bool tryWrite = conn->pendingOutItems.isEmpty();
+        // Only try writing if this item would be next
+        bool tryWrite = conn->pendingOutItems.isEmpty();
 
-		M2PendingOutItem *item = 0;
-		if(!conn->pendingOutItems.isEmpty())
-		{
-			M2PendingOutItem &last = conn->pendingOutItems.last();
-			bool lastIsZeroChunk = (last.chunked && last.data.isEmpty());
+        M2PendingOutItem *item = 0;
+        if (!conn->pendingOutItems.isEmpty()) {
+            M2PendingOutItem &last = conn->pendingOutItems.last();
+            bool lastIsZeroChunk = (last.chunked && last.data.isEmpty());
 
-			// See if we can merge with the previous item
-			if(last.type == M2PendingOutItem::Response && last.chunked == chunked && !lastIsZeroChunk)
-				item = &last;
-		}
-		if(!item)
-		{
-			conn->pendingOutItems += M2PendingOutItem(M2PendingOutItem::Response);
-			item = &(conn->pendingOutItems.last());
-		}
+            // See if we can merge with the previous item
+            if (last.type == M2PendingOutItem::Response && last.chunked == chunked &&
+                !lastIsZeroChunk)
+                item = &last;
+        }
+        if (!item) {
+            conn->pendingOutItems += M2PendingOutItem(M2PendingOutItem::Response);
+            item = &(conn->pendingOutItems.last());
+        }
 
-		item->data += data;
-		item->chunked = chunked;
+        item->data += data;
+        item->chunked = chunked;
 
-		if(tryWrite)
-			m2_tryWriteQueued(conn);
-	}
+        if (tryWrite)
+            m2_tryWriteQueued(conn);
+    }
 
-	void m2_queueFrame(M2Connection *conn, const QByteArray &data, int contentSize)
-	{
-		// Only try writing if this item would be next
-		bool tryWrite = conn->pendingOutItems.isEmpty();
+    void m2_queueFrame(M2Connection *conn, const QByteArray &data, int contentSize) {
+        // Only try writing if this item would be next
+        bool tryWrite = conn->pendingOutItems.isEmpty();
 
-		M2PendingOutItem item(M2PendingOutItem::Frame);
-		item.data += data;
-		item.contentSize = contentSize;
-		conn->pendingOutItems += item;
+        M2PendingOutItem item(M2PendingOutItem::Frame);
+        item.data += data;
+        item.contentSize = contentSize;
+        conn->pendingOutItems += item;
 
-		if(tryWrite)
-			m2_tryWriteQueued(conn);
-	}
+        if (tryWrite)
+            m2_tryWriteQueued(conn);
+    }
 
-	void m2_queueClose(M2Connection *conn)
-	{
-		// Only try writing if this item would be next
-		bool tryWrite = conn->pendingOutItems.isEmpty();
+    void m2_queueClose(M2Connection *conn) {
+        // Only try writing if this item would be next
+        bool tryWrite = conn->pendingOutItems.isEmpty();
 
-		conn->pendingOutItems += M2PendingOutItem(M2PendingOutItem::Close);
+        conn->pendingOutItems += M2PendingOutItem(M2PendingOutItem::Close);
 
-		if(tryWrite)
-			m2_tryWriteQueued(conn);
-	}
+        if (tryWrite)
+            m2_tryWriteQueued(conn);
+    }
 
-	// Return true if connection was deleted as a result of writing queued items
-	bool m2_tryWriteQueued(M2Connection *conn)
-	{
-		while(!conn->pendingOutItems.isEmpty() && conn->canWrite())
-		{
-			M2PendingOutItem *item = &conn->pendingOutItems.first();
-			if(item->type == M2PendingOutItem::Headers)
-			{
-				M2ResponsePacket packet;
-				packet.sender = m2_send_idents[conn->identIndex];
-				packet.id = conn->id;
-				packet.data = item->data.take();
+    // Return true if connection was deleted as a result of writing queued items
+    bool m2_tryWriteQueued(M2Connection *conn) {
+        while (!conn->pendingOutItems.isEmpty() && conn->canWrite()) {
+            M2PendingOutItem *item = &conn->pendingOutItems.first();
+            if (item->type == M2PendingOutItem::Headers) {
+                M2ResponsePacket packet;
+                packet.sender = m2_send_idents[conn->identIndex];
+                packet.id = conn->id;
+                packet.data = item->data.take();
 
-				conn->pendingOutItems.removeFirst();
+                conn->pendingOutItems.removeFirst();
 
-				m2_writeData(conn, packet, 0);
+                m2_writeData(conn, packet, 0);
 
-				if(!conn->flowControl)
-					handleConnectionBytesWritten(conn, packet.data.size(), true);
-			}
-			else if(item->type == M2PendingOutItem::Response)
-			{
-				// Only write what we're allowed to
-				int maxSize;
-				if(conn->outCreditsEnabled)
-				{
-					if(item->chunked)
-						maxSize = conn->outCredits - 16; // Make room for chunked header
-					else
-						maxSize = conn->outCredits;
-				}
-				else
-				{
-					maxSize = 200000; // Some reasonable max
-				}
+                if (!conn->flowControl)
+                    handleConnectionBytesWritten(conn, packet.data.size(), true);
+            } else if (item->type == M2PendingOutItem::Response) {
+                // Only write what we're allowed to
+                int maxSize;
+                if (conn->outCreditsEnabled) {
+                    if (item->chunked)
+                        maxSize = conn->outCredits - 16; // Make room for chunked header
+                    else
+                        maxSize = conn->outCredits;
+                } else {
+                    maxSize = 200000; // Some reasonable max
+                }
 
-				if(maxSize <= 0)
-				{
-					// Can't write at this time
-					break;
-				}
+                if (maxSize <= 0) {
+                    // Can't write at this time
+                    break;
+                }
 
-				QByteArray data = item->data.take(maxSize);
-				int contentSize = data.size();
+                QByteArray data = item->data.take(maxSize);
+                int contentSize = data.size();
 
-				M2ResponsePacket packet;
-				packet.sender = m2_send_idents[conn->identIndex];
-				packet.id = conn->id;
+                M2ResponsePacket packet;
+                packet.sender = m2_send_idents[conn->identIndex];
+                packet.id = conn->id;
 
-				if(item->chunked)
-					packet.data = makeChunkHeader(data.size()) + data + makeChunkFooter();
-				else
-					packet.data = data;
+                if (item->chunked)
+                    packet.data = makeChunkHeader(data.size()) + data + makeChunkFooter();
+                else
+                    packet.data = data;
 
-				if(item->data.isEmpty())
-					conn->pendingOutItems.removeFirst();
+                if (item->data.isEmpty())
+                    conn->pendingOutItems.removeFirst();
 
-				m2_writeData(conn, packet, contentSize);
+                m2_writeData(conn, packet, contentSize);
 
-				if(!conn->flowControl)
-					handleConnectionBytesWritten(conn, packet.data.size(), true);
-			}
-			else if(item->type == M2PendingOutItem::Frame)
-			{
-				M2ResponsePacket packet;
-				packet.sender = m2_send_idents[conn->identIndex];
-				packet.id = conn->id;
-				packet.data = item->data.take();
+                if (!conn->flowControl)
+                    handleConnectionBytesWritten(conn, packet.data.size(), true);
+            } else if (item->type == M2PendingOutItem::Frame) {
+                M2ResponsePacket packet;
+                packet.sender = m2_send_idents[conn->identIndex];
+                packet.id = conn->id;
+                packet.data = item->data.take();
 
-				int contentSize = item->contentSize;
+                int contentSize = item->contentSize;
 
-				conn->pendingOutItems.removeFirst();
+                conn->pendingOutItems.removeFirst();
 
-				m2_writeData(conn, packet, contentSize);
+                m2_writeData(conn, packet, contentSize);
 
-				if(!conn->flowControl)
-					handleConnectionBytesWritten(conn, packet.data.size(), true);
-			}
-			else if(item->type == M2PendingOutItem::Close)
-			{
-				conn->pendingOutItems.removeFirst();
+                if (!conn->flowControl)
+                    handleConnectionBytesWritten(conn, packet.data.size(), true);
+            } else if (item->type == M2PendingOutItem::Close) {
+                conn->pendingOutItems.removeFirst();
 
-				m2_writeClose(conn); // This will delete the connection
-				return true;
-			}
-		}
+                m2_writeClose(conn); // This will delete the connection
+                return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	void m2_writeClose(const QByteArray &sender, const QByteArray &id)
-	{
-		M2ResponsePacket mresp;
-		mresp.sender = sender;
-		mresp.id = id;
-		mresp.data = "";
-		m2_out_write(mresp);
-	}
+    void m2_writeClose(const QByteArray &sender, const QByteArray &id) {
+        M2ResponsePacket mresp;
+        mresp.sender = sender;
+        mresp.id = id;
+        mresp.data = "";
+        m2_out_write(mresp);
+    }
 
-	void m2_writeClose(M2Connection *conn)
-	{
-		m2_writeClose(m2_send_idents[conn->identIndex], conn->id);
-		removeConnection(conn);
-		delete conn;
-	}
+    void m2_writeClose(M2Connection *conn) {
+        m2_writeClose(m2_send_idents[conn->identIndex], conn->id);
+        removeConnection(conn);
+        delete conn;
+    }
 
-	void m2_writeErrorClose(const QByteArray &sender, const QByteArray &id)
-	{
-		// Same as closing. In the future we may want to send something interesting first.
-		m2_writeClose(sender, id);
-	}
+    void m2_writeErrorClose(const QByteArray &sender, const QByteArray &id) {
+        // Same as closing. In the future we may want to send something interesting
+        // first.
+        m2_writeClose(sender, id);
+    }
 
-	void m2_writeErrorClose(M2Connection *conn)
-	{
-		// Same as closing. In the future we may want to send something interesting first.
-		m2_writeClose(conn);
-	}
+    void m2_writeErrorClose(M2Connection *conn) {
+        // Same as closing. In the future we may want to send something interesting
+        // first.
+        m2_writeClose(conn);
+    }
 
-	void zhttp_out_write(Mode mode, const ZhttpRequestPacket &packet)
-	{
-		const char *logprefix = (mode == Http ? "zhttp" : "zws");
+    void zhttp_out_write(Mode mode, const ZhttpRequestPacket &packet) {
+        const char *logprefix = (mode == Http ? "zhttp" : "zws");
 
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s: OUT", logprefix);
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s: OUT", logprefix);
 
-		if(mode == Http)
-			zhttp_out_sock->write(QList<QByteArray>() << buf);
-		else // WebSocket
-			zws_out_sock->write(QList<QByteArray>() << buf);
-	}
+        if (mode == Http)
+            zhttp_out_sock->write(QList<QByteArray>() << buf);
+        else // WebSocket
+            zws_out_sock->write(QList<QByteArray>() << buf);
+    }
 
-	void zhttp_out_write(Mode mode, const ZhttpRequestPacket &packet, const QByteArray &instanceAddress)
-	{
-		const char *logprefix = (mode == Http ? "zhttp" : "zws");
+    void zhttp_out_write(Mode mode, const ZhttpRequestPacket &packet,
+                         const QByteArray &instanceAddress) {
+        const char *logprefix = (mode == Http ? "zhttp" : "zws");
 
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = QByteArray("T") + TnetString::fromVariant(vpacket);
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s: OUT instance=%s", logprefix, instanceAddress.data());
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, vpacket, "body", "%s: OUT instance=%s",
+                                           logprefix, instanceAddress.data());
 
-		QList<QByteArray> message;
-		message += instanceAddress;
-		message += QByteArray();
-		message += buf;
+        QList<QByteArray> message;
+        message += instanceAddress;
+        message += QByteArray();
+        message += buf;
 
-		if(mode == Http)
-			zhttp_out_stream_sock->write(message);
-		else // WebSocket
-			zws_out_stream_sock->write(message);
-	}
+        if (mode == Http)
+            zhttp_out_stream_sock->write(message);
+        else // WebSocket
+            zws_out_stream_sock->write(message);
+    }
 
-	void zhttp_out_writeFirst(Session *s, const ZhttpRequestPacket &packet)
-	{
-		ZhttpRequestPacket out = packet;
-		out.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-		out.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-		zhttp_out_write(s->mode, out);
-	}
+    void zhttp_out_writeFirst(Session *s, const ZhttpRequestPacket &packet) {
+        ZhttpRequestPacket out = packet;
+        out.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+        out.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+        zhttp_out_write(s->mode, out);
+    }
 
-	void zhttp_out_write(Session *s, const ZhttpRequestPacket &packet)
-	{
-		assert(!s->zhttpAddress.isEmpty());
+    void zhttp_out_write(Session *s, const ZhttpRequestPacket &packet) {
+        assert(!s->zhttpAddress.isEmpty());
 
-		ZhttpRequestPacket out = packet;
-		out.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-		out.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-		zhttp_out_write(s->mode, out, s->zhttpAddress);
-	}
+        ZhttpRequestPacket out = packet;
+        out.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+        out.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+        zhttp_out_write(s->mode, out, s->zhttpAddress);
+    }
 
-	void handleControlResponse(int index, const Variant &data)
-	{
+    void handleControlResponse(int index, const Variant &data) {
 #ifdef CONTROL_PORT_DEBUG
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("m2: IN control %s %s", m2_send_idents[index].data(), qPrintable(TnetString::variantToString(data)));
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("m2: IN control %s %s", m2_send_idents[index].data(),
+                      qPrintable(TnetString::variantToString(data)));
 #endif
 
-		if(typeId(data) != VariantType::Hash)
-			return;
-
-		VariantHash vhash = data.toHash();
-
-		if(!vhash.contains("rows"))
-			return;
-
-		Variant rows = vhash["rows"];
-
-		// Once we get at least one successful response then we flag the port as working
-		if(!controlPorts[index].works)
-		{
-			controlPorts[index].works = true;
-			log_debug("control port index=%d works", index);
-		}
-
-		QSet<QByteArray> ids;
-		for(const Variant &row : rows.toList())
-		{
-			if(typeId(row) != VariantType::List)
-				break;
-
-			VariantList vlist = row.toList();
-			QByteArray id = vlist[0].toByteArray();
-			int bytes_written = vlist[7].toInt();
-
-			ids += id;
-
-			M2Connection *conn = m2ConnectionsByRid.value(Rid(m2_send_idents[index], id));
-			if(!conn || !conn->flowControl || conn->outCreditsEnabled)
-				continue;
-
-			if(bytes_written > conn->confirmedBytesWritten)
-			{
-				int written = bytes_written - conn->confirmedBytesWritten;
-				conn->confirmedBytesWritten = bytes_written;
-
-				handleConnectionBytesWritten(conn, written, true);
-
-				// If we had any pending writes to make, now's the time.
-				// note: this might delete the connection but that's fine
-				m2_tryWriteQueued(conn);
-			}
-		}
-
-		// Any connections missing?
-		QList<M2Connection*> gone;
-		QHashIterator<Rid, M2Connection*> it(m2ConnectionsByRid);
-		while(it.hasNext())
-		{
-			it.next();
-			M2Connection *conn = it.value();
-			if(conn->identIndex == index)
-			{
-				// Only check for missing connections that aren't flagged
-				if(!conn->isNew)
-				{
-					if(!ids.contains(conn->id))
-						gone += conn;
-				}
-				else
-				{
-					// Clear the flag so the connection gets processed next time
-					conn->isNew = false;
-				}
-			}
-		}
-		foreach(M2Connection *conn, gone)
-		{
-			log_debug("m2: %s id=%s disconnected", m2_send_idents[conn->identIndex].data(), conn->id.data());
-
-			if(conn->session)
-				endSession(conn->session, "disconnected");
-
-			removeConnection(conn);
-			delete conn;
-		}
-	}
-
-	// Return true if connection was deleted as a result of handling bytes written
-	void handleConnectionBytesWritten(M2Connection *conn, int written, bool giveCredits)
-	{
-		int bodyWritten = conn->bodyTracker.finished(written);
-		int packetsWritten = conn->packetTracker.finished(written);
-
-		conn->packetsPending -= packetsWritten;
-
-		if(conn->waitForAllWritten && conn->packetsPending == 0 && conn->pendingOutItems.isEmpty())
-			conn->waitForAllWritten = false;
-
-		if(conn->session && bodyWritten > 0)
-		{
-			Session *s = conn->session;
-
-			// Update lastActive
-			qint64 now = QDateTime::currentMSecsSinceEpoch();
-			sessionsByLastActive.remove(QPair<qint64, Session*>(s->lastActive, s));
-			s->lastActive = now;
-			sessionsByLastActive.insert(QPair<qint64, Session*>(s->lastActive, s), s);
-
-			handleSessionBodyWritten(s, bodyWritten, giveCredits);
-		}
-	}
-
-	void handleSessionBodyWritten(Session *s, int written, bool giveCredits)
-	{
-		s->pendingInCredits += written;
-
-		log_debug("request id=%s written %d%s", s->id.data(), written, s->conn->flowControl ? "" : " (no flow control)");
-
-		if(s->inHandoff)
-			return;
-
-		// Address could be empty here if we're handling write of non-sequenced response
-		if(giveCredits && !s->zhttpAddress.isEmpty())
-		{
-			ZhttpRequestPacket zreq;
-			zreq.type = ZhttpRequestPacket::Credit;
-			zreq.credits = s->pendingInCredits;
-			s->pendingInCredits = 0;
-			zhttp_out_write(s, zreq);
-		}
-	}
-
-	void endSession(Session *s, const QByteArray &errorCondition = QByteArray())
-	{
-		// If we are in handoff or haven't received a worker ack, then queue the state
-		if(s->inHandoff || s->zhttpAddress.isEmpty())
-		{
-			if(!errorCondition.isEmpty())
-				s->errorCondition = errorCondition;
-
-			// Keep the session around
-			unlinkConnection(s);
-		}
-		else
-		{
-			if(sessionsToCancel.isEmpty() && zhttpCancelMeter < ZHTTP_CANCEL_PER_REFRESH)
-			{
-				++zhttpCancelMeter;
-
-				ZhttpRequestPacket zreq;
-
-				if(!errorCondition.isEmpty())
-				{
-					zreq.type = ZhttpRequestPacket::Error;
-					zreq.condition = "disconnected";
-				}
-				else
-					zreq.type = ZhttpRequestPacket::Cancel;
-
-				zhttp_out_write(s, zreq);
-
-				destroySession(s);
-			}
-			else
-			{
-				queueCancelSession(s);
-			}
-		}
-	}
-
-	void handleZhttpIn(Mode mode, const CowByteArrayList &message)
-	{
-		const char *logprefix = (mode == Http ? "zhttp" : "zws");
-
-		if(message.count() != 1)
-		{
-			log_warning("%s: received message with parts != 1, skipping", logprefix);
-			return;
-		}
-
-		int at = message[0].indexOf(' ');
-		if(at == -1)
-		{
-			log_warning("%s: received message with invalid format, skipping", logprefix);
-			return;
-		}
-
-		CowByteArray dataRaw = message[0].mid(at + 1);
-		if(dataRaw.length() < 1 || dataRaw[0] != 'T')
-		{
-			log_warning("%s: received message with invalid format (missing type), skipping", logprefix);
-			return;
-		}
-
-		Variant data = TnetString::toVariant(dataRaw.mid(1));
-		if(data.isNull())
-		{
-			log_warning("%s: received message with invalid format (tnetstring parse failed), skipping", logprefix);
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "%s: IN", logprefix);
-
-		ZhttpResponsePacket zresp;
-		if(!zresp.fromVariant(data))
-		{
-			log_warning("%s: received message with invalid format (parse failed), skipping", logprefix);
-			return;
-		}
-
-		foreach(const ZhttpResponsePacket::Id &id, zresp.ids)
-			handleZhttpIn(logprefix, mode, id.id.asQByteArray(), id.seq, zresp);
-	}
-
-	void handleZhttpIn(const char *logprefix, Mode mode, const QByteArray &id, int seq, const ZhttpResponsePacket &zresp)
-	{
-		Session *s;
-		if(mode == Http)
-			s = sessionsByZhttpRid.value(Rid(zhttpInstanceId, id));
-		else // WebSocket
-			s = sessionsByZwsRid.value(Rid(zwsInstanceId, id));
-
-		if(!s)
-		{
-			log_debug("%s: received message for unknown request id, canceling", logprefix);
-
-			// If this was not an error packet, send cancel
-			if(!isErrorPacket(zresp) && !zresp.from.isEmpty())
-			{
-				ZhttpRequestPacket zreq;
-				zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
-				zreq.ids += ZhttpRequestPacket::Id(id);
-				zreq.type = ZhttpRequestPacket::Cancel;
-				zhttp_out_write(mode, zreq, zresp.from.asQByteArray());
-			}
-
-			return;
-		}
-
-		// Mode will always match here
-		assert(s->mode == mode);
-
-		if(s->inSeq == 0)
-		{
-			// Are we expecting a sequence of packets after the first?
-			if((!isErrorPacket(zresp) && zresp.type != ZhttpResponsePacket::Data) || (zresp.type == ZhttpResponsePacket::Data && zresp.more))
-			{
-				// Sequence must have from address
-				if(zresp.from.isEmpty())
-				{
-					log_warning("%s: received first response of sequence with no from address, canceling", logprefix);
-					destroySessionAndErrorConnection(s);
-					return;
-				}
-
-				s->zhttpAddress = zresp.from.asQByteArray();
-
-				if(seq != 0)
-				{
-					log_warning("%s: received first response of sequence without valid seq, canceling", logprefix);
-					ZhttpRequestPacket zreq;
-					zreq.type = ZhttpRequestPacket::Cancel;
-					zhttp_out_write(s, zreq);
-					destroySessionAndErrorConnection(s);
-					return;
-				}
-			}
-			else
-			{
-				// If not sequenced, then there might be a from address
-				if(!zresp.from.isEmpty())
-					s->zhttpAddress = zresp.from.asQByteArray();
-
-				// If not sequenced, but seq is provided, then it must be 0
-				if(seq != -1 && seq != 0)
-				{
-					log_warning("%s: received response out of sequence (got=%d, expected=-1,0), canceling", logprefix, seq);
-
-					if(!s->zhttpAddress.isEmpty())
-					{
-						ZhttpRequestPacket zreq;
-						zreq.type = ZhttpRequestPacket::Cancel;
-						zhttp_out_write(s, zreq);
-					}
-
-					destroySessionAndErrorConnection(s);
-					return;
-				}
-			}
-		}
-		else
-		{
-			if(seq != -1 && seq != s->inSeq)
-			{
-				log_warning("%s: received response out of sequence (got=%d, expected=%d), canceling", logprefix, seq, s->inSeq);
-				ZhttpRequestPacket zreq;
-				zreq.type = ZhttpRequestPacket::Cancel;
-				zhttp_out_write(s, zreq);
-				destroySessionAndErrorConnection(s);
-				return;
-			}
-
-			// If a new from address is provided, update our copy
-			if(!zresp.from.isEmpty())
-				s->zhttpAddress = zresp.from.asQByteArray();
-		}
-
-		// Only bump sequence if seq was provided
-		if(seq != -1)
-			++(s->inSeq);
-
-		qint64 now = QDateTime::currentMSecsSinceEpoch();
-
-		if(s->lastRefresh < 0 && !s->zhttpAddress.isEmpty())
-		{
-			// Once we have the peer's address, set up refresh
-
-			s->lastRefresh = now;
-			sessionsByLastRefresh.insert(QPair<qint64, Session*>(s->lastRefresh, s), s);
-
-			s->refreshBucket = smallestSessionRefreshBucket();
-			sessionRefreshBuckets[s->refreshBucket] += s;
-		}
-
-		// Update lastActive
-		sessionsByLastActive.remove(QPair<qint64, Session*>(s->lastActive, s));
-		s->lastActive = now;
-		sessionsByLastActive.insert(QPair<qint64, Session*>(s->lastActive, s), s);
-
-		if(s->pendingCancel)
-			return;
-
-		// A session without a connection is just waiting to report error
-		if(!s->conn)
-		{
-			// If we were in handoff, it's okay to send right now since we'd
-			// be clearing the handoff state later on in this method anyway
-			if(!s->zhttpAddress.isEmpty())
-			{
-				ZhttpRequestPacket zreq;
-				if(!s->errorCondition.isEmpty())
-				{
-					zreq.type = ZhttpRequestPacket::Error;
-					zreq.condition = s->errorCondition;
-				}
-				else
-					zreq.type = ZhttpRequestPacket::Cancel;
-				zhttp_out_write(s, zreq);
-			}
-
-			destroySession(s);
-			return;
-		}
-
-		// If peer supports multi feature then flag it on the session
-		bool multiWasTurnedOn = false;
-		if(!s->multi && zresp.multi)
-		{
-			s->multi = true;
-			multiWasTurnedOn = true;
-		}
-
-		if(s->inHandoff)
-		{
-			// Receiving any message means handoff is complete
-			s->inHandoff = false;
-
-			// Refresh would have already been set up once if we are here
-			assert(s->lastRefresh >= 0);
-
-			sessionsByLastRefresh.insert(QPair<qint64, Session*>(s->lastRefresh, s), s);
-			s->refreshBucket = smallestSessionRefreshBucket();
-			sessionRefreshBuckets[s->refreshBucket] += s;
-
-			// In order to have been in a handoff state, we would have
-			// had to receive a from address sometime earlier, so it
-			// should be safe to call zhttp_out_write with session.
-
-			if(multiWasTurnedOn)
-			{
-				// Acknowledge the feature
-				ZhttpRequestPacket zreq;
-				zreq.type = ZhttpRequestPacket::KeepAlive;
-				zreq.multi = true;
-				zhttp_out_write(s, zreq);
-			}
-
-			if(s->mode == Http)
-			{
-				if(!s->pendingIn.isEmpty())
-				{
-					ZhttpRequestPacket zreq;
-					zreq.type = ZhttpRequestPacket::Data;
-
-					// Send credits too, if needed (though this probably can't happen,
-					// since http data flows only in one direction at a time. We
-					// can't have pending request body data while at the same
-					// time be acking received response body data).
-					if(s->pendingInCredits > 0)
-					{
-						zreq.credits = s->pendingInCredits;
-						s->pendingInCredits = 0;
-					}
-
-					zreq.body = s->pendingIn.take();
-					zreq.more = !s->inFinished;
-					zhttp_out_write(s, zreq);
-				}
-			}
-			else // WebSocket
-			{
-				while(!s->pendingInPackets.isEmpty())
-				{
-					ZhttpRequestPacket zreq = s->pendingInPackets.takeFirst();
-
-					// Send credits too, if needed
-					if(zreq.type == ZhttpRequestPacket::Data && s->pendingInCredits > 0)
-					{
-						zreq.credits = s->pendingInCredits;
-						s->pendingInCredits = 0;
-					}
-
-					zhttp_out_write(s, zreq);
-				}
-			}
-
-			// If we didn't send credits as part of a data packet, we'll do them now
-			if(s->pendingInCredits > 0)
-			{
-				ZhttpRequestPacket zreq;
-				zreq.type = ZhttpRequestPacket::Credit;
-				zreq.credits = s->pendingInCredits;
-				s->pendingInCredits = 0;
-				zhttp_out_write(s, zreq);
-			}
-		}
-
-		if(zresp.type == ZhttpResponsePacket::Data)
-		{
-			log_debug("zhttp: id=%s response data size=%d%s", s->id.data(), zresp.body.size(), zresp.more ? " M" : "");
-
-			// Data packet may have credits
-			if(zresp.credits > 0)
-			{
-				VariantHash args;
-				args["credits"] = zresp.credits;
-				m2_writeCtl(s->conn, args);
-			}
-
-			if(s->mode == Http)
-			{
-				bool firstDataPacket = !s->sentResponseHeader;
-
-				// Respond with data if we have body data or this is the first packet
-				if(!zresp.body.isEmpty() || firstDataPacket)
-				{
-					if(firstDataPacket)
-					{
-						// Use flow control if the control port works and the response is more than one packet
-						if((s->conn->outCreditsEnabled || controlPorts[s->conn->identIndex].works) && zresp.more)
-							s->conn->flowControl = true;
-						else
-							s->conn->flowControl = false;
-
-						s->sentResponseHeader = true;
-
-						if(zresp.more && !zresp.headers.contains("Content-Length"))
-						{
-							if(s->allowChunked)
-							{
-								s->chunked = true;
-							}
-							else
-							{
-								// Disable persistence
-								s->persistent = false;
-								s->respondKeepAlive = false;
-							}
-						}
-
-						if(s->method == "HEAD" || (zresp.code == 204 || zresp.code == 304))
-							s->responseHeadersOnly = true;
-
-						HttpHeaders headers = zresp.headers;
-						QList<QByteArray> connHeaders = headers.takeAll("Connection").asQByteArrayList();
-						foreach(const QByteArray &h, connHeaders)
-							headers.removeAll(h);
-
-						headers.removeAll("Transfer-Encoding");
-
-						connHeaders.clear();
-						if(s->respondKeepAlive)
-							connHeaders += "Keep-Alive";
-						if(s->respondClose)
-							connHeaders += "close";
-
-						if(!s->responseHeadersOnly)
-						{
-							if(s->chunked)
-							{
-								connHeaders += "Transfer-Encoding";
-								headers += HttpHeader("Transfer-Encoding", "chunked");
-							}
-							else if(!zresp.more && !headers.contains("Content-Length"))
-							{
-								headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
-							}
-						}
-
-						if(!connHeaders.isEmpty())
-							headers += HttpHeader("Connection", HttpHeaders::join(connHeaders));
-
-						log_info("OUT %s id=%s code=%d %d%s", m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(), zresp.code, zresp.body.size(), zresp.more ? " M": "");
-
-						m2_queueHeaders(s->conn, createResponseHeader(zresp.code, zresp.reason.asQByteArray(), headers));
-					}
-
-					if(!zresp.body.isEmpty())
-					{
-						if(s->responseHeadersOnly)
-						{
-							log_warning("%s: received unexpected response body, canceling", logprefix);
-
-							bool persistent = s->persistent;
-
-							// Cancel and destroy session
-							M2Connection *conn = s->conn;
-							if(!s->zhttpAddress.isEmpty())
-							{
-								ZhttpRequestPacket zreq;
-								zreq.type = ZhttpRequestPacket::Cancel;
-								zhttp_out_write(s, zreq);
-							}
-							destroySession(s);
-							if(!persistent)
-								m2_queueClose(conn);
-							return;
-						}
-
-						m2_queueResponse(s->conn, zresp.body.asQByteArray(), s->chunked);
-					}
-
-					if(!zresp.more && s->chunked)
-					{
-						// Send closing chunk
-						m2_queueResponse(s->conn, QByteArray(), true);
-					}
-				}
-				else
-				{
-					if(!zresp.more && s->chunked)
-					{
-						// Send closing chunk
-						m2_queueResponse(s->conn, QByteArray(), true);
-					}
-				}
-
-				if(!zresp.more)
-				{
-					bool persistent = s->persistent;
-					M2Connection *conn = s->conn;
-					destroySession(s);
-					if(!persistent)
-						m2_queueClose(conn);
-				}
-			}
-			else // WebSocket
-			{
-				if(!s->sentResponseHeader)
-				{
-					s->sentResponseHeader = true;
-					if(s->conn->outCreditsEnabled || controlPorts[s->conn->identIndex].works)
-						s->conn->flowControl = true;
-					else
-						s->conn->flowControl = false;
-
-					HttpHeaders headers = zresp.headers;
-					QList<QByteArray> connHeaders = headers.takeAll("Connection").asQByteArrayList();
-					foreach(const QByteArray &h, connHeaders)
-						headers.removeAll(h);
-					headers.removeAll("Transfer-Encoding");
-					headers.removeAll("Upgrade");
-					headers.removeAll("Sec-WebSocket-Accept");
-
-					headers += HttpHeader("Upgrade", "websocket");
-					headers += HttpHeader("Connection", "Upgrade");
-					headers += HttpHeader("Sec-WebSocket-Accept", s->acceptToken);
-
-					QByteArray reason;
-					if(!zresp.reason.isEmpty())
-						reason = zresp.reason.asQByteArray();
-					else
-						reason = "Switching Protocols";
-
-					log_info("OUT %s id=%s code=%d 0 M", m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(), zresp.code);
-
-					m2_queueHeaders(s->conn, createResponseHeader(101, reason, headers));
-				}
-				else
-				{
-					int opcode;
-					if(s->conn->continuation)
-					{
-						opcode = 0;
-					}
-					else
-					{
-						if(zresp.contentType == "binary")
-							opcode = 2;
-						else // Text
-							opcode = 1;
-					}
-
-					s->conn->continuation = zresp.more;
-
-					QByteArray frame = makeWsHeader(!zresp.more, opcode, zresp.body.size()) + zresp.body.asQByteArray();
-
-					m2_queueFrame(s->conn, frame, zresp.body.size());
-				}
-			}
-		}
-		else if(zresp.type == ZhttpResponsePacket::Error)
-		{
-			log_debug("%s: id=%s error condition=%s", logprefix, s->id.data(), zresp.condition.data());
-
-			if(s->mode == WebSocket && zresp.condition == "rejected")
-			{
-				HttpHeaders headers = zresp.headers;
-				QList<QByteArray> connHeaders = headers.takeAll("Connection").asQByteArrayList();
-				foreach(const QByteArray &h, connHeaders)
-					headers.removeAll(h);
-
-				headers.removeAll("Transfer-Encoding");
-
-				if(!headers.contains("Content-Length"))
-					headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
-
-				connHeaders.clear();
-
-				// if HTTP/1.1, include "Connection: close"
-				if(s->allowChunked)
-					connHeaders += "close";
-
-				if(!connHeaders.isEmpty())
-					headers += HttpHeader("Connection", HttpHeaders::join(connHeaders));
-
-				log_info("OUT %s id=%s code=%d %d", m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(), zresp.code, zresp.body.size());
-
-				m2_queueHeaders(s->conn, createResponseHeader(zresp.code, zresp.reason.asQByteArray(), headers));
-				m2_queueResponse(s->conn, zresp.body.asQByteArray(), false);
-
-				M2Connection *conn = s->conn;
-				destroySession(s);
-				m2_queueClose(conn);
-			}
-			else
-				destroySessionAndErrorConnection(s);
-		}
-		else if(zresp.type == ZhttpResponsePacket::Credit)
-		{
-			if(zresp.credits > 0)
-			{
-				VariantHash args;
-				args["credits"] = zresp.credits;
-				m2_writeCtl(s->conn, args);
-			}
-		}
-		else if(zresp.type == ZhttpResponsePacket::KeepAlive)
-		{
-			// Nothing to do
-		}
-		else if(zresp.type == ZhttpResponsePacket::Cancel)
-		{
-			destroySessionAndErrorConnection(s);
-		}
-		else if(zresp.type == ZhttpResponsePacket::HandoffStart)
-		{
-			s->inHandoff = true;
-
-			sessionRefreshBuckets[s->refreshBucket].remove(s);
-			sessionsByLastRefresh.remove(QPair<qint64, Session*>(s->lastRefresh, s));
-
-			// Whoever picks up after handoff can turn this on
-			s->multi = false;
-
-			ZhttpRequestPacket zreq;
-			zreq.type = ZhttpRequestPacket::HandoffProceed;
-			zhttp_out_write(s, zreq);
-		}
-		else if(zresp.type == ZhttpResponsePacket::Close || zresp.type == ZhttpResponsePacket::Ping || zresp.type == ZhttpResponsePacket::Pong)
-		{
-			int opcode;
-			if(zresp.type == ZhttpResponsePacket::Close)
-			{
-				opcode = 8;
-				s->upClosed = true;
-			}
-			else if(zresp.type == ZhttpResponsePacket::Ping)
-				opcode = 9;
-			else // Pong
-				opcode = 10;
-
-			QByteArray data;
-			if(zresp.type == ZhttpResponsePacket::Close)
-			{
-				data.resize(2 + zresp.body.size());
-				writeBigEndian(data.data(), zresp.code != -1 ? zresp.code : 1000, 2);
-				if(!zresp.body.isEmpty())
-				{
-					memcpy(data.data() + 2, zresp.body.data(), zresp.body.size());
-				}
-			} else {
-				data = zresp.body.asQByteArray();
-			}
-
-			QByteArray frame = makeWsHeader(true, opcode, data.size()) + data;
-
-			m2_queueFrame(s->conn, frame, data.size());
-
-			if(s->downClosed && s->upClosed)
-			{
-				M2Connection *conn = s->conn;
-				destroySession(s);
-				m2_queueClose(conn);
-			}
-		}
-		else
-		{
-			log_warning("%s: id=%s unsupported type: %d", logprefix, s->id.data(), (int)zresp.type);
-		}
-	}
-
-	void refreshM2Connections(qint64 now)
-	{
-		QHash<int, QList<QByteArray> > connIdListBySender;
-
-		// Process the current bucket
-		const QSet<M2Connection*> &bucket = m2ConnectionRefreshBuckets[currentM2RefreshBucket];
-		foreach(M2Connection *conn, bucket)
-		{
-			// Move to the end
-			QPair<qint64, M2Connection*> k(conn->lastRefresh, conn);
-			m2ConnectionsByLastRefresh.remove(k);
-			conn->lastRefresh = now;
-			m2ConnectionsByLastRefresh.insert(QPair<qint64, M2Connection*>(conn->lastRefresh, conn), conn);
-
-			if(!connIdListBySender.contains(conn->identIndex))
-				connIdListBySender.insert(conn->identIndex, QList<QByteArray>());
-
-			QList<QByteArray> &connIdList = connIdListBySender[conn->identIndex];
-			connIdList += conn->id;
-
-			// If we're at max, send out now
-			if(connIdList.count() >= M2_HANDLER_TARGETS_MAX)
-			{
-				VariantHash args;
-				args["keep-alive"] = true;
-				m2_writeCtlMany(m2_send_idents[conn->identIndex], connIdList, args);
-
-				connIdList.clear();
-				connIdListBySender.remove(conn->identIndex);
-			}
-		}
-
-		// Process any others
-		qint64 threshold = now - M2_CONNECTION_MUST_PROCESS;
-		while(!m2ConnectionsByLastRefresh.isEmpty())
-		{
-			QMap<QPair<qint64, M2Connection*>, M2Connection*>::iterator it = m2ConnectionsByLastRefresh.begin();
-			M2Connection *conn = it.value();
-
-			if(conn->lastRefresh > threshold)
-				break;
-
-			// Move to the end
-			m2ConnectionsByLastRefresh.erase(it);
-			conn->lastRefresh = now;
-			m2ConnectionsByLastRefresh.insert(QPair<qint64, M2Connection*>(conn->lastRefresh, conn), conn);
-
-			if(!connIdListBySender.contains(conn->identIndex))
-				connIdListBySender.insert(conn->identIndex, QList<QByteArray>());
-
-			QList<QByteArray> &connIdList = connIdListBySender[conn->identIndex];
-			connIdList += conn->id;
-
-			// If we're at max, send out now
-			if(connIdList.count() >= M2_HANDLER_TARGETS_MAX)
-			{
-				VariantHash args;
-				args["keep-alive"] = true;
-				m2_writeCtlMany(m2_send_idents[conn->identIndex], connIdList, args);
-
-				connIdList.clear();
-				connIdListBySender.remove(conn->identIndex);
-			}
-		}
-
-		// Send last packet
-		QHashIterator<int, QList<QByteArray> > cit(connIdListBySender);
-		while(cit.hasNext())
-		{
-			cit.next();
-			int index = cit.key();
-			const QList<QByteArray> &connIdList = cit.value();
-
-			if(!connIdList.isEmpty())
-			{
-				VariantHash args;
-				args["keep-alive"] = true;
-				m2_writeCtlMany(m2_send_idents[index], connIdList, args);
-			}
-		}
-
-		++currentM2RefreshBucket;
-		if(currentM2RefreshBucket >= M2_REFRESH_BUCKETS)
-			currentM2RefreshBucket = 0;
-	}
-
-	void refreshSessions(qint64 now)
-	{
-		QHash<QByteArray, QList<Session*> > sessionListBySender[2]; // Index corresponds to mode
-
-		// Process the current bucket
-		const QSet<Session*> &bucket = sessionRefreshBuckets[currentSessionRefreshBucket];
-		foreach(Session *s, bucket)
-		{
-			assert(!s->inHandoff && !s->zhttpAddress.isEmpty());
-
-			// Move to the end
-			QPair<qint64, Session*> k(s->lastRefresh, s);
-			sessionsByLastRefresh.remove(k);
-			s->lastRefresh = now;
-			sessionsByLastRefresh.insert(QPair<qint64, Session*>(s->lastRefresh, s), s);
-
-			if(s->multi)
-			{
-				if(!sessionListBySender[s->mode].contains(s->zhttpAddress))
-					sessionListBySender[s->mode].insert(s->zhttpAddress, QList<Session*>());
-
-				QList<Session*> &sessionList = sessionListBySender[s->mode][s->zhttpAddress];
-				sessionList += s;
-
-				// If we're at max, send out now
-				if(sessionList.count() >= ZHTTP_IDS_MAX)
-				{
-					ZhttpRequestPacket zreq;
-					zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-					foreach(Session *i, sessionList)
-						zreq.ids += ZhttpRequestPacket::Id(i->id, (i->outSeq)++);
-					zreq.type = ZhttpRequestPacket::KeepAlive;
-					zhttp_out_write(s->mode, zreq, s->zhttpAddress);
-
-					sessionList.clear();
-					sessionListBySender[s->mode].remove(s->zhttpAddress);
-				}
-			}
-			else
-			{
-				// Session doesn't support sending with multiple ids
-				ZhttpRequestPacket zreq;
-				zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-				zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-				zreq.type = ZhttpRequestPacket::KeepAlive;
-				zhttp_out_write(s->mode, zreq, s->zhttpAddress);
-			}
-		}
-
-		// Process any others
-		qint64 threshold = now - ZHTTP_MUST_PROCESS;
-		while(!sessionsByLastRefresh.isEmpty())
-		{
-			QMap<QPair<qint64, Session*>, Session*>::iterator it = sessionsByLastRefresh.begin();
-			Session *s = it.value();
-
-			if(s->lastRefresh > threshold)
-				break;
-
-			assert(!s->inHandoff && !s->zhttpAddress.isEmpty());
-
-			// Move to the end
-			sessionsByLastRefresh.erase(it);
-			s->lastRefresh = now;
-			sessionsByLastRefresh.insert(QPair<qint64, Session*>(s->lastRefresh, s), s);
-
-			if(s->multi)
-			{
-				if(!sessionListBySender[s->mode].contains(s->zhttpAddress))
-					sessionListBySender[s->mode].insert(s->zhttpAddress, QList<Session*>());
-
-				QList<Session*> &sessionList = sessionListBySender[s->mode][s->zhttpAddress];
-				sessionList += s;
-
-				// If we're at max, send out now
-				if(sessionList.count() >= ZHTTP_IDS_MAX)
-				{
-					ZhttpRequestPacket zreq;
-					zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-					foreach(Session *i, sessionList)
-						zreq.ids += ZhttpRequestPacket::Id(i->id, (i->outSeq)++);
-					zreq.type = ZhttpRequestPacket::KeepAlive;
-					zhttp_out_write(s->mode, zreq, s->zhttpAddress);
-
-					sessionList.clear();
-					sessionListBySender[s->mode].remove(s->zhttpAddress);
-				}
-			}
-			else
-			{
-				// Session doesn't support sending with multiple ids
-				ZhttpRequestPacket zreq;
-				zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-				zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-				zreq.type = ZhttpRequestPacket::KeepAlive;
-				zhttp_out_write(s->mode, zreq, s->zhttpAddress);
-			}
-		}
-
-		// Send last packets
-		for(int n = 0; n < 2; ++n)
-		{
-			Mode mode = (Mode)n;
-
-			QHashIterator<QByteArray, QList<Session*> > sit(sessionListBySender[n]);
-			while(sit.hasNext())
-			{
-				sit.next();
-				const QByteArray &zhttpAddress = sit.key();
-				const QList<Session*> &sessionList = sit.value();
-
-				if(!sessionList.isEmpty())
-				{
-					ZhttpRequestPacket zreq;
-					zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
-					foreach(Session *s, sessionList)
-						zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-					zreq.type = ZhttpRequestPacket::KeepAlive;
-					zhttp_out_write(mode, zreq, zhttpAddress);
-				}
-			}
-		}
-
-		++currentSessionRefreshBucket;
-		if(currentSessionRefreshBucket >= ZHTTP_REFRESH_BUCKETS)
-			currentSessionRefreshBucket = 0;
-	}
-
-	void expireSessions(qint64 now)
-	{
-		qint64 threshold = now - ZHTTP_EXPIRE;
-		while(!sessionsByLastActive.isEmpty())
-		{
-			QMap<QPair<qint64, Session*>, Session*>::iterator it = sessionsByLastActive.begin();
-			Session *s = it.value();
-
-			if(s->lastActive > threshold)
-				break;
-
-			log_warning("timing out request %s", s->id.data());
-			destroySessionAndErrorConnection(s);
-		}
-	}
-
-	void cancelSessions()
-	{
-		int sent = zhttpCancelMeter;
-
-		if(zhttpCancelMeter > ZHTTP_CANCEL_PER_REFRESH)
-			zhttpCancelMeter -= ZHTTP_CANCEL_PER_REFRESH;
-		else
-			zhttpCancelMeter = 0;
-
-		QHash<QByteArray, QList<Session*> > sessionListBySender[2]; // Index corresponds to mode
-
-		while(!sessionsToCancel.isEmpty() && sent < ZHTTP_CANCEL_PER_REFRESH)
-		{
-			QSet<Session*>::iterator it = sessionsToCancel.begin();
-			Session *s = (*it);
-			sessionsToCancel.erase(it);
-
-			if(s->multi)
-			{
-				if(!sessionListBySender[s->mode].contains(s->zhttpAddress))
-					sessionListBySender[s->mode].insert(s->zhttpAddress, QList<Session*>());
-
-				QList<Session*> &sessionList = sessionListBySender[s->mode][s->zhttpAddress];
-				sessionList += s;
-
-				// If we're at max, send out now
-				if(sessionList.count() >= ZHTTP_IDS_MAX)
-				{
-					ZhttpRequestPacket zreq;
-					zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-					foreach(Session *i, sessionList)
-						zreq.ids += ZhttpRequestPacket::Id(i->id, (i->outSeq)++);
-					zreq.type = ZhttpRequestPacket::Cancel;
-					zhttp_out_write(s->mode, zreq, s->zhttpAddress);
-
-					Mode mode = s->mode;
-					QByteArray zhttpAddress = s->zhttpAddress;
-
-					foreach(Session *s, sessionList)
-						destroySession(s);
-
-					sessionList.clear();
-					sessionListBySender[mode].remove(zhttpAddress);
-				}
-			}
-			else
-			{
-				// Session doesn't support sending with multiple ids
-				ZhttpRequestPacket zreq;
-				zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
-				zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-				zreq.type = ZhttpRequestPacket::Cancel;
-				zhttp_out_write(s->mode, zreq, s->zhttpAddress);
-
-				destroySession(s);
-			}
-
-			++sent;
-		}
-
-		// Send last packets
-		for(int n = 0; n < 2; ++n)
-		{
-			Mode mode = (Mode)n;
-
-			QHashIterator<QByteArray, QList<Session*> > sit(sessionListBySender[n]);
-			while(sit.hasNext())
-			{
-				sit.next();
-				const QByteArray &zhttpAddress = sit.key();
-				const QList<Session*> &sessionList = sit.value();
-
-				if(!sessionList.isEmpty())
-				{
-					ZhttpRequestPacket zreq;
-					zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
-					foreach(Session *s, sessionList)
-						zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
-					zreq.type = ZhttpRequestPacket::Cancel;
-					zhttp_out_write(mode, zreq, zhttpAddress);
-				}
-
-				foreach(Session *s, sessionList)
-					destroySession(s);
-			}
-		}
-	}
-
-	void m2_in_readyRead(const CowByteArrayList &message)
-	{
-		if(message.count() != 1)
-		{
-			log_warning("m2: received message with parts != 1, skipping");
-			return;
-		}
-
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logByteArray(LOG_LEVEL_DEBUG, message[0].asQByteArray(), "m2: IN");
-
-		M2RequestPacket mreq;
-		if(!mreq.fromByteArray(message[0].asQByteArray()))
-		{
-			log_warning("m2: received message with invalid format, skipping");
-			return;
-		}
-
-		if(mreq.type == M2RequestPacket::Disconnect)
-		{
-			log_debug("m2: %s id=%s disconnected", mreq.sender.data(), mreq.id.data());
-
-			Rid rid(mreq.sender, mreq.id);
-
-			M2Connection *conn = m2ConnectionsByRid.value(rid);
-			if(!conn)
-				return;
-
-			if(conn->session)
-				endSession(conn->session);
-
-			removeConnection(conn);
-			delete conn;
-
-			return;
-		}
-
-		qint64 now = QDateTime::currentMSecsSinceEpoch();
-
-		Rid m2Rid(mreq.sender, mreq.id);
-
-		M2Connection *conn = m2ConnectionsByRid.value(m2Rid);
-		if(!conn)
-		{
-			if(mreq.version.isEmpty())
-			{
-				if(mreq.type == M2RequestPacket::HttpRequest || mreq.type == M2RequestPacket::WebSocketHandshake) {
-					log_warning("m2: id=%s no version on initial packet", mreq.id.data());
-				}
-
-				m2_writeCtlCancel(mreq.sender, mreq.id);
-				return;
-			}
-
-			if(mreq.version != "HTTP/1.0" && mreq.version != "HTTP/1.1")
-			{
-				log_error("m2: id=%s unknown version: %s", mreq.id.data(), mreq.version.data());
-				m2_writeCtlCancel(mreq.sender, mreq.id);
-				return;
-			}
-
-			int index = -1;
-			for(int n = 0; n < m2_send_idents.count(); ++n)
-			{
-				if(m2_send_idents[n] == mreq.sender)
-				{
-					index = n;
-					break;
-				}
-			}
-
-			if(index == -1)
-			{
-				log_error("m2: id=%s unknown send_ident [%s]", mreq.id.data(), mreq.sender.data());
-				return;
-			}
-
-			if(sessionsByM2Rid.contains(m2Rid))
-			{
-				log_warning("m2: received duplicate request id=%s, skipping", mreq.id.data());
-				m2_writeCtlCancel(mreq.sender, mreq.id);
-				return;
-			}
-
-			conn = new M2Connection;
-			conn->identIndex = index;
-			conn->id = mreq.id;
-
-			if(mreq.downloadCredits >= 0)
-			{
-				conn->outCreditsEnabled = true;
-				conn->outCredits += mreq.downloadCredits;
-			}
-			else
-			{
-				if(controlPorts[index].state == ControlPort::Disabled)
-				{
-					log_debug("activating control port index=%d", index);
-					controlPorts[index].state = ControlPort::Idle;
-
-					if(!statusTimer->isActive())
-						statusTimer->start();
-				}
-
-				// If we were in the middle of requesting control info when this
-				// http request arrived, then there's a chance the control
-				// response won't account for this request (for example if the
-				// control response was generated and was in the middle of being
-				// delivered when this http request arrived). We'll flag the
-				// connection as "new" in this case, so in the control response
-				// handler we know to skip over it until the next control
-				// request.
-				if(controlPorts[index].state == ControlPort::ExpectingResponse)
-					conn->isNew = true;
-			}
-
-			m2ConnectionsByRid.insert(m2Rid, conn);
-
-			conn->lastRefresh = now;
-			m2ConnectionsByLastRefresh.insert(QPair<qint64, M2Connection*>(conn->lastRefresh, conn), conn);
-
-			conn->refreshBucket = smallestM2RefreshBucket();
-			m2ConnectionRefreshBuckets[conn->refreshBucket] += conn;
-		}
-		else
-		{
-			// If packet contained credits, handle them now
-			if(conn->outCreditsEnabled && mreq.downloadCredits > 0)
-			{
-				conn->outCredits += mreq.downloadCredits;
-				handleConnectionBytesWritten(conn, mreq.downloadCredits, true);
-
-				// If we had any pending writes to make, now's the time
-				bool connDeleted = m2_tryWriteQueued(conn);
-				if(connDeleted)
-					return;
-			}
-
-			// If the packet only held credits, then there's nothing else to do
-			if(mreq.type == M2RequestPacket::Credits)
-				return;
-		}
-
-		bool requestBodyMore = false;
-		if(mreq.type == M2RequestPacket::HttpRequest && mreq.uploadStreamOffset >= 0 && !mreq.uploadStreamDone)
-			requestBodyMore = true;
-
-		Session *s = sessionsByM2Rid.value(m2Rid);
-		if(!s)
-		{
-			if(mreq.type == M2RequestPacket::HttpRequest && mreq.uploadStreamOffset > 0)
-			{
-				log_warning("m2: id=%s stream offset > 0 but session unknown", mreq.id.data());
-				m2_writeCtlCancel(conn);
-				return;
-			}
-
-			if(mreq.type != M2RequestPacket::HttpRequest && mreq.type != M2RequestPacket::WebSocketHandshake)
-			{
-				log_warning("m2: received unexpected starting packet type: %d", (int)mreq.type);
-				m2_writeCtlCancel(conn);
-				return;
-			}
-
-			QByteArray scheme;
-			if(mreq.type == M2RequestPacket::HttpRequest)
-			{
-				if(mreq.scheme == "https")
-					scheme = "https";
-				else
-					scheme = "http";
-			}
-			else // WebSocketHandshake
-			{
-				if(mreq.scheme == "https" || mreq.scheme == "wss")
-					scheme = "wss";
-				else
-					scheme = "ws";
-			}
-
-			QByteArray host = mreq.headers.get("Host").asQByteArray();
-			if(host.isEmpty())
-				host = "localhost";
-
-			if(!validateHost(host))
-			{
-				log_warning("m2: invalid host [%s]", host.data());
-				m2_writeErrorClose(conn);
-				return;
-			}
-
-			if(!mreq.uri.startsWith('/'))
-			{
-				log_warning("m2: invalid uri [%s]", mreq.uri.data());
-				m2_writeErrorClose(conn);
-				return;
-			}
-
-			QByteArray uriRaw = scheme + "://" + host + mreq.uri;
-			Url uri = Url::fromEncoded(uriRaw, Url::TolerantMode);
-			if(!uri.isValid())
-			{
-				log_warning("m2: invalid constructed uri: [%s]", uriRaw.data());
-				m2_writeErrorClose(conn);
-				return;
-			}
-
-			if(maxSessions >= 0 && sessionsByZhttpRid.count() + sessionsByZwsRid.count() >= maxSessions)
-			{
-				log_warning("m2: max open sessions reached (%d), refusing new session", maxSessions);
-				m2_writeErrorClose(conn);
-				return;
-			}
-
-			s = new Session;
-			s->conn = conn;
-			s->conn->session = s;
-			s->id = m2_send_idents[conn->identIndex] + '_' + conn->id + '_' + QByteArray::number((conn->subIdBase)++, 16);
-			s->method = mreq.method;
-
-			if(mreq.type == M2RequestPacket::HttpRequest)
-			{
-				s->mode = Http;
-
-				if(mreq.version == "HTTP/1.0")
-				{
-					if(mreq.headers.getAll("Connection").contains("Keep-Alive"))
-					{
-						s->persistent = true;
-						s->respondKeepAlive = true;
-					}
-				}
-				else if(mreq.version == "HTTP/1.1")
-				{
-					s->allowChunked = true;
-
-					if(mreq.headers.getAll("Connection").contains("close"))
-						s->respondClose = true;
-					else
-						s->persistent = true;
-				}
-
-				s->readCount += mreq.body.size();
-
-				if(!requestBodyMore)
-					s->inFinished = true;
-			}
-			else // WebSocketHandshake
-			{
-				s->mode = WebSocket;
-				s->acceptToken = mreq.body;
-			}
-
-			sessionsByM2Rid.insert(m2Rid, s);
-
-			qint64 now = QDateTime::currentMSecsSinceEpoch();
-
-			s->lastActive = now;
-			sessionsByLastActive.insert(QPair<qint64, Session*>(s->lastActive, s), s);
-
-			if(mreq.type == M2RequestPacket::HttpRequest)
-				sessionsByZhttpRid.insert(Rid(zhttpInstanceId, s->id), s);
-			else // WebSocketHandshake
-				sessionsByZwsRid.insert(Rid(zwsInstanceId, s->id), s);
-
-			log_info("IN %s id=%s %s %s", m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(), s->mode == Http ? qPrintable(mreq.method) : "GET", uri.toEncoded().data());
-
-			ZhttpRequestPacket zreq;
-
-			zreq.type = ZhttpRequestPacket::Data;
-			if(conn->outCreditsEnabled)
-				zreq.credits = conn->outCredits;
-			else
-				zreq.credits = m2_client_buffer;
-			zreq.uri = uri;
-			zreq.headers = mreq.headers;
-			zreq.peerAddress = mreq.remoteAddress;
-			if(mreq.type == M2RequestPacket::HttpRequest && zhttpConnectPort != -1)
-				zreq.connectPort = zhttpConnectPort;
-			else if(zwsConnectPort != -1) // WebSocketHandshake
-				zreq.connectPort = zwsConnectPort;
-			if(ignorePolicies)
-				zreq.ignorePolicies = true;
-
-			if(mreq.type == M2RequestPacket::HttpRequest)
-			{
-				zreq.stream = true;
-				zreq.method = mreq.method;
-				zreq.body = mreq.body;
-				zreq.more = !s->inFinished;
-			}
-
-			zreq.multi = true;
-
-			zhttp_out_writeFirst(s, zreq);
-		}
-		else
-		{
-			assert(s->conn == conn);
-
-			if(mreq.type != M2RequestPacket::HttpRequest && mreq.type != M2RequestPacket::WebSocketFrame)
-			{
-				log_warning("m2: received unexpected subsequent packet type: %d", (int)mreq.type);
-				endSession(s);
-				m2_writeCtlCancel(conn);
-				return;
-			}
-
-			if(mreq.type == M2RequestPacket::HttpRequest)
-			{
-				int offset = 0;
-				if(mreq.uploadStreamOffset > 0)
-					offset = mreq.uploadStreamOffset;
-
-				if(offset != s->readCount)
-				{
-					log_warning("m2: %s id=%s unexpected stream offset (got=%d, expected=%d)", m2_send_idents[s->conn->identIndex].data(), mreq.id.data(), offset, s->readCount);
-					endSession(s);
-					m2_writeCtlCancel(conn);
-					return;
-				}
-
-				s->readCount += mreq.body.size();
-
-				if(!requestBodyMore)
-					s->inFinished = true;
-			}
-
-			if(s->zhttpAddress.isEmpty())
-			{
-				log_error("m2: %s id=%s multiple packets from m2 before response from zhttp", m2_send_idents[s->conn->identIndex].data(), mreq.id.data());
-				endSession(s);
-				m2_writeCtlCancel(conn);
-				return;
-			}
-
-			if(mreq.type == M2RequestPacket::HttpRequest)
-			{
-				if(s->inHandoff)
-				{
-					s->pendingIn += mreq.body;
-				}
-				else
-				{
-					ZhttpRequestPacket zreq;
-					zreq.type = ZhttpRequestPacket::Data;
-					zreq.body = mreq.body;
-					zreq.more = !s->inFinished;
-					zhttp_out_write(s, zreq);
-				}
-			}
-			else // WebSocketFrame
-			{
-				int opcode = mreq.frameFlags & 0x0f;
-				if(opcode != 1 && opcode != 2 && opcode != 8 && opcode != 9 && opcode != 10)
-				{
-					log_warning("m2: %s id=%s unsupported ws opcode: %d", m2_send_idents[s->conn->identIndex].data(), mreq.id.data(), opcode);
-					endSession(s);
-					m2_writeCtlCancel(conn);
-					return;
-				}
-
-				if(s->downClosed)
-				{
-					log_debug("m2: %s id=%s ignoring frame after close", m2_send_idents[s->conn->identIndex].data(), mreq.id.data());
-					return;
-				}
-
-				ZhttpRequestPacket zreq;
-
-				if(opcode == 1 || opcode == 2)
-				{
-					zreq.type = ZhttpRequestPacket::Data;
-					if(opcode == 2)
-						zreq.contentType = "binary";
-					zreq.body = mreq.body;
-				}
-				else if(opcode == 8)
-				{
-					zreq.type = ZhttpRequestPacket::Close;
-					if(mreq.body.size() >= 2)
-					{
-						int hi = (unsigned char)mreq.body[0];
-						int lo = (unsigned char)mreq.body[1];
-						zreq.code = (hi << 8) + lo;
-						zreq.body = mreq.body.mid(2);
-					}
-
-					s->downClosed = true;
-				}
-				else if(opcode == 9)
-				{
-					zreq.type = ZhttpRequestPacket::Ping;
-					zreq.body = mreq.body;
-				}
-				else // 10
-				{
-					zreq.type = ZhttpRequestPacket::Pong;
-					zreq.body = mreq.body;
-				}
-
-				if(s->inHandoff)
-				{
-					s->pendingInPackets += zreq;
-				}
-				else
-				{
-					zhttp_out_write(s, zreq);
-
-					if(s->downClosed && s->upClosed)
-					{
-						destroySession(s); // We aren't in handoff so this is safe
-						m2_queueClose(conn);
-					}
-				}
-			}
-		}
-	}
-
-	void m2_control_readyRead(ZmqSocket *sock)
-	{
-		int index = -1;
-		for(int n = 0; n < controlPorts.count(); ++n)
-		{
-			if(controlPorts[n].sock == sock)
-			{
-				index = n;
-				break;
-			}
-		}
-
-		assert(index != -1);
-		ControlPort &c = controlPorts[index];
-
-		while(sock->canRead())
-		{
-			CowByteArrayList message = sock->read();
-
-			if(message.count() != 2)
-			{
-				log_warning("m2: received control response with parts != 2, skipping");
-				continue;
-			}
-
-			Variant data = TnetString::toVariant(message[1]);
-			if(data.isNull())
-			{
-				log_warning("m2: received control response with invalid format (tnetstring parse failed), skipping");
-				continue;
-			}
-
-			if(c.state != ControlPort::ExpectingResponse)
-			{
-				log_warning("m2: received unexpected control response, skipping");
-				continue;
-			}
-
-			handleControlResponse(index, data);
-
-			bool needControlPort = false;
-			QHashIterator<Rid, M2Connection*> it(m2ConnectionsByRid);
-			while(it.hasNext())
-			{
-				it.next();
-				M2Connection *conn = it.value();
-				if(!conn->outCreditsEnabled)
-					needControlPort = true;
-			}
-
-			if(needControlPort)
-			{
-				c.state = ControlPort::Idle;
-			}
-			else
-			{
-				log_debug("deactivating control port index=%d", index);
-				c.state = ControlPort::Disabled;
-
-				bool allDisabled = true;
-				foreach(const ControlPort &i, controlPorts)
-				{
-					if(i.state != ControlPort::Disabled)
-					{
-						allDisabled = false;
-						break;
-					}
-				}
-				if(allDisabled)
-					statusTimer->stop();
-			}
-
-			c.reqStartTime = -1;
-		}
-	}
-
-	void zhttp_in_readyRead(const CowByteArrayList &message)
-	{
-		handleZhttpIn(Http, message);
-	}
-
-	void zws_in_readyRead(const CowByteArrayList &message)
-	{
-		handleZhttpIn(WebSocket, message);
-	}
+        if (typeId(data) != VariantType::Hash)
+            return;
+
+        VariantHash vhash = data.toHash();
+
+        if (!vhash.contains("rows"))
+            return;
+
+        Variant rows = vhash["rows"];
+
+        // Once we get at least one successful response then we flag the port as
+        // working
+        if (!controlPorts[index].works) {
+            controlPorts[index].works = true;
+            log_debug("control port index=%d works", index);
+        }
+
+        QSet<QByteArray> ids;
+        for (const Variant &row : rows.toList()) {
+            if (typeId(row) != VariantType::List)
+                break;
+
+            VariantList vlist = row.toList();
+            QByteArray id = vlist[0].toByteArray();
+            int bytes_written = vlist[7].toInt();
+
+            ids += id;
+
+            M2Connection *conn = m2ConnectionsByRid.value(Rid(m2_send_idents[index], id));
+            if (!conn || !conn->flowControl || conn->outCreditsEnabled)
+                continue;
+
+            if (bytes_written > conn->confirmedBytesWritten) {
+                int written = bytes_written - conn->confirmedBytesWritten;
+                conn->confirmedBytesWritten = bytes_written;
+
+                handleConnectionBytesWritten(conn, written, true);
+
+                // If we had any pending writes to make, now's the time.
+                // note: this might delete the connection but that's fine
+                m2_tryWriteQueued(conn);
+            }
+        }
+
+        // Any connections missing?
+        QList<M2Connection *> gone;
+        QHashIterator<Rid, M2Connection *> it(m2ConnectionsByRid);
+        while (it.hasNext()) {
+            it.next();
+            M2Connection *conn = it.value();
+            if (conn->identIndex == index) {
+                // Only check for missing connections that aren't flagged
+                if (!conn->isNew) {
+                    if (!ids.contains(conn->id))
+                        gone += conn;
+                } else {
+                    // Clear the flag so the connection gets processed next time
+                    conn->isNew = false;
+                }
+            }
+        }
+        foreach (M2Connection *conn, gone) {
+            log_debug("m2: %s id=%s disconnected", m2_send_idents[conn->identIndex].data(),
+                      conn->id.data());
+
+            if (conn->session)
+                endSession(conn->session, "disconnected");
+
+            removeConnection(conn);
+            delete conn;
+        }
+    }
+
+    // Return true if connection was deleted as a result of handling bytes written
+    void handleConnectionBytesWritten(M2Connection *conn, int written, bool giveCredits) {
+        int bodyWritten = conn->bodyTracker.finished(written);
+        int packetsWritten = conn->packetTracker.finished(written);
+
+        conn->packetsPending -= packetsWritten;
+
+        if (conn->waitForAllWritten && conn->packetsPending == 0 && conn->pendingOutItems.isEmpty())
+            conn->waitForAllWritten = false;
+
+        if (conn->session && bodyWritten > 0) {
+            Session *s = conn->session;
+
+            // Update lastActive
+            qint64 now = QDateTime::currentMSecsSinceEpoch();
+            sessionsByLastActive.remove(QPair<qint64, Session *>(s->lastActive, s));
+            s->lastActive = now;
+            sessionsByLastActive.insert(QPair<qint64, Session *>(s->lastActive, s), s);
+
+            handleSessionBodyWritten(s, bodyWritten, giveCredits);
+        }
+    }
+
+    void handleSessionBodyWritten(Session *s, int written, bool giveCredits) {
+        s->pendingInCredits += written;
+
+        log_debug("request id=%s written %d%s", s->id.data(), written,
+                  s->conn->flowControl ? "" : " (no flow control)");
+
+        if (s->inHandoff)
+            return;
+
+        // Address could be empty here if we're handling write of non-sequenced
+        // response
+        if (giveCredits && !s->zhttpAddress.isEmpty()) {
+            ZhttpRequestPacket zreq;
+            zreq.type = ZhttpRequestPacket::Credit;
+            zreq.credits = s->pendingInCredits;
+            s->pendingInCredits = 0;
+            zhttp_out_write(s, zreq);
+        }
+    }
+
+    void endSession(Session *s, const QByteArray &errorCondition = QByteArray()) {
+        // If we are in handoff or haven't received a worker ack, then queue the
+        // state
+        if (s->inHandoff || s->zhttpAddress.isEmpty()) {
+            if (!errorCondition.isEmpty())
+                s->errorCondition = errorCondition;
+
+            // Keep the session around
+            unlinkConnection(s);
+        } else {
+            if (sessionsToCancel.isEmpty() && zhttpCancelMeter < ZHTTP_CANCEL_PER_REFRESH) {
+                ++zhttpCancelMeter;
+
+                ZhttpRequestPacket zreq;
+
+                if (!errorCondition.isEmpty()) {
+                    zreq.type = ZhttpRequestPacket::Error;
+                    zreq.condition = "disconnected";
+                } else
+                    zreq.type = ZhttpRequestPacket::Cancel;
+
+                zhttp_out_write(s, zreq);
+
+                destroySession(s);
+            } else {
+                queueCancelSession(s);
+            }
+        }
+    }
+
+    void handleZhttpIn(Mode mode, const CowByteArrayList &message) {
+        const char *logprefix = (mode == Http ? "zhttp" : "zws");
+
+        if (message.count() != 1) {
+            log_warning("%s: received message with parts != 1, skipping", logprefix);
+            return;
+        }
+
+        int at = message[0].indexOf(' ');
+        if (at == -1) {
+            log_warning("%s: received message with invalid format, skipping", logprefix);
+            return;
+        }
+
+        CowByteArray dataRaw = message[0].mid(at + 1);
+        if (dataRaw.length() < 1 || dataRaw[0] != 'T') {
+            log_warning("%s: received message with invalid format (missing type), skipping",
+                        logprefix);
+            return;
+        }
+
+        Variant data = TnetString::toVariant(dataRaw.mid(1));
+        if (data.isNull()) {
+            log_warning("%s: received message with invalid format (tnetstring parse "
+                        "failed), skipping",
+                        logprefix);
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariantWithContent(LOG_LEVEL_DEBUG, data, "body", "%s: IN", logprefix);
+
+        ZhttpResponsePacket zresp;
+        if (!zresp.fromVariant(data)) {
+            log_warning("%s: received message with invalid format (parse failed), skipping",
+                        logprefix);
+            return;
+        }
+
+        foreach (const ZhttpResponsePacket::Id &id, zresp.ids)
+            handleZhttpIn(logprefix, mode, id.id.asQByteArray(), id.seq, zresp);
+    }
+
+    void handleZhttpIn(const char *logprefix, Mode mode, const QByteArray &id, int seq,
+                       const ZhttpResponsePacket &zresp) {
+        Session *s;
+        if (mode == Http)
+            s = sessionsByZhttpRid.value(Rid(zhttpInstanceId, id));
+        else // WebSocket
+            s = sessionsByZwsRid.value(Rid(zwsInstanceId, id));
+
+        if (!s) {
+            log_debug("%s: received message for unknown request id, canceling", logprefix);
+
+            // If this was not an error packet, send cancel
+            if (!isErrorPacket(zresp) && !zresp.from.isEmpty()) {
+                ZhttpRequestPacket zreq;
+                zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
+                zreq.ids += ZhttpRequestPacket::Id(id);
+                zreq.type = ZhttpRequestPacket::Cancel;
+                zhttp_out_write(mode, zreq, zresp.from.asQByteArray());
+            }
+
+            return;
+        }
+
+        // Mode will always match here
+        assert(s->mode == mode);
+
+        if (s->inSeq == 0) {
+            // Are we expecting a sequence of packets after the first?
+            if ((!isErrorPacket(zresp) && zresp.type != ZhttpResponsePacket::Data) ||
+                (zresp.type == ZhttpResponsePacket::Data && zresp.more)) {
+                // Sequence must have from address
+                if (zresp.from.isEmpty()) {
+                    log_warning("%s: received first response of sequence with no from "
+                                "address, canceling",
+                                logprefix);
+                    destroySessionAndErrorConnection(s);
+                    return;
+                }
+
+                s->zhttpAddress = zresp.from.asQByteArray();
+
+                if (seq != 0) {
+                    log_warning("%s: received first response of sequence without valid "
+                                "seq, canceling",
+                                logprefix);
+                    ZhttpRequestPacket zreq;
+                    zreq.type = ZhttpRequestPacket::Cancel;
+                    zhttp_out_write(s, zreq);
+                    destroySessionAndErrorConnection(s);
+                    return;
+                }
+            } else {
+                // If not sequenced, then there might be a from address
+                if (!zresp.from.isEmpty())
+                    s->zhttpAddress = zresp.from.asQByteArray();
+
+                // If not sequenced, but seq is provided, then it must be 0
+                if (seq != -1 && seq != 0) {
+                    log_warning("%s: received response out of sequence (got=%d, "
+                                "expected=-1,0), canceling",
+                                logprefix, seq);
+
+                    if (!s->zhttpAddress.isEmpty()) {
+                        ZhttpRequestPacket zreq;
+                        zreq.type = ZhttpRequestPacket::Cancel;
+                        zhttp_out_write(s, zreq);
+                    }
+
+                    destroySessionAndErrorConnection(s);
+                    return;
+                }
+            }
+        } else {
+            if (seq != -1 && seq != s->inSeq) {
+                log_warning("%s: received response out of sequence (got=%d, "
+                            "expected=%d), canceling",
+                            logprefix, seq, s->inSeq);
+                ZhttpRequestPacket zreq;
+                zreq.type = ZhttpRequestPacket::Cancel;
+                zhttp_out_write(s, zreq);
+                destroySessionAndErrorConnection(s);
+                return;
+            }
+
+            // If a new from address is provided, update our copy
+            if (!zresp.from.isEmpty())
+                s->zhttpAddress = zresp.from.asQByteArray();
+        }
+
+        // Only bump sequence if seq was provided
+        if (seq != -1)
+            ++(s->inSeq);
+
+        qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+        if (s->lastRefresh < 0 && !s->zhttpAddress.isEmpty()) {
+            // Once we have the peer's address, set up refresh
+
+            s->lastRefresh = now;
+            sessionsByLastRefresh.insert(QPair<qint64, Session *>(s->lastRefresh, s), s);
+
+            s->refreshBucket = smallestSessionRefreshBucket();
+            sessionRefreshBuckets[s->refreshBucket] += s;
+        }
+
+        // Update lastActive
+        sessionsByLastActive.remove(QPair<qint64, Session *>(s->lastActive, s));
+        s->lastActive = now;
+        sessionsByLastActive.insert(QPair<qint64, Session *>(s->lastActive, s), s);
+
+        if (s->pendingCancel)
+            return;
+
+        // A session without a connection is just waiting to report error
+        if (!s->conn) {
+            // If we were in handoff, it's okay to send right now since we'd
+            // be clearing the handoff state later on in this method anyway
+            if (!s->zhttpAddress.isEmpty()) {
+                ZhttpRequestPacket zreq;
+                if (!s->errorCondition.isEmpty()) {
+                    zreq.type = ZhttpRequestPacket::Error;
+                    zreq.condition = s->errorCondition;
+                } else
+                    zreq.type = ZhttpRequestPacket::Cancel;
+                zhttp_out_write(s, zreq);
+            }
+
+            destroySession(s);
+            return;
+        }
+
+        // If peer supports multi feature then flag it on the session
+        bool multiWasTurnedOn = false;
+        if (!s->multi && zresp.multi) {
+            s->multi = true;
+            multiWasTurnedOn = true;
+        }
+
+        if (s->inHandoff) {
+            // Receiving any message means handoff is complete
+            s->inHandoff = false;
+
+            // Refresh would have already been set up once if we are here
+            assert(s->lastRefresh >= 0);
+
+            sessionsByLastRefresh.insert(QPair<qint64, Session *>(s->lastRefresh, s), s);
+            s->refreshBucket = smallestSessionRefreshBucket();
+            sessionRefreshBuckets[s->refreshBucket] += s;
+
+            // In order to have been in a handoff state, we would have
+            // had to receive a from address sometime earlier, so it
+            // should be safe to call zhttp_out_write with session.
+
+            if (multiWasTurnedOn) {
+                // Acknowledge the feature
+                ZhttpRequestPacket zreq;
+                zreq.type = ZhttpRequestPacket::KeepAlive;
+                zreq.multi = true;
+                zhttp_out_write(s, zreq);
+            }
+
+            if (s->mode == Http) {
+                if (!s->pendingIn.isEmpty()) {
+                    ZhttpRequestPacket zreq;
+                    zreq.type = ZhttpRequestPacket::Data;
+
+                    // Send credits too, if needed (though this probably can't happen,
+                    // since http data flows only in one direction at a time. We
+                    // can't have pending request body data while at the same
+                    // time be acking received response body data).
+                    if (s->pendingInCredits > 0) {
+                        zreq.credits = s->pendingInCredits;
+                        s->pendingInCredits = 0;
+                    }
+
+                    zreq.body = s->pendingIn.take();
+                    zreq.more = !s->inFinished;
+                    zhttp_out_write(s, zreq);
+                }
+            } else // WebSocket
+            {
+                while (!s->pendingInPackets.isEmpty()) {
+                    ZhttpRequestPacket zreq = s->pendingInPackets.takeFirst();
+
+                    // Send credits too, if needed
+                    if (zreq.type == ZhttpRequestPacket::Data && s->pendingInCredits > 0) {
+                        zreq.credits = s->pendingInCredits;
+                        s->pendingInCredits = 0;
+                    }
+
+                    zhttp_out_write(s, zreq);
+                }
+            }
+
+            // If we didn't send credits as part of a data packet, we'll do them now
+            if (s->pendingInCredits > 0) {
+                ZhttpRequestPacket zreq;
+                zreq.type = ZhttpRequestPacket::Credit;
+                zreq.credits = s->pendingInCredits;
+                s->pendingInCredits = 0;
+                zhttp_out_write(s, zreq);
+            }
+        }
+
+        if (zresp.type == ZhttpResponsePacket::Data) {
+            log_debug("zhttp: id=%s response data size=%d%s", s->id.data(), zresp.body.size(),
+                      zresp.more ? " M" : "");
+
+            // Data packet may have credits
+            if (zresp.credits > 0) {
+                VariantHash args;
+                args["credits"] = zresp.credits;
+                m2_writeCtl(s->conn, args);
+            }
+
+            if (s->mode == Http) {
+                bool firstDataPacket = !s->sentResponseHeader;
+
+                // Respond with data if we have body data or this is the first packet
+                if (!zresp.body.isEmpty() || firstDataPacket) {
+                    if (firstDataPacket) {
+                        // Use flow control if the control port works and the response is
+                        // more than one packet
+                        if ((s->conn->outCreditsEnabled ||
+                             controlPorts[s->conn->identIndex].works) &&
+                            zresp.more)
+                            s->conn->flowControl = true;
+                        else
+                            s->conn->flowControl = false;
+
+                        s->sentResponseHeader = true;
+
+                        if (zresp.more && !zresp.headers.contains("Content-Length")) {
+                            if (s->allowChunked) {
+                                s->chunked = true;
+                            } else {
+                                // Disable persistence
+                                s->persistent = false;
+                                s->respondKeepAlive = false;
+                            }
+                        }
+
+                        if (s->method == "HEAD" || (zresp.code == 204 || zresp.code == 304))
+                            s->responseHeadersOnly = true;
+
+                        HttpHeaders headers = zresp.headers;
+                        QList<QByteArray> connHeaders =
+                            headers.takeAll("Connection").asQByteArrayList();
+                        foreach (const QByteArray &h, connHeaders)
+                            headers.removeAll(h);
+
+                        headers.removeAll("Transfer-Encoding");
+
+                        connHeaders.clear();
+                        if (s->respondKeepAlive)
+                            connHeaders += "Keep-Alive";
+                        if (s->respondClose)
+                            connHeaders += "close";
+
+                        if (!s->responseHeadersOnly) {
+                            if (s->chunked) {
+                                connHeaders += "Transfer-Encoding";
+                                headers += HttpHeader("Transfer-Encoding", "chunked");
+                            } else if (!zresp.more && !headers.contains("Content-Length")) {
+                                headers += HttpHeader("Content-Length",
+                                                      QByteArray::number(zresp.body.size()));
+                            }
+                        }
+
+                        if (!connHeaders.isEmpty())
+                            headers += HttpHeader("Connection", HttpHeaders::join(connHeaders));
+
+                        log_info("OUT %s id=%s code=%d %d%s",
+                                 m2_send_idents[s->conn->identIndex].data(), s->conn->id.data(),
+                                 zresp.code, zresp.body.size(), zresp.more ? " M" : "");
+
+                        m2_queueHeaders(
+                            s->conn,
+                            createResponseHeader(zresp.code, zresp.reason.asQByteArray(), headers));
+                    }
+
+                    if (!zresp.body.isEmpty()) {
+                        if (s->responseHeadersOnly) {
+                            log_warning("%s: received unexpected response body, canceling",
+                                        logprefix);
+
+                            bool persistent = s->persistent;
+
+                            // Cancel and destroy session
+                            M2Connection *conn = s->conn;
+                            if (!s->zhttpAddress.isEmpty()) {
+                                ZhttpRequestPacket zreq;
+                                zreq.type = ZhttpRequestPacket::Cancel;
+                                zhttp_out_write(s, zreq);
+                            }
+                            destroySession(s);
+                            if (!persistent)
+                                m2_queueClose(conn);
+                            return;
+                        }
+
+                        m2_queueResponse(s->conn, zresp.body.asQByteArray(), s->chunked);
+                    }
+
+                    if (!zresp.more && s->chunked) {
+                        // Send closing chunk
+                        m2_queueResponse(s->conn, QByteArray(), true);
+                    }
+                } else {
+                    if (!zresp.more && s->chunked) {
+                        // Send closing chunk
+                        m2_queueResponse(s->conn, QByteArray(), true);
+                    }
+                }
+
+                if (!zresp.more) {
+                    bool persistent = s->persistent;
+                    M2Connection *conn = s->conn;
+                    destroySession(s);
+                    if (!persistent)
+                        m2_queueClose(conn);
+                }
+            } else // WebSocket
+            {
+                if (!s->sentResponseHeader) {
+                    s->sentResponseHeader = true;
+                    if (s->conn->outCreditsEnabled || controlPorts[s->conn->identIndex].works)
+                        s->conn->flowControl = true;
+                    else
+                        s->conn->flowControl = false;
+
+                    HttpHeaders headers = zresp.headers;
+                    QList<QByteArray> connHeaders =
+                        headers.takeAll("Connection").asQByteArrayList();
+                    foreach (const QByteArray &h, connHeaders)
+                        headers.removeAll(h);
+                    headers.removeAll("Transfer-Encoding");
+                    headers.removeAll("Upgrade");
+                    headers.removeAll("Sec-WebSocket-Accept");
+
+                    headers += HttpHeader("Upgrade", "websocket");
+                    headers += HttpHeader("Connection", "Upgrade");
+                    headers += HttpHeader("Sec-WebSocket-Accept", s->acceptToken);
+
+                    QByteArray reason;
+                    if (!zresp.reason.isEmpty())
+                        reason = zresp.reason.asQByteArray();
+                    else
+                        reason = "Switching Protocols";
+
+                    log_info("OUT %s id=%s code=%d 0 M", m2_send_idents[s->conn->identIndex].data(),
+                             s->conn->id.data(), zresp.code);
+
+                    m2_queueHeaders(s->conn, createResponseHeader(101, reason, headers));
+                } else {
+                    int opcode;
+                    if (s->conn->continuation) {
+                        opcode = 0;
+                    } else {
+                        if (zresp.contentType == "binary")
+                            opcode = 2;
+                        else // Text
+                            opcode = 1;
+                    }
+
+                    s->conn->continuation = zresp.more;
+
+                    QByteArray frame = makeWsHeader(!zresp.more, opcode, zresp.body.size()) +
+                                       zresp.body.asQByteArray();
+
+                    m2_queueFrame(s->conn, frame, zresp.body.size());
+                }
+            }
+        } else if (zresp.type == ZhttpResponsePacket::Error) {
+            log_debug("%s: id=%s error condition=%s", logprefix, s->id.data(),
+                      zresp.condition.data());
+
+            if (s->mode == WebSocket && zresp.condition == "rejected") {
+                HttpHeaders headers = zresp.headers;
+                QList<QByteArray> connHeaders = headers.takeAll("Connection").asQByteArrayList();
+                foreach (const QByteArray &h, connHeaders)
+                    headers.removeAll(h);
+
+                headers.removeAll("Transfer-Encoding");
+
+                if (!headers.contains("Content-Length"))
+                    headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
+
+                connHeaders.clear();
+
+                // if HTTP/1.1, include "Connection: close"
+                if (s->allowChunked)
+                    connHeaders += "close";
+
+                if (!connHeaders.isEmpty())
+                    headers += HttpHeader("Connection", HttpHeaders::join(connHeaders));
+
+                log_info("OUT %s id=%s code=%d %d", m2_send_idents[s->conn->identIndex].data(),
+                         s->conn->id.data(), zresp.code, zresp.body.size());
+
+                m2_queueHeaders(s->conn, createResponseHeader(
+                                             zresp.code, zresp.reason.asQByteArray(), headers));
+                m2_queueResponse(s->conn, zresp.body.asQByteArray(), false);
+
+                M2Connection *conn = s->conn;
+                destroySession(s);
+                m2_queueClose(conn);
+            } else
+                destroySessionAndErrorConnection(s);
+        } else if (zresp.type == ZhttpResponsePacket::Credit) {
+            if (zresp.credits > 0) {
+                VariantHash args;
+                args["credits"] = zresp.credits;
+                m2_writeCtl(s->conn, args);
+            }
+        } else if (zresp.type == ZhttpResponsePacket::KeepAlive) {
+            // Nothing to do
+        } else if (zresp.type == ZhttpResponsePacket::Cancel) {
+            destroySessionAndErrorConnection(s);
+        } else if (zresp.type == ZhttpResponsePacket::HandoffStart) {
+            s->inHandoff = true;
+
+            sessionRefreshBuckets[s->refreshBucket].remove(s);
+            sessionsByLastRefresh.remove(QPair<qint64, Session *>(s->lastRefresh, s));
+
+            // Whoever picks up after handoff can turn this on
+            s->multi = false;
+
+            ZhttpRequestPacket zreq;
+            zreq.type = ZhttpRequestPacket::HandoffProceed;
+            zhttp_out_write(s, zreq);
+        } else if (zresp.type == ZhttpResponsePacket::Close ||
+                   zresp.type == ZhttpResponsePacket::Ping ||
+                   zresp.type == ZhttpResponsePacket::Pong) {
+            int opcode;
+            if (zresp.type == ZhttpResponsePacket::Close) {
+                opcode = 8;
+                s->upClosed = true;
+            } else if (zresp.type == ZhttpResponsePacket::Ping)
+                opcode = 9;
+            else // Pong
+                opcode = 10;
+
+            QByteArray data;
+            if (zresp.type == ZhttpResponsePacket::Close) {
+                data.resize(2 + zresp.body.size());
+                writeBigEndian(data.data(), zresp.code != -1 ? zresp.code : 1000, 2);
+                if (!zresp.body.isEmpty()) {
+                    memcpy(data.data() + 2, zresp.body.data(), zresp.body.size());
+                }
+            } else {
+                data = zresp.body.asQByteArray();
+            }
+
+            QByteArray frame = makeWsHeader(true, opcode, data.size()) + data;
+
+            m2_queueFrame(s->conn, frame, data.size());
+
+            if (s->downClosed && s->upClosed) {
+                M2Connection *conn = s->conn;
+                destroySession(s);
+                m2_queueClose(conn);
+            }
+        } else {
+            log_warning("%s: id=%s unsupported type: %d", logprefix, s->id.data(), (int)zresp.type);
+        }
+    }
+
+    void refreshM2Connections(qint64 now) {
+        QHash<int, QList<QByteArray>> connIdListBySender;
+
+        // Process the current bucket
+        const QSet<M2Connection *> &bucket = m2ConnectionRefreshBuckets[currentM2RefreshBucket];
+        foreach (M2Connection *conn, bucket) {
+            // Move to the end
+            QPair<qint64, M2Connection *> k(conn->lastRefresh, conn);
+            m2ConnectionsByLastRefresh.remove(k);
+            conn->lastRefresh = now;
+            m2ConnectionsByLastRefresh.insert(
+                QPair<qint64, M2Connection *>(conn->lastRefresh, conn), conn);
+
+            if (!connIdListBySender.contains(conn->identIndex))
+                connIdListBySender.insert(conn->identIndex, QList<QByteArray>());
+
+            QList<QByteArray> &connIdList = connIdListBySender[conn->identIndex];
+            connIdList += conn->id;
+
+            // If we're at max, send out now
+            if (connIdList.count() >= M2_HANDLER_TARGETS_MAX) {
+                VariantHash args;
+                args["keep-alive"] = true;
+                m2_writeCtlMany(m2_send_idents[conn->identIndex], connIdList, args);
+
+                connIdList.clear();
+                connIdListBySender.remove(conn->identIndex);
+            }
+        }
+
+        // Process any others
+        qint64 threshold = now - M2_CONNECTION_MUST_PROCESS;
+        while (!m2ConnectionsByLastRefresh.isEmpty()) {
+            QMap<QPair<qint64, M2Connection *>, M2Connection *>::iterator it =
+                m2ConnectionsByLastRefresh.begin();
+            M2Connection *conn = it.value();
+
+            if (conn->lastRefresh > threshold)
+                break;
+
+            // Move to the end
+            m2ConnectionsByLastRefresh.erase(it);
+            conn->lastRefresh = now;
+            m2ConnectionsByLastRefresh.insert(
+                QPair<qint64, M2Connection *>(conn->lastRefresh, conn), conn);
+
+            if (!connIdListBySender.contains(conn->identIndex))
+                connIdListBySender.insert(conn->identIndex, QList<QByteArray>());
+
+            QList<QByteArray> &connIdList = connIdListBySender[conn->identIndex];
+            connIdList += conn->id;
+
+            // If we're at max, send out now
+            if (connIdList.count() >= M2_HANDLER_TARGETS_MAX) {
+                VariantHash args;
+                args["keep-alive"] = true;
+                m2_writeCtlMany(m2_send_idents[conn->identIndex], connIdList, args);
+
+                connIdList.clear();
+                connIdListBySender.remove(conn->identIndex);
+            }
+        }
+
+        // Send last packet
+        QHashIterator<int, QList<QByteArray>> cit(connIdListBySender);
+        while (cit.hasNext()) {
+            cit.next();
+            int index = cit.key();
+            const QList<QByteArray> &connIdList = cit.value();
+
+            if (!connIdList.isEmpty()) {
+                VariantHash args;
+                args["keep-alive"] = true;
+                m2_writeCtlMany(m2_send_idents[index], connIdList, args);
+            }
+        }
+
+        ++currentM2RefreshBucket;
+        if (currentM2RefreshBucket >= M2_REFRESH_BUCKETS)
+            currentM2RefreshBucket = 0;
+    }
+
+    void refreshSessions(qint64 now) {
+        QHash<QByteArray, QList<Session *>> sessionListBySender[2]; // Index corresponds to mode
+
+        // Process the current bucket
+        const QSet<Session *> &bucket = sessionRefreshBuckets[currentSessionRefreshBucket];
+        foreach (Session *s, bucket) {
+            assert(!s->inHandoff && !s->zhttpAddress.isEmpty());
+
+            // Move to the end
+            QPair<qint64, Session *> k(s->lastRefresh, s);
+            sessionsByLastRefresh.remove(k);
+            s->lastRefresh = now;
+            sessionsByLastRefresh.insert(QPair<qint64, Session *>(s->lastRefresh, s), s);
+
+            if (s->multi) {
+                if (!sessionListBySender[s->mode].contains(s->zhttpAddress))
+                    sessionListBySender[s->mode].insert(s->zhttpAddress, QList<Session *>());
+
+                QList<Session *> &sessionList = sessionListBySender[s->mode][s->zhttpAddress];
+                sessionList += s;
+
+                // If we're at max, send out now
+                if (sessionList.count() >= ZHTTP_IDS_MAX) {
+                    ZhttpRequestPacket zreq;
+                    zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+                    foreach (Session *i, sessionList)
+                        zreq.ids += ZhttpRequestPacket::Id(i->id, (i->outSeq)++);
+                    zreq.type = ZhttpRequestPacket::KeepAlive;
+                    zhttp_out_write(s->mode, zreq, s->zhttpAddress);
+
+                    sessionList.clear();
+                    sessionListBySender[s->mode].remove(s->zhttpAddress);
+                }
+            } else {
+                // Session doesn't support sending with multiple ids
+                ZhttpRequestPacket zreq;
+                zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+                zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+                zreq.type = ZhttpRequestPacket::KeepAlive;
+                zhttp_out_write(s->mode, zreq, s->zhttpAddress);
+            }
+        }
+
+        // Process any others
+        qint64 threshold = now - ZHTTP_MUST_PROCESS;
+        while (!sessionsByLastRefresh.isEmpty()) {
+            QMap<QPair<qint64, Session *>, Session *>::iterator it = sessionsByLastRefresh.begin();
+            Session *s = it.value();
+
+            if (s->lastRefresh > threshold)
+                break;
+
+            assert(!s->inHandoff && !s->zhttpAddress.isEmpty());
+
+            // Move to the end
+            sessionsByLastRefresh.erase(it);
+            s->lastRefresh = now;
+            sessionsByLastRefresh.insert(QPair<qint64, Session *>(s->lastRefresh, s), s);
+
+            if (s->multi) {
+                if (!sessionListBySender[s->mode].contains(s->zhttpAddress))
+                    sessionListBySender[s->mode].insert(s->zhttpAddress, QList<Session *>());
+
+                QList<Session *> &sessionList = sessionListBySender[s->mode][s->zhttpAddress];
+                sessionList += s;
+
+                // If we're at max, send out now
+                if (sessionList.count() >= ZHTTP_IDS_MAX) {
+                    ZhttpRequestPacket zreq;
+                    zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+                    foreach (Session *i, sessionList)
+                        zreq.ids += ZhttpRequestPacket::Id(i->id, (i->outSeq)++);
+                    zreq.type = ZhttpRequestPacket::KeepAlive;
+                    zhttp_out_write(s->mode, zreq, s->zhttpAddress);
+
+                    sessionList.clear();
+                    sessionListBySender[s->mode].remove(s->zhttpAddress);
+                }
+            } else {
+                // Session doesn't support sending with multiple ids
+                ZhttpRequestPacket zreq;
+                zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+                zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+                zreq.type = ZhttpRequestPacket::KeepAlive;
+                zhttp_out_write(s->mode, zreq, s->zhttpAddress);
+            }
+        }
+
+        // Send last packets
+        for (int n = 0; n < 2; ++n) {
+            Mode mode = (Mode)n;
+
+            QHashIterator<QByteArray, QList<Session *>> sit(sessionListBySender[n]);
+            while (sit.hasNext()) {
+                sit.next();
+                const QByteArray &zhttpAddress = sit.key();
+                const QList<Session *> &sessionList = sit.value();
+
+                if (!sessionList.isEmpty()) {
+                    ZhttpRequestPacket zreq;
+                    zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
+                    foreach (Session *s, sessionList)
+                        zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+                    zreq.type = ZhttpRequestPacket::KeepAlive;
+                    zhttp_out_write(mode, zreq, zhttpAddress);
+                }
+            }
+        }
+
+        ++currentSessionRefreshBucket;
+        if (currentSessionRefreshBucket >= ZHTTP_REFRESH_BUCKETS)
+            currentSessionRefreshBucket = 0;
+    }
+
+    void expireSessions(qint64 now) {
+        qint64 threshold = now - ZHTTP_EXPIRE;
+        while (!sessionsByLastActive.isEmpty()) {
+            QMap<QPair<qint64, Session *>, Session *>::iterator it = sessionsByLastActive.begin();
+            Session *s = it.value();
+
+            if (s->lastActive > threshold)
+                break;
+
+            log_warning("timing out request %s", s->id.data());
+            destroySessionAndErrorConnection(s);
+        }
+    }
+
+    void cancelSessions() {
+        int sent = zhttpCancelMeter;
+
+        if (zhttpCancelMeter > ZHTTP_CANCEL_PER_REFRESH)
+            zhttpCancelMeter -= ZHTTP_CANCEL_PER_REFRESH;
+        else
+            zhttpCancelMeter = 0;
+
+        QHash<QByteArray, QList<Session *>> sessionListBySender[2]; // Index corresponds to mode
+
+        while (!sessionsToCancel.isEmpty() && sent < ZHTTP_CANCEL_PER_REFRESH) {
+            QSet<Session *>::iterator it = sessionsToCancel.begin();
+            Session *s = (*it);
+            sessionsToCancel.erase(it);
+
+            if (s->multi) {
+                if (!sessionListBySender[s->mode].contains(s->zhttpAddress))
+                    sessionListBySender[s->mode].insert(s->zhttpAddress, QList<Session *>());
+
+                QList<Session *> &sessionList = sessionListBySender[s->mode][s->zhttpAddress];
+                sessionList += s;
+
+                // If we're at max, send out now
+                if (sessionList.count() >= ZHTTP_IDS_MAX) {
+                    ZhttpRequestPacket zreq;
+                    zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+                    foreach (Session *i, sessionList)
+                        zreq.ids += ZhttpRequestPacket::Id(i->id, (i->outSeq)++);
+                    zreq.type = ZhttpRequestPacket::Cancel;
+                    zhttp_out_write(s->mode, zreq, s->zhttpAddress);
+
+                    Mode mode = s->mode;
+                    QByteArray zhttpAddress = s->zhttpAddress;
+
+                    foreach (Session *s, sessionList)
+                        destroySession(s);
+
+                    sessionList.clear();
+                    sessionListBySender[mode].remove(zhttpAddress);
+                }
+            } else {
+                // Session doesn't support sending with multiple ids
+                ZhttpRequestPacket zreq;
+                zreq.from = (s->mode == Http ? zhttpInstanceId : zwsInstanceId);
+                zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+                zreq.type = ZhttpRequestPacket::Cancel;
+                zhttp_out_write(s->mode, zreq, s->zhttpAddress);
+
+                destroySession(s);
+            }
+
+            ++sent;
+        }
+
+        // Send last packets
+        for (int n = 0; n < 2; ++n) {
+            Mode mode = (Mode)n;
+
+            QHashIterator<QByteArray, QList<Session *>> sit(sessionListBySender[n]);
+            while (sit.hasNext()) {
+                sit.next();
+                const QByteArray &zhttpAddress = sit.key();
+                const QList<Session *> &sessionList = sit.value();
+
+                if (!sessionList.isEmpty()) {
+                    ZhttpRequestPacket zreq;
+                    zreq.from = (mode == Http ? zhttpInstanceId : zwsInstanceId);
+                    foreach (Session *s, sessionList)
+                        zreq.ids += ZhttpRequestPacket::Id(s->id, (s->outSeq)++);
+                    zreq.type = ZhttpRequestPacket::Cancel;
+                    zhttp_out_write(mode, zreq, zhttpAddress);
+                }
+
+                foreach (Session *s, sessionList)
+                    destroySession(s);
+            }
+        }
+    }
+
+    void m2_in_readyRead(const CowByteArrayList &message) {
+        if (message.count() != 1) {
+            log_warning("m2: received message with parts != 1, skipping");
+            return;
+        }
+
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logByteArray(LOG_LEVEL_DEBUG, message[0].asQByteArray(), "m2: IN");
+
+        M2RequestPacket mreq;
+        if (!mreq.fromByteArray(message[0].asQByteArray())) {
+            log_warning("m2: received message with invalid format, skipping");
+            return;
+        }
+
+        if (mreq.type == M2RequestPacket::Disconnect) {
+            log_debug("m2: %s id=%s disconnected", mreq.sender.data(), mreq.id.data());
+
+            Rid rid(mreq.sender, mreq.id);
+
+            M2Connection *conn = m2ConnectionsByRid.value(rid);
+            if (!conn)
+                return;
+
+            if (conn->session)
+                endSession(conn->session);
+
+            removeConnection(conn);
+            delete conn;
+
+            return;
+        }
+
+        qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+        Rid m2Rid(mreq.sender, mreq.id);
+
+        M2Connection *conn = m2ConnectionsByRid.value(m2Rid);
+        if (!conn) {
+            if (mreq.version.isEmpty()) {
+                if (mreq.type == M2RequestPacket::HttpRequest ||
+                    mreq.type == M2RequestPacket::WebSocketHandshake) {
+                    log_warning("m2: id=%s no version on initial packet", mreq.id.data());
+                }
+
+                m2_writeCtlCancel(mreq.sender, mreq.id);
+                return;
+            }
+
+            if (mreq.version != "HTTP/1.0" && mreq.version != "HTTP/1.1") {
+                log_error("m2: id=%s unknown version: %s", mreq.id.data(), mreq.version.data());
+                m2_writeCtlCancel(mreq.sender, mreq.id);
+                return;
+            }
+
+            int index = -1;
+            for (int n = 0; n < m2_send_idents.count(); ++n) {
+                if (m2_send_idents[n] == mreq.sender) {
+                    index = n;
+                    break;
+                }
+            }
+
+            if (index == -1) {
+                log_error("m2: id=%s unknown send_ident [%s]", mreq.id.data(), mreq.sender.data());
+                return;
+            }
+
+            if (sessionsByM2Rid.contains(m2Rid)) {
+                log_warning("m2: received duplicate request id=%s, skipping", mreq.id.data());
+                m2_writeCtlCancel(mreq.sender, mreq.id);
+                return;
+            }
+
+            conn = new M2Connection;
+            conn->identIndex = index;
+            conn->id = mreq.id;
+
+            if (mreq.downloadCredits >= 0) {
+                conn->outCreditsEnabled = true;
+                conn->outCredits += mreq.downloadCredits;
+            } else {
+                if (controlPorts[index].state == ControlPort::Disabled) {
+                    log_debug("activating control port index=%d", index);
+                    controlPorts[index].state = ControlPort::Idle;
+
+                    if (!statusTimer->isActive())
+                        statusTimer->start();
+                }
+
+                // If we were in the middle of requesting control info when this
+                // http request arrived, then there's a chance the control
+                // response won't account for this request (for example if the
+                // control response was generated and was in the middle of being
+                // delivered when this http request arrived). We'll flag the
+                // connection as "new" in this case, so in the control response
+                // handler we know to skip over it until the next control
+                // request.
+                if (controlPorts[index].state == ControlPort::ExpectingResponse)
+                    conn->isNew = true;
+            }
+
+            m2ConnectionsByRid.insert(m2Rid, conn);
+
+            conn->lastRefresh = now;
+            m2ConnectionsByLastRefresh.insert(
+                QPair<qint64, M2Connection *>(conn->lastRefresh, conn), conn);
+
+            conn->refreshBucket = smallestM2RefreshBucket();
+            m2ConnectionRefreshBuckets[conn->refreshBucket] += conn;
+        } else {
+            // If packet contained credits, handle them now
+            if (conn->outCreditsEnabled && mreq.downloadCredits > 0) {
+                conn->outCredits += mreq.downloadCredits;
+                handleConnectionBytesWritten(conn, mreq.downloadCredits, true);
+
+                // If we had any pending writes to make, now's the time
+                bool connDeleted = m2_tryWriteQueued(conn);
+                if (connDeleted)
+                    return;
+            }
+
+            // If the packet only held credits, then there's nothing else to do
+            if (mreq.type == M2RequestPacket::Credits)
+                return;
+        }
+
+        bool requestBodyMore = false;
+        if (mreq.type == M2RequestPacket::HttpRequest && mreq.uploadStreamOffset >= 0 &&
+            !mreq.uploadStreamDone)
+            requestBodyMore = true;
+
+        Session *s = sessionsByM2Rid.value(m2Rid);
+        if (!s) {
+            if (mreq.type == M2RequestPacket::HttpRequest && mreq.uploadStreamOffset > 0) {
+                log_warning("m2: id=%s stream offset > 0 but session unknown", mreq.id.data());
+                m2_writeCtlCancel(conn);
+                return;
+            }
+
+            if (mreq.type != M2RequestPacket::HttpRequest &&
+                mreq.type != M2RequestPacket::WebSocketHandshake) {
+                log_warning("m2: received unexpected starting packet type: %d", (int)mreq.type);
+                m2_writeCtlCancel(conn);
+                return;
+            }
+
+            QByteArray scheme;
+            if (mreq.type == M2RequestPacket::HttpRequest) {
+                if (mreq.scheme == "https")
+                    scheme = "https";
+                else
+                    scheme = "http";
+            } else // WebSocketHandshake
+            {
+                if (mreq.scheme == "https" || mreq.scheme == "wss")
+                    scheme = "wss";
+                else
+                    scheme = "ws";
+            }
+
+            QByteArray host = mreq.headers.get("Host").asQByteArray();
+            if (host.isEmpty())
+                host = "localhost";
+
+            if (!validateHost(host)) {
+                log_warning("m2: invalid host [%s]", host.data());
+                m2_writeErrorClose(conn);
+                return;
+            }
+
+            if (!mreq.uri.startsWith('/')) {
+                log_warning("m2: invalid uri [%s]", mreq.uri.data());
+                m2_writeErrorClose(conn);
+                return;
+            }
+
+            QByteArray uriRaw = scheme + "://" + host + mreq.uri;
+            Url uri = Url::fromEncoded(uriRaw, Url::TolerantMode);
+            if (!uri.isValid()) {
+                log_warning("m2: invalid constructed uri: [%s]", uriRaw.data());
+                m2_writeErrorClose(conn);
+                return;
+            }
+
+            if (maxSessions >= 0 &&
+                sessionsByZhttpRid.count() + sessionsByZwsRid.count() >= maxSessions) {
+                log_warning("m2: max open sessions reached (%d), refusing new session",
+                            maxSessions);
+                m2_writeErrorClose(conn);
+                return;
+            }
+
+            s = new Session;
+            s->conn = conn;
+            s->conn->session = s;
+            s->id = m2_send_idents[conn->identIndex] + '_' + conn->id + '_' +
+                    QByteArray::number((conn->subIdBase)++, 16);
+            s->method = mreq.method;
+
+            if (mreq.type == M2RequestPacket::HttpRequest) {
+                s->mode = Http;
+
+                if (mreq.version == "HTTP/1.0") {
+                    if (mreq.headers.getAll("Connection").contains("Keep-Alive")) {
+                        s->persistent = true;
+                        s->respondKeepAlive = true;
+                    }
+                } else if (mreq.version == "HTTP/1.1") {
+                    s->allowChunked = true;
+
+                    if (mreq.headers.getAll("Connection").contains("close"))
+                        s->respondClose = true;
+                    else
+                        s->persistent = true;
+                }
+
+                s->readCount += mreq.body.size();
+
+                if (!requestBodyMore)
+                    s->inFinished = true;
+            } else // WebSocketHandshake
+            {
+                s->mode = WebSocket;
+                s->acceptToken = mreq.body;
+            }
+
+            sessionsByM2Rid.insert(m2Rid, s);
+
+            qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+            s->lastActive = now;
+            sessionsByLastActive.insert(QPair<qint64, Session *>(s->lastActive, s), s);
+
+            if (mreq.type == M2RequestPacket::HttpRequest)
+                sessionsByZhttpRid.insert(Rid(zhttpInstanceId, s->id), s);
+            else // WebSocketHandshake
+                sessionsByZwsRid.insert(Rid(zwsInstanceId, s->id), s);
+
+            log_info("IN %s id=%s %s %s", m2_send_idents[s->conn->identIndex].data(),
+                     s->conn->id.data(), s->mode == Http ? qPrintable(mreq.method) : "GET",
+                     uri.toEncoded().data());
+
+            ZhttpRequestPacket zreq;
+
+            zreq.type = ZhttpRequestPacket::Data;
+            if (conn->outCreditsEnabled)
+                zreq.credits = conn->outCredits;
+            else
+                zreq.credits = m2_client_buffer;
+            zreq.uri = uri;
+            zreq.headers = mreq.headers;
+            zreq.peerAddress = mreq.remoteAddress;
+            if (mreq.type == M2RequestPacket::HttpRequest && zhttpConnectPort != -1)
+                zreq.connectPort = zhttpConnectPort;
+            else if (zwsConnectPort != -1) // WebSocketHandshake
+                zreq.connectPort = zwsConnectPort;
+            if (ignorePolicies)
+                zreq.ignorePolicies = true;
+
+            if (mreq.type == M2RequestPacket::HttpRequest) {
+                zreq.stream = true;
+                zreq.method = mreq.method;
+                zreq.body = mreq.body;
+                zreq.more = !s->inFinished;
+            }
+
+            zreq.multi = true;
+
+            zhttp_out_writeFirst(s, zreq);
+        } else {
+            assert(s->conn == conn);
+
+            if (mreq.type != M2RequestPacket::HttpRequest &&
+                mreq.type != M2RequestPacket::WebSocketFrame) {
+                log_warning("m2: received unexpected subsequent packet type: %d", (int)mreq.type);
+                endSession(s);
+                m2_writeCtlCancel(conn);
+                return;
+            }
+
+            if (mreq.type == M2RequestPacket::HttpRequest) {
+                int offset = 0;
+                if (mreq.uploadStreamOffset > 0)
+                    offset = mreq.uploadStreamOffset;
+
+                if (offset != s->readCount) {
+                    log_warning("m2: %s id=%s unexpected stream offset (got=%d, expected=%d)",
+                                m2_send_idents[s->conn->identIndex].data(), mreq.id.data(), offset,
+                                s->readCount);
+                    endSession(s);
+                    m2_writeCtlCancel(conn);
+                    return;
+                }
+
+                s->readCount += mreq.body.size();
+
+                if (!requestBodyMore)
+                    s->inFinished = true;
+            }
+
+            if (s->zhttpAddress.isEmpty()) {
+                log_error("m2: %s id=%s multiple packets from m2 before response from zhttp",
+                          m2_send_idents[s->conn->identIndex].data(), mreq.id.data());
+                endSession(s);
+                m2_writeCtlCancel(conn);
+                return;
+            }
+
+            if (mreq.type == M2RequestPacket::HttpRequest) {
+                if (s->inHandoff) {
+                    s->pendingIn += mreq.body;
+                } else {
+                    ZhttpRequestPacket zreq;
+                    zreq.type = ZhttpRequestPacket::Data;
+                    zreq.body = mreq.body;
+                    zreq.more = !s->inFinished;
+                    zhttp_out_write(s, zreq);
+                }
+            } else // WebSocketFrame
+            {
+                int opcode = mreq.frameFlags & 0x0f;
+                if (opcode != 1 && opcode != 2 && opcode != 8 && opcode != 9 && opcode != 10) {
+                    log_warning("m2: %s id=%s unsupported ws opcode: %d",
+                                m2_send_idents[s->conn->identIndex].data(), mreq.id.data(), opcode);
+                    endSession(s);
+                    m2_writeCtlCancel(conn);
+                    return;
+                }
+
+                if (s->downClosed) {
+                    log_debug("m2: %s id=%s ignoring frame after close",
+                              m2_send_idents[s->conn->identIndex].data(), mreq.id.data());
+                    return;
+                }
+
+                ZhttpRequestPacket zreq;
+
+                if (opcode == 1 || opcode == 2) {
+                    zreq.type = ZhttpRequestPacket::Data;
+                    if (opcode == 2)
+                        zreq.contentType = "binary";
+                    zreq.body = mreq.body;
+                } else if (opcode == 8) {
+                    zreq.type = ZhttpRequestPacket::Close;
+                    if (mreq.body.size() >= 2) {
+                        int hi = (unsigned char)mreq.body[0];
+                        int lo = (unsigned char)mreq.body[1];
+                        zreq.code = (hi << 8) + lo;
+                        zreq.body = mreq.body.mid(2);
+                    }
+
+                    s->downClosed = true;
+                } else if (opcode == 9) {
+                    zreq.type = ZhttpRequestPacket::Ping;
+                    zreq.body = mreq.body;
+                } else // 10
+                {
+                    zreq.type = ZhttpRequestPacket::Pong;
+                    zreq.body = mreq.body;
+                }
+
+                if (s->inHandoff) {
+                    s->pendingInPackets += zreq;
+                } else {
+                    zhttp_out_write(s, zreq);
+
+                    if (s->downClosed && s->upClosed) {
+                        destroySession(s); // We aren't in handoff so this is safe
+                        m2_queueClose(conn);
+                    }
+                }
+            }
+        }
+    }
+
+    void m2_control_readyRead(ZmqSocket *sock) {
+        int index = -1;
+        for (int n = 0; n < controlPorts.count(); ++n) {
+            if (controlPorts[n].sock == sock) {
+                index = n;
+                break;
+            }
+        }
+
+        assert(index != -1);
+        ControlPort &c = controlPorts[index];
+
+        while (sock->canRead()) {
+            CowByteArrayList message = sock->read();
+
+            if (message.count() != 2) {
+                log_warning("m2: received control response with parts != 2, skipping");
+                continue;
+            }
+
+            Variant data = TnetString::toVariant(message[1]);
+            if (data.isNull()) {
+                log_warning("m2: received control response with invalid format "
+                            "(tnetstring parse failed), skipping");
+                continue;
+            }
+
+            if (c.state != ControlPort::ExpectingResponse) {
+                log_warning("m2: received unexpected control response, skipping");
+                continue;
+            }
+
+            handleControlResponse(index, data);
+
+            bool needControlPort = false;
+            QHashIterator<Rid, M2Connection *> it(m2ConnectionsByRid);
+            while (it.hasNext()) {
+                it.next();
+                M2Connection *conn = it.value();
+                if (!conn->outCreditsEnabled)
+                    needControlPort = true;
+            }
+
+            if (needControlPort) {
+                c.state = ControlPort::Idle;
+            } else {
+                log_debug("deactivating control port index=%d", index);
+                c.state = ControlPort::Disabled;
+
+                bool allDisabled = true;
+                foreach (const ControlPort &i, controlPorts) {
+                    if (i.state != ControlPort::Disabled) {
+                        allDisabled = false;
+                        break;
+                    }
+                }
+                if (allDisabled)
+                    statusTimer->stop();
+            }
+
+            c.reqStartTime = -1;
+        }
+    }
+
+    void zhttp_in_readyRead(const CowByteArrayList &message) { handleZhttpIn(Http, message); }
+
+    void zws_in_readyRead(const CowByteArrayList &message) { handleZhttpIn(WebSocket, message); }
 
 private slots:
-	void status_timeout()
-	{
-		int now = time.elapsed();
+    void status_timeout() {
+        int now = time.elapsed();
 
-		for(int n = 0; n < controlPorts.count(); ++n)
-		{
-			ControlPort &c = controlPorts[n];
+        for (int n = 0; n < controlPorts.count(); ++n) {
+            ControlPort &c = controlPorts[n];
 
-			if(c.state == ControlPort::Disabled)
-				continue;
+            if (c.state == ControlPort::Disabled)
+                continue;
 
-			// If idle or expired, make request
-			if(c.state == ControlPort::Idle || (c.state == ControlPort::ExpectingResponse && c.reqStartTime + CONTROL_REQUEST_EXPIRE <= now))
-			{
-				// Query m2 for connection info (to track bytes written)
-				VariantHash cmdArgs;
-				cmdArgs["what"] = QByteArray("net");
-				c.state = ControlPort::ExpectingResponse;
-				c.reqStartTime = now;
-				m2_control_write(n, "status", cmdArgs);
-			}
-		}
-	}
+            // If idle or expired, make request
+            if (c.state == ControlPort::Idle || (c.state == ControlPort::ExpectingResponse &&
+                                                 c.reqStartTime + CONTROL_REQUEST_EXPIRE <= now)) {
+                // Query m2 for connection info (to track bytes written)
+                VariantHash cmdArgs;
+                cmdArgs["what"] = QByteArray("net");
+                c.state = ControlPort::ExpectingResponse;
+                c.reqStartTime = now;
+                m2_control_write(n, "status", cmdArgs);
+            }
+        }
+    }
 
-	void refresh_timeout()
-	{
-		qint64 now = QDateTime::currentMSecsSinceEpoch();
+    void refresh_timeout() {
+        qint64 now = QDateTime::currentMSecsSinceEpoch();
 
-		refreshM2Connections(now);
-		refreshSessions(now);
-		expireSessions(now);
-		cancelSessions();
-	}
+        refreshM2Connections(now);
+        refreshSessions(now);
+        expireSessions(now);
+        cancelSessions();
+    }
 
-	void reload()
-	{
-		log_info("reloading");
-		log_rotate();
-	}
+    void reload() {
+        log_info("reloading");
+        log_rotate();
+    }
 
-	void doQuit()
-	{
-		log_info("stopping...");
+    void doQuit() {
+        log_info("stopping...");
 
-		// Remove the handler, so if we get another signal then we crash out
-		ProcessQuit::cleanup();
+        // Remove the handler, so if we get another signal then we crash out
+        ProcessQuit::cleanup();
 
-		log_info("stopped");
-		q->quit(0);
-	}
+        log_info("stopped");
+        q->quit(0);
+    }
 };
 
-M2AdapterApp::M2AdapterApp(QObject *parent) :
-	QObject(parent)
-{
-	d = new Private(this);
-}
+M2AdapterApp::M2AdapterApp(QObject *parent) : QObject(parent) { d = new Private(this); }
 
-M2AdapterApp::~M2AdapterApp()
-{
-	delete d;
-}
+M2AdapterApp::~M2AdapterApp() { delete d; }
 
-void M2AdapterApp::start()
-{
-	d->start();
-}
+void M2AdapterApp::start() { d->start(); }
 
 #include "m2adapterapp.moc"

--- a/src/m2adapter/m2adapterapp.h
+++ b/src/m2adapter/m2adapterapp.h
@@ -30,22 +30,21 @@ using std::map;
 using SignalInt = boost::signals2::signal<void(int)>;
 using Connection = boost::signals2::scoped_connection;
 
-class M2AdapterApp : public QObject
-{
-	Q_OBJECT
+class M2AdapterApp : public QObject {
+    Q_OBJECT
 
 public:
-	M2AdapterApp(QObject *parent = 0);
-	~M2AdapterApp();
+    M2AdapterApp(QObject *parent = 0);
+    ~M2AdapterApp();
 
-	void start();
+    void start();
 
-	SignalInt quit;
+    SignalInt quit;
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 };
 
 #endif

--- a/src/m2adapter/m2adaptermain.cpp
+++ b/src/m2adapter/m2adaptermain.cpp
@@ -20,38 +20,33 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "m2adapterapp.h"
 #include <QCoreApplication>
 #include <QTimer>
-#include "m2adapterapp.h"
 
-class M2AdapterAppMain
-{
+class M2AdapterAppMain {
 public:
-	M2AdapterApp *app;
+    M2AdapterApp *app;
 
-	void start()
-	{
-		app = new M2AdapterApp;
-		app->quit.connect(boost::bind(&M2AdapterAppMain::app_quit, this, boost::placeholders::_1));
-		app->start();
-	}
+    void start() {
+        app = new M2AdapterApp;
+        app->quit.connect(boost::bind(&M2AdapterAppMain::app_quit, this, boost::placeholders::_1));
+        app->start();
+    }
 
-	void app_quit(int returnCode)
-	{
-		delete app;
-		QCoreApplication::exit(returnCode);
-	}
+    void app_quit(int returnCode) {
+        delete app;
+        QCoreApplication::exit(returnCode);
+    }
 };
 
 extern "C" {
 
-int m2adapter_main(int argc, char **argv)
-{
-	QCoreApplication qapp(argc, argv);
+int m2adapter_main(int argc, char **argv) {
+    QCoreApplication qapp(argc, argv);
 
-	M2AdapterAppMain appMain;
-	QTimer::singleShot(0, [&appMain]() {appMain.start();});
-	return qapp.exec();
+    M2AdapterAppMain appMain;
+    QTimer::singleShot(0, [&appMain]() { appMain.start(); });
+    return qapp.exec();
 }
-
 }

--- a/src/m2adapter/m2requestpacket.cpp
+++ b/src/m2adapter/m2requestpacket.cpp
@@ -23,281 +23,251 @@
 
 #include "m2requestpacket.h"
 
-#include <QSet>
+#include "qtcompat.h"
+#include "tnetstring.h"
+#include "variant.h"
 #include <QJsonDocument>
 #include <QJsonObject>
-#include "qtcompat.h"
-#include "variant.h"
-#include "tnetstring.h"
+#include <QSet>
 
-static bool isAllCaps(const QString &s)
-{
-	for(int n = 0; n < s.length(); ++n)
-	{
-		QChar c = s[n];
+static bool isAllCaps(const QString &s) {
+    for (int n = 0; n < s.length(); ++n) {
+        QChar c = s[n];
 
-		// Non-letters are allowed, so what we really check against is
-		// lowercase
-		if(c.isLower())
-			return false;
-	}
+        // Non-letters are allowed, so what we really check against is
+        // lowercase
+        if (c.isLower())
+            return false;
+    }
 
-	return true;
+    return true;
 }
 
-static QString makeMixedCaseHeader(const QString &s)
-{
-	QString out;
-	for(int n = 0; n < s.length(); ++n)
-	{
-		QChar c = s[n];
-		if(n == 0 || (n - 1 >= 0 && s[n - 1] == '-'))
-			out += c.toUpper();
-		else
-			out += c;
-	}
+static QString makeMixedCaseHeader(const QString &s) {
+    QString out;
+    for (int n = 0; n < s.length(); ++n) {
+        QChar c = s[n];
+        if (n == 0 || (n - 1 >= 0 && s[n - 1] == '-'))
+            out += c.toUpper();
+        else
+            out += c;
+    }
 
-	return out;
+    return out;
 }
 
-M2RequestPacket::M2RequestPacket() :
-	type((Type)-1),
-	uploadDone(false),
-	uploadStreamOffset(-1),
-	uploadStreamDone(false),
-	downloadCredits(-1),
-	frameFlags(0)
-{
-}
+M2RequestPacket::M2RequestPacket()
+    : type((Type)-1),
+      uploadDone(false),
+      uploadStreamOffset(-1),
+      uploadStreamDone(false),
+      downloadCredits(-1),
+      frameFlags(0) {}
 
-bool M2RequestPacket::fromByteArray(const QByteArray &in)
-{
-	int start = 0;
-	int end = in.indexOf(' ');
-	if(end == -1)
-		return false;
+bool M2RequestPacket::fromByteArray(const QByteArray &in) {
+    int start = 0;
+    int end = in.indexOf(' ');
+    if (end == -1)
+        return false;
 
-	sender = in.mid(start, end - start);
+    sender = in.mid(start, end - start);
 
-	start = end + 1;
-	end = in.indexOf(' ', start);
-	if(end == -1)
-		return false;
+    start = end + 1;
+    end = in.indexOf(' ', start);
+    if (end == -1)
+        return false;
 
-	id = in.mid(start, end - start);
+    id = in.mid(start, end - start);
 
-	start = end + 1;
-	end = in.indexOf(' ', start);
-	if(end == -1)
-		return false;
+    start = end + 1;
+    end = in.indexOf(' ', start);
+    if (end == -1)
+        return false;
 
-	start = end + 1;
-	TnetString::Type htype;
-	int offset, size;
-	if(!TnetString::check(in, start, &htype, &offset, &size))
-		return false;
+    start = end + 1;
+    TnetString::Type htype;
+    int offset, size;
+    if (!TnetString::check(in, start, &htype, &offset, &size))
+        return false;
 
-	if(htype != TnetString::Hash && htype != TnetString::ByteArray)
-		return false;
+    if (htype != TnetString::Hash && htype != TnetString::ByteArray)
+        return false;
 
-	bool ok;
-	Variant vheaders = TnetString::toVariant(in, start, htype, offset, size, &ok);
-	if(!ok)
-		return false;
+    bool ok;
+    Variant vheaders = TnetString::toVariant(in, start, htype, offset, size, &ok);
+    if (!ok)
+        return false;
 
-	QSet<QString> skipHeaders;
-	skipHeaders += "x-mongrel2-upload-start";
-	skipHeaders += "x-mongrel2-upload-done";
+    QSet<QString> skipHeaders;
+    skipHeaders += "x-mongrel2-upload-start";
+    skipHeaders += "x-mongrel2-upload-done";
 
-	headers.clear(); // Will store full headers
-	QMap<QString, QByteArray> m2headers; // Single-value map for easy processing
-	if(htype == TnetString::Hash)
-	{
-		VariantMap headersMap = vheaders.toMap();
-		for(auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit)
-		{
-			const QString &key = vit.key();
-			const Variant &val = vit.value();
+    headers.clear();                     // Will store full headers
+    QMap<QString, QByteArray> m2headers; // Single-value map for easy processing
+    if (htype == TnetString::Hash) {
+        VariantMap headersMap = vheaders.toMap();
+        for (auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit) {
+            const QString &key = vit.key();
+            const Variant &val = vit.value();
 
-			if(typeId(val) == VariantType::ByteArray)
-			{
-				QByteArray ba = val.toByteArray();
+            if (typeId(val) == VariantType::ByteArray) {
+                QByteArray ba = val.toByteArray();
 
-				m2headers[key] = ba;
+                m2headers[key] = ba;
 
-				if(!isAllCaps(key) && !skipHeaders.contains(key))
-					headers += HttpHeader(makeMixedCaseHeader(key).toLatin1(), ba);
-			}
-			else if(typeId(val) == VariantType::List)
-			{
-				VariantList vl = val.toList();
-				if(vl.isEmpty())
-					return false;
+                if (!isAllCaps(key) && !skipHeaders.contains(key))
+                    headers += HttpHeader(makeMixedCaseHeader(key).toLatin1(), ba);
+            } else if (typeId(val) == VariantType::List) {
+                VariantList vl = val.toList();
+                if (vl.isEmpty())
+                    return false;
 
-				if(typeId(vl[0]) != VariantType::ByteArray)
-					return false;
+                if (typeId(vl[0]) != VariantType::ByteArray)
+                    return false;
 
-				m2headers[key] = vl[0].toByteArray();
+                m2headers[key] = vl[0].toByteArray();
 
-				if(!isAllCaps(key) && !skipHeaders.contains(key))
-				{
-					QByteArray name = makeMixedCaseHeader(key).toLatin1();
+                if (!isAllCaps(key) && !skipHeaders.contains(key)) {
+                    QByteArray name = makeMixedCaseHeader(key).toLatin1();
 
-					for(const Variant &v : vl)
-					{
-						if(typeId(v) != VariantType::ByteArray)
-							return false;
+                    for (const Variant &v : vl) {
+                        if (typeId(v) != VariantType::ByteArray)
+                            return false;
 
-						headers += HttpHeader(name, v.toByteArray());
-					}
-				}
-			}
-			else
-				return false;
-		}
-	}
-	else // ByteArray
-	{
-		QJsonParseError error;
-		QJsonDocument doc = QJsonDocument::fromJson(vheaders.toByteArray(), &error);
-		if(error.error != QJsonParseError::NoError || !doc.isObject())
-			return false;
+                        headers += HttpHeader(name, v.toByteArray());
+                    }
+                }
+            } else
+                return false;
+        }
+    } else // ByteArray
+    {
+        QJsonParseError error;
+        QJsonDocument doc = QJsonDocument::fromJson(vheaders.toByteArray(), &error);
+        if (error.error != QJsonParseError::NoError || !doc.isObject())
+            return false;
 
-		VariantMap headersMap = doc.object().toVariantMap();
-		for(auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit)
-		{
-			const QString &key = vit.key();
-			const Variant &val = vit.value();
+        VariantMap headersMap = doc.object().toVariantMap();
+        for (auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit) {
+            const QString &key = vit.key();
+            const Variant &val = vit.value();
 
-			if(typeId(val) == VariantType::String)
-			{
-				QByteArray ba = val.toString().toUtf8();
+            if (typeId(val) == VariantType::String) {
+                QByteArray ba = val.toString().toUtf8();
 
-				m2headers[key] = ba;
+                m2headers[key] = ba;
 
-				if(!isAllCaps(key) && !skipHeaders.contains(key))
-					headers += HttpHeader(makeMixedCaseHeader(key).toLatin1(), ba);
-			}
-			else if(typeId(val) == VariantType::List)
-			{
-				VariantList vl = val.toList();
-				if(vl.isEmpty())
-					return false;
+                if (!isAllCaps(key) && !skipHeaders.contains(key))
+                    headers += HttpHeader(makeMixedCaseHeader(key).toLatin1(), ba);
+            } else if (typeId(val) == VariantType::List) {
+                VariantList vl = val.toList();
+                if (vl.isEmpty())
+                    return false;
 
-				if(typeId(vl[0]) != VariantType::String)
-					return false;
+                if (typeId(vl[0]) != VariantType::String)
+                    return false;
 
-				m2headers[key] = vl[0].toString().toUtf8();
+                m2headers[key] = vl[0].toString().toUtf8();
 
-				if(!isAllCaps(key) && !skipHeaders.contains(key))
-				{
-					QByteArray name = makeMixedCaseHeader(key).toLatin1();
+                if (!isAllCaps(key) && !skipHeaders.contains(key)) {
+                    QByteArray name = makeMixedCaseHeader(key).toLatin1();
 
-					for(const Variant &v : vl)
-					{
-						if(typeId(v) != VariantType::String)
-							return false;
+                    for (const Variant &v : vl) {
+                        if (typeId(v) != VariantType::String)
+                            return false;
 
-						headers += HttpHeader(name, v.toString().toUtf8());
-					}
-				}
-			}
-			else
-				return false;
-		}
-	}
+                        headers += HttpHeader(name, v.toString().toUtf8());
+                    }
+                }
+            } else
+                return false;
+        }
+    }
 
-	start = offset + size + 1;
-	TnetString::Type btype;
-	if(!TnetString::check(in, start, &btype, &offset, &size))
-		return false;
+    start = offset + size + 1;
+    TnetString::Type btype;
+    if (!TnetString::check(in, start, &btype, &offset, &size))
+        return false;
 
-	if(btype != TnetString::ByteArray)
-		return false;
+    if (btype != TnetString::ByteArray)
+        return false;
 
-	body = TnetString::toByteArray(in, start, offset, size, &ok);
-	if(!ok)
-		return false;
+    body = TnetString::toByteArray(in, start, offset, size, &ok);
+    if (!ok)
+        return false;
 
-	scheme = m2headers.value("URL_SCHEME");
-	version = m2headers.value("VERSION");
+    scheme = m2headers.value("URL_SCHEME");
+    version = m2headers.value("VERSION");
 
-	QByteArray m2method = m2headers.value("METHOD");
+    QByteArray m2method = m2headers.value("METHOD");
 
-	if(m2headers.contains("DOWNLOAD_CREDITS"))
-		downloadCredits = m2headers.value("DOWNLOAD_CREDITS").toInt();
+    if (m2headers.contains("DOWNLOAD_CREDITS"))
+        downloadCredits = m2headers.value("DOWNLOAD_CREDITS").toInt();
 
-	if(m2method == "JSON")
-	{
-		QJsonParseError error;
-		QJsonDocument doc = QJsonDocument::fromJson(body, &error);
-		if(error.error != QJsonParseError::NoError || !doc.isObject())
-			return false;
+    if (m2method == "JSON") {
+        QJsonParseError error;
+        QJsonDocument doc = QJsonDocument::fromJson(body, &error);
+        if (error.error != QJsonParseError::NoError || !doc.isObject())
+            return false;
 
-		VariantMap data = doc.object().toVariantMap();
-		if(!data.contains("type") || typeId(data["type"]) != VariantType::String)
-			return false;
+        VariantMap data = doc.object().toVariantMap();
+        if (!data.contains("type") || typeId(data["type"]) != VariantType::String)
+            return false;
 
-		QString jtype = data["type"].toString();
+        QString jtype = data["type"].toString();
 
-		if(jtype == "disconnect")
-			type = Disconnect;
-		else if(jtype == "credits")
-			type = Credits;
-		else
-			return false;
+        if (jtype == "disconnect")
+            type = Disconnect;
+        else if (jtype == "credits")
+            type = Credits;
+        else
+            return false;
 
-		return true;
-	}
+        return true;
+    }
 
-	QByteArray m2RemoteAddr = m2headers.value("REMOTE_ADDR");
+    QByteArray m2RemoteAddr = m2headers.value("REMOTE_ADDR");
 
-	method = QString::fromLatin1(m2method);
-	uri = m2headers.value("URI");
+    method = QString::fromLatin1(m2method);
+    uri = m2headers.value("URI");
 
-	remoteAddress = QHostAddress();
-	if(!m2RemoteAddr.isEmpty())
-		remoteAddress = QHostAddress(QString::fromLatin1(m2RemoteAddr));
+    remoteAddress = QHostAddress();
+    if (!m2RemoteAddr.isEmpty())
+        remoteAddress = QHostAddress(QString::fromLatin1(m2RemoteAddr));
 
-	if(m2method == "WEBSOCKET_HANDSHAKE")
-	{
-		type = WebSocketHandshake;
-		return true;
-	}
-	else if(m2method == "WEBSOCKET")
-	{
-		type = WebSocketFrame;
+    if (m2method == "WEBSOCKET_HANDSHAKE") {
+        type = WebSocketHandshake;
+        return true;
+    } else if (m2method == "WEBSOCKET") {
+        type = WebSocketFrame;
 
-		QByteArray flagsStr = m2headers.value("FLAGS");
-		frameFlags = flagsStr.toInt(&ok, 16);
-		return ok;
-	}
+        QByteArray flagsStr = m2headers.value("FLAGS");
+        frameFlags = flagsStr.toInt(&ok, 16);
+        return ok;
+    }
 
-	type = HttpRequest;
+    type = HttpRequest;
 
-	QByteArray uploadStartRaw = m2headers.value("x-mongrel2-upload-start");
-	QByteArray uploadDoneRaw = m2headers.value("x-mongrel2-upload-done");
-	if(!uploadDoneRaw.isEmpty())
-	{
-		// These headers must match for the packet to be valid. Not
-		// sure why mongrel2 can't enforce this for us but whatever
-		if(uploadStartRaw != uploadDoneRaw)
-			return false;
+    QByteArray uploadStartRaw = m2headers.value("x-mongrel2-upload-start");
+    QByteArray uploadDoneRaw = m2headers.value("x-mongrel2-upload-done");
+    if (!uploadDoneRaw.isEmpty()) {
+        // These headers must match for the packet to be valid. Not
+        // sure why mongrel2 can't enforce this for us but whatever
+        if (uploadStartRaw != uploadDoneRaw)
+            return false;
 
-		uploadFile = QString::fromUtf8(uploadDoneRaw);
-		uploadDone = true;
-	}
-	else if(!uploadStartRaw.isEmpty())
-	{
-		uploadFile = QString::fromUtf8(uploadStartRaw);
-	}
+        uploadFile = QString::fromUtf8(uploadDoneRaw);
+        uploadDone = true;
+    } else if (!uploadStartRaw.isEmpty()) {
+        uploadFile = QString::fromUtf8(uploadStartRaw);
+    }
 
-	QByteArray uploadStreamRaw = m2headers.value("UPLOAD_STREAM");
-	QByteArray uploadStreamDoneRaw = m2headers.value("UPLOAD_STREAM_DONE");
-	if(!uploadStreamRaw.isEmpty())
-		uploadStreamOffset = uploadStreamRaw.toInt();
-	if(!uploadStreamDoneRaw.isEmpty() && uploadStreamDoneRaw != "0")
-		uploadStreamDone = true;
+    QByteArray uploadStreamRaw = m2headers.value("UPLOAD_STREAM");
+    QByteArray uploadStreamDoneRaw = m2headers.value("UPLOAD_STREAM_DONE");
+    if (!uploadStreamRaw.isEmpty())
+        uploadStreamOffset = uploadStreamRaw.toInt();
+    if (!uploadStreamDoneRaw.isEmpty() && uploadStreamDoneRaw != "0")
+        uploadStreamDone = true;
 
-	return true;
+    return true;
 }

--- a/src/m2adapter/m2requestpacket.h
+++ b/src/m2adapter/m2requestpacket.h
@@ -23,47 +23,45 @@
 #ifndef M2REQUESTPACKET_H
 #define M2REQUESTPACKET_H
 
-#include <QHostAddress>
 #include "httpheaders.h"
+#include <QHostAddress>
 
-class M2RequestPacket
-{
+class M2RequestPacket {
 public:
-	enum Type
-	{
-		HttpRequest,
-		WebSocketHandshake, // Body will contain accept token
-		WebSocketFrame,
-		Disconnect,
-		Credits
-	};
+    enum Type {
+        HttpRequest,
+        WebSocketHandshake, // Body will contain accept token
+        WebSocketFrame,
+        Disconnect,
+        Credits
+    };
 
-	QByteArray sender;
-	QByteArray id;
+    QByteArray sender;
+    QByteArray id;
 
-	Type type;
+    Type type;
 
-	QHostAddress remoteAddress;
-	QByteArray scheme;
-	QByteArray version;
-	QString method;
-	QByteArray uri;
-	HttpHeaders headers;
-	QByteArray body;
+    QHostAddress remoteAddress;
+    QByteArray scheme;
+    QByteArray version;
+    QString method;
+    QByteArray uri;
+    HttpHeaders headers;
+    QByteArray body;
 
-	QString uploadFile;
-	bool uploadDone;
+    QString uploadFile;
+    bool uploadDone;
 
-	int uploadStreamOffset;
-	bool uploadStreamDone;
+    int uploadStreamOffset;
+    bool uploadStreamDone;
 
-	int downloadCredits;
+    int downloadCredits;
 
-	int frameFlags;
+    int frameFlags;
 
-	M2RequestPacket();
+    M2RequestPacket();
 
-	bool fromByteArray(const QByteArray &in);
+    bool fromByteArray(const QByteArray &in);
 };
 
 #endif

--- a/src/m2adapter/m2responsepacket.cpp
+++ b/src/m2adapter/m2responsepacket.cpp
@@ -24,11 +24,8 @@
 
 #include "tnetstring.h"
 
-M2ResponsePacket::M2ResponsePacket()
-{
-}
+M2ResponsePacket::M2ResponsePacket() {}
 
-QByteArray M2ResponsePacket::toByteArray() const
-{
-	return sender + ' ' + TnetString::fromByteArray(id) + ' ' + data;
+QByteArray M2ResponsePacket::toByteArray() const {
+    return sender + ' ' + TnetString::fromByteArray(id) + ' ' + data;
 }

--- a/src/m2adapter/m2responsepacket.h
+++ b/src/m2adapter/m2responsepacket.h
@@ -25,16 +25,15 @@
 
 #include <QByteArray>
 
-class M2ResponsePacket
-{
+class M2ResponsePacket {
 public:
-	QByteArray sender;
-	QByteArray id;
-	QByteArray data;
+    QByteArray sender;
+    QByteArray id;
+    QByteArray data;
 
-	M2ResponsePacket();
+    M2ResponsePacket();
 
-	QByteArray toByteArray() const;
+    QByteArray toByteArray() const;
 };
 
 #endif

--- a/src/proxy/acceptdata.h
+++ b/src/proxy/acceptdata.h
@@ -24,86 +24,80 @@
 #ifndef ACCEPTDATA_H
 #define ACCEPTDATA_H
 
-#include <QList>
-#include "variant.h"
 #include "httpheaders.h"
+#include "inspectdata.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
-#include "inspectdata.h"
+#include "variant.h"
 #include "zhttprequest.h"
+#include <QList>
 
 /// Data container for HTTP accept request/response info passed to handler
-class AcceptData
-{
+class AcceptData {
 public:
-	class Request
-	{
-	public:
-		ZhttpRequest::Rid rid;
-		bool https;
-		QHostAddress peerAddress;
-		QHostAddress logicalPeerAddress;
-		bool debug;
-		bool isRetry;
-		bool autoCrossOrigin;
-		QByteArray jsonpCallback;
-		bool jsonpExtendedResponse;
-		int unreportedTime;
+    class Request {
+    public:
+        ZhttpRequest::Rid rid;
+        bool https;
+        QHostAddress peerAddress;
+        QHostAddress logicalPeerAddress;
+        bool debug;
+        bool isRetry;
+        bool autoCrossOrigin;
+        QByteArray jsonpCallback;
+        bool jsonpExtendedResponse;
+        int unreportedTime;
 
-		// Zhttp
-		int responseCode;
-		int inSeq;
-		int outSeq;
-		int outCredits;
-		bool routerResp;
-		Variant userData;
+        // Zhttp
+        int responseCode;
+        int inSeq;
+        int outSeq;
+        int outCredits;
+        bool routerResp;
+        Variant userData;
 
-		Request() :
-			https(false),
-			debug(false),
-			isRetry(false),
-			autoCrossOrigin(false),
-			jsonpExtendedResponse(false),
-			unreportedTime(-1),
-			responseCode(-1),
-			inSeq(-1),
-			outSeq(-1),
-			outCredits(-1),
-			routerResp(false)
-		{
-		}
-	};
+        Request()
+            : https(false),
+              debug(false),
+              isRetry(false),
+              autoCrossOrigin(false),
+              jsonpExtendedResponse(false),
+              unreportedTime(-1),
+              responseCode(-1),
+              inSeq(-1),
+              outSeq(-1),
+              outCredits(-1),
+              routerResp(false) {}
+    };
 
-	QList<Request> requests;
-	HttpRequestData requestData;
-	HttpRequestData origRequestData;
+    QList<Request> requests;
+    HttpRequestData requestData;
+    HttpRequestData origRequestData;
 
-	bool haveInspectData;
-	InspectData inspectData;
+    bool haveInspectData;
+    InspectData inspectData;
 
-	bool haveResponse;
-	HttpResponseData response;
+    bool haveResponse;
+    HttpResponseData response;
 
-	QByteArray route;
-	bool separateStats;
-	QByteArray channelPrefix;
-	int logLevel;
-	QList<QByteArray> channels;
-	bool trusted; // Whether a trusted target was used
-	bool useSession;
-	bool responseSent;
-	VariantList connMaxPackets;
+    QByteArray route;
+    bool separateStats;
+    QByteArray channelPrefix;
+    int logLevel;
+    QList<QByteArray> channels;
+    bool trusted; // Whether a trusted target was used
+    bool useSession;
+    bool responseSent;
+    VariantList connMaxPackets;
 
-	AcceptData() :
-		haveInspectData(false),
-		haveResponse(false),
-		separateStats(false),
-		logLevel(-1),
-		trusted(false),
-		useSession(false),
-		responseSent(false)
-	{
-	}
+    AcceptData()
+        : haveInspectData(false),
+          haveResponse(false),
+          separateStats(false),
+          logLevel(-1),
+          trusted(false),
+          useSession(false),
+          responseSent(false) {}
 };
 
 #endif

--- a/src/proxy/acceptrequest.cpp
+++ b/src/proxy/acceptrequest.cpp
@@ -23,344 +23,305 @@
 
 #include "acceptrequest.h"
 
+#include "acceptdata.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include "acceptdata.h"
 
-static Variant acceptDataToVariant(const AcceptData &adata)
-{
-	VariantHash obj;
+static Variant acceptDataToVariant(const AcceptData &adata) {
+    VariantHash obj;
 
-	{
-		VariantList vrequests;
-		foreach(const AcceptData::Request &r, adata.requests)
-		{
-			VariantHash vrequest;
+    {
+        VariantList vrequests;
+        foreach (const AcceptData::Request &r, adata.requests) {
+            VariantHash vrequest;
 
-			VariantHash vrid;
-			vrid["sender"] = r.rid.first;
-			vrid["id"] = r.rid.second;
+            VariantHash vrid;
+            vrid["sender"] = r.rid.first;
+            vrid["id"] = r.rid.second;
 
-			vrequest["rid"] = vrid;
+            vrequest["rid"] = vrid;
 
-			if(r.https)
-				vrequest["https"] = true;
+            if (r.https)
+                vrequest["https"] = true;
 
-			if(!r.peerAddress.isNull())
-				vrequest["peer-address"] = r.peerAddress.toString().toUtf8();
+            if (!r.peerAddress.isNull())
+                vrequest["peer-address"] = r.peerAddress.toString().toUtf8();
 
-			if(!r.logicalPeerAddress.isNull())
-				vrequest["logical-peer-address"] = r.logicalPeerAddress.toString().toUtf8();
+            if (!r.logicalPeerAddress.isNull())
+                vrequest["logical-peer-address"] = r.logicalPeerAddress.toString().toUtf8();
 
-			if(r.debug)
-				vrequest["debug"] = true;
+            if (r.debug)
+                vrequest["debug"] = true;
 
-			if(r.isRetry)
-				vrequest["is-retry"] = true;
+            if (r.isRetry)
+                vrequest["is-retry"] = true;
 
-			if(r.autoCrossOrigin)
-				vrequest["auto-cross-origin"] = true;
+            if (r.autoCrossOrigin)
+                vrequest["auto-cross-origin"] = true;
 
-			if(!r.jsonpCallback.isEmpty())
-			{
-				vrequest["jsonp-callback"] = r.jsonpCallback;
+            if (!r.jsonpCallback.isEmpty()) {
+                vrequest["jsonp-callback"] = r.jsonpCallback;
 
-				if(r.jsonpExtendedResponse)
-					vrequest["jsonp-extended-response"] = true;
-			}
+                if (r.jsonpExtendedResponse)
+                    vrequest["jsonp-extended-response"] = true;
+            }
 
-			if(r.unreportedTime > 0)
-				vrequest["unreported-time"] = r.unreportedTime;
+            if (r.unreportedTime > 0)
+                vrequest["unreported-time"] = r.unreportedTime;
 
-			if(r.responseCode != -1)
-				vrequest["response-code"] = r.responseCode;
+            if (r.responseCode != -1)
+                vrequest["response-code"] = r.responseCode;
 
-			vrequest["in-seq"] = r.inSeq;
-			vrequest["out-seq"] = r.outSeq;
-			vrequest["out-credits"] = r.outCredits;
+            vrequest["in-seq"] = r.inSeq;
+            vrequest["out-seq"] = r.outSeq;
+            vrequest["out-credits"] = r.outCredits;
 
-			if(r.routerResp)
-				vrequest["router-resp"] = true;
+            if (r.routerResp)
+                vrequest["router-resp"] = true;
 
-			if(r.userData.isValid())
-				vrequest["user-data"] = r.userData;
+            if (r.userData.isValid())
+                vrequest["user-data"] = r.userData;
 
-			vrequests += vrequest;
-		}
+            vrequests += vrequest;
+        }
 
-		obj["requests"] = vrequests;
-	}
+        obj["requests"] = vrequests;
+    }
 
-	{
-		const HttpRequestData &requestData = adata.requestData;
-		VariantHash vrequestData;
+    {
+        const HttpRequestData &requestData = adata.requestData;
+        VariantHash vrequestData;
 
-		vrequestData["method"] = requestData.method.toLatin1();
-		vrequestData["uri"] = requestData.uri.toEncoded();
+        vrequestData["method"] = requestData.method.toLatin1();
+        vrequestData["uri"] = requestData.uri.toEncoded();
 
-		VariantList vheaders;
-		foreach(const HttpHeader &h, requestData.headers)
-		{
-			VariantList vheader;
-			vheader += h.first.asQByteArray();
-			vheader += h.second.asQByteArray();
-			vheaders += Variant(vheader);
-		}
+        VariantList vheaders;
+        foreach (const HttpHeader &h, requestData.headers) {
+            VariantList vheader;
+            vheader += h.first.asQByteArray();
+            vheader += h.second.asQByteArray();
+            vheaders += Variant(vheader);
+        }
 
-		vrequestData["headers"] = vheaders;
+        vrequestData["headers"] = vheaders;
 
-		vrequestData["body"] = requestData.body;
+        vrequestData["body"] = requestData.body;
 
-		obj["request-data"] = vrequestData;
-	}
+        obj["request-data"] = vrequestData;
+    }
 
-	{
-		const HttpRequestData &requestData = adata.origRequestData;
-		VariantHash vrequestData;
+    {
+        const HttpRequestData &requestData = adata.origRequestData;
+        VariantHash vrequestData;
 
-		vrequestData["method"] = requestData.method.toLatin1();
-		vrequestData["uri"] = requestData.uri.toEncoded();
+        vrequestData["method"] = requestData.method.toLatin1();
+        vrequestData["uri"] = requestData.uri.toEncoded();
 
-		VariantList vheaders;
-		foreach(const HttpHeader &h, requestData.headers)
-		{
-			VariantList vheader;
-			vheader += h.first.asQByteArray();
-			vheader += h.second.asQByteArray();
-			vheaders += Variant(vheader);
-		}
+        VariantList vheaders;
+        foreach (const HttpHeader &h, requestData.headers) {
+            VariantList vheader;
+            vheader += h.first.asQByteArray();
+            vheader += h.second.asQByteArray();
+            vheaders += Variant(vheader);
+        }
 
-		vrequestData["headers"] = vheaders;
+        vrequestData["headers"] = vheaders;
 
-		vrequestData["body"] = requestData.body;
+        vrequestData["body"] = requestData.body;
 
-		obj["orig-request-data"] = vrequestData;
-	}
+        obj["orig-request-data"] = vrequestData;
+    }
 
-	if(adata.haveInspectData)
-	{
-		VariantHash vinspect;
+    if (adata.haveInspectData) {
+        VariantHash vinspect;
 
-		vinspect["no-proxy"] = !adata.inspectData.doProxy;
+        vinspect["no-proxy"] = !adata.inspectData.doProxy;
 
-		if(!adata.inspectData.sharingKey.isEmpty())
-			vinspect["sharing-key"] = adata.inspectData.sharingKey;
+        if (!adata.inspectData.sharingKey.isEmpty())
+            vinspect["sharing-key"] = adata.inspectData.sharingKey;
 
-		if(!adata.inspectData.sid.isEmpty())
-			vinspect["sid"] = adata.inspectData.sid;
+        if (!adata.inspectData.sid.isEmpty())
+            vinspect["sid"] = adata.inspectData.sid;
 
-		if(!adata.inspectData.lastIds.isEmpty())
-		{
-			VariantHash vlastIds;
-			QHashIterator<QByteArray, QByteArray> it(adata.inspectData.lastIds);
-			while(it.hasNext())
-			{
-				it.next();
-				vlastIds[QString::fromUtf8(it.key())] = it.value();
-			}
+        if (!adata.inspectData.lastIds.isEmpty()) {
+            VariantHash vlastIds;
+            QHashIterator<QByteArray, QByteArray> it(adata.inspectData.lastIds);
+            while (it.hasNext()) {
+                it.next();
+                vlastIds[QString::fromUtf8(it.key())] = it.value();
+            }
 
-			vinspect["last-ids"] = vlastIds;
-		}
+            vinspect["last-ids"] = vlastIds;
+        }
 
-		if(adata.inspectData.userData.isValid())
-			vinspect["user-data"] = adata.inspectData.userData;
+        if (adata.inspectData.userData.isValid())
+            vinspect["user-data"] = adata.inspectData.userData;
 
-		obj["inspect"] = vinspect;
-	}
+        obj["inspect"] = vinspect;
+    }
 
-	if(adata.haveResponse)
-	{
-		VariantHash vresponse;
+    if (adata.haveResponse) {
+        VariantHash vresponse;
 
-		vresponse["code"] = adata.response.code;
-		vresponse["reason"] = adata.response.reason;
+        vresponse["code"] = adata.response.code;
+        vresponse["reason"] = adata.response.reason;
 
-		VariantList vheaders;
-		foreach(const HttpHeader &h, adata.response.headers)
-		{
-			VariantList vheader;
-			vheader += h.first.asQByteArray();
-			vheader += h.second.asQByteArray();
-			vheaders += Variant(vheader);
-		}
-		vresponse["headers"] = vheaders;
+        VariantList vheaders;
+        foreach (const HttpHeader &h, adata.response.headers) {
+            VariantList vheader;
+            vheader += h.first.asQByteArray();
+            vheader += h.second.asQByteArray();
+            vheaders += Variant(vheader);
+        }
+        vresponse["headers"] = vheaders;
 
-		vresponse["body"] = adata.response.body;
+        vresponse["body"] = adata.response.body;
 
-		obj["response"] = vresponse;
-	}
+        obj["response"] = vresponse;
+    }
 
-	if(!adata.route.isEmpty())
-		obj["route"] = adata.route;
+    if (!adata.route.isEmpty())
+        obj["route"] = adata.route;
 
-	if(adata.separateStats)
-		obj["separate-stats"] = true;
+    if (adata.separateStats)
+        obj["separate-stats"] = true;
 
-	if(!adata.channelPrefix.isEmpty())
-		obj["channel-prefix"] = adata.channelPrefix;
+    if (!adata.channelPrefix.isEmpty())
+        obj["channel-prefix"] = adata.channelPrefix;
 
-	if(adata.logLevel >= 0)
-		obj["log-level"] = adata.logLevel;
+    if (adata.logLevel >= 0)
+        obj["log-level"] = adata.logLevel;
 
-	if(!adata.channels.isEmpty())
-	{
-		VariantList vchannels;
-		foreach(const QByteArray &channel, adata.channels)
-			vchannels += channel;
-		obj["channels"] = vchannels;
-	}
+    if (!adata.channels.isEmpty()) {
+        VariantList vchannels;
+        foreach (const QByteArray &channel, adata.channels)
+            vchannels += channel;
+        obj["channels"] = vchannels;
+    }
 
-	if(adata.trusted)
-		obj["trusted"] = true;
+    if (adata.trusted)
+        obj["trusted"] = true;
 
-	if(adata.useSession)
-		obj["use-session"] = true;
+    if (adata.useSession)
+        obj["use-session"] = true;
 
-	if(adata.responseSent)
-		obj["response-sent"] = true;
+    if (adata.responseSent)
+        obj["response-sent"] = true;
 
-	if(!adata.connMaxPackets.isEmpty())
-		obj["conn-max"] = adata.connMaxPackets;
+    if (!adata.connMaxPackets.isEmpty())
+        obj["conn-max"] = adata.connMaxPackets;
 
-	return obj;
+    return obj;
 }
 
-static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok)
-{
-	AcceptRequest::ResponseData out;
+static AcceptRequest::ResponseData convertResult(const Variant &in, bool *ok) {
+    AcceptRequest::ResponseData out;
 
-	if(typeId(in) != VariantType::Hash)
-	{
-		*ok = false;
-		return AcceptRequest::ResponseData();
-	}
+    if (typeId(in) != VariantType::Hash) {
+        *ok = false;
+        return AcceptRequest::ResponseData();
+    }
 
-	VariantHash obj = in.toHash();
+    VariantHash obj = in.toHash();
 
-	if(obj.contains("accepted"))
-	{
-		if(typeId(obj["accepted"]) != VariantType::Bool)
-		{
-			*ok = false;
-			return AcceptRequest::ResponseData();
-		}
+    if (obj.contains("accepted")) {
+        if (typeId(obj["accepted"]) != VariantType::Bool) {
+            *ok = false;
+            return AcceptRequest::ResponseData();
+        }
 
-		out.accepted = obj["accepted"].toBool();
-	}
+        out.accepted = obj["accepted"].toBool();
+    }
 
-	if(obj.contains("response"))
-	{
-		if(typeId(obj["response"]) != VariantType::Hash)
-		{
-			*ok = false;
-			return AcceptRequest::ResponseData();
-		}
+    if (obj.contains("response")) {
+        if (typeId(obj["response"]) != VariantType::Hash) {
+            *ok = false;
+            return AcceptRequest::ResponseData();
+        }
 
-		VariantHash vresponse = obj["response"].toHash();
+        VariantHash vresponse = obj["response"].toHash();
 
-		if(vresponse.contains("code"))
-		{
-			if(!canConvert(vresponse["code"], VariantType::Int))
-			{
-				*ok = false;
-				return AcceptRequest::ResponseData();
-			}
+        if (vresponse.contains("code")) {
+            if (!canConvert(vresponse["code"], VariantType::Int)) {
+                *ok = false;
+                return AcceptRequest::ResponseData();
+            }
 
-			out.response.code = vresponse["code"].toInt();
-		}
+            out.response.code = vresponse["code"].toInt();
+        }
 
-		if(vresponse.contains("reason"))
-		{
-			if(typeId(vresponse["reason"]) != VariantType::ByteArray)
-			{
-				*ok = false;
-				return AcceptRequest::ResponseData();
-			}
+        if (vresponse.contains("reason")) {
+            if (typeId(vresponse["reason"]) != VariantType::ByteArray) {
+                *ok = false;
+                return AcceptRequest::ResponseData();
+            }
 
-			out.response.reason = vresponse["reason"].toByteArray();
-		}
+            out.response.reason = vresponse["reason"].toByteArray();
+        }
 
-		if(vresponse.contains("headers"))
-		{
-			if(typeId(vresponse["headers"]) != VariantType::List)
-			{
-				*ok = false;
-				return AcceptRequest::ResponseData();
-			}
+        if (vresponse.contains("headers")) {
+            if (typeId(vresponse["headers"]) != VariantType::List) {
+                *ok = false;
+                return AcceptRequest::ResponseData();
+            }
 
-			for(const Variant &i : vresponse["headers"].toList())
-			{
-				VariantList list = i.toList();
-				if(list.count() != 2)
-				{
-					*ok = false;
-					return AcceptRequest::ResponseData();
-				}
+            for (const Variant &i : vresponse["headers"].toList()) {
+                VariantList list = i.toList();
+                if (list.count() != 2) {
+                    *ok = false;
+                    return AcceptRequest::ResponseData();
+                }
 
-				if(typeId(list[0]) != VariantType::ByteArray || typeId(list[1]) != VariantType::ByteArray)
-				{
-					*ok = false;
-					return AcceptRequest::ResponseData();
-				}
+                if (typeId(list[0]) != VariantType::ByteArray ||
+                    typeId(list[1]) != VariantType::ByteArray) {
+                    *ok = false;
+                    return AcceptRequest::ResponseData();
+                }
 
-				out.response.headers += QPair<QByteArray, QByteArray>(list[0].toByteArray(), list[1].toByteArray());
-			}
-		}
+                out.response.headers +=
+                    QPair<QByteArray, QByteArray>(list[0].toByteArray(), list[1].toByteArray());
+            }
+        }
 
-		if(vresponse.contains("body"))
-		{
-			if(typeId(vresponse["body"]) != VariantType::ByteArray)
-			{
-				*ok = false;
-				return AcceptRequest::ResponseData();
-			}
+        if (vresponse.contains("body")) {
+            if (typeId(vresponse["body"]) != VariantType::ByteArray) {
+                *ok = false;
+                return AcceptRequest::ResponseData();
+            }
 
-			out.response.body = vresponse["body"].toByteArray();
-		}
-	}
+            out.response.body = vresponse["body"].toByteArray();
+        }
+    }
 
-	*ok = true;
-	return out;
+    *ok = true;
+    return out;
 }
 
-class AcceptRequest::Private
-{
+class AcceptRequest::Private {
 public:
-	AcceptRequest *q;
-	ResponseData result;
+    AcceptRequest *q;
+    ResponseData result;
 
-	Private(AcceptRequest *_q) :
-		q(_q)
-	{
-	}
+    Private(AcceptRequest *_q) : q(_q) {}
 };
 
-AcceptRequest::AcceptRequest(ZrpcManager *manager) :
-	ZrpcRequest(manager)
-{
-	d = std::make_unique<Private>(this);
+AcceptRequest::AcceptRequest(ZrpcManager *manager) : ZrpcRequest(manager) {
+    d = std::make_unique<Private>(this);
 }
 
 AcceptRequest::~AcceptRequest() = default;
 
-AcceptRequest::ResponseData AcceptRequest::result() const
-{
-	return d->result;
+AcceptRequest::ResponseData AcceptRequest::result() const { return d->result; }
+
+void AcceptRequest::start(const AcceptData &adata) {
+    ZrpcRequest::start("accept", acceptDataToVariant(adata).toHash());
 }
 
-void AcceptRequest::start(const AcceptData &adata)
-{
-	ZrpcRequest::start("accept", acceptDataToVariant(adata).toHash());
+void AcceptRequest::onSuccess() {
+    bool ok;
+    d->result = convertResult(ZrpcRequest::result(), &ok);
+    if (!ok) {
+        setError(ErrorFormat);
+        return;
+    }
 }
-
-void AcceptRequest::onSuccess()
-{
-	bool ok;
-	d->result = convertResult(ZrpcRequest::result(), &ok);
-	if(!ok)
-	{
-		setError(ErrorFormat);
-		return;
-	}
-}
-

--- a/src/proxy/acceptrequest.h
+++ b/src/proxy/acceptrequest.h
@@ -31,34 +31,29 @@ class AcceptData;
 class ZrpcManager;
 
 /// Manages handoff of Accept-type HTTP request to the handler
-class AcceptRequest : public ZrpcRequest
-{
+class AcceptRequest : public ZrpcRequest {
 public:
-	class ResponseData
-	{
-	public:
-		bool accepted;
-		HttpResponseData response;
+    class ResponseData {
+    public:
+        bool accepted;
+        HttpResponseData response;
 
-		ResponseData() :
-			accepted(false)
-		{
-		}
-	};
+        ResponseData() : accepted(false) {}
+    };
 
-	AcceptRequest(ZrpcManager *manager);
-	~AcceptRequest();
+    AcceptRequest(ZrpcManager *manager);
+    ~AcceptRequest();
 
-	ResponseData result() const;
+    ResponseData result() const;
 
-	void start(const AcceptData &adata);
+    void start(const AcceptData &adata);
 
 protected:
-	virtual void onSuccess();
+    virtual void onSuccess();
 
 private:
-	class Private;
-	std::unique_ptr<Private> d;
+    class Private;
+    std::unique_ptr<Private> d;
 };
 
 #endif

--- a/src/proxy/connectionmanager.cpp
+++ b/src/proxy/connectionmanager.cpp
@@ -22,102 +22,79 @@
 
 #include "connectionmanager.h"
 
-#include <assert.h>
-#include <QHash>
 #include "uuidutil.h"
+#include <QHash>
+#include <assert.h>
 
-class ConnectionManager::Private
-{
+class ConnectionManager::Private {
 public:
-	class Item
-	{
-	public:
-		QPair<QByteArray, QByteArray> rid;
-		WebSocket *sock;
-		QByteArray cid;
-		WsProxySession *proxy;
+    class Item {
+    public:
+        QPair<QByteArray, QByteArray> rid;
+        WebSocket *sock;
+        QByteArray cid;
+        WsProxySession *proxy;
 
-		Item() :
-			sock(0),
-			proxy(0)
-		{
-		}
-	};
+        Item() : sock(0), proxy(0) {}
+    };
 
-	QHash<WebSocket*, Item*> itemsBySock;
-	QHash<QByteArray, Item*> itemsByCid;
+    QHash<WebSocket *, Item *> itemsBySock;
+    QHash<QByteArray, Item *> itemsByCid;
 
-	Private()
-	{
-	}
+    Private() {}
 
-	~Private()
-	{
-		clearItemsBySock();
-	}
+    ~Private() { clearItemsBySock(); }
 
-	void clearItemsBySock()
-	{
-		qDeleteAll(itemsBySock);
-		itemsBySock.clear();
-		itemsByCid.clear();
-	}
+    void clearItemsBySock() {
+        qDeleteAll(itemsBySock);
+        itemsBySock.clear();
+        itemsByCid.clear();
+    }
 };
 
-ConnectionManager::ConnectionManager()
-{
-	d = new Private;
+ConnectionManager::ConnectionManager() { d = new Private; }
+
+ConnectionManager::~ConnectionManager() { delete d; }
+
+QByteArray ConnectionManager::addConnection(WebSocket *sock) {
+    assert(!d->itemsBySock.contains(sock));
+
+    Private::Item *i = new Private::Item;
+    i->sock = sock;
+    i->cid = UuidUtil::createUuid();
+    d->itemsBySock[i->sock] = i;
+    d->itemsByCid[i->cid] = i;
+
+    return i->cid;
 }
 
-ConnectionManager::~ConnectionManager()
-{
-	delete d;
+QByteArray ConnectionManager::getConnection(WebSocket *sock) const {
+    Private::Item *i = d->itemsBySock.value(sock);
+    if (!i)
+        return QByteArray();
+
+    return i->cid;
 }
 
-QByteArray ConnectionManager::addConnection(WebSocket *sock)
-{
-	assert(!d->itemsBySock.contains(sock));
-
-	Private::Item *i = new Private::Item;
-	i->sock = sock;
-	i->cid = UuidUtil::createUuid();
-	d->itemsBySock[i->sock] = i;
-	d->itemsByCid[i->cid] = i;
-
-	return i->cid;
+void ConnectionManager::removeConnection(WebSocket *sock) {
+    Private::Item *i = d->itemsBySock.value(sock);
+    assert(i);
+    d->itemsBySock.remove(sock);
+    d->itemsByCid.remove(i->cid);
+    delete i;
 }
 
-QByteArray ConnectionManager::getConnection(WebSocket *sock) const
-{
-	Private::Item *i = d->itemsBySock.value(sock);
-	if(!i)
-		return QByteArray();
+WsProxySession *ConnectionManager::getProxyForConnection(const QByteArray &cid) const {
+    Private::Item *i = d->itemsByCid.value(cid);
+    if (!i)
+        return 0;
 
-	return i->cid;
+    return i->proxy;
 }
 
-void ConnectionManager::removeConnection(WebSocket *sock)
-{
-	Private::Item *i = d->itemsBySock.value(sock);
-	assert(i);
-	d->itemsBySock.remove(sock);
-	d->itemsByCid.remove(i->cid);
-	delete i;
-}
+void ConnectionManager::setProxyForConnection(WebSocket *sock, WsProxySession *proxy) {
+    Private::Item *i = d->itemsBySock.value(sock);
+    assert(i);
 
-WsProxySession *ConnectionManager::getProxyForConnection(const QByteArray &cid) const
-{
-	Private::Item *i = d->itemsByCid.value(cid);
-	if(!i)
-		return 0;
-
-	return i->proxy;
-}
-
-void ConnectionManager::setProxyForConnection(WebSocket *sock, WsProxySession *proxy)
-{
-	Private::Item *i = d->itemsBySock.value(sock);
-	assert(i);
-
-	i->proxy = proxy;
+    i->proxy = proxy;
 }

--- a/src/proxy/connectionmanager.h
+++ b/src/proxy/connectionmanager.h
@@ -23,35 +23,34 @@
 #ifndef CONNECTIONMANAGER_H
 #define CONNECTIONMANAGER_H
 
-#include <QPair>
 #include <QByteArray>
+#include <QPair>
 
 class WebSocket;
 class WsProxySession;
 
 /// Manages mapping between WebSocket connections and their connection IDs
 /// and tracks which proxy session owns each connection
-class ConnectionManager
-{
+class ConnectionManager {
 public:
-	ConnectionManager();
-	~ConnectionManager();
+    ConnectionManager();
+    ~ConnectionManager();
 
-	// Returns cid
-	QByteArray addConnection(WebSocket *sock);
+    // Returns cid
+    QByteArray addConnection(WebSocket *sock);
 
-	// Returns cid or empty
-	QByteArray getConnection(WebSocket *sock) const;
+    // Returns cid or empty
+    QByteArray getConnection(WebSocket *sock) const;
 
-	void removeConnection(WebSocket *sock);
+    void removeConnection(WebSocket *sock);
 
-	WsProxySession *getProxyForConnection(const QByteArray &cid) const;
+    WsProxySession *getProxyForConnection(const QByteArray &cid) const;
 
-	void setProxyForConnection(WebSocket *sock, WsProxySession *proxy);
+    void setProxyForConnection(WebSocket *sock, WsProxySession *proxy);
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -23,984 +23,876 @@
 
 #include "domainmap.h"
 
-#include <assert.h>
-#include <thread>
-#include <pthread.h>
-#include <QStringList>
-#include <QHash>
-#include <QMutex>
-#include <QWaitCondition>
-#include <QFile>
-#include <QDir>
-#include <QTextStream>
-#include "log.h"
-#include "timer.h"
 #include "defercall.h"
 #include "eventloop.h"
 #include "filewatcher.h"
+#include "log.h"
 #include "routesfile.h"
+#include "timer.h"
+#include <QDir>
+#include <QFile>
+#include <QHash>
+#include <QMutex>
+#include <QStringList>
+#include <QTextStream>
+#include <QWaitCondition>
+#include <assert.h>
+#include <pthread.h>
+#include <thread>
 
 #define WORKER_THREAD_TIMERS 10
 #define WORKER_THREAD_SOCKETNOTIFIERS 1
 
-static QString readFile(const QString &name, QString *errorMessage)
-{
-	QFile f(name);
-	if(!f.open(QFile::ReadOnly))
-	{
-		*errorMessage = QString("failed to open %1: %2").arg(name, f.errorString());
-		return QByteArray();
-	}
+static QString readFile(const QString &name, QString *errorMessage) {
+    QFile f(name);
+    if (!f.open(QFile::ReadOnly)) {
+        *errorMessage = QString("failed to open %1: %2").arg(name, f.errorString());
+        return QByteArray();
+    }
 
-	QByteArray data = f.readAll();
+    QByteArray data = f.readAll();
 
-	if(f.error() != QFileDevice::NoError)
-	{
-		*errorMessage = QString("failed to read %1: %2").arg(name, f.errorString());
-		return QByteArray();
-	}
+    if (f.error() != QFileDevice::NoError) {
+        *errorMessage = QString("failed to read %1: %2").arg(name, f.errorString());
+        return QByteArray();
+    }
 
-	return QString::fromUtf8(data);
+    return QString::fromUtf8(data);
 }
 
-class DomainMap::Worker
-{
+class DomainMap::Worker {
 public:
-	enum AddRuleResult
-	{
-		AddRuleOk,
-		AddRuleNoDomainOrId,
-		AddRuleDuplicate,
-	};
+    enum AddRuleResult {
+        AddRuleOk,
+        AddRuleNoDomainOrId,
+        AddRuleDuplicate,
+    };
 
-	class Rule
-	{
-	public:
-		QString domain;
+    class Rule {
+    public:
+        QString domain;
 
-		int proto; // -1=unspecified, 0=http, 1=websocket
-		QByteArray pathBeg;
-		int ssl; // -1=unspecified, 0=no, 1=yes
+        int proto; // -1=unspecified, 0=http, 1=websocket
+        QByteArray pathBeg;
+        int ssl; // -1=unspecified, 0=no, 1=yes
 
-		QByteArray id;
-		bool explicitId; // If the id was provided by the user
-		QByteArray sigIss;
-		Jwt::EncodingKey sigKey;
-		QByteArray prefix;
-		bool origHeaders;
-		QString asHost;
-		int pathRemove;
-		QByteArray pathPrepend;
-		bool debug;
-		bool autoCrossOrigin;
-		JsonpConfig jsonpConfig;
-		bool session;
-		QByteArray sockJsPath;
-		QByteArray sockJsAsPath;
-		HttpHeaders headers;
-		bool grip;
-		QList<Target> targets;
-		int logLevel;
+        QByteArray id;
+        bool explicitId; // If the id was provided by the user
+        QByteArray sigIss;
+        Jwt::EncodingKey sigKey;
+        QByteArray prefix;
+        bool origHeaders;
+        QString asHost;
+        int pathRemove;
+        QByteArray pathPrepend;
+        bool debug;
+        bool autoCrossOrigin;
+        JsonpConfig jsonpConfig;
+        bool session;
+        QByteArray sockJsPath;
+        QByteArray sockJsAsPath;
+        HttpHeaders headers;
+        bool grip;
+        QList<Target> targets;
+        int logLevel;
 
-		Rule() :
-			proto(-1),
-			ssl(-1),
-			explicitId(false),
-			origHeaders(false),
-			pathRemove(0),
-			debug(false),
-			autoCrossOrigin(false),
-			session(false),
-			grip(true),
-			logLevel(LOG_LEVEL_DEBUG)
-		{
-		}
+        Rule()
+            : proto(-1),
+              ssl(-1),
+              explicitId(false),
+              origHeaders(false),
+              pathRemove(0),
+              debug(false),
+              autoCrossOrigin(false),
+              session(false),
+              grip(true),
+              logLevel(LOG_LEVEL_DEBUG) {}
 
-		// Checks only the condition, not sig/targets
-		bool compare(const Rule &other) const
-		{
-			return (proto == other.proto && ssl == other.ssl && pathBeg == other.pathBeg);
-		}
+        // Checks only the condition, not sig/targets
+        bool compare(const Rule &other) const {
+            return (proto == other.proto && ssl == other.ssl && pathBeg == other.pathBeg);
+        }
 
-		inline bool matchProto(Protocol reqProto) const
-		{
-			return ((proto == 0 && reqProto == Http) || (proto == 1 && reqProto == WebSocket));
-		}
+        inline bool matchProto(Protocol reqProto) const {
+            return ((proto == 0 && reqProto == Http) || (proto == 1 && reqProto == WebSocket));
+        }
 
-		inline bool matchSsl(bool reqSsl) const
-		{
-			return ((ssl == 0 && !reqSsl) || (ssl == 1 && reqSsl));
-		}
+        inline bool matchSsl(bool reqSsl) const {
+            return ((ssl == 0 && !reqSsl) || (ssl == 1 && reqSsl));
+        }
 
-		bool isMatch(Protocol reqProto, bool reqSsl, const QByteArray &reqPath) const
-		{
-			return ((proto == -1 || matchProto(reqProto)) && (ssl == -1 || matchSsl(reqSsl)) && (pathBeg.isEmpty() || reqPath.startsWith(pathBeg)));
-		}
+        bool isMatch(Protocol reqProto, bool reqSsl, const QByteArray &reqPath) const {
+            return ((proto == -1 || matchProto(reqProto)) && (ssl == -1 || matchSsl(reqSsl)) &&
+                    (pathBeg.isEmpty() || reqPath.startsWith(pathBeg)));
+        }
 
-		bool isMoreSpecificMatch(const Rule &other, Protocol reqProto, bool reqSsl, const QByteArray &reqPath) const
-		{
-			// Have to at least be a match
-			if(!isMatch(reqProto, reqSsl, reqPath))
-				return false;
+        bool isMoreSpecificMatch(const Rule &other, Protocol reqProto, bool reqSsl,
+                                 const QByteArray &reqPath) const {
+            // Have to at least be a match
+            if (!isMatch(reqProto, reqSsl, reqPath))
+                return false;
 
-			// Now let's see if we're a better match
+            // Now let's see if we're a better match
 
-			if(other.proto == -1 && proto != -1)
-				return true;
-			else if(other.proto != -1 && proto == -1)
-				return false;
+            if (other.proto == -1 && proto != -1)
+                return true;
+            else if (other.proto != -1 && proto == -1)
+                return false;
 
-			if(pathBeg.size() > other.pathBeg.size())
-				return true;
+            if (pathBeg.size() > other.pathBeg.size())
+                return true;
 
-			if(other.ssl == -1 && ssl != -1)
-				return true;
+            if (other.ssl == -1 && ssl != -1)
+                return true;
 
-			return false;
-		}
+            return false;
+        }
 
-		QByteArray idFromCondition() const {
-			QString domainStr;
-			if(!domain.isEmpty())
-				domainStr = domain;
-			else
-				domainStr = "*";
+        QByteArray idFromCondition() const {
+            QString domainStr;
+            if (!domain.isEmpty())
+                domainStr = domain;
+            else
+                domainStr = "*";
 
-			QString protoStr;
-			if(proto == 0)
-				protoStr = "http";
-			else if(proto == 1)
-				protoStr = "ws";
-			else
-				protoStr = "*";
+            QString protoStr;
+            if (proto == 0)
+                protoStr = "http";
+            else if (proto == 1)
+                protoStr = "ws";
+            else
+                protoStr = "*";
 
-			QString sslStr;
-			if(ssl == 0)
-				sslStr = "ssl";
-			else if(ssl == 1)
-				sslStr = "no-ssl";
-			else
-				sslStr = "*";
+            QString sslStr;
+            if (ssl == 0)
+                sslStr = "ssl";
+            else if (ssl == 1)
+                sslStr = "no-ssl";
+            else
+                sslStr = "*";
 
-			QString pathBegStr;
-			if(!pathBeg.isEmpty())
-				pathBegStr = pathBeg;
-			else
-				pathBegStr = "*";
+            QString pathBegStr;
+            if (!pathBeg.isEmpty())
+                pathBegStr = pathBeg;
+            else
+                pathBegStr = "*";
 
-			return (domainStr + ',' + protoStr + ',' + sslStr + ',' + pathBegStr).toUtf8();
-		}
+            return (domainStr + ',' + protoStr + ',' + sslStr + ',' + pathBegStr).toUtf8();
+        }
 
-		Entry toEntry() const
-		{
-			Entry e;
-			e.pathBeg = pathBeg;
-			e.id = id;
-			e.sigIss = sigIss;
-			e.sigKey = sigKey;
-			e.prefix = prefix;
-			e.origHeaders = origHeaders;
-			e.asHost = asHost;
-			e.pathRemove = pathRemove;
-			e.pathPrepend = pathPrepend;
-			e.debug = debug;
-			e.autoCrossOrigin = autoCrossOrigin;
-			e.jsonpConfig = jsonpConfig;
-			e.session = session;
-			e.sockJsPath = sockJsPath;
-			e.sockJsAsPath = sockJsAsPath;
-			e.headers = headers;
-			e.separateStats = explicitId;
-			e.grip = grip;
-			e.targets = targets;
-			e.logLevel = logLevel;
-			return e;
-		}
-	};
+        Entry toEntry() const {
+            Entry e;
+            e.pathBeg = pathBeg;
+            e.id = id;
+            e.sigIss = sigIss;
+            e.sigKey = sigKey;
+            e.prefix = prefix;
+            e.origHeaders = origHeaders;
+            e.asHost = asHost;
+            e.pathRemove = pathRemove;
+            e.pathPrepend = pathPrepend;
+            e.debug = debug;
+            e.autoCrossOrigin = autoCrossOrigin;
+            e.jsonpConfig = jsonpConfig;
+            e.session = session;
+            e.sockJsPath = sockJsPath;
+            e.sockJsAsPath = sockJsAsPath;
+            e.headers = headers;
+            e.separateStats = explicitId;
+            e.grip = grip;
+            e.targets = targets;
+            e.logLevel = logLevel;
+            return e;
+        }
+    };
 
-	QMutex m;
-	QString fileName;
-	QList<Rule> allRules;
-	QHash< QString, QList<Rule> > rulesByDomain;
-	QHash<QString, Rule> rulesById;
-	Timer t;
-	Connection tConnection;
-	FileWatcher watcher;
-	DeferCall deferCall;
+    QMutex m;
+    QString fileName;
+    QList<Rule> allRules;
+    QHash<QString, QList<Rule>> rulesByDomain;
+    QHash<QString, Rule> rulesById;
+    Timer t;
+    Connection tConnection;
+    FileWatcher watcher;
+    DeferCall deferCall;
 
-	Worker()
-	{
-		tConnection = t.timeout.connect(boost::bind(&Worker::doReload, this));
-		t.setSingleShot(true);
-	}
+    Worker() {
+        tConnection = t.timeout.connect(boost::bind(&Worker::doReload, this));
+        t.setSingleShot(true);
+    }
 
-	void reload()
-	{
-		QFile file(fileName);
-		if(!file.open(QFile::ReadOnly))
-		{
-			log_warning("unable to open routes file: %s", qPrintable(fileName));
-			return;
-		}
+    void reload() {
+        QFile file(fileName);
+        if (!file.open(QFile::ReadOnly)) {
+            log_warning("unable to open routes file: %s", qPrintable(fileName));
+            return;
+        }
 
-		QDir fileDir = QFileInfo(fileName).absoluteDir();
+        QDir fileDir = QFileInfo(fileName).absoluteDir();
 
-		QList<Rule> all;
-		QHash< QString, QList<Rule> > domainMap;
-		QHash<QString, Rule> idMap;
+        QList<Rule> all;
+        QHash<QString, QList<Rule>> domainMap;
+        QHash<QString, Rule> idMap;
 
-		QTextStream ts(&file);
-		for(int lineNum = 1; !ts.atEnd(); ++lineNum)
-		{
-			QString line = ts.readLine();
+        QTextStream ts(&file);
+        for (int lineNum = 1; !ts.atEnd(); ++lineNum) {
+            QString line = ts.readLine();
 
-			Rule r;
-			if(!parseRouteLine(line, fileName, lineNum, fileDir, &r))
-			{
-				// ParseRouteLine will have logged a message if needed
-				continue;
-			}
+            Rule r;
+            if (!parseRouteLine(line, fileName, lineNum, fileDir, &r)) {
+                // ParseRouteLine will have logged a message if needed
+                continue;
+            }
 
-			if(r.id.isEmpty())
-				r.id = r.idFromCondition();
+            if (r.id.isEmpty())
+                r.id = r.idFromCondition();
 
-			AddRuleResult ret = addRule(r, &all, &domainMap, &idMap);
-			if(ret != AddRuleOk)
-			{
-				if(ret == AddRuleNoDomainOrId)
-					log_warning("%s:%d condition has no domain or id", qPrintable(fileName), lineNum);
-				else // AddRuleDuplicate
-					log_warning("%s:%d skipping duplicate condition", qPrintable(fileName), lineNum);
+            AddRuleResult ret = addRule(r, &all, &domainMap, &idMap);
+            if (ret != AddRuleOk) {
+                if (ret == AddRuleNoDomainOrId)
+                    log_warning("%s:%d condition has no domain or id", qPrintable(fileName),
+                                lineNum);
+                else // AddRuleDuplicate
+                    log_warning("%s:%d skipping duplicate condition", qPrintable(fileName),
+                                lineNum);
 
-				continue;
-			}
-		}
+                continue;
+            }
+        }
 
-		log_debug("routes by domain:");
-		QHashIterator< QString, QList<Rule> > it(domainMap);
-		while(it.hasNext())
-		{
-			it.next();
+        log_debug("routes by domain:");
+        QHashIterator<QString, QList<Rule>> it(domainMap);
+        while (it.hasNext()) {
+            it.next();
 
-			const QString &domain = it.key();
-			const QList<Rule> &rules = it.value();
-			foreach(const Rule &r, rules)
-			{
-				QStringList tstr;
-				foreach(const Target &t, r.targets)
-				{
-					if(t.type == Target::Test)
-						tstr += "test";
-					else if(t.type == Target::Custom)
-						tstr += t.zhttpRoute.baseSpec;
-					else // Default
-						tstr += t.connectHost + ';' + QString::number(t.connectPort);
-				}
+            const QString &domain = it.key();
+            const QList<Rule> &rules = it.value();
+            foreach (const Rule &r, rules) {
+                QStringList tstr;
+                foreach (const Target &t, r.targets) {
+                    if (t.type == Target::Test)
+                        tstr += "test";
+                    else if (t.type == Target::Custom)
+                        tstr += t.zhttpRoute.baseSpec;
+                    else // Default
+                        tstr += t.connectHost + ';' + QString::number(t.connectPort);
+                }
 
-				if(!domain.isEmpty())
-					log_debug("  %s: %s", qPrintable(domain), qPrintable(tstr.join(" ")));
-				else
-					log_debug("  (default): %s", qPrintable(tstr.join(" ")));
-			}
-		}
+                if (!domain.isEmpty())
+                    log_debug("  %s: %s", qPrintable(domain), qPrintable(tstr.join(" ")));
+                else
+                    log_debug("  (default): %s", qPrintable(tstr.join(" ")));
+            }
+        }
 
-		// Atomically replace the map
-		m.lock();
-		allRules = all;
-		rulesByDomain = domainMap;
-		rulesById = idMap;
-		m.unlock();
+        // Atomically replace the map
+        m.lock();
+        allRules = all;
+        rulesByDomain = domainMap;
+        rulesById = idMap;
+        m.unlock();
 
-		log_info("routes loaded with %d entries", allRules.count());
+        log_info("routes loaded with %d entries", allRules.count());
 
-		deferCall.defer([=] { doChanged(); });
-	}
+        deferCall.defer([=] { doChanged(); });
+    }
 
-	// Mutex must be locked when calling this method
-	bool addRouteLine(const QString &line)
-	{
-		Rule r;
-		if(!parseRouteLine(line, "<route>", 1, QDir::current(), &r))
-			return false;
+    // Mutex must be locked when calling this method
+    bool addRouteLine(const QString &line) {
+        Rule r;
+        if (!parseRouteLine(line, "<route>", 1, QDir::current(), &r))
+            return false;
 
-		if(addRule(r, &allRules, &rulesByDomain, &rulesById) != AddRuleOk)
-			return false;
+        if (addRule(r, &allRules, &rulesByDomain, &rulesById) != AddRuleOk)
+            return false;
 
-		return true;
-	}
+        return true;
+    }
 
-	Signal started;
-	Signal changed;
+    Signal started;
+    Signal changed;
 
-	void start()
-	{
-		if(!fileName.isEmpty())
-		{
-			watcher.fileChanged.connect(boost::bind(&Worker::fileChanged, this));
+    void start() {
+        if (!fileName.isEmpty()) {
+            watcher.fileChanged.connect(boost::bind(&Worker::fileChanged, this));
 
-			if(!watcher.start(fileName)) {
-				log_error("failed to watch %s", qPrintable(fileName));
-			}
+            if (!watcher.start(fileName)) {
+                log_error("failed to watch %s", qPrintable(fileName));
+            }
 
-			reload();
-		}
+            reload();
+        }
 
-		started();
-	}
+        started();
+    }
 
-	void fileChanged()
-	{
-		// Inotify tends to give us extra events so let's hang around a
-		// little bit before reloading
-		if(!t.isActive())
-		{
-			log_info("routes file changed, reloading");
-			t.start(1000);
-		}
-	}
+    void fileChanged() {
+        // Inotify tends to give us extra events so let's hang around a
+        // little bit before reloading
+        if (!t.isActive()) {
+            log_info("routes file changed, reloading");
+            t.start(1000);
+        }
+    }
 
-	void doReload()
-	{
-		reload();
-	}
+    void doReload() { reload(); }
 
 private:
-	static bool parseRouteLine(const QString &line, const QString &fileName, int lineNum, const QDir &fileDir, Rule *rule)
-	{
-		bool ok;
-		QString errmsg;
-		QList<RoutesFile::RouteSection> sections = RoutesFile::parseLine(line, &ok, &errmsg);
-		if(!ok)
-		{
-			log_warning("%s:%d: %s", qPrintable(fileName), lineNum, qPrintable(errmsg));
-			return false;
-		}
-
-		if(sections.isEmpty())
-		{
-			// Nothing. Could happen if line is blank or commented out
-			return false;
-		}
-
-		if(sections.count() < 2)
-		{
-			log_warning("%s:%d: must specify condition and at least one target", qPrintable(fileName), lineNum);
-			return false;
-		}
-
-		QString val = sections[0].value;
-		QMultiHash<QString, QString> props = sections[0].props;
-
-		Rule r;
-
-		if(val.isEmpty())
-			r.domain = QString(); // Null means unspecified
-		else if(val == "*")
-			r.domain = QString(""); // Empty means wildcard
-		else
-			r.domain = val; // Non-empty means exact match
-
-		r.jsonpConfig.mode = JsonpConfig::Extended;
-
-		if(props.contains("proto"))
-		{
-			val = props.value("proto");
-			if(val == "http")
-				r.proto = 0;
-			else if(val == "ws")
-				r.proto = 1;
-			else
-			{
-				log_warning("%s:%d: proto must be set to 'http' or 'ws'", qPrintable(fileName), lineNum);
-				return false;
-			}
-		}
-
-		if(props.contains("ssl"))
-		{
-			val = props.value("ssl");
-			if(val == "yes")
-				r.ssl = 1;
-			else if(val == "no")
-				r.ssl = 0;
-			else
-			{
-				log_warning("%s:%d: ssl must be set to 'yes' or 'no'", qPrintable(fileName), lineNum);
-				return false;
-			}
-		}
-
-		if(props.contains("id"))
-		{
-			r.id = props.value("id").toUtf8();
-			r.explicitId = true;
-		}
-
-		if(props.contains("path_beg"))
-		{
-			QString pathBeg = props.value("path_beg");
-			if(pathBeg.isEmpty())
-			{
-				log_warning("%s:%d: path_beg cannot be empty", qPrintable(fileName), lineNum);
-				return false;
-			}
-
-			r.pathBeg = pathBeg.toUtf8();
-		}
-
-		if(props.contains("sig_iss"))
-		{
-			r.sigIss = props.value("sig_iss").toUtf8();
-		}
-
-		if(props.contains("sig_key"))
-		{
-			r.sigKey = Jwt::EncodingKey::fromConfigString(props.value("sig_key"), fileDir);
-		}
-
-		if(props.contains("prefix"))
-		{
-			r.prefix = props.value("prefix").toUtf8();
-		}
-
-		if(props.contains("orig_headers"))
-		{
-			r.origHeaders = true;
-		}
-
-		if(props.contains("as_host"))
-		{
-			r.asHost = props.value("as_host");
-		}
-
-		if(props.contains("path_rem"))
-		{
-			r.pathRemove = props.value("path_rem").toInt();
-		}
-
-		if(props.contains("replace_beg"))
-		{
-			r.pathRemove = r.pathBeg.length();
-			r.pathPrepend = props.value("replace_beg").toUtf8();
-		}
-
-		if(props.contains("debug"))
-			r.debug = true;
-
-		if(props.contains("aco"))
-			r.autoCrossOrigin = true;
-
-		if(props.contains("jsonp_mode"))
-		{
-			val = props.value("jsonp_mode");
-			if(val == "basic")
-				r.jsonpConfig.mode = JsonpConfig::Basic;
-			else if(val == "extended")
-				r.jsonpConfig.mode = JsonpConfig::Extended;
-			else
-			{
-				log_warning("%s:%d: jsonp_mode must be set to 'basic' or 'extended'", qPrintable(fileName), lineNum);
-				return false;
-			}
-		}
-
-		if(props.contains("jsonp_cb"))
-			r.jsonpConfig.callbackParam = props.value("jsonp_cb").toUtf8();
-
-		if(props.contains("jsonp_body"))
-			r.jsonpConfig.bodyParam = props.value("jsonp_body").toUtf8();
-
-		if(props.contains("jsonp_defcb"))
-			r.jsonpConfig.defaultCallback = props.value("jsonp_defcb").toUtf8();
-
-		if(r.jsonpConfig.mode == JsonpConfig::Basic)
-			r.jsonpConfig.defaultMethod = "POST";
-		else // Extended
-			r.jsonpConfig.defaultMethod = "GET";
-
-		if(props.contains("jsonp_defmethod"))
-			r.jsonpConfig.defaultMethod = props.value("jsonp_defmethod");
-
-		if(props.contains("session"))
-			r.session = true;
-
-		if(props.contains("sockjs"))
-			r.sockJsPath = props.value("sockjs").toUtf8();
-
-		if(props.contains("sockjs_as_path"))
-			r.sockJsAsPath = props.value("sockjs_as_path").toUtf8();
-
-		if(props.contains("header"))
-		{
-			foreach(const QString &s, props.values("header"))
-			{
-				int at = s.indexOf(':');
-				if(at < 1)
-				{
-					log_warning("%s:%d: header must use format 'name:value'", qPrintable(fileName), lineNum);
-					return false;
-				}
-
-				QByteArray name = s.mid(0, at).toUtf8();
-				QByteArray value = s.mid(at + 1).toUtf8();
-
-				// Trim left side of value
-				int n = 0;
-				while(n < value.length() && value[n] == ' ')
-				{
-					++n;
-				}
-				if(n > 0)
-					value = value.mid(n);
-
-				r.headers += HttpHeader(name, value);
-			}
-		}
-
-		if(props.contains("no_grip"))
-			r.grip = false;
-
-		if(props.contains("log_level"))
-		{
-			r.logLevel = props.value("log_level").toInt();
-		}
-
-		ok = true;
-		for(int n = 1; n < sections.count(); ++n)
-		{
-			QString val = sections[n].value;
-			QMultiHash<QString, QString> props = sections[n].props;
-
-			Target target;
-
-			if(val == "test")
-			{
-				target.type = Target::Test;
-			}
-			else if(val.startsWith("zhttp/"))
-			{
-				target.type = Target::Custom;
-
-				target.zhttpRoute.baseSpec = val.mid(6);
-			}
-			else if(val.startsWith("zhttpreq/"))
-			{
-				target.type = Target::Custom;
-
-				target.zhttpRoute.baseSpec = val.mid(9);
-				target.zhttpRoute.req = true;
-			}
-			else
-			{
-				QString host;
-				int portPos = -1;
-
-				if(val.startsWith("["))
-				{
-					// Ipv6 address
-					int at = val.indexOf("]:");
-					if(at >= 0)
-					{
-						host = val.mid(1, at - 1);
-						portPos = at + 2;
-					}
-				}
-				else
-				{
-					// Domain or ipv4 address
-					int at = val.indexOf(':');
-					if(at >= 0)
-					{
-						host = val.mid(0, at);
-						portPos = at + 1;
-					}
-				}
-
-				if(portPos < 0)
-				{
-					log_warning("%s:%d: target bad format", qPrintable(fileName), lineNum);
-					ok = false;
-					break;
-				}
-
-				QString sport = val.mid(portPos);
-				int port = sport.toInt(&ok);
-				if(!ok || port < 1 || port > 65535)
-				{
-					log_warning("%s:%d: target invalid port", qPrintable(fileName), lineNum);
-					ok = false;
-					break;
-				}
-
-				target.type = Target::Default;
-				target.connectHost = host;
-				target.connectPort = port;
-			}
-
-			if(props.contains("ssl"))
-				target.ssl = true;
-
-			if(props.contains("untrusted"))
-				target.trusted = false;
-			else
-				target.trusted = true;
-
-			if(props.contains("trust_connect_host"))
-				target.trustConnectHost = true;
-
-			if(props.contains("insecure"))
-				target.insecure = true;
-
-			if(props.contains("host"))
-				target.host = props.value("host");
-
-			if(props.contains("sub"))
-			{
-				foreach(const QString &s, props.values("sub"))
-				{
-					if(!s.isEmpty())
-						target.subscriptions += s;
-				}
-			}
-
-			if(props.contains("over_http"))
-				target.overHttp = true;
-
-			if(props.contains("one_event"))
-				target.oneEvent = true;
-
-			if(props.contains("ipc_file_mode"))
-			{
-				bool ok_;
-				int x = props.value("ipc_file_mode").toInt(&ok_, 8);
-				if(ok_ && x >= 0)
-					target.zhttpRoute.ipcFileMode = x;
-			}
-
-			if(props.contains("client_cert"))
-			{
-				QString err;
-				QString data = readFile(props.value("client_cert"), &err);
-				if(!err.isEmpty())
-				{
-					log_warning("%s:%d: %s", qPrintable(fileName), lineNum, qPrintable(err));
-					ok = false;
-					break;
-				}
-
-				target.clientCert = data;
-			}
-
-			if(props.contains("client_key"))
-			{
-				QString err;
-				QString data = readFile(props.value("client_key"), &err);
-				if(!err.isEmpty())
-				{
-					log_warning("%s:%d: %s", qPrintable(fileName), lineNum, qPrintable(err));
-					ok = false;
-					break;
-				}
-
-				target.clientKey = data;
-			}
-
-			r.targets += target;
-		}
-
-		if(!ok)
-			return false;
-
-		*rule = r;
-		return true;
-	}
-
-	static AddRuleResult addRule(const Rule &r, QList<Rule> *all, QHash< QString,QList<Rule> > *domainMap, QHash<QString, Rule> *idMap)
-	{
-		if(r.domain.isNull() && r.id.isEmpty())
-			return AddRuleNoDomainOrId;
-
-		bool addByDomain = false;
-		bool addById = false;
-
-		if(!r.domain.isNull())
-		{
-			if(domainMap->contains(r.domain))
-			{
-				QList<Rule> *rules = &((*domainMap)[r.domain]);
-
-				bool found = false;
-				foreach(const Rule &b, *rules)
-				{
-					if(b.compare(r))
-					{
-						found = true;
-						break;
-					}
-				}
-
-				if(found)
-					return AddRuleDuplicate;
-			}
-
-			addByDomain = true;
-		}
-
-		if(!r.id.isEmpty())
-		{
-			if(!idMap->contains(r.id))
-			{
-				addById = true;
-			}
-			else
-			{
-				// Mark the key as unusable
-				idMap->insert(r.id, Rule());
-			}
-		}
-
-		*all += r;
-
-		if(addByDomain)
-		{
-			if(!domainMap->contains(r.domain))
-				domainMap->insert(r.domain, QList<Rule>());
-
-			QList<Rule> *rules = &((*domainMap)[r.domain]);
-
-			*rules += r;
-		}
-
-		if(addById)
-		{
-			idMap->insert(r.id, r);
-		}
-
-		return AddRuleOk;
-	}
-
-	void doChanged()
-	{
-		changed();
-	}
+    static bool parseRouteLine(const QString &line, const QString &fileName, int lineNum,
+                               const QDir &fileDir, Rule *rule) {
+        bool ok;
+        QString errmsg;
+        QList<RoutesFile::RouteSection> sections = RoutesFile::parseLine(line, &ok, &errmsg);
+        if (!ok) {
+            log_warning("%s:%d: %s", qPrintable(fileName), lineNum, qPrintable(errmsg));
+            return false;
+        }
+
+        if (sections.isEmpty()) {
+            // Nothing. Could happen if line is blank or commented out
+            return false;
+        }
+
+        if (sections.count() < 2) {
+            log_warning("%s:%d: must specify condition and at least one target",
+                        qPrintable(fileName), lineNum);
+            return false;
+        }
+
+        QString val = sections[0].value;
+        QMultiHash<QString, QString> props = sections[0].props;
+
+        Rule r;
+
+        if (val.isEmpty())
+            r.domain = QString(); // Null means unspecified
+        else if (val == "*")
+            r.domain = QString(""); // Empty means wildcard
+        else
+            r.domain = val; // Non-empty means exact match
+
+        r.jsonpConfig.mode = JsonpConfig::Extended;
+
+        if (props.contains("proto")) {
+            val = props.value("proto");
+            if (val == "http")
+                r.proto = 0;
+            else if (val == "ws")
+                r.proto = 1;
+            else {
+                log_warning("%s:%d: proto must be set to 'http' or 'ws'", qPrintable(fileName),
+                            lineNum);
+                return false;
+            }
+        }
+
+        if (props.contains("ssl")) {
+            val = props.value("ssl");
+            if (val == "yes")
+                r.ssl = 1;
+            else if (val == "no")
+                r.ssl = 0;
+            else {
+                log_warning("%s:%d: ssl must be set to 'yes' or 'no'", qPrintable(fileName),
+                            lineNum);
+                return false;
+            }
+        }
+
+        if (props.contains("id")) {
+            r.id = props.value("id").toUtf8();
+            r.explicitId = true;
+        }
+
+        if (props.contains("path_beg")) {
+            QString pathBeg = props.value("path_beg");
+            if (pathBeg.isEmpty()) {
+                log_warning("%s:%d: path_beg cannot be empty", qPrintable(fileName), lineNum);
+                return false;
+            }
+
+            r.pathBeg = pathBeg.toUtf8();
+        }
+
+        if (props.contains("sig_iss")) {
+            r.sigIss = props.value("sig_iss").toUtf8();
+        }
+
+        if (props.contains("sig_key")) {
+            r.sigKey = Jwt::EncodingKey::fromConfigString(props.value("sig_key"), fileDir);
+        }
+
+        if (props.contains("prefix")) {
+            r.prefix = props.value("prefix").toUtf8();
+        }
+
+        if (props.contains("orig_headers")) {
+            r.origHeaders = true;
+        }
+
+        if (props.contains("as_host")) {
+            r.asHost = props.value("as_host");
+        }
+
+        if (props.contains("path_rem")) {
+            r.pathRemove = props.value("path_rem").toInt();
+        }
+
+        if (props.contains("replace_beg")) {
+            r.pathRemove = r.pathBeg.length();
+            r.pathPrepend = props.value("replace_beg").toUtf8();
+        }
+
+        if (props.contains("debug"))
+            r.debug = true;
+
+        if (props.contains("aco"))
+            r.autoCrossOrigin = true;
+
+        if (props.contains("jsonp_mode")) {
+            val = props.value("jsonp_mode");
+            if (val == "basic")
+                r.jsonpConfig.mode = JsonpConfig::Basic;
+            else if (val == "extended")
+                r.jsonpConfig.mode = JsonpConfig::Extended;
+            else {
+                log_warning("%s:%d: jsonp_mode must be set to 'basic' or 'extended'",
+                            qPrintable(fileName), lineNum);
+                return false;
+            }
+        }
+
+        if (props.contains("jsonp_cb"))
+            r.jsonpConfig.callbackParam = props.value("jsonp_cb").toUtf8();
+
+        if (props.contains("jsonp_body"))
+            r.jsonpConfig.bodyParam = props.value("jsonp_body").toUtf8();
+
+        if (props.contains("jsonp_defcb"))
+            r.jsonpConfig.defaultCallback = props.value("jsonp_defcb").toUtf8();
+
+        if (r.jsonpConfig.mode == JsonpConfig::Basic)
+            r.jsonpConfig.defaultMethod = "POST";
+        else // Extended
+            r.jsonpConfig.defaultMethod = "GET";
+
+        if (props.contains("jsonp_defmethod"))
+            r.jsonpConfig.defaultMethod = props.value("jsonp_defmethod");
+
+        if (props.contains("session"))
+            r.session = true;
+
+        if (props.contains("sockjs"))
+            r.sockJsPath = props.value("sockjs").toUtf8();
+
+        if (props.contains("sockjs_as_path"))
+            r.sockJsAsPath = props.value("sockjs_as_path").toUtf8();
+
+        if (props.contains("header")) {
+            foreach (const QString &s, props.values("header")) {
+                int at = s.indexOf(':');
+                if (at < 1) {
+                    log_warning("%s:%d: header must use format 'name:value'", qPrintable(fileName),
+                                lineNum);
+                    return false;
+                }
+
+                QByteArray name = s.mid(0, at).toUtf8();
+                QByteArray value = s.mid(at + 1).toUtf8();
+
+                // Trim left side of value
+                int n = 0;
+                while (n < value.length() && value[n] == ' ') {
+                    ++n;
+                }
+                if (n > 0)
+                    value = value.mid(n);
+
+                r.headers += HttpHeader(name, value);
+            }
+        }
+
+        if (props.contains("no_grip"))
+            r.grip = false;
+
+        if (props.contains("log_level")) {
+            r.logLevel = props.value("log_level").toInt();
+        }
+
+        ok = true;
+        for (int n = 1; n < sections.count(); ++n) {
+            QString val = sections[n].value;
+            QMultiHash<QString, QString> props = sections[n].props;
+
+            Target target;
+
+            if (val == "test") {
+                target.type = Target::Test;
+            } else if (val.startsWith("zhttp/")) {
+                target.type = Target::Custom;
+
+                target.zhttpRoute.baseSpec = val.mid(6);
+            } else if (val.startsWith("zhttpreq/")) {
+                target.type = Target::Custom;
+
+                target.zhttpRoute.baseSpec = val.mid(9);
+                target.zhttpRoute.req = true;
+            } else {
+                QString host;
+                int portPos = -1;
+
+                if (val.startsWith("[")) {
+                    // Ipv6 address
+                    int at = val.indexOf("]:");
+                    if (at >= 0) {
+                        host = val.mid(1, at - 1);
+                        portPos = at + 2;
+                    }
+                } else {
+                    // Domain or ipv4 address
+                    int at = val.indexOf(':');
+                    if (at >= 0) {
+                        host = val.mid(0, at);
+                        portPos = at + 1;
+                    }
+                }
+
+                if (portPos < 0) {
+                    log_warning("%s:%d: target bad format", qPrintable(fileName), lineNum);
+                    ok = false;
+                    break;
+                }
+
+                QString sport = val.mid(portPos);
+                int port = sport.toInt(&ok);
+                if (!ok || port < 1 || port > 65535) {
+                    log_warning("%s:%d: target invalid port", qPrintable(fileName), lineNum);
+                    ok = false;
+                    break;
+                }
+
+                target.type = Target::Default;
+                target.connectHost = host;
+                target.connectPort = port;
+            }
+
+            if (props.contains("ssl"))
+                target.ssl = true;
+
+            if (props.contains("untrusted"))
+                target.trusted = false;
+            else
+                target.trusted = true;
+
+            if (props.contains("trust_connect_host"))
+                target.trustConnectHost = true;
+
+            if (props.contains("insecure"))
+                target.insecure = true;
+
+            if (props.contains("host"))
+                target.host = props.value("host");
+
+            if (props.contains("sub")) {
+                foreach (const QString &s, props.values("sub")) {
+                    if (!s.isEmpty())
+                        target.subscriptions += s;
+                }
+            }
+
+            if (props.contains("over_http"))
+                target.overHttp = true;
+
+            if (props.contains("one_event"))
+                target.oneEvent = true;
+
+            if (props.contains("ipc_file_mode")) {
+                bool ok_;
+                int x = props.value("ipc_file_mode").toInt(&ok_, 8);
+                if (ok_ && x >= 0)
+                    target.zhttpRoute.ipcFileMode = x;
+            }
+
+            if (props.contains("client_cert")) {
+                QString err;
+                QString data = readFile(props.value("client_cert"), &err);
+                if (!err.isEmpty()) {
+                    log_warning("%s:%d: %s", qPrintable(fileName), lineNum, qPrintable(err));
+                    ok = false;
+                    break;
+                }
+
+                target.clientCert = data;
+            }
+
+            if (props.contains("client_key")) {
+                QString err;
+                QString data = readFile(props.value("client_key"), &err);
+                if (!err.isEmpty()) {
+                    log_warning("%s:%d: %s", qPrintable(fileName), lineNum, qPrintable(err));
+                    ok = false;
+                    break;
+                }
+
+                target.clientKey = data;
+            }
+
+            r.targets += target;
+        }
+
+        if (!ok)
+            return false;
+
+        *rule = r;
+        return true;
+    }
+
+    static AddRuleResult addRule(const Rule &r, QList<Rule> *all,
+                                 QHash<QString, QList<Rule>> *domainMap,
+                                 QHash<QString, Rule> *idMap) {
+        if (r.domain.isNull() && r.id.isEmpty())
+            return AddRuleNoDomainOrId;
+
+        bool addByDomain = false;
+        bool addById = false;
+
+        if (!r.domain.isNull()) {
+            if (domainMap->contains(r.domain)) {
+                QList<Rule> *rules = &((*domainMap)[r.domain]);
+
+                bool found = false;
+                foreach (const Rule &b, *rules) {
+                    if (b.compare(r)) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found)
+                    return AddRuleDuplicate;
+            }
+
+            addByDomain = true;
+        }
+
+        if (!r.id.isEmpty()) {
+            if (!idMap->contains(r.id)) {
+                addById = true;
+            } else {
+                // Mark the key as unusable
+                idMap->insert(r.id, Rule());
+            }
+        }
+
+        *all += r;
+
+        if (addByDomain) {
+            if (!domainMap->contains(r.domain))
+                domainMap->insert(r.domain, QList<Rule>());
+
+            QList<Rule> *rules = &((*domainMap)[r.domain]);
+
+            *rules += r;
+        }
+
+        if (addById) {
+            idMap->insert(r.id, r);
+        }
+
+        return AddRuleOk;
+    }
+
+    void doChanged() { changed(); }
 };
 
-class DomainMap::Thread
-{
+class DomainMap::Thread {
 public:
-	QString fileName;
-	std::thread thread;
-	std::unique_ptr<EventLoop> loop;
-	std::unique_ptr<Worker> worker;
-	QMutex m;
-	QWaitCondition w;
+    QString fileName;
+    std::thread thread;
+    std::unique_ptr<EventLoop> loop;
+    std::unique_ptr<Worker> worker;
+    QMutex m;
+    QWaitCondition w;
 
-	~Thread()
-	{
-		if(worker)
-		{
-			worker->deferCall.defer([&] {
-				// NOTE: called from worker thread
-				loop->exit(0);
-			});
-		}
+    ~Thread() {
+        if (worker) {
+            worker->deferCall.defer([&] {
+                // NOTE: called from worker thread
+                loop->exit(0);
+            });
+        }
 
-		thread.join();
-	}
+        thread.join();
+    }
 
-	void start()
-	{
-		QMutexLocker locker(&m);
+    void start() {
+        QMutexLocker locker(&m);
 
-		thread = std::thread([=] {
+        thread = std::thread([=] {
 #ifdef Q_OS_MAC
-			pthread_setname_np("domainmap");
+            pthread_setname_np("domainmap");
 #else
-			pthread_setname_np(pthread_self(), "domainmap");
+            pthread_setname_np(pthread_self(), "domainmap");
 #endif
 
-			run();
-		});
+            run();
+        });
 
-		w.wait(&m);
-	}
+        w.wait(&m);
+    }
 
-	void run()
-	{
-		// Will unlock during exec
-		m.lock();
+    void run() {
+        // Will unlock during exec
+        m.lock();
 
-		int registrationsMax = WORKER_THREAD_TIMERS + WORKER_THREAD_SOCKETNOTIFIERS;
-		loop = std::make_unique<EventLoop>(registrationsMax);
+        int registrationsMax = WORKER_THREAD_TIMERS + WORKER_THREAD_SOCKETNOTIFIERS;
+        loop = std::make_unique<EventLoop>(registrationsMax);
 
-		worker = std::make_unique<Worker>();
-		worker->fileName = fileName;
+        worker = std::make_unique<Worker>();
+        worker->fileName = fileName;
 
-		worker->started.connect([&] {
-			w.wakeOne();
-			m.unlock();
-		});
+        worker->started.connect([&] {
+            w.wakeOne();
+            m.unlock();
+        });
 
-		worker->deferCall.defer([=] { worker->start(); });
+        worker->deferCall.defer([=] { worker->start(); });
 
-		loop->exec();
+        loop->exec();
 
-		worker.reset();
-		loop.reset();
-	}
+        worker.reset();
+        loop.reset();
+    }
 };
 
-class DomainMap::Private
-{
+class DomainMap::Private {
 public:
-	DomainMap *q;
-	Thread *thread;
-	Connection changedConnection;
-	DeferCall deferCall;
+    DomainMap *q;
+    Thread *thread;
+    Connection changedConnection;
+    DeferCall deferCall;
 
-	Private(DomainMap *_q) :
-		q(_q),
-		thread(0)
-	{
-	}
+    Private(DomainMap *_q) : q(_q), thread(0) {}
 
-	~Private()
-	{
-		changedConnection.disconnect();
-		delete thread;
-	}
+    ~Private() {
+        changedConnection.disconnect();
+        delete thread;
+    }
 
-	void start(const QString &fileName = QString())
-	{
-		thread = new Thread;
-		thread->fileName = fileName;
-		thread->start();
+    void start(const QString &fileName = QString()) {
+        thread = new Thread;
+        thread->fileName = fileName;
+        thread->start();
 
-		// Worker guaranteed to exist after starting
-		changedConnection = thread->worker->changed.connect(boost::bind(&Private::workerChanged, this));
-	}
+        // Worker guaranteed to exist after starting
+        changedConnection =
+            thread->worker->changed.connect(boost::bind(&Private::workerChanged, this));
+    }
 
 private:
-	// NOTE: called from worker thread
-	void workerChanged()
-	{
-		deferCall.defer([=] {
-			// NOTE: called from outer thread
-			doChanged();
-		});
-	}
+    // NOTE: called from worker thread
+    void workerChanged() {
+        deferCall.defer([=] {
+            // NOTE: called from outer thread
+            doChanged();
+        });
+    }
 
-	void doChanged()
-	{
-		q->changed();
-	}
+    void doChanged() { q->changed(); }
 };
 
-DomainMap::DomainMap()
-{
-	d = new Private(this);
-	d->start();
+DomainMap::DomainMap() {
+    d = new Private(this);
+    d->start();
 }
 
-DomainMap::DomainMap(const QString &fileName)
-{
-	d = new Private(this);
-	d->start(fileName);
+DomainMap::DomainMap(const QString &fileName) {
+    d = new Private(this);
+    d->start(fileName);
 }
 
-DomainMap::~DomainMap()
-{
-	delete d;
+DomainMap::~DomainMap() { delete d; }
+
+void DomainMap::reload() {
+    Worker *worker = d->thread->worker.get();
+
+    worker->deferCall.defer([=] {
+        // NOTE: called from worker thread
+        worker->doReload();
+    });
 }
 
-void DomainMap::reload()
-{
-	Worker *worker = d->thread->worker.get();
+bool DomainMap::isIdShared(const QString &id) const {
+    QMutexLocker locker(&d->thread->worker->m);
 
-	worker->deferCall.defer([=] {
-		// NOTE: called from worker thread
-		worker->doReload();
-	});
+    if (!d->thread->worker->rulesById.contains(id))
+        return false;
+
+    const Worker::Rule *r = &d->thread->worker->rulesById[id];
+
+    return r->id.isEmpty();
 }
 
-bool DomainMap::isIdShared(const QString &id) const
-{
-	QMutexLocker locker(&d->thread->worker->m);
+DomainMap::Entry DomainMap::entry(Protocol proto, bool ssl, const QString &domain,
+                                  const QByteArray &path) const {
+    QMutexLocker locker(&d->thread->worker->m);
 
-	if(!d->thread->worker->rulesById.contains(id))
-		return false;
+    const QList<Worker::Rule> *rules;
+    QString empty("");
+    if (d->thread->worker->rulesByDomain.contains(domain))
+        rules = &d->thread->worker->rulesByDomain[domain];
+    else if (d->thread->worker->rulesByDomain.contains(empty))
+        rules = &d->thread->worker->rulesByDomain[empty];
+    else
+        return Entry();
 
-	const Worker::Rule *r = &d->thread->worker->rulesById[id];
+    const Worker::Rule *best = 0;
+    foreach (const Worker::Rule &r, *rules) {
+        if ((!best && r.isMatch(proto, ssl, path)) ||
+            (best && r.isMoreSpecificMatch(*best, proto, ssl, path))) {
+            best = &r;
+        }
+    }
 
-	return r->id.isEmpty();
+    if (!best)
+        return Entry();
+
+    assert(!best->targets.isEmpty());
+
+    return best->toEntry();
 }
 
-DomainMap::Entry DomainMap::entry(Protocol proto, bool ssl, const QString &domain, const QByteArray &path) const
-{
-	QMutexLocker locker(&d->thread->worker->m);
+DomainMap::Entry DomainMap::entry(const QString &id) const {
+    QMutexLocker locker(&d->thread->worker->m);
 
-	const QList<Worker::Rule> *rules;
-	QString empty("");
-	if(d->thread->worker->rulesByDomain.contains(domain))
-		rules = &d->thread->worker->rulesByDomain[domain];
-	else if(d->thread->worker->rulesByDomain.contains(empty))
-		rules = &d->thread->worker->rulesByDomain[empty];
-	else
-		return Entry();
+    if (!d->thread->worker->rulesById.contains(id))
+        return Entry();
 
-	const Worker::Rule *best = 0;
-	foreach(const Worker::Rule &r, *rules)
-	{
-		if((!best && r.isMatch(proto, ssl, path)) || (best && r.isMoreSpecificMatch(*best, proto, ssl, path)))
-		{
-			best = &r;
-		}
-	}
+    const Worker::Rule *r = &d->thread->worker->rulesById[id];
 
-	if(!best)
-		return Entry();
+    // This can happen if there were duplicate route IDs
+    if (r->id.isEmpty())
+        return Entry();
 
-	assert(!best->targets.isEmpty());
-
-	return best->toEntry();
+    return r->toEntry();
 }
 
-DomainMap::Entry DomainMap::entry(const QString &id) const
-{
-	QMutexLocker locker(&d->thread->worker->m);
+QList<DomainMap::ZhttpRoute> DomainMap::zhttpRoutes() const {
+    QMutexLocker locker(&d->thread->worker->m);
 
-	if(!d->thread->worker->rulesById.contains(id))
-		return Entry();
+    QList<ZhttpRoute> out;
 
-	const Worker::Rule *r = &d->thread->worker->rulesById[id];
+    foreach (const Worker::Rule &r, d->thread->worker->allRules) {
+        foreach (const Target &t, r.targets) {
+            if (!t.zhttpRoute.isNull() && !out.contains(t.zhttpRoute))
+                out += t.zhttpRoute;
+        }
+    }
 
-	// This can happen if there were duplicate route IDs
-	if(r->id.isEmpty())
-		return Entry();
-
-	return r->toEntry();
+    return out;
 }
 
-QList<DomainMap::ZhttpRoute> DomainMap::zhttpRoutes() const
-{
-	QMutexLocker locker(&d->thread->worker->m);
-
-	QList<ZhttpRoute> out;
-
-	foreach(const Worker::Rule &r, d->thread->worker->allRules)
-	{
-		foreach(const Target &t, r.targets)
-		{
-			if(!t.zhttpRoute.isNull() && !out.contains(t.zhttpRoute))
-				out += t.zhttpRoute;
-		}
-	}
-
-	return out;
-}
-
-bool DomainMap::addRouteLine(const QString &line)
-{
-	QMutexLocker locker(&d->thread->worker->m);
-	return d->thread->worker->addRouteLine(line);
+bool DomainMap::addRouteLine(const QString &line) {
+    QMutexLocker locker(&d->thread->worker->m);
+    return d->thread->worker->addRouteLine(line);
 }

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -24,12 +24,12 @@
 #ifndef DOMAINMAP_H
 #define DOMAINMAP_H
 
+#include "httpheaders.h"
+#include "jwt.h"
+#include "log.h"
 #include <QPair>
 #include <QString>
 #include <QStringList>
-#include "log.h"
-#include "httpheaders.h"
-#include "jwt.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -37,174 +37,137 @@ using Connection = boost::signals2::scoped_connection;
 
 /// Offers fast access to the routes file. The table is maintained
 /// by a background thread so that file access doesn't cause blocking.
-class DomainMap
-{
+class DomainMap {
 public:
-	class JsonpConfig
-	{
-	public:
-		enum Mode
-		{
-			Basic,
-			Extended
-		};
+    class JsonpConfig {
+    public:
+        enum Mode { Basic, Extended };
 
-		Mode mode;
-		QByteArray callbackParam;
-		QByteArray bodyParam;
-		QByteArray defaultCallback;
-		QString defaultMethod;
+        Mode mode;
+        QByteArray callbackParam;
+        QByteArray bodyParam;
+        QByteArray defaultCallback;
+        QString defaultMethod;
 
-		JsonpConfig() :
-			mode(Extended)
-		{
-		}
-	};
+        JsonpConfig() : mode(Extended) {}
+    };
 
-	enum Protocol
-	{
-		Http,
-		WebSocket
-	};
+    enum Protocol { Http, WebSocket };
 
-	class ZhttpRoute
-	{
-	public:
-		QString baseSpec;
-		bool req;
-		int ipcFileMode;
+    class ZhttpRoute {
+    public:
+        QString baseSpec;
+        bool req;
+        int ipcFileMode;
 
-		ZhttpRoute() :
-			req(false),
-			ipcFileMode(-1)
-		{
-		}
+        ZhttpRoute() : req(false), ipcFileMode(-1) {}
 
-		bool isNull() const
-		{
-			return baseSpec.isEmpty();
-		}
+        bool isNull() const { return baseSpec.isEmpty(); }
 
-		bool operator==(const ZhttpRoute &other) const
-		{
-			// Only compare spec
-			return (baseSpec == other.baseSpec);
-		}
-	};
+        bool operator==(const ZhttpRoute &other) const {
+            // Only compare spec
+            return (baseSpec == other.baseSpec);
+        }
+    };
 
-	class Target
-	{
-	public:
-		enum Type
-		{
-			Default,
-			Custom,
-			Test
-		};
+    class Target {
+    public:
+        enum Type { Default, Custom, Test };
 
-		Type type;
-		QString connectHost;
-		int connectPort;
-		ZhttpRoute zhttpRoute;
-		bool ssl; // Use https
-		bool trusted; // Bypass zurl access policies
-		bool trustConnectHost; // Verify cert against target host
-		bool insecure; // Ignore server certificate validity
-		QString host; // Override input host
-		QStringList subscriptions; // Implicit subscriptions
-		bool overHttp; // Use websocket-over-http protocol
-		bool oneEvent; // Send one event at a time with overHttp
-		QString clientCert;
-		QString clientKey;
+        Type type;
+        QString connectHost;
+        int connectPort;
+        ZhttpRoute zhttpRoute;
+        bool ssl;                  // Use https
+        bool trusted;              // Bypass zurl access policies
+        bool trustConnectHost;     // Verify cert against target host
+        bool insecure;             // Ignore server certificate validity
+        QString host;              // Override input host
+        QStringList subscriptions; // Implicit subscriptions
+        bool overHttp;             // Use websocket-over-http protocol
+        bool oneEvent;             // Send one event at a time with overHttp
+        QString clientCert;
+        QString clientKey;
 
-		Target() :
-			type(Default),
-			connectPort(-1),
-			ssl(false),
-			trusted(false),
-			trustConnectHost(false),
-			insecure(false),
-			overHttp(false),
-			oneEvent(false)
-		{
-		}
-	};
+        Target()
+            : type(Default),
+              connectPort(-1),
+              ssl(false),
+              trusted(false),
+              trustConnectHost(false),
+              insecure(false),
+              overHttp(false),
+              oneEvent(false) {}
+    };
 
-	class Entry
-	{
-	public:
-		QByteArray id;
-		QByteArray pathBeg;
-		QByteArray sigIss;
-		Jwt::EncodingKey sigKey;
-		QByteArray prefix;
-		bool origHeaders;
-		QString asHost;
-		int pathRemove;
-		QByteArray pathPrepend;
-		bool debug;
-		bool autoCrossOrigin;
-		JsonpConfig jsonpConfig;
-		bool session;
-		QByteArray sockJsPath;
-		QByteArray sockJsAsPath;
-		HttpHeaders headers;
-		bool separateStats;
-		bool grip;
-		QList<Target> targets;
-		int logLevel;
+    class Entry {
+    public:
+        QByteArray id;
+        QByteArray pathBeg;
+        QByteArray sigIss;
+        Jwt::EncodingKey sigKey;
+        QByteArray prefix;
+        bool origHeaders;
+        QString asHost;
+        int pathRemove;
+        QByteArray pathPrepend;
+        bool debug;
+        bool autoCrossOrigin;
+        JsonpConfig jsonpConfig;
+        bool session;
+        QByteArray sockJsPath;
+        QByteArray sockJsAsPath;
+        HttpHeaders headers;
+        bool separateStats;
+        bool grip;
+        QList<Target> targets;
+        int logLevel;
 
-		bool isNull() const
-		{
-			return targets.isEmpty();
-		}
+        bool isNull() const { return targets.isEmpty(); }
 
-		QByteArray statsRoute() const
-		{
-			if(separateStats)
-				return id;
-			else
-				return QByteArray(); // Global stats
-		}
+        QByteArray statsRoute() const {
+            if (separateStats)
+                return id;
+            else
+                return QByteArray(); // Global stats
+        }
 
-		Entry() :
-			origHeaders(false),
-			pathRemove(0),
-			debug(false),
-			autoCrossOrigin(false),
-			session(false),
-			separateStats(false),
-			grip(true),
-			logLevel(LOG_LEVEL_DEBUG)
-		{
-		}
-	};
+        Entry()
+            : origHeaders(false),
+              pathRemove(0),
+              debug(false),
+              autoCrossOrigin(false),
+              session(false),
+              separateStats(false),
+              grip(true),
+              logLevel(LOG_LEVEL_DEBUG) {}
+    };
 
-	DomainMap();
-	DomainMap(const QString &fileName);
-	~DomainMap();
+    DomainMap();
+    DomainMap(const QString &fileName);
+    ~DomainMap();
 
-	// Shouldn't really ever need to call this, but it's here in case the
-	// underlying file watching doesn't work
-	void reload();
+    // Shouldn't really ever need to call this, but it's here in case the
+    // underlying file watching doesn't work
+    void reload();
 
-	bool isIdShared(const QString &id) const;
-	Entry entry(Protocol proto, bool ssl, const QString &domain, const QByteArray &path) const;
-	Entry entry(const QString &id) const;
+    bool isIdShared(const QString &id) const;
+    Entry entry(Protocol proto, bool ssl, const QString &domain, const QByteArray &path) const;
+    Entry entry(const QString &id) const;
 
-	QList<ZhttpRoute> zhttpRoutes() const;
+    QList<ZhttpRoute> zhttpRoutes() const;
 
-	bool addRouteLine(const QString &line);
+    bool addRouteLine(const QString &line);
 
-	Signal changed;
+    Signal changed;
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 
-	class Thread;
-	class Worker;
+    class Thread;
+    class Worker;
 };
 
 #endif

--- a/src/proxy/inspectrequest.cpp
+++ b/src/proxy/inspectrequest.cpp
@@ -23,150 +23,124 @@
 
 #include "inspectrequest.h"
 
+#include "inspectdata.h"
 #include "packet/httprequestdata.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include "inspectdata.h"
 
-static InspectData resultToData(const Variant &in, bool *ok)
-{
-	InspectData out;
+static InspectData resultToData(const Variant &in, bool *ok) {
+    InspectData out;
 
-	if(typeId(in) != VariantType::Hash)
-	{
-		*ok = false;
-		return InspectData();
-	}
+    if (typeId(in) != VariantType::Hash) {
+        *ok = false;
+        return InspectData();
+    }
 
-	VariantHash obj = in.toHash();
+    VariantHash obj = in.toHash();
 
-	if(!obj.contains("no-proxy") || typeId(obj["no-proxy"]) != VariantType::Bool)
-	{
-		*ok = false;
-		return InspectData();
-	}
-	out.doProxy = !obj["no-proxy"].toBool();
+    if (!obj.contains("no-proxy") || typeId(obj["no-proxy"]) != VariantType::Bool) {
+        *ok = false;
+        return InspectData();
+    }
+    out.doProxy = !obj["no-proxy"].toBool();
 
-	out.sharingKey.clear();
-	if(obj.contains("sharing-key"))
-	{
-		if(typeId(obj["sharing-key"]) != VariantType::ByteArray)
-		{
-			*ok = false;
-			return InspectData();
-		}
+    out.sharingKey.clear();
+    if (obj.contains("sharing-key")) {
+        if (typeId(obj["sharing-key"]) != VariantType::ByteArray) {
+            *ok = false;
+            return InspectData();
+        }
 
-		out.sharingKey = obj["sharing-key"].toByteArray();
-	}
+        out.sharingKey = obj["sharing-key"].toByteArray();
+    }
 
-	out.sid.clear();
-	if(obj.contains("sid"))
-	{
-		if(typeId(obj["sid"]) != VariantType::ByteArray)
-		{
-			*ok = false;
-			return InspectData();
-		}
+    out.sid.clear();
+    if (obj.contains("sid")) {
+        if (typeId(obj["sid"]) != VariantType::ByteArray) {
+            *ok = false;
+            return InspectData();
+        }
 
-		out.sid = obj["sid"].toByteArray();
-	}
+        out.sid = obj["sid"].toByteArray();
+    }
 
-	out.lastIds.clear();
-	if(obj.contains("last-ids"))
-	{
-		if(typeId(obj["last-ids"]) != VariantType::Hash)
-		{
-			*ok = false;
-			return InspectData();
-		}
+    out.lastIds.clear();
+    if (obj.contains("last-ids")) {
+        if (typeId(obj["last-ids"]) != VariantType::Hash) {
+            *ok = false;
+            return InspectData();
+        }
 
-		VariantHash vlastIds = obj["last-ids"].toHash();
-		for(auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it)
-		{
-			if(typeId(it.value()) != VariantType::ByteArray)
-			{
-				*ok = false;
-				return InspectData();
-			}
+        VariantHash vlastIds = obj["last-ids"].toHash();
+        for (auto it = vlastIds.constBegin(); it != vlastIds.constEnd(); ++it) {
+            if (typeId(it.value()) != VariantType::ByteArray) {
+                *ok = false;
+                return InspectData();
+            }
 
-			QByteArray key = it.key().toUtf8();
-			QByteArray val = it.value().toByteArray();
-			out.lastIds.insert(key, val);
-		}
-	}
+            QByteArray key = it.key().toUtf8();
+            QByteArray val = it.value().toByteArray();
+            out.lastIds.insert(key, val);
+        }
+    }
 
-	out.userData = obj["user-data"];
+    out.userData = obj["user-data"];
 
-	*ok = true;
-	return out;
+    *ok = true;
+    return out;
 }
 
-class InspectRequest::Private
-{
+class InspectRequest::Private {
 public:
-	InspectRequest *q;
-	InspectData idata;
+    InspectRequest *q;
+    InspectData idata;
 
-	Private(InspectRequest *_q) :
-		q(_q)
-	{
-	}
+    Private(InspectRequest *_q) : q(_q) {}
 };
 
-InspectRequest::InspectRequest(ZrpcManager *manager) :
-	ZrpcRequest(manager)
-{
-	d = new Private(this);
+InspectRequest::InspectRequest(ZrpcManager *manager) : ZrpcRequest(manager) {
+    d = new Private(this);
 }
 
-InspectRequest::~InspectRequest()
-{
-	delete d;
+InspectRequest::~InspectRequest() { delete d; }
+
+InspectData InspectRequest::result() const { return d->idata; }
+
+void InspectRequest::start(const HttpRequestData &hdata, bool truncated, bool getSession,
+                           bool autoShare) {
+    VariantHash args;
+
+    args["method"] = hdata.method.toLatin1();
+    args["uri"] = hdata.uri.toEncoded();
+
+    VariantList vheaders;
+    foreach (const HttpHeader &h, hdata.headers) {
+        VariantList vheader;
+        vheader += h.first.asQByteArray();
+        vheader += h.second.asQByteArray();
+        vheaders += Variant(vheader);
+    }
+
+    args["headers"] = vheaders;
+    args["body"] = hdata.body;
+
+    if (truncated)
+        args["truncated"] = true;
+
+    if (getSession)
+        args["get-session"] = true;
+
+    if (autoShare)
+        args["auto-share"] = true;
+
+    ZrpcRequest::start("inspect", args);
 }
 
-InspectData InspectRequest::result() const
-{
-	return d->idata;
-}
-
-void InspectRequest::start(const HttpRequestData &hdata, bool truncated, bool getSession, bool autoShare)
-{
-	VariantHash args;
-
-	args["method"] = hdata.method.toLatin1();
-	args["uri"] = hdata.uri.toEncoded();
-
-	VariantList vheaders;
-	foreach(const HttpHeader &h, hdata.headers)
-	{
-		VariantList vheader;
-		vheader += h.first.asQByteArray();
-		vheader += h.second.asQByteArray();
-		vheaders += Variant(vheader);
-	}
-
-	args["headers"] = vheaders;
-	args["body"] = hdata.body;
-
-	if(truncated)
-		args["truncated"] = true;
-
-	if(getSession)
-		args["get-session"] = true;
-
-	if(autoShare)
-		args["auto-share"] = true;
-
-	ZrpcRequest::start("inspect", args);
-}
-
-void InspectRequest::onSuccess()
-{
-	bool ok;
-	d->idata = resultToData(ZrpcRequest::result(), &ok);
-	if(!ok)
-	{
-		setError(ErrorFormat);
-		return;
-	}
+void InspectRequest::onSuccess() {
+    bool ok;
+    d->idata = resultToData(ZrpcRequest::result(), &ok);
+    if (!ok) {
+        setError(ErrorFormat);
+        return;
+    }
 }

--- a/src/proxy/inspectrequest.h
+++ b/src/proxy/inspectrequest.h
@@ -30,23 +30,23 @@ class HttpRequestData;
 class InspectData;
 class ZrpcManager;
 
-/// Requests handler decision on whether to proxy HTTP request to backend or accept it
-class InspectRequest : public ZrpcRequest
-{
+/// Requests handler decision on whether to proxy HTTP request to backend or
+/// accept it
+class InspectRequest : public ZrpcRequest {
 public:
-	InspectRequest(ZrpcManager *manager);
-	~InspectRequest();
+    InspectRequest(ZrpcManager *manager);
+    ~InspectRequest();
 
-	InspectData result() const;
+    InspectData result() const;
 
-	void start(const HttpRequestData &hdata, bool truncated, bool getSession, bool autoShare);
+    void start(const HttpRequestData &hdata, bool truncated, bool getSession, bool autoShare);
 
 protected:
-	virtual void onSuccess();
+    virtual void onSuccess();
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -21,571 +21,559 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <assert.h>
-#include <unistd.h>
-#include <string>
-#include <vector>
-#include <thread>
-#include <pthread.h>
-#include <boost/algorithm/string.hpp>
+#include "config.h"
+#include "defercall.h"
+#include "domainmap.h"
+#include "eventloop.h"
+#include "log.h"
+#include "processquit.h"
+#include "proxyargsdata.h"
+#include "proxyengine.h"
+#include "rust/bindings.h"
+#include "settings.h"
+#include "simplehttpserver.h"
+#include "timer.h"
+#include "xffrule.h"
 #include <QCommandLineParser>
-#include <QStringList>
 #include <QFile>
 #include <QFileInfo>
 #include <QMutex>
+#include <QStringList>
 #include <QWaitCondition>
-#include "rust/bindings.h"
-#include "eventloop.h"
-#include "processquit.h"
-#include "timer.h"
-#include "defercall.h"
-#include "log.h"
-#include "simplehttpserver.h"
-#include "settings.h"
-#include "xffrule.h"
-#include "domainmap.h"
-#include "config.h"
-#include "proxyengine.h"
-#include "proxyargsdata.h"
+#include <assert.h>
+#include <boost/algorithm/string.hpp>
+#include <pthread.h>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
 
-static void trimlist(QStringList *list)
-{
-	for(int n = 0; n < list->count(); ++n)
-	{
-		if((*list)[n].isEmpty())
-		{
-			list->removeAt(n);
-			--n; // Adjust position
-		}
-	}
+static void trimlist(QStringList *list) {
+    for (int n = 0; n < list->count(); ++n) {
+        if ((*list)[n].isEmpty()) {
+            list->removeAt(n);
+            --n; // Adjust position
+        }
+    }
 }
 
-static XffRule parse_xffRule(const QStringList &in)
-{
-	XffRule out;
-	foreach(const QString &s, in)
-	{
-		if(s.startsWith("truncate:"))
-		{
-			bool ok;
-			int x = s.mid(9).toInt(&ok);
-			if(!ok)
-				return out;
+static XffRule parse_xffRule(const QStringList &in) {
+    XffRule out;
+    foreach (const QString &s, in) {
+        if (s.startsWith("truncate:")) {
+            bool ok;
+            int x = s.mid(9).toInt(&ok);
+            if (!ok)
+                return out;
 
-			out.truncate = x;
-		}
-		else if(s == "append")
-			out.append = true;
-	}
-	return out;
+            out.truncate = x;
+        } else if (s == "append")
+            out.append = true;
+    }
+    return out;
 }
 
-static QString suffixSpec(const QString &s, int i)
-{
-	if(s.startsWith("ipc:"))
-		return s + QString("-%1").arg(i);
+static QString suffixSpec(const QString &s, int i) {
+    if (s.startsWith("ipc:"))
+        return s + QString("-%1").arg(i);
 
-	return s;
+    return s;
 }
 
-static QStringList suffixSpecs(const QStringList &l, int i)
-{
-	if(l.count() == 1 && l[0].startsWith("ipc:"))
-		return QStringList() << (l[0] + QString("-%1").arg(i));
+static QStringList suffixSpecs(const QStringList &l, int i) {
+    if (l.count() == 1 && l[0].startsWith("ipc:"))
+        return QStringList() << (l[0] + QString("-%1").arg(i));
 
-	return l;
+    return l;
 }
 
-enum CommandLineParseResult
-{
-	CommandLineOk,
-	CommandLineError,
-	CommandLineVersionRequested,
-	CommandLineHelpRequested
+enum CommandLineParseResult {
+    CommandLineOk,
+    CommandLineError,
+    CommandLineVersionRequested,
+    CommandLineHelpRequested
 };
 
-/// Wraps Engine with lifecycle signals and defer call support 
-class EngineWorker
-{
+/// Wraps Engine with lifecycle signals and defer call support
+class EngineWorker {
 public:
-	EngineWorker(const Engine::Configuration &config, DomainMap *domainMap) :
-		config_(config),
-		engine_(std::make_unique<Engine>(domainMap))
-	{
-	}
+    EngineWorker(const Engine::Configuration &config, DomainMap *domainMap)
+        : config_(config), engine_(std::make_unique<Engine>(domainMap)) {}
 
-	DeferCall deferCall;
+    DeferCall deferCall;
 
-	Signal started;
-	Signal stopped;
-	Signal error;
+    Signal started;
+    Signal stopped;
+    Signal error;
 
-	void start()
-	{
-		if(!engine_->start(config_))
-		{
-			engine_.reset();
+    void start() {
+        if (!engine_->start(config_)) {
+            engine_.reset();
 
-			error();
-			return;
-		}
+            error();
+            return;
+        }
 
-		started();
-	}
+        started();
+    }
 
-	void stop()
-	{
-		engine_.reset();
+    void stop() {
+        engine_.reset();
 
-		stopped();
-	}
+        stopped();
+    }
 
-	void routesChanged()
-	{
-		if(engine_)
-			engine_->routesChanged();
-	}
+    void routesChanged() {
+        if (engine_)
+            engine_->routesChanged();
+    }
 
 private:
-	Engine::Configuration config_;
-	std::unique_ptr<Engine> engine_;
+    Engine::Configuration config_;
+    std::unique_ptr<Engine> engine_;
 };
 
 /// Wraps an Engine instance to run in its own thread
-class EngineThread
-{
+class EngineThread {
 public:
-	std::thread thread;
-	QMutex m;
-	QWaitCondition w;
-	Engine::Configuration config;
-	DomainMap *domainMap;
-	std::unique_ptr<EngineWorker> worker;
+    std::thread thread;
+    QMutex m;
+    QWaitCondition w;
+    Engine::Configuration config;
+    DomainMap *domainMap;
+    std::unique_ptr<EngineWorker> worker;
 
-	EngineThread(const Engine::Configuration &_config, DomainMap *_domainMap) :
-		config(_config),
-		domainMap(_domainMap)
-	{
-	}
+    EngineThread(const Engine::Configuration &_config, DomainMap *_domainMap)
+        : config(_config), domainMap(_domainMap) {}
 
-	~EngineThread()
-	{
-		stop();
-		thread.join();
-	}
+    ~EngineThread() {
+        stop();
+        thread.join();
+    }
 
-	bool start()
-	{
-		QString name = "proxy-worker-" + QString::number(config.id);
+    bool start() {
+        QString name = "proxy-worker-" + QString::number(config.id);
 
-		QMutexLocker locker(&m);
+        QMutexLocker locker(&m);
 
-		thread = std::thread([=] {
+        thread = std::thread([=] {
 #ifdef Q_OS_MAC
-			pthread_setname_np(name.toUtf8().data());
+            pthread_setname_np(name.toUtf8().data());
 #else
-			pthread_setname_np(pthread_self(), name.toUtf8().data());
+            pthread_setname_np(pthread_self(), name.toUtf8().data());
 #endif
 
-			run();
-		});
+            run();
+        });
 
-		w.wait(&m);
-		return (bool)worker;
-	}
+        w.wait(&m);
+        return (bool)worker;
+    }
 
-	void stop()
-	{
-		QMutexLocker locker(&m);
+    void stop() {
+        QMutexLocker locker(&m);
 
-		if(worker)
-		{
-			worker->deferCall.defer([=] {
-				// NOTE: called from worker thread
-				worker->stop();
-			});
-		}
-	}
+        if (worker) {
+            worker->deferCall.defer([=] {
+                // NOTE: called from worker thread
+                worker->stop();
+            });
+        }
+    }
 
-	void routesChanged()
-	{
-		QMutexLocker locker(&m);
+    void routesChanged() {
+        QMutexLocker locker(&m);
 
-		if(worker)
-		{
-			worker->deferCall.defer([=] {
-				// NOTE: called from worker thread
-				worker->routesChanged();
-			});
-		}
-	}
+        if (worker) {
+            worker->deferCall.defer([=] {
+                // NOTE: called from worker thread
+                worker->routesChanged();
+            });
+        }
+    }
 
-	void run()
-	{
-		// Will unlock during exec
-		m.lock();
+    void run() {
+        // Will unlock during exec
+        m.lock();
 
-		// Enough timers for sessions and zroutes, plus an extra 100 for misc
-		int timersMax = (config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100;
+        // Enough timers for sessions and zroutes, plus an extra 100 for misc
+        int timersMax =
+            (config.sessionsMax * TIMERS_PER_SESSION) + (ZROUTES_MAX * TIMERS_PER_ZROUTE) + 100;
 
-		// Enough for zroutes and prometheus requests, plus an extra 100 for misc
-		int socketNotifiersMax = (SOCKETNOTIFIERS_PER_ZROUTE * ZROUTES_MAX) + (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * PROMETHEUS_CONNECTIONS_MAX) + 100;
+        // Enough for zroutes and prometheus requests, plus an extra 100 for misc
+        int socketNotifiersMax =
+            (SOCKETNOTIFIERS_PER_ZROUTE * ZROUTES_MAX) +
+            (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST * PROMETHEUS_CONNECTIONS_MAX) + 100;
 
-		int registrationsMax = timersMax + socketNotifiersMax;
-		std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
+        int registrationsMax = timersMax + socketNotifiersMax;
+        std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
 
-		worker = std::make_unique<EngineWorker>(config, domainMap);
+        worker = std::make_unique<EngineWorker>(config, domainMap);
 
-		worker->started.connect([&] {
-			log_debug("worker %d: started", config.id);
+        worker->started.connect([&] {
+            log_debug("worker %d: started", config.id);
 
-			// Unblock start()
-			w.wakeOne();
-			m.unlock();
-		});
+            // Unblock start()
+            w.wakeOne();
+            m.unlock();
+        });
 
-		worker->stopped.connect([&] {
-			worker.reset();
+        worker->stopped.connect([&] {
+            worker.reset();
 
-			log_debug("worker %d: stopped", config.id);
+            log_debug("worker %d: stopped", config.id);
 
-			loop->exit(0);
-		});
+            loop->exit(0);
+        });
 
-		worker->error.connect([&] {
-			worker.reset();
+        worker->error.connect([&] {
+            worker.reset();
 
-			loop->exit(0);
+            loop->exit(0);
 
-			// Unblock start()
-			w.wakeOne();
-			m.unlock();
-		});
+            // Unblock start()
+            w.wakeOne();
+            m.unlock();
+        });
 
-		worker->deferCall.defer([=] { worker->start(); });
+        worker->deferCall.defer([=] { worker->start(); });
 
-		loop->exec();
-	}
+        loop->exec();
+    }
 };
 
-static int runLoop(const Engine::Configuration &config, const QStringList &routeLines, const QString &routesFile, int workerCount)
-{
-	// Plenty for the main thread
-	int timersMax = 100;
+static int runLoop(const Engine::Configuration &config, const QStringList &routeLines,
+                   const QString &routesFile, int workerCount) {
+    // Plenty for the main thread
+    int timersMax = 100;
 
-	// For processQuit
-	int socketNotifiersMax = 1;
+    // For processQuit
+    int socketNotifiersMax = 1;
 
-	int registrationsMax = timersMax + socketNotifiersMax;
-	std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
+    int registrationsMax = timersMax + socketNotifiersMax;
+    std::unique_ptr<EventLoop> loop = std::make_unique<EventLoop>(registrationsMax);
 
-	std::unique_ptr<DomainMap> domainMap;
-	std::list<EngineThread*> threads;
+    std::unique_ptr<DomainMap> domainMap;
+    std::list<EngineThread *> threads;
 
-	DeferCall deferCall;
-	deferCall.defer([&] {
-		if(!routeLines.isEmpty())
-		{
-			domainMap = std::make_unique<DomainMap>();
-			foreach(const QString &line, routeLines)
-				domainMap->addRouteLine(line);
-		}
-		else
-			domainMap = std::make_unique<DomainMap>(routesFile);
+    DeferCall deferCall;
+    deferCall.defer([&] {
+        if (!routeLines.isEmpty()) {
+            domainMap = std::make_unique<DomainMap>();
+            foreach (const QString &line, routeLines)
+                domainMap->addRouteLine(line);
+        } else
+            domainMap = std::make_unique<DomainMap>(routesFile);
 
-		domainMap->changed.connect([&] {
-			for(EngineThread *t : threads)
-				t->routesChanged();
-		});
+        domainMap->changed.connect([&] {
+            for (EngineThread *t : threads)
+                t->routesChanged();
+        });
 
-		ProcessQuit::instance()->quit.connect([&] {
-			log_info("stopping...");
+        ProcessQuit::instance()->quit.connect([&] {
+            log_info("stopping...");
 
-			// Remove the handler, so if we get another signal then we crash out
-			ProcessQuit::cleanup();
+            // Remove the handler, so if we get another signal then we crash out
+            ProcessQuit::cleanup();
 
-			for(EngineThread *t : threads)
-				t->stop();
+            for (EngineThread *t : threads)
+                t->stop();
 
-			for(EngineThread *t : threads)
-				delete t;
+            for (EngineThread *t : threads)
+                delete t;
 
-			threads.clear();
+            threads.clear();
 
-			log_debug("stopped");
+            log_debug("stopped");
 
-			loop->exit(0);
-		});
+            loop->exit(0);
+        });
 
-		ProcessQuit::instance()->hup.connect([&] {
-			log_info("reloading");
-			log_rotate();
-			domainMap->reload();
-		});
+        ProcessQuit::instance()->hup.connect([&] {
+            log_info("reloading");
+            log_rotate();
+            domainMap->reload();
+        });
 
-		for(int n = 0; n < workerCount; ++n)
-		{
-			Engine::Configuration wconfig = config;
+        for (int n = 0; n < workerCount; ++n) {
+            Engine::Configuration wconfig = config;
 
-			wconfig.id = n;
+            wconfig.id = n;
 
-			if(workerCount > 1)
-			{
-				wconfig.clientId += '-' + QByteArray::number(n);
+            if (workerCount > 1) {
+                wconfig.clientId += '-' + QByteArray::number(n);
 
-				wconfig.inspectSpec = suffixSpec(wconfig.inspectSpec, n);
-				wconfig.acceptSpec = suffixSpec(wconfig.acceptSpec, n);
-				wconfig.retryInSpec = suffixSpec(wconfig.retryInSpec, n);
-				wconfig.wsControlInitSpecs = suffixSpecs(wconfig.wsControlInitSpecs, n);
-				wconfig.wsControlStreamSpecs = suffixSpecs(wconfig.wsControlStreamSpecs, n);
-				wconfig.statsSpec = suffixSpec(wconfig.statsSpec, n);
-				wconfig.commandSpec = suffixSpec(wconfig.commandSpec, n);
-				wconfig.intServerInSpecs = suffixSpecs(wconfig.intServerInSpecs, n);
-				wconfig.intServerInStreamSpecs = suffixSpecs(wconfig.intServerInStreamSpecs, n);
-				wconfig.intServerOutSpecs = suffixSpecs(wconfig.intServerOutSpecs, n);
-			}
+                wconfig.inspectSpec = suffixSpec(wconfig.inspectSpec, n);
+                wconfig.acceptSpec = suffixSpec(wconfig.acceptSpec, n);
+                wconfig.retryInSpec = suffixSpec(wconfig.retryInSpec, n);
+                wconfig.wsControlInitSpecs = suffixSpecs(wconfig.wsControlInitSpecs, n);
+                wconfig.wsControlStreamSpecs = suffixSpecs(wconfig.wsControlStreamSpecs, n);
+                wconfig.statsSpec = suffixSpec(wconfig.statsSpec, n);
+                wconfig.commandSpec = suffixSpec(wconfig.commandSpec, n);
+                wconfig.intServerInSpecs = suffixSpecs(wconfig.intServerInSpecs, n);
+                wconfig.intServerInStreamSpecs = suffixSpecs(wconfig.intServerInStreamSpecs, n);
+                wconfig.intServerOutSpecs = suffixSpecs(wconfig.intServerOutSpecs, n);
+            }
 
-			EngineThread *t = new EngineThread(wconfig, domainMap.get());
-			if(!t->start())
-			{
-				delete t;
+            EngineThread *t = new EngineThread(wconfig, domainMap.get());
+            if (!t->start()) {
+                delete t;
 
-				for(EngineThread *t : threads)
-					delete t;
+                for (EngineThread *t : threads)
+                    delete t;
 
-				threads.clear();
-				loop->exit(1);
-				return;
-			}
+                threads.clear();
+                loop->exit(1);
+                return;
+            }
 
-			threads.push_back(t);
-		}
+            threads.push_back(t);
+        }
 
-		log_info("started");
-	});
+        log_info("started");
+    });
 
-	return loop->exec();
+    return loop->exec();
 }
 
 extern "C" {
 
-int proxy_init(const ffi::ProxyCliArgs *argsFfi)
-{
-	ProxyArgsData args(argsFfi);
+int proxy_init(const ffi::ProxyCliArgs *argsFfi) {
+    ProxyArgsData args(argsFfi);
 
-	// Set the log level
-	if(args.logLevel != -1)
-		log_setOutputLevel(args.logLevel);
-	else
-		log_setOutputLevel(LOG_LEVEL_INFO);
+    // Set the log level
+    if (args.logLevel != -1)
+        log_setOutputLevel(args.logLevel);
+    else
+        log_setOutputLevel(LOG_LEVEL_INFO);
 
-	// Set the log file if specified
-	if(!args.logFile.isEmpty())
-	{
-		if(!log_setFile(args.logFile))
-		{
-			log_error("failed to open log file: %s", qPrintable(args.logFile));
-			return 1;
-		}
-	}
+    // Set the log file if specified
+    if (!args.logFile.isEmpty()) {
+        if (!log_setFile(args.logFile)) {
+            log_error("failed to open log file: %s", qPrintable(args.logFile));
+            return 1;
+        }
+    }
 
-	log_debug("starting...");
+    log_debug("starting...");
 
-	// QSettings doesn't inform us if the config file can't be opened, so do that ourselves
-	{
-		QFile file(args.configFile);
-		if(!file.open(QIODevice::ReadOnly))
-		{
-			log_error("failed to open config file: %s", qPrintable(args.configFile));
-			return 1;
-		}
-	}
+    // QSettings doesn't inform us if the config file can't be opened, so do that
+    // ourselves
+    {
+        QFile file(args.configFile);
+        if (!file.open(QIODevice::ReadOnly)) {
+            log_error("failed to open config file: %s", qPrintable(args.configFile));
+            return 1;
+        }
+    }
 
-	QDir configDir = QFileInfo(args.configFile).absoluteDir();
+    QDir configDir = QFileInfo(args.configFile).absoluteDir();
 
-	Settings settings(args.configFile);
-	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+    Settings settings(args.configFile);
+    if (!args.ipcPrefix.isEmpty())
+        settings.setIpcPrefix(args.ipcPrefix);
 
-	QStringList services = settings.value("runner/services").toStringList();
+    QStringList services = settings.value("runner/services").toStringList();
 
-	int workerCount = settings.value("proxy/workers", 1).toInt();
-	QStringList connmgr_in_specs = settings.value("proxy/connmgr_in_specs").toStringList();
-	trimlist(&connmgr_in_specs);
-	QStringList connmgr_in_stream_specs = settings.value("proxy/connmgr_in_stream_specs").toStringList();
-	trimlist(&connmgr_in_stream_specs);
-	QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
-	trimlist(&connmgr_out_specs);
-	QStringList condure_in_specs = settings.value("proxy/condure_in_specs").toStringList();
-	trimlist(&condure_in_specs);
-	connmgr_in_specs += condure_in_specs;
-	QStringList condure_in_stream_specs = settings.value("proxy/condure_in_stream_specs").toStringList();
-	trimlist(&condure_in_stream_specs);
-	connmgr_in_stream_specs += condure_in_stream_specs;
-	QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
-	trimlist(&condure_out_specs);
-	connmgr_out_specs += condure_out_specs;
-	QStringList m2a_in_specs = settings.value("proxy/m2a_in_specs").toStringList();
-	trimlist(&m2a_in_specs);
-	QStringList m2a_in_stream_specs = settings.value("proxy/m2a_in_stream_specs").toStringList();
-	trimlist(&m2a_in_stream_specs);
-	QStringList m2a_out_specs = settings.value("proxy/m2a_out_specs").toStringList();
-	trimlist(&m2a_out_specs);
-	QStringList connmgr_client_out_specs = settings.value("proxy/connmgr_client_out_specs").toStringList();
-	trimlist(&connmgr_client_out_specs);
-	QStringList connmgr_client_out_stream_specs = settings.value("proxy/connmgr_client_out_stream_specs").toStringList();
-	trimlist(&connmgr_client_out_stream_specs);
-	QStringList connmgr_client_in_specs = settings.value("proxy/connmgr_client_in_specs").toStringList();
-	trimlist(&connmgr_client_in_specs);
-	QStringList condure_client_out_specs = settings.value("proxy/condure_client_out_specs").toStringList();
-	trimlist(&condure_client_out_specs);
-	connmgr_client_out_specs += condure_client_out_specs;
-	QStringList condure_client_out_stream_specs = settings.value("proxy/condure_client_out_stream_specs").toStringList();
-	trimlist(&condure_client_out_stream_specs);
-	connmgr_client_out_stream_specs += condure_client_out_stream_specs;
-	QStringList condure_client_in_specs = settings.value("proxy/condure_client_in_specs").toStringList();
-	trimlist(&condure_client_in_specs);
-	connmgr_client_in_specs += condure_client_in_specs;
-	QStringList zurl_out_specs = settings.value("proxy/zurl_out_specs").toStringList();
-	trimlist(&zurl_out_specs);
-	QStringList zurl_out_stream_specs = settings.value("proxy/zurl_out_stream_specs").toStringList();
-	trimlist(&zurl_out_stream_specs);
-	QStringList zurl_in_specs = settings.value("proxy/zurl_in_specs").toStringList();
-	trimlist(&zurl_in_specs);
-	QString handler_inspect_spec = settings.value("proxy/handler_inspect_spec").toString();
-	QString handler_accept_spec = settings.value("proxy/handler_accept_spec").toString();
-	QString handler_retry_in_spec = settings.value("proxy/handler_retry_in_spec").toString();
-	QStringList handler_ws_control_init_specs = settings.value("proxy/handler_ws_control_init_specs").toStringList();
-	trimlist(&handler_ws_control_init_specs);
-	QStringList handler_ws_control_stream_specs = settings.value("proxy/handler_ws_control_stream_specs").toStringList();
-	trimlist(&handler_ws_control_stream_specs);
-	QString stats_spec = settings.value("proxy/stats_spec").toString();
-	QString command_spec = settings.value("proxy/command_spec").toString();
-	QStringList intreq_in_specs = settings.value("proxy/intreq_in_specs").toStringList();
-	trimlist(&intreq_in_specs);
-	QStringList intreq_in_stream_specs = settings.value("proxy/intreq_in_stream_specs").toStringList();
-	trimlist(&intreq_in_stream_specs);
-	QStringList intreq_out_specs = settings.value("proxy/intreq_out_specs").toStringList();
-	trimlist(&intreq_out_specs);
-	bool ok;
-	int ipcFileMode = settings.value("proxy/ipc_file_mode", -1).toString().toInt(&ok, 8);
-	int sessionsMax = settings.value("proxy/max_open_requests", -1).toInt();
-	QString routesFile = settings.value("proxy/routesfile").toString();
-	bool debug = settings.value("proxy/debug").toBool();
-	bool autoCrossOrigin = settings.value("proxy/auto_cross_origin").toBool();
-	bool acceptXForwardedProtocol = settings.value("proxy/accept_x_forwarded_protocol").toBool();
-	QString setXForwardedProtocol = settings.value("proxy/set_x_forwarded_protocol").toString();
-	bool setXfProto = (setXForwardedProtocol == "true" || setXForwardedProtocol == "proto-only");
-	bool setXfProtocol = (setXForwardedProtocol == "true");
-	XffRule xffRule = parse_xffRule(settings.value("proxy/x_forwarded_for").toStringList());
-	XffRule xffTrustedRule = parse_xffRule(settings.value("proxy/x_forwarded_for_trusted").toStringList());
-	QStringList origHeadersNeedMarkStr = settings.value("proxy/orig_headers_need_mark").toStringList();
-	trimlist(&origHeadersNeedMarkStr);
-	bool acceptPushpinRoute = settings.value("proxy/accept_pushpin_route").toBool();
-	QByteArray cdnLoop = settings.value("proxy/cdn_loop").toString().toUtf8();
-	bool logFrom = settings.value("proxy/log_from").toBool();
-	bool logUserAgent = settings.value("proxy/log_user_agent").toBool();
-	QByteArray sigIss = settings.value("proxy/sig_iss", "pushpin").toString().toUtf8();
-	Jwt::EncodingKey sigKey = Jwt::EncodingKey::fromConfigString(settings.value("proxy/sig_key").toString(), configDir);
-	Jwt::DecodingKey upstreamKey = Jwt::DecodingKey::fromConfigString(settings.value("proxy/upstream_key").toString(), configDir);
-	QString sockJsUrl = settings.value("proxy/sockjs_url").toString();
-	int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
-	bool statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
-	int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
-	int statsConnectionsMaxTtl = settings.value("proxy/stats_connections_max_ttl", 60).toInt();
-	int statsReportInterval = settings.value("proxy/stats_report_interval", 10).toInt();
-	QString prometheusPort = settings.value("proxy/prometheus_port").toString();
-	QString prometheusPrefix = settings.value("proxy/prometheus_prefix").toString();
+    int workerCount = settings.value("proxy/workers", 1).toInt();
+    QStringList connmgr_in_specs = settings.value("proxy/connmgr_in_specs").toStringList();
+    trimlist(&connmgr_in_specs);
+    QStringList connmgr_in_stream_specs =
+        settings.value("proxy/connmgr_in_stream_specs").toStringList();
+    trimlist(&connmgr_in_stream_specs);
+    QStringList connmgr_out_specs = settings.value("proxy/connmgr_out_specs").toStringList();
+    trimlist(&connmgr_out_specs);
+    QStringList condure_in_specs = settings.value("proxy/condure_in_specs").toStringList();
+    trimlist(&condure_in_specs);
+    connmgr_in_specs += condure_in_specs;
+    QStringList condure_in_stream_specs =
+        settings.value("proxy/condure_in_stream_specs").toStringList();
+    trimlist(&condure_in_stream_specs);
+    connmgr_in_stream_specs += condure_in_stream_specs;
+    QStringList condure_out_specs = settings.value("proxy/condure_out_specs").toStringList();
+    trimlist(&condure_out_specs);
+    connmgr_out_specs += condure_out_specs;
+    QStringList m2a_in_specs = settings.value("proxy/m2a_in_specs").toStringList();
+    trimlist(&m2a_in_specs);
+    QStringList m2a_in_stream_specs = settings.value("proxy/m2a_in_stream_specs").toStringList();
+    trimlist(&m2a_in_stream_specs);
+    QStringList m2a_out_specs = settings.value("proxy/m2a_out_specs").toStringList();
+    trimlist(&m2a_out_specs);
+    QStringList connmgr_client_out_specs =
+        settings.value("proxy/connmgr_client_out_specs").toStringList();
+    trimlist(&connmgr_client_out_specs);
+    QStringList connmgr_client_out_stream_specs =
+        settings.value("proxy/connmgr_client_out_stream_specs").toStringList();
+    trimlist(&connmgr_client_out_stream_specs);
+    QStringList connmgr_client_in_specs =
+        settings.value("proxy/connmgr_client_in_specs").toStringList();
+    trimlist(&connmgr_client_in_specs);
+    QStringList condure_client_out_specs =
+        settings.value("proxy/condure_client_out_specs").toStringList();
+    trimlist(&condure_client_out_specs);
+    connmgr_client_out_specs += condure_client_out_specs;
+    QStringList condure_client_out_stream_specs =
+        settings.value("proxy/condure_client_out_stream_specs").toStringList();
+    trimlist(&condure_client_out_stream_specs);
+    connmgr_client_out_stream_specs += condure_client_out_stream_specs;
+    QStringList condure_client_in_specs =
+        settings.value("proxy/condure_client_in_specs").toStringList();
+    trimlist(&condure_client_in_specs);
+    connmgr_client_in_specs += condure_client_in_specs;
+    QStringList zurl_out_specs = settings.value("proxy/zurl_out_specs").toStringList();
+    trimlist(&zurl_out_specs);
+    QStringList zurl_out_stream_specs =
+        settings.value("proxy/zurl_out_stream_specs").toStringList();
+    trimlist(&zurl_out_stream_specs);
+    QStringList zurl_in_specs = settings.value("proxy/zurl_in_specs").toStringList();
+    trimlist(&zurl_in_specs);
+    QString handler_inspect_spec = settings.value("proxy/handler_inspect_spec").toString();
+    QString handler_accept_spec = settings.value("proxy/handler_accept_spec").toString();
+    QString handler_retry_in_spec = settings.value("proxy/handler_retry_in_spec").toString();
+    QStringList handler_ws_control_init_specs =
+        settings.value("proxy/handler_ws_control_init_specs").toStringList();
+    trimlist(&handler_ws_control_init_specs);
+    QStringList handler_ws_control_stream_specs =
+        settings.value("proxy/handler_ws_control_stream_specs").toStringList();
+    trimlist(&handler_ws_control_stream_specs);
+    QString stats_spec = settings.value("proxy/stats_spec").toString();
+    QString command_spec = settings.value("proxy/command_spec").toString();
+    QStringList intreq_in_specs = settings.value("proxy/intreq_in_specs").toStringList();
+    trimlist(&intreq_in_specs);
+    QStringList intreq_in_stream_specs =
+        settings.value("proxy/intreq_in_stream_specs").toStringList();
+    trimlist(&intreq_in_stream_specs);
+    QStringList intreq_out_specs = settings.value("proxy/intreq_out_specs").toStringList();
+    trimlist(&intreq_out_specs);
+    bool ok;
+    int ipcFileMode = settings.value("proxy/ipc_file_mode", -1).toString().toInt(&ok, 8);
+    int sessionsMax = settings.value("proxy/max_open_requests", -1).toInt();
+    QString routesFile = settings.value("proxy/routesfile").toString();
+    bool debug = settings.value("proxy/debug").toBool();
+    bool autoCrossOrigin = settings.value("proxy/auto_cross_origin").toBool();
+    bool acceptXForwardedProtocol = settings.value("proxy/accept_x_forwarded_protocol").toBool();
+    QString setXForwardedProtocol = settings.value("proxy/set_x_forwarded_protocol").toString();
+    bool setXfProto = (setXForwardedProtocol == "true" || setXForwardedProtocol == "proto-only");
+    bool setXfProtocol = (setXForwardedProtocol == "true");
+    XffRule xffRule = parse_xffRule(settings.value("proxy/x_forwarded_for").toStringList());
+    XffRule xffTrustedRule =
+        parse_xffRule(settings.value("proxy/x_forwarded_for_trusted").toStringList());
+    QStringList origHeadersNeedMarkStr =
+        settings.value("proxy/orig_headers_need_mark").toStringList();
+    trimlist(&origHeadersNeedMarkStr);
+    bool acceptPushpinRoute = settings.value("proxy/accept_pushpin_route").toBool();
+    QByteArray cdnLoop = settings.value("proxy/cdn_loop").toString().toUtf8();
+    bool logFrom = settings.value("proxy/log_from").toBool();
+    bool logUserAgent = settings.value("proxy/log_user_agent").toBool();
+    QByteArray sigIss = settings.value("proxy/sig_iss", "pushpin").toString().toUtf8();
+    Jwt::EncodingKey sigKey =
+        Jwt::EncodingKey::fromConfigString(settings.value("proxy/sig_key").toString(), configDir);
+    Jwt::DecodingKey upstreamKey = Jwt::DecodingKey::fromConfigString(
+        settings.value("proxy/upstream_key").toString(), configDir);
+    QString sockJsUrl = settings.value("proxy/sockjs_url").toString();
+    int clientMaxconn = settings.value("runner/client_maxconn", 50000).toInt();
+    bool statsConnectionSend = settings.value("global/stats_connection_send", true).toBool();
+    int statsConnectionTtl = settings.value("global/stats_connection_ttl", 120).toInt();
+    int statsConnectionsMaxTtl = settings.value("proxy/stats_connections_max_ttl", 60).toInt();
+    int statsReportInterval = settings.value("proxy/stats_report_interval", 10).toInt();
+    QString prometheusPort = settings.value("proxy/prometheus_port").toString();
+    QString prometheusPrefix = settings.value("proxy/prometheus_prefix").toString();
 
-	QList<QByteArray> origHeadersNeedMark;
-	foreach(const QString &s, origHeadersNeedMarkStr)
-		origHeadersNeedMark += s.toUtf8();
+    QList<QByteArray> origHeadersNeedMark;
+    foreach (const QString &s, origHeadersNeedMarkStr)
+        origHeadersNeedMark += s.toUtf8();
 
-	// If routesFile is a relative path, then use it relative to the config file location
-	QFileInfo fi(routesFile);
-	if(fi.isRelative())
-		routesFile = QFileInfo(configDir, routesFile).filePath();
+    // If routesFile is a relative path, then use it relative to the config file
+    // location
+    QFileInfo fi(routesFile);
+    if (fi.isRelative())
+        routesFile = QFileInfo(configDir, routesFile).filePath();
 
-	if(!(!connmgr_in_specs.isEmpty() && !connmgr_in_stream_specs.isEmpty() && !connmgr_out_specs.isEmpty()) && !(!m2a_in_specs.isEmpty() && !m2a_in_stream_specs.isEmpty() && !m2a_out_specs.isEmpty()))
-	{
-		log_error("must set connmgr_in_specs, connmgr_in_stream_specs, and connmgr_out_specs, or m2a_in_specs, m2a_in_stream_specs, and m2a_out_specs");
-		return 1;
-	}
+    if (!(!connmgr_in_specs.isEmpty() && !connmgr_in_stream_specs.isEmpty() &&
+          !connmgr_out_specs.isEmpty()) &&
+        !(!m2a_in_specs.isEmpty() && !m2a_in_stream_specs.isEmpty() && !m2a_out_specs.isEmpty())) {
+        log_error("must set connmgr_in_specs, connmgr_in_stream_specs, and "
+                  "connmgr_out_specs, or m2a_in_specs, m2a_in_stream_specs, and "
+                  "m2a_out_specs");
+        return 1;
+    }
 
-	if(!(!connmgr_client_out_specs.isEmpty() && !connmgr_client_out_stream_specs.isEmpty() && !connmgr_client_in_specs.isEmpty()) && !(!zurl_out_specs.isEmpty() && !zurl_out_stream_specs.isEmpty() && !zurl_in_specs.isEmpty()))
-	{
-		log_error("must set connmgr_client_out_specs, connmgr_client_out_stream_specs, and connmgr_client_in_specs, or zurl_out_specs, zurl_out_stream_specs, and zurl_in_specs");
-		return 1;
-	}
+    if (!(!connmgr_client_out_specs.isEmpty() && !connmgr_client_out_stream_specs.isEmpty() &&
+          !connmgr_client_in_specs.isEmpty()) &&
+        !(!zurl_out_specs.isEmpty() && !zurl_out_stream_specs.isEmpty() &&
+          !zurl_in_specs.isEmpty())) {
+        log_error("must set connmgr_client_out_specs, "
+                  "connmgr_client_out_stream_specs, and connmgr_client_in_specs, "
+                  "or zurl_out_specs, zurl_out_stream_specs, and zurl_in_specs");
+        return 1;
+    }
 
-	// SessionsMax should not exceed clientMaxconn
-	if(sessionsMax >= 0)
-		sessionsMax = qMin(sessionsMax, clientMaxconn);
-	else
-		sessionsMax = clientMaxconn;
+    // SessionsMax should not exceed clientMaxconn
+    if (sessionsMax >= 0)
+        sessionsMax = qMin(sessionsMax, clientMaxconn);
+    else
+        sessionsMax = clientMaxconn;
 
-	Engine::Configuration config;
-	config.appVersion = Config::get().version;
-	config.clientId = "proxy_" + QByteArray::number(getpid());
-	if(!services.contains("mongrel2") && (!connmgr_in_specs.isEmpty() || !connmgr_in_stream_specs.isEmpty() || !connmgr_out_specs.isEmpty()))
-	{
-		config.serverInSpecs = connmgr_in_specs;
-		config.serverInStreamSpecs = connmgr_in_stream_specs;
-		config.serverOutSpecs = connmgr_out_specs;
-	}
-	else
-	{
-		config.serverInSpecs = m2a_in_specs;
-		config.serverInStreamSpecs = m2a_in_stream_specs;
-		config.serverOutSpecs = m2a_out_specs;
-	}
-	if(!services.contains("zurl") && (!connmgr_client_out_specs.isEmpty() || !connmgr_client_out_stream_specs.isEmpty() || !connmgr_client_in_specs.isEmpty()))
-	{
-		config.clientOutSpecs = connmgr_client_out_specs;
-		config.clientOutStreamSpecs = connmgr_client_out_stream_specs;
-		config.clientInSpecs = connmgr_client_in_specs;
-	}
-	else
-	{
-		config.clientOutSpecs = zurl_out_specs;
-		config.clientOutStreamSpecs = zurl_out_stream_specs;
-		config.clientInSpecs = zurl_in_specs;
-	}
-	config.inspectSpec = handler_inspect_spec;
-	config.acceptSpec = handler_accept_spec;
-	config.retryInSpec = handler_retry_in_spec;
-	config.wsControlInitSpecs = handler_ws_control_init_specs;
-	config.wsControlStreamSpecs = handler_ws_control_stream_specs;
-	config.statsSpec = stats_spec;
-	config.commandSpec = command_spec;
-	config.intServerInSpecs = intreq_in_specs;
-	config.intServerInStreamSpecs = intreq_in_stream_specs;
-	config.intServerOutSpecs = intreq_out_specs;
-	config.ipcFileMode = ipcFileMode;
-	config.sessionsMax = sessionsMax / workerCount;
-	config.debug = debug;
-	config.autoCrossOrigin = autoCrossOrigin;
-	config.acceptXForwardedProto = acceptXForwardedProtocol;
-	config.setXForwardedProto = setXfProto;
-	config.setXForwardedProtocol = setXfProtocol;
-	config.xffUntrustedRule = xffRule;
-	config.xffTrustedRule = xffTrustedRule;
-	config.origHeadersNeedMark = origHeadersNeedMark;
-	config.acceptPushpinRoute = acceptPushpinRoute;
-	config.cdnLoop = cdnLoop;
-	config.logFrom = logFrom;
-	config.logUserAgent = logUserAgent;
-	config.sigIss = sigIss;
-	config.sigKey = sigKey;
-	config.upstreamKey = upstreamKey;
-	config.sockJsUrl = sockJsUrl;
-	config.statsConnectionSend = statsConnectionSend;
-	config.statsConnectionTtl = statsConnectionTtl;
-	config.statsConnectionsMaxTtl = statsConnectionsMaxTtl;
-	config.statsReportInterval = statsReportInterval;
-	config.prometheusPort = prometheusPort;
-	config.prometheusPrefix = prometheusPrefix;
+    Engine::Configuration config;
+    config.appVersion = Config::get().version;
+    config.clientId = "proxy_" + QByteArray::number(getpid());
+    if (!services.contains("mongrel2") &&
+        (!connmgr_in_specs.isEmpty() || !connmgr_in_stream_specs.isEmpty() ||
+         !connmgr_out_specs.isEmpty())) {
+        config.serverInSpecs = connmgr_in_specs;
+        config.serverInStreamSpecs = connmgr_in_stream_specs;
+        config.serverOutSpecs = connmgr_out_specs;
+    } else {
+        config.serverInSpecs = m2a_in_specs;
+        config.serverInStreamSpecs = m2a_in_stream_specs;
+        config.serverOutSpecs = m2a_out_specs;
+    }
+    if (!services.contains("zurl") &&
+        (!connmgr_client_out_specs.isEmpty() || !connmgr_client_out_stream_specs.isEmpty() ||
+         !connmgr_client_in_specs.isEmpty())) {
+        config.clientOutSpecs = connmgr_client_out_specs;
+        config.clientOutStreamSpecs = connmgr_client_out_stream_specs;
+        config.clientInSpecs = connmgr_client_in_specs;
+    } else {
+        config.clientOutSpecs = zurl_out_specs;
+        config.clientOutStreamSpecs = zurl_out_stream_specs;
+        config.clientInSpecs = zurl_in_specs;
+    }
+    config.inspectSpec = handler_inspect_spec;
+    config.acceptSpec = handler_accept_spec;
+    config.retryInSpec = handler_retry_in_spec;
+    config.wsControlInitSpecs = handler_ws_control_init_specs;
+    config.wsControlStreamSpecs = handler_ws_control_stream_specs;
+    config.statsSpec = stats_spec;
+    config.commandSpec = command_spec;
+    config.intServerInSpecs = intreq_in_specs;
+    config.intServerInStreamSpecs = intreq_in_stream_specs;
+    config.intServerOutSpecs = intreq_out_specs;
+    config.ipcFileMode = ipcFileMode;
+    config.sessionsMax = sessionsMax / workerCount;
+    config.debug = debug;
+    config.autoCrossOrigin = autoCrossOrigin;
+    config.acceptXForwardedProto = acceptXForwardedProtocol;
+    config.setXForwardedProto = setXfProto;
+    config.setXForwardedProtocol = setXfProtocol;
+    config.xffUntrustedRule = xffRule;
+    config.xffTrustedRule = xffTrustedRule;
+    config.origHeadersNeedMark = origHeadersNeedMark;
+    config.acceptPushpinRoute = acceptPushpinRoute;
+    config.cdnLoop = cdnLoop;
+    config.logFrom = logFrom;
+    config.logUserAgent = logUserAgent;
+    config.sigIss = sigIss;
+    config.sigKey = sigKey;
+    config.upstreamKey = upstreamKey;
+    config.sockJsUrl = sockJsUrl;
+    config.statsConnectionSend = statsConnectionSend;
+    config.statsConnectionTtl = statsConnectionTtl;
+    config.statsConnectionsMaxTtl = statsConnectionsMaxTtl;
+    config.statsReportInterval = statsReportInterval;
+    config.prometheusPort = prometheusPort;
+    config.prometheusPrefix = prometheusPrefix;
 
-	return runLoop(config, args.routeLines, routesFile, workerCount);
+    return runLoop(config, args.routeLines, routesFile, workerCount);
 }
-
 }

--- a/src/proxy/proxyargsdata.cpp
+++ b/src/proxy/proxyargsdata.cpp
@@ -23,15 +23,13 @@
 
 #include "proxyargsdata.h"
 
-ProxyArgsData::ProxyArgsData(const ffi::ProxyCliArgs *argsFfi)
-{
-	configFile = QString::fromUtf8(argsFfi->config_file);
-	logFile    = QString::fromUtf8(argsFfi->log_file);
-	logLevel   = argsFfi->log_level;
-	ipcPrefix  = QString::fromUtf8(argsFfi->ipc_prefix);
+ProxyArgsData::ProxyArgsData(const ffi::ProxyCliArgs *argsFfi) {
+    configFile = QString::fromUtf8(argsFfi->config_file);
+    logFile = QString::fromUtf8(argsFfi->log_file);
+    logLevel = argsFfi->log_level;
+    ipcPrefix = QString::fromUtf8(argsFfi->ipc_prefix);
 
-	for (unsigned int i = 0; i < argsFfi->routes_count; ++i)
-	{
-		routeLines << QString::fromUtf8(argsFfi->routes[i]);
-	}
+    for (unsigned int i = 0; i < argsFfi->routes_count; ++i) {
+        routeLines << QString::fromUtf8(argsFfi->routes[i]);
+    }
 }

--- a/src/proxy/proxyargsdata.h
+++ b/src/proxy/proxyargsdata.h
@@ -24,21 +24,20 @@
 #ifndef PROXYARGSDATA_H
 #define PROXYARGSDATA_H
 
+#include "rust/bindings.h"
 #include <QString>
 #include <QStringList>
-#include "rust/bindings.h"
 
 /// Stores the arguments passed into the proxy application from command line
-class ProxyArgsData
-{
+class ProxyArgsData {
 public:
-	QString configFile;
-	QString logFile;
-	int logLevel;
-	QString ipcPrefix;
-	QStringList routeLines;
+    QString configFile;
+    QString logFile;
+    int logLevel;
+    QString ipcPrefix;
+    QStringList routeLines;
 
-	ProxyArgsData(const ffi::ProxyCliArgs *argsFfi);
+    ProxyArgsData(const ffi::ProxyCliArgs *argsFfi);
 };
 
 #endif

--- a/src/proxy/proxyargstest.cpp
+++ b/src/proxy/proxyargstest.cpp
@@ -20,77 +20,77 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <filesystem>
-#include "test.h"
-#include "log.h"
 #include "config.h"
-#include "settings.h"
+#include "log.h"
 #include "proxyargsdata.h"
+#include "settings.h"
+#include "test.h"
+#include <filesystem>
 
-static void proxyargstest()
-{
-	// Get file for example config
-	std::string configFile = "examples/config/pushpin.conf";
+static void proxyargstest() {
+    // Get file for example config
+    std::string configFile = "examples/config/pushpin.conf";
 
-	// Create test routes array
-	const char* route1 = "route1";
-	const char* route2 = "route2";
-	const char* routes[] = { route1, route2 };
+    // Create test routes array
+    const char *route1 = "route1";
+    const char *route2 = "route2";
+    const char *routes[] = {route1, route2};
 
-	ffi::ProxyCliArgs argsFfi = {
-		const_cast<char*>(configFile.c_str()),  // config_file
-		const_cast<char*>("proxy-log.txt"),     // log_file
-		3,                                      // log_level
-		const_cast<char*>("ipc:prefix"),        // ipc_prefix
-		const_cast<char**>(routes),             // Routes
-		2                                       // routes_count
-	};
+    ffi::ProxyCliArgs argsFfi = {
+        const_cast<char *>(configFile.c_str()), // config_file
+        const_cast<char *>("proxy-log.txt"),    // log_file
+        3,                                      // log_level
+        const_cast<char *>("ipc:prefix"),       // ipc_prefix
+        const_cast<char **>(routes),            // Routes
+        2                                       // routes_count
+    };
 
-	// Verify ProxyArgsData parsing
-	ProxyArgsData args(&argsFfi);
-	TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
-	TEST_ASSERT_EQ(args.logFile, QString("proxy-log.txt"));
-	TEST_ASSERT_EQ(args.logLevel, 3);
-	TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
-	TEST_ASSERT_EQ(args.routeLines, QStringList({"route1", "route2"}));
+    // Verify ProxyArgsData parsing
+    ProxyArgsData args(&argsFfi);
+    TEST_ASSERT_EQ(args.configFile, QString("examples/config/pushpin.conf"));
+    TEST_ASSERT_EQ(args.logFile, QString("proxy-log.txt"));
+    TEST_ASSERT_EQ(args.logLevel, 3);
+    TEST_ASSERT_EQ(args.ipcPrefix, QString("ipc:prefix"));
+    TEST_ASSERT_EQ(args.routeLines, QStringList({"route1", "route2"}));
 
-	Settings settings(args.configFile);
-	if (!args.ipcPrefix.isEmpty()) settings.setIpcPrefix(args.ipcPrefix);
+    Settings settings(args.configFile);
+    if (!args.ipcPrefix.isEmpty())
+        settings.setIpcPrefix(args.ipcPrefix);
 
-	// Test command-line overrides were applied
-	TEST_ASSERT_EQ(settings.ipcPrefix(), QString("ipc:prefix"));
+    // Test command-line overrides were applied
+    TEST_ASSERT_EQ(settings.ipcPrefix(), QString("ipc:prefix"));
 
-	// Create empty routes array for testing
-	static const char* routesEmpty[] = {};
+    // Create empty routes array for testing
+    static const char *routesEmpty[] = {};
 
-	// Set up valid empty command line arguments
-	ffi::ProxyCliArgs argsFfiEmpty = {
-		const_cast<char*>(configFile.c_str()),  // config_file
-		const_cast<char*>(""),                  // log_file
-		2,                                      // log_level
-		const_cast<char*>(""),                  // ipc_prefix
-		const_cast<char**>(routesEmpty),        // Routes array
-		0                                       // routes_count
-	};
+    // Set up valid empty command line arguments
+    ffi::ProxyCliArgs argsFfiEmpty = {
+        const_cast<char *>(configFile.c_str()), // config_file
+        const_cast<char *>(""),                 // log_file
+        2,                                      // log_level
+        const_cast<char *>(""),                 // ipc_prefix
+        const_cast<char **>(routesEmpty),       // Routes array
+        0                                       // routes_count
+    };
 
-	// Verify ProxyArgsData parsing with empty arguments
-	ProxyArgsData argsEmpty(&argsFfiEmpty);
-	TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
-	TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
-	TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
-	TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
-	TEST_ASSERT_EQ(argsEmpty.routeLines, QStringList());
+    // Verify ProxyArgsData parsing with empty arguments
+    ProxyArgsData argsEmpty(&argsFfiEmpty);
+    TEST_ASSERT_EQ(argsEmpty.configFile, QString("examples/config/pushpin.conf"));
+    TEST_ASSERT_EQ(argsEmpty.logFile, QString(""));
+    TEST_ASSERT_EQ(argsEmpty.logLevel, 2);
+    TEST_ASSERT_EQ(argsEmpty.ipcPrefix, QString(""));
+    TEST_ASSERT_EQ(argsEmpty.routeLines, QStringList());
 
-	Settings settingsEmpty(argsEmpty.configFile);
-	if (!argsEmpty.ipcPrefix.isEmpty()) settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
+    Settings settingsEmpty(argsEmpty.configFile);
+    if (!argsEmpty.ipcPrefix.isEmpty())
+        settingsEmpty.setIpcPrefix(argsEmpty.ipcPrefix);
 
-	// Test that no overrides were applied (should use config file defaults)
-	TEST_ASSERT_EQ(settingsEmpty.ipcPrefix(), QString("pushpin-"));
+    // Test that no overrides were applied (should use config file defaults)
+    TEST_ASSERT_EQ(settingsEmpty.ipcPrefix(), QString("pushpin-"));
 }
 
-extern "C" int proxyargs_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(proxyargstest());
+extern "C" int proxyargs_test(ffi::TestException *out_ex) {
+    TEST_CATCH(proxyargstest());
 
-	return 0;
+    return 0;
 }

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -23,1010 +23,912 @@
 
 #include "proxyengine.h"
 
-#include <assert.h>
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "zmqreqmessage.h"
-#include "tnetstring.h"
+#include "connectionmanager.h"
+#include "defercall.h"
+#include "domainmap.h"
+#include "inspectdata.h"
+#include "log.h"
+#include "logutil.h"
 #include "packet/httpresponsedata.h"
 #include "packet/retryrequestpacket.h"
 #include "packet/statspacket.h"
 #include "packet/zrpcrequestpacket.h"
-#include "qtcompat.h"
-#include "variant.h"
-#include "timer.h"
-#include "defercall.h"
-#include "log.h"
-#include "inspectdata.h"
-#include "zhttpmanager.h"
-#include "zhttprequest.h"
-#include "zwebsocket.h"
-#include "websocketoverhttp.h"
-#include "domainmap.h"
-#include "zroutes.h"
-#include "zrpcmanager.h"
-#include "zrpcrequest.h"
-#include "zrpcchecker.h"
-#include "wscontrolmanager.h"
-#include "requestsession.h"
 #include "proxysession.h"
-#include "wsproxysession.h"
-#include "statsmanager.h"
-#include "connectionmanager.h"
-#include "zutil.h"
+#include "qtcompat.h"
+#include "requestsession.h"
 #include "sockjsmanager.h"
 #include "sockjssession.h"
-#include "logutil.h"
+#include "statsmanager.h"
+#include "timer.h"
+#include "tnetstring.h"
+#include "variant.h"
+#include "websocketoverhttp.h"
+#include "wscontrolmanager.h"
+#include "wsproxysession.h"
+#include "zhttpmanager.h"
+#include "zhttprequest.h"
+#include "zmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zroutes.h"
+#include "zrpcchecker.h"
+#include "zrpcmanager.h"
+#include "zrpcrequest.h"
+#include "zutil.h"
+#include "zwebsocket.h"
+#include <assert.h>
 
 #define DEFAULT_HWM 1000
 
-class Engine::Private
-{
+class Engine::Private {
 public:
-	class ProxyItem
-	{
-	public:
-		bool shared;
-		QByteArray key;
-		ProxySession *ps;
-
-		ProxyItem() :
-			shared(false),
-			ps(0)
-		{
-		}
-	};
-
-	class WsProxyItem
-	{
-	public:
-		WsProxySession *ps;
-
-		WsProxyItem() :
-			ps(0)
-		{
-		}
-	};
-
-	struct RequestSessionConnections {
-		Connection inspectedConnection;
-		Connection inspectErrorConnection;
-		Connection finishedConnection;
-		Connection finishedByAcceptConnection;
-	};
-
-	struct ProxySessionConnections {
-		Connection addNotAllowedConnection;
-		Connection finishedConnection;
-		Connection reqSessionDestroyedConnection;
-	};
-
-	Engine *q;
-	bool destroying;
-	DomainMap *domainMap;
-	Configuration config;
-	std::unique_ptr<ZhttpManager> zhttpIn;
-	std::unique_ptr<ZhttpManager> intZhttpIn;
-	std::unique_ptr<ZRoutes> zroutes;
-	std::unique_ptr<ZrpcManager> inspect;
-	std::unique_ptr<WsControlManager> wsControl;
-	std::unique_ptr<ZrpcChecker> inspectChecker;
-	std::unique_ptr<StatsManager> stats;
-	std::unique_ptr<ZrpcManager> command;
-	std::unique_ptr<ZrpcManager> accept;
-	std::unique_ptr<ZmqSocket> handler_retry_in_sock;
-	std::unique_ptr<ZmqValve> handler_retry_in_valve;
-	QSet<RequestSession*> requestSessions;
-	QHash<QByteArray, ProxyItem*> proxyItemsByKey;
-	QHash<ProxySession*, ProxyItem*> proxyItemsBySession;
-	QHash<WsProxySession*, WsProxyItem*> wsProxyItemsBySession;
-	std::unique_ptr<SockJsManager> sockJsManager;
-	ConnectionManager connectionManager;
-	LogUtil::Config logConfig;
-	Connection cmdReqReadyConnection;
-	Connection sessionReadyConnection;
-	Connection requestReadyConnection;
-	Connection socketReadyConnection;
-	Connection iRequestReadyConnection;
-	map<RequestSession*, RequestSessionConnections> reqSessionConnectionMap;
-	map<ProxySession*, ProxySessionConnections> proxySessionConnectionMap;
-	Connection connMaxConnection;
-	Connection rrConnection;
-
-	Private(Engine *_q, DomainMap *_domainMap) :
-		q(_q),
-		destroying(false),
-		domainMap(_domainMap)
-	{
-	}
-
-	~Private()
-	{
-		destroying = true;
-
-		// Need to delete all objects that may have connections before
-		// deleting zhttpmanagers/zroutes
-
-		QHashIterator<ProxySession*, ProxyItem*> it(proxyItemsBySession);
-		while(it.hasNext())
-		{
-			it.next();
-			delete it.key();
-			delete it.value();
-		}
-
-		proxyItemsBySession.clear();
-		proxyItemsByKey.clear();
-
-		QHashIterator<WsProxySession*, WsProxyItem*> wit(wsProxyItemsBySession);
-		while(wit.hasNext())
-		{
-			wit.next();
-			delete wit.key();
-			delete wit.value();
-		}
-
-		wsProxyItemsBySession.clear();
-
-		foreach(RequestSession *rs, requestSessions){
-			reqSessionConnectionMap.erase(rs);
-			delete rs;
-		}
-		requestSessions.clear();
-
-		// May have background connections
-		sockJsManager.reset();
-
-		WebSocketOverHttp::clearDisconnectManager();
-
-		// Need to make sure this is deleted before inspect manager
-		inspectChecker.reset();
-	}
-
-	bool start(const Configuration &_config)
-	{
-		config = _config;
-
-		logConfig.fromAddress = config.logFrom;
-		logConfig.userAgent = config.logUserAgent;
-
-		WebSocketOverHttp::setMaxManagedDisconnects(config.sessionsMax);
-
-		zhttpIn = std::make_unique<ZhttpManager>();
-		requestReadyConnection = zhttpIn->requestReady.connect(boost::bind(&Private::zhttpIn_requestReady, this));
-		socketReadyConnection = zhttpIn->socketReady.connect(boost::bind(&Private::zhttpIn_socketReady, this));
-
-		zhttpIn->setInstanceId(config.clientId);
-		zhttpIn->setServerInSpecs(config.serverInSpecs);
-		zhttpIn->setServerInStreamSpecs(config.serverInStreamSpecs);
-		zhttpIn->setServerOutSpecs(config.serverOutSpecs);
-
-		if(!config.intServerInSpecs.isEmpty() && !config.intServerInStreamSpecs.isEmpty() && !config.intServerOutSpecs.isEmpty())
-		{
-			intZhttpIn = std::make_unique<ZhttpManager>();
-			intZhttpIn->setBind(true);
-			intZhttpIn->setIpcFileMode(config.ipcFileMode);
-			iRequestReadyConnection = intZhttpIn->requestReady.connect(boost::bind(&Private::intZhttpIn_requestReady, this));
-
-			intZhttpIn->setInstanceId(config.clientId);
-			intZhttpIn->setServerInSpecs(config.intServerInSpecs);
-			intZhttpIn->setServerInStreamSpecs(config.intServerInStreamSpecs);
-			intZhttpIn->setServerOutSpecs(config.intServerOutSpecs);
-		}
-
-		zroutes = std::make_unique<ZRoutes>();
-		zroutes->setInstanceId(config.clientId);
-		zroutes->setDefaultOutSpecs(config.clientOutSpecs);
-		zroutes->setDefaultOutStreamSpecs(config.clientOutStreamSpecs);
-		zroutes->setDefaultInSpecs(config.clientInSpecs);
-
-		sockJsManager = std::make_unique<SockJsManager>(config.sockJsUrl);
-		sessionReadyConnection = sockJsManager->sessionReady.connect(boost::bind(&Private::sockjs_sessionReady, this));
-		
-		// Set up the Inspect endpoint in pushpin-handler
-		if(!config.inspectSpec.isEmpty())
-		{
-			inspect = std::make_unique<ZrpcManager>();
-			inspect->setBind(true);
-			inspect->setIpcFileMode(config.ipcFileMode);
-			if(!inspect->setClientSpecs(QStringList() << config.inspectSpec))
-			{
-				// ZrpcManager logs error
-				return false;
-			}
-
-			inspect->setTimeout(config.inspectTimeout);
-
-			inspectChecker = std::make_unique<ZrpcChecker>();
-		}
-		
-		// Set up the Accept endpoint in pushpin-handler
-		if(!config.acceptSpec.isEmpty())
-		{
-			accept = std::make_unique<ZrpcManager>();
-			accept->setInstanceId(config.clientId);
-			accept->setBind(true);
-			accept->setIpcFileMode(config.ipcFileMode);
-			if(!accept->setClientSpecs(QStringList() << config.acceptSpec))
-			{
-				// ZrpcManager logs error
-				return false;
-			}
-
-			// There's no acceptTimeout config option so we'll reuse inspectTimeout
-			accept->setTimeout(config.inspectTimeout);
-		}
-
-		if(!config.retryInSpec.isEmpty())
-		{
-			handler_retry_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-
-			handler_retry_in_sock->setIdentity(config.clientId);
-			handler_retry_in_sock->setHwm(DEFAULT_HWM);
-
-			QString errorMessage;
-			if(!ZUtil::setupSocket(handler_retry_in_sock.get(), config.retryInSpec, true, config.ipcFileMode, &errorMessage))
-			{
-				log_error("%s", qPrintable(errorMessage));
-				return false;
-			}
-
-			handler_retry_in_valve = std::make_unique<ZmqValve>(handler_retry_in_sock.get());
-			rrConnection = handler_retry_in_valve->readyRead.connect(boost::bind(&Private::handler_retry_in_readyRead, this, boost::placeholders::_1));
-		}
-
-		if(handler_retry_in_valve)
-			handler_retry_in_valve->open();
-
-		if(!config.wsControlInitSpecs.isEmpty() && !config.wsControlStreamSpecs.isEmpty())
-		{
-			wsControl = std::make_unique<WsControlManager>();
-
-			wsControl->setIdentity(config.clientId);
-			wsControl->setIpcFileMode(config.ipcFileMode);
-
-			if(!wsControl->setInitSpecs(config.wsControlInitSpecs))
-			{
-				log_error("unable to bind to handler_ws_control_init_specs: %s", qPrintable(config.wsControlInitSpecs.join(", ")));
-				return false;
-			}
-
-			if(!wsControl->setStreamSpecs(config.wsControlStreamSpecs))
-			{
-				log_error("unable to bind to handler_ws_control_stream_specs: %s", qPrintable(config.wsControlStreamSpecs.join(", ")));
-				return false;
-			}
-		}
-
-		// Set up StatsManager
-		if(!config.statsSpec.isEmpty() || !config.prometheusPort.isEmpty())
-		{
-			stats = std::make_unique<StatsManager>(config.sessionsMax, 0, PROMETHEUS_CONNECTIONS_MAX);
-
-			connMaxConnection = stats->connMax.connect(boost::bind(&Private::stats_connMax, this, boost::placeholders::_1));
-
-			stats->setInstanceId(config.clientId);
-			stats->setIpcFileMode(config.ipcFileMode);
-			stats->setConnectionSendEnabled(config.statsConnectionSend);
-			stats->setConnectionsMaxSendEnabled(!config.statsConnectionSend);
-			stats->setConnectionTtl(config.statsConnectionTtl);
-			stats->setConnectionsMaxTtl(config.statsConnectionsMaxTtl);
-			stats->setReportInterval(config.statsReportInterval);
-
-			if(!config.statsSpec.isEmpty())
-			{
-				if(!stats->setSpec(config.statsSpec))
-				{
-					// StatsManager logs error
-					return false;
-				}
-			}
-
-			if(!config.prometheusPort.isEmpty())
-			{
-				stats->setPrometheusPrefix(config.prometheusPrefix);
-
-				if(!stats->setPrometheusPort(config.prometheusPort))
-				{
-					log_error("unable to bind to prometheus port: %s", qPrintable(config.prometheusPort));
-					return false;
-				}
-			}
-		}
-
-		if(!config.commandSpec.isEmpty())
-		{
-			command = std::make_unique<ZrpcManager>();
-			command->setBind(true);
-			command->setIpcFileMode(config.ipcFileMode);
-			cmdReqReadyConnection = command->requestReady.connect(boost::bind(&Private::command_requestReady, this));
-
-			if(!command->setServerSpecs(QStringList() << config.commandSpec))
-			{
-				// ZrpcManager logs error
-				return false;
-			}
-		}
-
-		// Init zroutes
-		routesChanged();
-
-		return true;
-	}
-
-	void routesChanged()
-	{
-		auto zhttpRoutes = domainMap->zhttpRoutes();
-
-		if(zhttpRoutes.count() > ZROUTES_MAX)
-		{
-			log_warning("too many unique zhttp route targets, limiting to %d", ZROUTES_MAX);
-			zhttpRoutes = zhttpRoutes.mid(0, ZROUTES_MAX);
-		}
-
-		// Connect to new zhttp targets, disconnect from old
-		zroutes->setup(zhttpRoutes);
-	}
-
-	void doProxy(RequestSession *rs, const InspectData *idata = 0)
-	{
-		DomainMap::Entry route = rs->route();
-
-		// We'll always have a route
-		assert(!route.isNull());
-
-		bool sharable = (idata && !idata->sharingKey.isEmpty() && rs->haveCompleteRequestBody());
-
-		ProxySession *ps = 0;
-		if(sharable)
-		{
-			log_debug("need to proxy with sharing key: %s", idata->sharingKey.data());
-
-			ProxyItem *i = proxyItemsByKey.value(idata->sharingKey);
-			if(i)
-				ps = i->ps;
-		}
-
-		if(!ps)
-		{
-			log_debug("creating proxysession for id=%s", rs->rid().second.data());
-
-			ps = new ProxySession(zroutes.get(), accept.get(), logConfig, stats.get());
-			// TODO: use callbacks for performance
-			proxySessionConnectionMap[ps] = {
-				ps->addNotAllowed.connect(boost::bind(&Private::ps_addNotAllowed, this, ps)),
-				ps->finished.connect(boost::bind(&Private::ps_finished, this, ps)),
-				ps->requestSessionDestroyed.connect(boost::bind(&Private::ps_requestSessionDestroyed, this, boost::placeholders::_1, boost::placeholders::_2))
-			};
-
-			ps->setRoute(route);
-			ps->setDefaultSigKey(config.sigIss, config.sigKey);
-			ps->setAcceptXForwardedProtocol(config.acceptXForwardedProto);
-			ps->setUseXForwardedProtocol(config.setXForwardedProto, config.setXForwardedProtocol);
-			ps->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
-			ps->setOrigHeadersNeedMark(config.origHeadersNeedMark);
-			ps->setAcceptPushpinRoute(config.acceptPushpinRoute);
-			ps->setCdnLoop(config.cdnLoop);
-			ps->setProxyInitialResponseEnabled(true);
-
-			if(idata)
-				ps->setInspectData(*idata);
-
-			ProxyItem *i = new ProxyItem;
-			i->ps = ps;
-			proxyItemsBySession.insert(i->ps, i);
-
-			if(sharable)
-			{
-				i->shared = true;
-				i->key = idata->sharingKey;
-				proxyItemsByKey.insert(i->key, i);
-			}
-		}
-		else
-			log_debug("reusing proxysession");
-
-		// ProxySession will take it from here
-		// TODO: use callbacks for performance
-		reqSessionConnectionMap.erase(rs);
-
-		ps->add(rs);
-	}
-
-	void doProxySocket(WebSocket *sock, const DomainMap::Entry &route)
-	{
-		QByteArray cid = connectionManager.addConnection(sock);
-
-		WsProxySession *ps = new WsProxySession(zroutes.get(), &connectionManager, logConfig, stats.get(), wsControl.get());
-		ps->finishedByPassthroughCallback().add(Private::wsps_finishedByPassthrough_cb, this);
-
-		connectionManager.setProxyForConnection(sock, ps);
-
-		ps->setDebugEnabled(config.debug || route.debug);
-		ps->setDefaultSigKey(config.sigIss, config.sigKey);
-		ps->setDefaultUpstreamKey(config.upstreamKey);
-		ps->setAcceptXForwardedProtocol(config.acceptXForwardedProto);
-		ps->setUseXForwardedProtocol(config.setXForwardedProto, config.setXForwardedProtocol);
-		ps->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
-		ps->setOrigHeadersNeedMark(config.origHeadersNeedMark);
-		ps->setAcceptPushpinRoute(config.acceptPushpinRoute);
-		ps->setCdnLoop(config.cdnLoop);
-
-		WsProxyItem *i = new WsProxyItem;
-		i->ps = ps;
-		wsProxyItemsBySession.insert(i->ps, i);
-
-		// After this call, ps->logicalClientAddress() will be valid
-		ps->start(sock, cid, route);
-
-		if(stats)
-		{
-			stats->addConnection(cid, ps->statsRoute(), StatsManager::WebSocket, ps->logicalClientAddress(), sock->requestUri().scheme() == "wss", false);
-			stats->addActivity(ps->statsRoute());
-			stats->addRequestsReceived(1);
-		}
-	}
-
-	bool canTake()
-	{
-		// Don't accept new sessions during shutdown
-		if(destroying)
-			return false;
-
-		// Don't accept new sessions if we're servicing maximum
-		int curSessions = requestSessions.count() + wsProxyItemsBySession.count();
-		if(curSessions >= config.sessionsMax)
-			return false;
-
-		return true;
-	}
-
-	bool isXForwardedProtocolTls(const HttpHeaders &headers)
-	{
-		QByteArray xfp = headers.get("X-Forwarded-Proto").asQByteArray();
-		if(xfp.isEmpty())
-			xfp = headers.get("X-Forwarded-Protocol").asQByteArray();
-		return (!xfp.isEmpty() && (xfp == "https" || xfp == "wss"));
-	}
-
-	void tryTakeRequest()
-	{
-		if(!canTake())
-			return;
-
-		// Prioritize external requests over internal requests
-
-		ZhttpRequest *req = zhttpIn->takeNextRequest();
-		if(!req)
-		{
-			if(intZhttpIn)
-				req = intZhttpIn->takeNextRequest();
-
-			if(!req)
-				return;
-		}
-
-		QString routeId;
-		bool preferInternal = false;
-		bool autoShare = false;
-
-		Variant passthroughData = req->passthroughData();
-		if(passthroughData.isValid())
-		{
-			// Passthrough request, from handler
-
-			const VariantHash data = passthroughData.toHash();
-
-			// There is always a route
-			routeId = QString::fromUtf8(data["route"].toByteArray());
-
-			if(data.contains("prefer-internal"))
-				preferInternal = data["prefer-internal"].toBool();
-
-			if(data.contains("auto-share"))
-				autoShare = data["auto-share"].toBool();
-		}
-		else
-		{
-			// Regular request
-
-			if(config.acceptXForwardedProto && isXForwardedProtocolTls(req->requestHeaders()))
-				req->setIsTls(true);
-
-			if(config.acceptPushpinRoute)
-				routeId = QString::fromUtf8(req->requestHeaders().get("Pushpin-Route").asQByteArray());
-		}
-
-		RequestSession *rs = new RequestSession(config.id, domainMap, sockJsManager.get(), inspect.get(), inspectChecker.get(), accept.get(), stats.get());
-
-		if(passthroughData.isValid() && !preferInternal)
-		{
-			// Passthrough request with preferInternal=false. In this case,
-			// set up a direct route, using some settings from the original
-			// route
-
-			DomainMap::Entry originalRoute;
-			if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-				originalRoute = domainMap->entry(routeId);
-
-			const VariantHash data = passthroughData.toHash();
-
-			DomainMap::Entry route;
-
-			// Use sig settings from the original route, if available
-			if(!originalRoute.isNull())
-			{
-				route.sigIss = originalRoute.sigIss;
-				route.sigKey = originalRoute.sigKey;
-			}
-
-			DomainMap::Target target;
-			Url uri = req->requestUri();
-			bool isHttps = (uri.scheme() == "https");
-			target.connectHost = uri.host();
-			target.connectPort = uri.port(isHttps ? 443 : 80);
-			target.ssl = isHttps;
-			target.trusted = data["trusted"].toBool();
-
-			route.targets += target;
-
-			rs->setRoute(route);
-		}
-		else
-		{
-			// Regular request (with or without a route ID), or a passthrough
-			// request with preferInternal=true. In that case, use domainmap
-			// for lookup, with route ID if available
-
-			rs->setRouteId(routeId);
-		}
-
-		if(!passthroughData.isValid())
-		{
-			// These only make sense on regular requests
-
-			rs->setDebugEnabled(config.debug);
-			rs->setAutoCrossOrigin(config.autoCrossOrigin);
-			rs->setPrefetchSize(config.inspectPrefetch);
-			rs->setDefaultUpstreamKey(config.upstreamKey);
-			rs->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
-		}
-
-		rs->setAutoShare(autoShare);
-
-		// TODO: use callbacks for performance
-		reqSessionConnectionMap[rs] = {
-			rs->inspected.connect(boost::bind(&Private::rs_inspected, this, boost::placeholders::_1, rs)),
-			rs->inspectError.connect(boost::bind(&Private::rs_inspectError, this, rs)),
-			rs->finished.connect(boost::bind(&Private::rs_finished, this, rs)),
-			rs->finishedByAccept.connect(boost::bind(&Private::rs_finishedByAccept, this, rs))
-		};
-
-		requestSessions += rs;
-
-		rs->start(req);
-	}
-
-	void tryTakeSocket()
-	{
-		if(!canTake())
-			return;
-
-		ZWebSocket *sock = zhttpIn->takeNextSocket();
-		if(!sock)
-			return;
-
-		if(config.acceptXForwardedProto && isXForwardedProtocolTls(sock->requestHeaders()))
-			sock->setIsTls(true);
-
-		Url requestUri = sock->requestUri();
-
-		log_debug("worker %d: IN ws id=%s, %s", config.id, sock->rid().second.data(), requestUri.toEncoded().data());
-
-		bool isSecure = (requestUri.scheme() == "wss");
-		QString host = requestUri.host();
-
-		QByteArray encPath = requestUri.path(Url::FullyEncoded).toUtf8();
-
-		QString routeId;
-
-		if(config.acceptPushpinRoute)
-			routeId = QString::fromUtf8(sock->requestHeaders().get("Pushpin-Route").asQByteArray());
-
-		// Look up the route
-		DomainMap::Entry route;
-		if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-			route = domainMap->entry(routeId);
-		else
-			route = domainMap->entry(DomainMap::WebSocket, isSecure, host, encPath);
-
-		// Before we do anything else, see if this is a sockjs request
-		if(!route.isNull() && !route.sockJsPath.isEmpty() && encPath.startsWith(route.sockJsPath))
-		{
-			sockJsManager->giveSocket(sock, route.sockJsPath.length(), route.sockJsAsPath, route);
-			return;
-		}
-
-		log_debug("creating wsproxysession for zws id=%s", sock->rid().second.data());
-		doProxySocket(sock, route);
-	}
-
-	void tryTakeSockJsSession()
-	{
-		if(!canTake())
-			return;
-
-		SockJsSession *sock = sockJsManager->takeNext();
-		if(!sock)
-			return;
-
-		log_debug("IN sockjs obj=%p %s", sock, sock->requestUri().toEncoded().data());
-
-		log_debug("creating wsproxysession for sockjs=%p", sock);
-		doProxySocket(sock, sock->route());
-	}
-
-	void tryTakeNext()
-	{
-		tryTakeRequest();
-		tryTakeSocket();
-		tryTakeSockJsSession();
-	}
-
-	void logFinished(RequestSession *rs, bool accepted = false)
-	{
-		HttpResponseData resp = rs->responseData();
-
-		LogUtil::RequestData rd;
-
-		DomainMap::Entry route = rs->route();
-
-		// Only log route id if explicitly set
-		if(route.separateStats)
-			rd.routeId = route.id;
-
-		if(accepted)
-		{
-			rd.status = LogUtil::Accept;
-		}
-		else if(resp.code != -1)
-		{
-			rd.status = LogUtil::Response;
-			rd.responseData = resp;
-			rd.responseBodySize = rs->responseBodySize();
-		}
-		else
-		{
-			rd.status = LogUtil::Error;
-		}
-
-		rd.requestData = rs->requestData();
-
-		rd.fromAddress = rs->logicalPeerAddress();
-
-		LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
-	}
+    class ProxyItem {
+    public:
+        bool shared;
+        QByteArray key;
+        ProxySession *ps;
+
+        ProxyItem() : shared(false), ps(0) {}
+    };
+
+    class WsProxyItem {
+    public:
+        WsProxySession *ps;
+
+        WsProxyItem() : ps(0) {}
+    };
+
+    struct RequestSessionConnections {
+        Connection inspectedConnection;
+        Connection inspectErrorConnection;
+        Connection finishedConnection;
+        Connection finishedByAcceptConnection;
+    };
+
+    struct ProxySessionConnections {
+        Connection addNotAllowedConnection;
+        Connection finishedConnection;
+        Connection reqSessionDestroyedConnection;
+    };
+
+    Engine *q;
+    bool destroying;
+    DomainMap *domainMap;
+    Configuration config;
+    std::unique_ptr<ZhttpManager> zhttpIn;
+    std::unique_ptr<ZhttpManager> intZhttpIn;
+    std::unique_ptr<ZRoutes> zroutes;
+    std::unique_ptr<ZrpcManager> inspect;
+    std::unique_ptr<WsControlManager> wsControl;
+    std::unique_ptr<ZrpcChecker> inspectChecker;
+    std::unique_ptr<StatsManager> stats;
+    std::unique_ptr<ZrpcManager> command;
+    std::unique_ptr<ZrpcManager> accept;
+    std::unique_ptr<ZmqSocket> handler_retry_in_sock;
+    std::unique_ptr<ZmqValve> handler_retry_in_valve;
+    QSet<RequestSession *> requestSessions;
+    QHash<QByteArray, ProxyItem *> proxyItemsByKey;
+    QHash<ProxySession *, ProxyItem *> proxyItemsBySession;
+    QHash<WsProxySession *, WsProxyItem *> wsProxyItemsBySession;
+    std::unique_ptr<SockJsManager> sockJsManager;
+    ConnectionManager connectionManager;
+    LogUtil::Config logConfig;
+    Connection cmdReqReadyConnection;
+    Connection sessionReadyConnection;
+    Connection requestReadyConnection;
+    Connection socketReadyConnection;
+    Connection iRequestReadyConnection;
+    map<RequestSession *, RequestSessionConnections> reqSessionConnectionMap;
+    map<ProxySession *, ProxySessionConnections> proxySessionConnectionMap;
+    Connection connMaxConnection;
+    Connection rrConnection;
+
+    Private(Engine *_q, DomainMap *_domainMap) : q(_q), destroying(false), domainMap(_domainMap) {}
+
+    ~Private() {
+        destroying = true;
+
+        // Need to delete all objects that may have connections before
+        // deleting zhttpmanagers/zroutes
+
+        QHashIterator<ProxySession *, ProxyItem *> it(proxyItemsBySession);
+        while (it.hasNext()) {
+            it.next();
+            delete it.key();
+            delete it.value();
+        }
+
+        proxyItemsBySession.clear();
+        proxyItemsByKey.clear();
+
+        QHashIterator<WsProxySession *, WsProxyItem *> wit(wsProxyItemsBySession);
+        while (wit.hasNext()) {
+            wit.next();
+            delete wit.key();
+            delete wit.value();
+        }
+
+        wsProxyItemsBySession.clear();
+
+        foreach (RequestSession *rs, requestSessions) {
+            reqSessionConnectionMap.erase(rs);
+            delete rs;
+        }
+        requestSessions.clear();
+
+        // May have background connections
+        sockJsManager.reset();
+
+        WebSocketOverHttp::clearDisconnectManager();
+
+        // Need to make sure this is deleted before inspect manager
+        inspectChecker.reset();
+    }
+
+    bool start(const Configuration &_config) {
+        config = _config;
+
+        logConfig.fromAddress = config.logFrom;
+        logConfig.userAgent = config.logUserAgent;
+
+        WebSocketOverHttp::setMaxManagedDisconnects(config.sessionsMax);
+
+        zhttpIn = std::make_unique<ZhttpManager>();
+        requestReadyConnection =
+            zhttpIn->requestReady.connect(boost::bind(&Private::zhttpIn_requestReady, this));
+        socketReadyConnection =
+            zhttpIn->socketReady.connect(boost::bind(&Private::zhttpIn_socketReady, this));
+
+        zhttpIn->setInstanceId(config.clientId);
+        zhttpIn->setServerInSpecs(config.serverInSpecs);
+        zhttpIn->setServerInStreamSpecs(config.serverInStreamSpecs);
+        zhttpIn->setServerOutSpecs(config.serverOutSpecs);
+
+        if (!config.intServerInSpecs.isEmpty() && !config.intServerInStreamSpecs.isEmpty() &&
+            !config.intServerOutSpecs.isEmpty()) {
+            intZhttpIn = std::make_unique<ZhttpManager>();
+            intZhttpIn->setBind(true);
+            intZhttpIn->setIpcFileMode(config.ipcFileMode);
+            iRequestReadyConnection = intZhttpIn->requestReady.connect(
+                boost::bind(&Private::intZhttpIn_requestReady, this));
+
+            intZhttpIn->setInstanceId(config.clientId);
+            intZhttpIn->setServerInSpecs(config.intServerInSpecs);
+            intZhttpIn->setServerInStreamSpecs(config.intServerInStreamSpecs);
+            intZhttpIn->setServerOutSpecs(config.intServerOutSpecs);
+        }
+
+        zroutes = std::make_unique<ZRoutes>();
+        zroutes->setInstanceId(config.clientId);
+        zroutes->setDefaultOutSpecs(config.clientOutSpecs);
+        zroutes->setDefaultOutStreamSpecs(config.clientOutStreamSpecs);
+        zroutes->setDefaultInSpecs(config.clientInSpecs);
+
+        sockJsManager = std::make_unique<SockJsManager>(config.sockJsUrl);
+        sessionReadyConnection =
+            sockJsManager->sessionReady.connect(boost::bind(&Private::sockjs_sessionReady, this));
+
+        // Set up the Inspect endpoint in pushpin-handler
+        if (!config.inspectSpec.isEmpty()) {
+            inspect = std::make_unique<ZrpcManager>();
+            inspect->setBind(true);
+            inspect->setIpcFileMode(config.ipcFileMode);
+            if (!inspect->setClientSpecs(QStringList() << config.inspectSpec)) {
+                // ZrpcManager logs error
+                return false;
+            }
+
+            inspect->setTimeout(config.inspectTimeout);
+
+            inspectChecker = std::make_unique<ZrpcChecker>();
+        }
+
+        // Set up the Accept endpoint in pushpin-handler
+        if (!config.acceptSpec.isEmpty()) {
+            accept = std::make_unique<ZrpcManager>();
+            accept->setInstanceId(config.clientId);
+            accept->setBind(true);
+            accept->setIpcFileMode(config.ipcFileMode);
+            if (!accept->setClientSpecs(QStringList() << config.acceptSpec)) {
+                // ZrpcManager logs error
+                return false;
+            }
+
+            // There's no acceptTimeout config option so we'll reuse inspectTimeout
+            accept->setTimeout(config.inspectTimeout);
+        }
+
+        if (!config.retryInSpec.isEmpty()) {
+            handler_retry_in_sock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+
+            handler_retry_in_sock->setIdentity(config.clientId);
+            handler_retry_in_sock->setHwm(DEFAULT_HWM);
+
+            QString errorMessage;
+            if (!ZUtil::setupSocket(handler_retry_in_sock.get(), config.retryInSpec, true,
+                                    config.ipcFileMode, &errorMessage)) {
+                log_error("%s", qPrintable(errorMessage));
+                return false;
+            }
+
+            handler_retry_in_valve = std::make_unique<ZmqValve>(handler_retry_in_sock.get());
+            rrConnection = handler_retry_in_valve->readyRead.connect(
+                boost::bind(&Private::handler_retry_in_readyRead, this, boost::placeholders::_1));
+        }
+
+        if (handler_retry_in_valve)
+            handler_retry_in_valve->open();
+
+        if (!config.wsControlInitSpecs.isEmpty() && !config.wsControlStreamSpecs.isEmpty()) {
+            wsControl = std::make_unique<WsControlManager>();
+
+            wsControl->setIdentity(config.clientId);
+            wsControl->setIpcFileMode(config.ipcFileMode);
+
+            if (!wsControl->setInitSpecs(config.wsControlInitSpecs)) {
+                log_error("unable to bind to handler_ws_control_init_specs: %s",
+                          qPrintable(config.wsControlInitSpecs.join(", ")));
+                return false;
+            }
+
+            if (!wsControl->setStreamSpecs(config.wsControlStreamSpecs)) {
+                log_error("unable to bind to handler_ws_control_stream_specs: %s",
+                          qPrintable(config.wsControlStreamSpecs.join(", ")));
+                return false;
+            }
+        }
+
+        // Set up StatsManager
+        if (!config.statsSpec.isEmpty() || !config.prometheusPort.isEmpty()) {
+            stats =
+                std::make_unique<StatsManager>(config.sessionsMax, 0, PROMETHEUS_CONNECTIONS_MAX);
+
+            connMaxConnection = stats->connMax.connect(
+                boost::bind(&Private::stats_connMax, this, boost::placeholders::_1));
+
+            stats->setInstanceId(config.clientId);
+            stats->setIpcFileMode(config.ipcFileMode);
+            stats->setConnectionSendEnabled(config.statsConnectionSend);
+            stats->setConnectionsMaxSendEnabled(!config.statsConnectionSend);
+            stats->setConnectionTtl(config.statsConnectionTtl);
+            stats->setConnectionsMaxTtl(config.statsConnectionsMaxTtl);
+            stats->setReportInterval(config.statsReportInterval);
+
+            if (!config.statsSpec.isEmpty()) {
+                if (!stats->setSpec(config.statsSpec)) {
+                    // StatsManager logs error
+                    return false;
+                }
+            }
+
+            if (!config.prometheusPort.isEmpty()) {
+                stats->setPrometheusPrefix(config.prometheusPrefix);
+
+                if (!stats->setPrometheusPort(config.prometheusPort)) {
+                    log_error("unable to bind to prometheus port: %s",
+                              qPrintable(config.prometheusPort));
+                    return false;
+                }
+            }
+        }
+
+        if (!config.commandSpec.isEmpty()) {
+            command = std::make_unique<ZrpcManager>();
+            command->setBind(true);
+            command->setIpcFileMode(config.ipcFileMode);
+            cmdReqReadyConnection =
+                command->requestReady.connect(boost::bind(&Private::command_requestReady, this));
+
+            if (!command->setServerSpecs(QStringList() << config.commandSpec)) {
+                // ZrpcManager logs error
+                return false;
+            }
+        }
+
+        // Init zroutes
+        routesChanged();
+
+        return true;
+    }
+
+    void routesChanged() {
+        auto zhttpRoutes = domainMap->zhttpRoutes();
+
+        if (zhttpRoutes.count() > ZROUTES_MAX) {
+            log_warning("too many unique zhttp route targets, limiting to %d", ZROUTES_MAX);
+            zhttpRoutes = zhttpRoutes.mid(0, ZROUTES_MAX);
+        }
+
+        // Connect to new zhttp targets, disconnect from old
+        zroutes->setup(zhttpRoutes);
+    }
+
+    void doProxy(RequestSession *rs, const InspectData *idata = 0) {
+        DomainMap::Entry route = rs->route();
+
+        // We'll always have a route
+        assert(!route.isNull());
+
+        bool sharable = (idata && !idata->sharingKey.isEmpty() && rs->haveCompleteRequestBody());
+
+        ProxySession *ps = 0;
+        if (sharable) {
+            log_debug("need to proxy with sharing key: %s", idata->sharingKey.data());
+
+            ProxyItem *i = proxyItemsByKey.value(idata->sharingKey);
+            if (i)
+                ps = i->ps;
+        }
+
+        if (!ps) {
+            log_debug("creating proxysession for id=%s", rs->rid().second.data());
+
+            ps = new ProxySession(zroutes.get(), accept.get(), logConfig, stats.get());
+            // TODO: use callbacks for performance
+            proxySessionConnectionMap[ps] = {
+                ps->addNotAllowed.connect(boost::bind(&Private::ps_addNotAllowed, this, ps)),
+                ps->finished.connect(boost::bind(&Private::ps_finished, this, ps)),
+                ps->requestSessionDestroyed.connect(
+                    boost::bind(&Private::ps_requestSessionDestroyed, this, boost::placeholders::_1,
+                                boost::placeholders::_2))};
+
+            ps->setRoute(route);
+            ps->setDefaultSigKey(config.sigIss, config.sigKey);
+            ps->setAcceptXForwardedProtocol(config.acceptXForwardedProto);
+            ps->setUseXForwardedProtocol(config.setXForwardedProto, config.setXForwardedProtocol);
+            ps->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
+            ps->setOrigHeadersNeedMark(config.origHeadersNeedMark);
+            ps->setAcceptPushpinRoute(config.acceptPushpinRoute);
+            ps->setCdnLoop(config.cdnLoop);
+            ps->setProxyInitialResponseEnabled(true);
+
+            if (idata)
+                ps->setInspectData(*idata);
+
+            ProxyItem *i = new ProxyItem;
+            i->ps = ps;
+            proxyItemsBySession.insert(i->ps, i);
+
+            if (sharable) {
+                i->shared = true;
+                i->key = idata->sharingKey;
+                proxyItemsByKey.insert(i->key, i);
+            }
+        } else
+            log_debug("reusing proxysession");
+
+        // ProxySession will take it from here
+        // TODO: use callbacks for performance
+        reqSessionConnectionMap.erase(rs);
+
+        ps->add(rs);
+    }
+
+    void doProxySocket(WebSocket *sock, const DomainMap::Entry &route) {
+        QByteArray cid = connectionManager.addConnection(sock);
+
+        WsProxySession *ps = new WsProxySession(zroutes.get(), &connectionManager, logConfig,
+                                                stats.get(), wsControl.get());
+        ps->finishedByPassthroughCallback().add(Private::wsps_finishedByPassthrough_cb, this);
+
+        connectionManager.setProxyForConnection(sock, ps);
+
+        ps->setDebugEnabled(config.debug || route.debug);
+        ps->setDefaultSigKey(config.sigIss, config.sigKey);
+        ps->setDefaultUpstreamKey(config.upstreamKey);
+        ps->setAcceptXForwardedProtocol(config.acceptXForwardedProto);
+        ps->setUseXForwardedProtocol(config.setXForwardedProto, config.setXForwardedProtocol);
+        ps->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
+        ps->setOrigHeadersNeedMark(config.origHeadersNeedMark);
+        ps->setAcceptPushpinRoute(config.acceptPushpinRoute);
+        ps->setCdnLoop(config.cdnLoop);
+
+        WsProxyItem *i = new WsProxyItem;
+        i->ps = ps;
+        wsProxyItemsBySession.insert(i->ps, i);
+
+        // After this call, ps->logicalClientAddress() will be valid
+        ps->start(sock, cid, route);
+
+        if (stats) {
+            stats->addConnection(cid, ps->statsRoute(), StatsManager::WebSocket,
+                                 ps->logicalClientAddress(), sock->requestUri().scheme() == "wss",
+                                 false);
+            stats->addActivity(ps->statsRoute());
+            stats->addRequestsReceived(1);
+        }
+    }
+
+    bool canTake() {
+        // Don't accept new sessions during shutdown
+        if (destroying)
+            return false;
+
+        // Don't accept new sessions if we're servicing maximum
+        int curSessions = requestSessions.count() + wsProxyItemsBySession.count();
+        if (curSessions >= config.sessionsMax)
+            return false;
+
+        return true;
+    }
+
+    bool isXForwardedProtocolTls(const HttpHeaders &headers) {
+        QByteArray xfp = headers.get("X-Forwarded-Proto").asQByteArray();
+        if (xfp.isEmpty())
+            xfp = headers.get("X-Forwarded-Protocol").asQByteArray();
+        return (!xfp.isEmpty() && (xfp == "https" || xfp == "wss"));
+    }
+
+    void tryTakeRequest() {
+        if (!canTake())
+            return;
+
+        // Prioritize external requests over internal requests
+
+        ZhttpRequest *req = zhttpIn->takeNextRequest();
+        if (!req) {
+            if (intZhttpIn)
+                req = intZhttpIn->takeNextRequest();
+
+            if (!req)
+                return;
+        }
+
+        QString routeId;
+        bool preferInternal = false;
+        bool autoShare = false;
+
+        Variant passthroughData = req->passthroughData();
+        if (passthroughData.isValid()) {
+            // Passthrough request, from handler
+
+            const VariantHash data = passthroughData.toHash();
+
+            // There is always a route
+            routeId = QString::fromUtf8(data["route"].toByteArray());
+
+            if (data.contains("prefer-internal"))
+                preferInternal = data["prefer-internal"].toBool();
+
+            if (data.contains("auto-share"))
+                autoShare = data["auto-share"].toBool();
+        } else {
+            // Regular request
+
+            if (config.acceptXForwardedProto && isXForwardedProtocolTls(req->requestHeaders()))
+                req->setIsTls(true);
+
+            if (config.acceptPushpinRoute)
+                routeId =
+                    QString::fromUtf8(req->requestHeaders().get("Pushpin-Route").asQByteArray());
+        }
+
+        RequestSession *rs =
+            new RequestSession(config.id, domainMap, sockJsManager.get(), inspect.get(),
+                               inspectChecker.get(), accept.get(), stats.get());
+
+        if (passthroughData.isValid() && !preferInternal) {
+            // Passthrough request with preferInternal=false. In this case,
+            // set up a direct route, using some settings from the original
+            // route
+
+            DomainMap::Entry originalRoute;
+            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
+                originalRoute = domainMap->entry(routeId);
+
+            const VariantHash data = passthroughData.toHash();
+
+            DomainMap::Entry route;
+
+            // Use sig settings from the original route, if available
+            if (!originalRoute.isNull()) {
+                route.sigIss = originalRoute.sigIss;
+                route.sigKey = originalRoute.sigKey;
+            }
+
+            DomainMap::Target target;
+            Url uri = req->requestUri();
+            bool isHttps = (uri.scheme() == "https");
+            target.connectHost = uri.host();
+            target.connectPort = uri.port(isHttps ? 443 : 80);
+            target.ssl = isHttps;
+            target.trusted = data["trusted"].toBool();
+
+            route.targets += target;
+
+            rs->setRoute(route);
+        } else {
+            // Regular request (with or without a route ID), or a passthrough
+            // request with preferInternal=true. In that case, use domainmap
+            // for lookup, with route ID if available
+
+            rs->setRouteId(routeId);
+        }
+
+        if (!passthroughData.isValid()) {
+            // These only make sense on regular requests
+
+            rs->setDebugEnabled(config.debug);
+            rs->setAutoCrossOrigin(config.autoCrossOrigin);
+            rs->setPrefetchSize(config.inspectPrefetch);
+            rs->setDefaultUpstreamKey(config.upstreamKey);
+            rs->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
+        }
+
+        rs->setAutoShare(autoShare);
+
+        // TODO: use callbacks for performance
+        reqSessionConnectionMap[rs] = {
+            rs->inspected.connect(
+                boost::bind(&Private::rs_inspected, this, boost::placeholders::_1, rs)),
+            rs->inspectError.connect(boost::bind(&Private::rs_inspectError, this, rs)),
+            rs->finished.connect(boost::bind(&Private::rs_finished, this, rs)),
+            rs->finishedByAccept.connect(boost::bind(&Private::rs_finishedByAccept, this, rs))};
+
+        requestSessions += rs;
+
+        rs->start(req);
+    }
+
+    void tryTakeSocket() {
+        if (!canTake())
+            return;
+
+        ZWebSocket *sock = zhttpIn->takeNextSocket();
+        if (!sock)
+            return;
+
+        if (config.acceptXForwardedProto && isXForwardedProtocolTls(sock->requestHeaders()))
+            sock->setIsTls(true);
+
+        Url requestUri = sock->requestUri();
+
+        log_debug("worker %d: IN ws id=%s, %s", config.id, sock->rid().second.data(),
+                  requestUri.toEncoded().data());
+
+        bool isSecure = (requestUri.scheme() == "wss");
+        QString host = requestUri.host();
+
+        QByteArray encPath = requestUri.path(Url::FullyEncoded).toUtf8();
+
+        QString routeId;
+
+        if (config.acceptPushpinRoute)
+            routeId = QString::fromUtf8(sock->requestHeaders().get("Pushpin-Route").asQByteArray());
+
+        // Look up the route
+        DomainMap::Entry route;
+        if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
+            route = domainMap->entry(routeId);
+        else
+            route = domainMap->entry(DomainMap::WebSocket, isSecure, host, encPath);
+
+        // Before we do anything else, see if this is a sockjs request
+        if (!route.isNull() && !route.sockJsPath.isEmpty() &&
+            encPath.startsWith(route.sockJsPath)) {
+            sockJsManager->giveSocket(sock, route.sockJsPath.length(), route.sockJsAsPath, route);
+            return;
+        }
+
+        log_debug("creating wsproxysession for zws id=%s", sock->rid().second.data());
+        doProxySocket(sock, route);
+    }
+
+    void tryTakeSockJsSession() {
+        if (!canTake())
+            return;
+
+        SockJsSession *sock = sockJsManager->takeNext();
+        if (!sock)
+            return;
+
+        log_debug("IN sockjs obj=%p %s", sock, sock->requestUri().toEncoded().data());
+
+        log_debug("creating wsproxysession for sockjs=%p", sock);
+        doProxySocket(sock, sock->route());
+    }
+
+    void tryTakeNext() {
+        tryTakeRequest();
+        tryTakeSocket();
+        tryTakeSockJsSession();
+    }
+
+    void logFinished(RequestSession *rs, bool accepted = false) {
+        HttpResponseData resp = rs->responseData();
+
+        LogUtil::RequestData rd;
+
+        DomainMap::Entry route = rs->route();
+
+        // Only log route id if explicitly set
+        if (route.separateStats)
+            rd.routeId = route.id;
+
+        if (accepted) {
+            rd.status = LogUtil::Accept;
+        } else if (resp.code != -1) {
+            rd.status = LogUtil::Response;
+            rd.responseData = resp;
+            rd.responseBodySize = rs->responseBodySize();
+        } else {
+            rd.status = LogUtil::Error;
+        }
+
+        rd.requestData = rs->requestData();
+
+        rd.fromAddress = rs->logicalPeerAddress();
+
+        LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
+    }
 
 private:
-	void zhttpIn_requestReady()
-	{
-		tryTakeNext();
-	}
+    void zhttpIn_requestReady() { tryTakeNext(); }
 
-	void zhttpIn_socketReady()
-	{
-		tryTakeNext();
-	}
+    void zhttpIn_socketReady() { tryTakeNext(); }
 
-	void intZhttpIn_requestReady()
-	{
-		tryTakeNext();
-	}
+    void intZhttpIn_requestReady() { tryTakeNext(); }
 
-	void sockjs_sessionReady()
-	{
-		tryTakeNext();
-	}
+    void sockjs_sessionReady() { tryTakeNext(); }
 
-	void rs_inspectError(RequestSession *rs)
-	{
-		// Default action is to proxy without sharing
-		doProxy(rs);
-	}
+    void rs_inspectError(RequestSession *rs) {
+        // Default action is to proxy without sharing
+        doProxy(rs);
+    }
 
-	void rs_inspected(const InspectData &idata, RequestSession *rs)
-	{
-		// If we get here, then the request must be proxied. If it was to be directly
-		// accepted, then finishedByAccept would have been emitted instead
-		assert(idata.doProxy);
+    void rs_inspected(const InspectData &idata, RequestSession *rs) {
+        // If we get here, then the request must be proxied. If it was to be
+        // directly accepted, then finishedByAccept would have been emitted instead
+        assert(idata.doProxy);
 
-		doProxy(rs, &idata);
-	}
+        doProxy(rs, &idata);
+    }
 
-	void rs_finished(RequestSession *rs)
-	{
-		if(!rs->isSockJs())
-			logFinished(rs);
+    void rs_finished(RequestSession *rs) {
+        if (!rs->isSockJs())
+            logFinished(rs);
 
-		requestSessions.remove(rs);
-		reqSessionConnectionMap.erase(rs);
-		delete rs;
+        requestSessions.remove(rs);
+        reqSessionConnectionMap.erase(rs);
+        delete rs;
 
-		tryTakeNext();
-	}
+        tryTakeNext();
+    }
 
-	void rs_finishedByAccept(RequestSession *rs)
-	{
-		logFinished(rs, true);
+    void rs_finishedByAccept(RequestSession *rs) {
+        logFinished(rs, true);
 
-		requestSessions.remove(rs);
-		reqSessionConnectionMap.erase(rs);
-		delete rs;
+        requestSessions.remove(rs);
+        reqSessionConnectionMap.erase(rs);
+        delete rs;
 
-		tryTakeNext();
-	}
+        tryTakeNext();
+    }
 
-	void ps_addNotAllowed(ProxySession *ps)
-	{
-		ProxyItem *i = proxyItemsBySession.value(ps);
-		assert(i);
+    void ps_addNotAllowed(ProxySession *ps) {
+        ProxyItem *i = proxyItemsBySession.value(ps);
+        assert(i);
 
-		// No more sharing for this session
-		if(i->shared)
-		{
-			i->shared = false;
-			proxyItemsByKey.remove(i->key);
-		}
-	}
+        // No more sharing for this session
+        if (i->shared) {
+            i->shared = false;
+            proxyItemsByKey.remove(i->key);
+        }
+    }
 
-	void ps_finished(ProxySession *ps)
-	{
-		ProxyItem *i = proxyItemsBySession.value(ps);
-		assert(i);
+    void ps_finished(ProxySession *ps) {
+        ProxyItem *i = proxyItemsBySession.value(ps);
+        assert(i);
 
-		proxySessionConnectionMap.erase(ps);
-		
-		if(i->shared)
-			proxyItemsByKey.remove(i->key);
-		proxyItemsBySession.remove(i->ps);
-		delete i;
-		delete ps;
+        proxySessionConnectionMap.erase(ps);
 
-		tryTakeNext();
-	}
+        if (i->shared)
+            proxyItemsByKey.remove(i->key);
+        proxyItemsBySession.remove(i->ps);
+        delete i;
+        delete ps;
 
-	void ps_requestSessionDestroyed(RequestSession *rs, bool accept)
-	{
-		requestSessions.remove(rs);
+        tryTakeNext();
+    }
 
-		rs->setAccepted(accept);
+    void ps_requestSessionDestroyed(RequestSession *rs, bool accept) {
+        requestSessions.remove(rs);
 
-		tryTakeNext();
-	}
+        rs->setAccepted(accept);
 
-	static void wsps_finishedByPassthrough_cb(void *data, std::tuple<WsProxySession *> value)
-	{
-		Q_UNUSED(value);
+        tryTakeNext();
+    }
 
-		Private *self = (Private *)data;
+    static void wsps_finishedByPassthrough_cb(void *data, std::tuple<WsProxySession *> value) {
+        Q_UNUSED(value);
 
-		self->wsps_finishedByPassthrough(std::get<0>(value));
-	}
+        Private *self = (Private *)data;
 
-	void wsps_finishedByPassthrough(WsProxySession *ps)
-	{
-		WsProxyItem *i = wsProxyItemsBySession.value(ps);
-		assert(i);
+        self->wsps_finishedByPassthrough(std::get<0>(value));
+    }
 
-		if(stats)
-			stats->removeConnection(ps->cid(), false);
+    void wsps_finishedByPassthrough(WsProxySession *ps) {
+        WsProxyItem *i = wsProxyItemsBySession.value(ps);
+        assert(i);
 
-		wsProxyItemsBySession.remove(i->ps);
-		delete i;
+        if (stats)
+            stats->removeConnection(ps->cid(), false);
 
-		ps->finishedByPassthroughCallback().remove(this);
-		DeferCall::deleteLater(ps);
+        wsProxyItemsBySession.remove(i->ps);
+        delete i;
 
-		tryTakeNext();
-	}
+        ps->finishedByPassthroughCallback().remove(this);
+        DeferCall::deleteLater(ps);
+
+        tryTakeNext();
+    }
 
 private:
-	void handler_retry_in_readyRead(const CowByteArrayList &message)
-	{
-		ZmqReqMessage req(message);
+    void handler_retry_in_readyRead(const CowByteArrayList &message) {
+        ZmqReqMessage req(message);
 
-		if(req.content().count() != 1)
-		{
-			log_warning("retry: received message with parts != 1, skipping");
-			return;
-		}
+        if (req.content().count() != 1) {
+            log_warning("retry: received message with parts != 1, skipping");
+            return;
+        }
 
-		bool ok;
-		Variant data = TnetString::toVariant(req.content()[0], 0, &ok);
-		if(!ok)
-		{
-			log_warning("retry: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
+        bool ok;
+        Variant data = TnetString::toVariant(req.content()[0], 0, &ok);
+        if (!ok) {
+            log_warning("retry: received message with invalid format (tnetstring "
+                        "parse failed), skipping");
+            return;
+        }
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			log_debug("retry: IN %s", qPrintable(TnetString::variantToString(data, -1)));
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            log_debug("retry: IN %s", qPrintable(TnetString::variantToString(data, -1)));
 
-		RetryRequestPacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("retry: received message with invalid format (parse failed), skipping");
-			return;
-		}
+        RetryRequestPacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("retry: received message with invalid format (parse failed), "
+                        "skipping");
+            return;
+        }
 
-		log_debug("IN (retry) %s %s", qPrintable(p.requestData.method), p.requestData.uri.toEncoded().data());
+        log_debug("IN (retry) %s %s", qPrintable(p.requestData.method),
+                  p.requestData.uri.toEncoded().data());
 
-		InspectData idata;
-		if(p.haveInspectInfo)
-		{
-			idata.doProxy = p.inspectInfo.doProxy;
-			idata.sharingKey = p.inspectInfo.sharingKey;
-			idata.sid = p.inspectInfo.sid;
-			idata.lastIds = p.inspectInfo.lastIds;
-			idata.userData = p.inspectInfo.userData;
-		}
+        InspectData idata;
+        if (p.haveInspectInfo) {
+            idata.doProxy = p.inspectInfo.doProxy;
+            idata.sharingKey = p.inspectInfo.sharingKey;
+            idata.sid = p.inspectInfo.sid;
+            idata.lastIds = p.inspectInfo.lastIds;
+            idata.userData = p.inspectInfo.userData;
+        }
 
-		foreach(const RetryRequestPacket::Request &req, p.requests)
-		{
-			ZhttpRequest::ServerState ss;
-			ss.rid = ZhttpRequest::Rid(req.rid.first, req.rid.second);
-			ss.peerAddress = req.peerAddress;
-			ss.requestMethod = p.requestData.method;
-			ss.requestUri = p.requestData.uri;
-			if(req.https)
-				ss.requestUri.setScheme("https");
-			ss.requestHeaders = p.requestData.headers;
-			ss.requestBody = p.requestData.body;
-			ss.inSeq = req.inSeq;
-			ss.outSeq = req.outSeq;
-			ss.outCredits = req.outCredits;
-			ss.routerResp = req.routerResp;
-			ss.userData = req.userData;
+        foreach (const RetryRequestPacket::Request &req, p.requests) {
+            ZhttpRequest::ServerState ss;
+            ss.rid = ZhttpRequest::Rid(req.rid.first, req.rid.second);
+            ss.peerAddress = req.peerAddress;
+            ss.requestMethod = p.requestData.method;
+            ss.requestUri = p.requestData.uri;
+            if (req.https)
+                ss.requestUri.setScheme("https");
+            ss.requestHeaders = p.requestData.headers;
+            ss.requestBody = p.requestData.body;
+            ss.inSeq = req.inSeq;
+            ss.outSeq = req.outSeq;
+            ss.outCredits = req.outCredits;
+            ss.routerResp = req.routerResp;
+            ss.userData = req.userData;
 
-			ZhttpRequest *zhttpRequest = zhttpIn->createRequestFromState(ss);
+            ZhttpRequest *zhttpRequest = zhttpIn->createRequestFromState(ss);
 
-			RequestSession *rs = new RequestSession(config.id, domainMap, sockJsManager.get(), inspect.get(), inspectChecker.get(), accept.get(), stats.get());
+            RequestSession *rs =
+                new RequestSession(config.id, domainMap, sockJsManager.get(), inspect.get(),
+                                   inspectChecker.get(), accept.get(), stats.get());
 
-			requestSessions += rs;
+            requestSessions += rs;
 
-			rs->setDefaultUpstreamKey(config.upstreamKey);
-			rs->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
+            rs->setDefaultUpstreamKey(config.upstreamKey);
+            rs->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
 
-			if(!p.route.isEmpty())
-				rs->setRouteId(QString::fromUtf8(p.route));
+            if (!p.route.isEmpty())
+                rs->setRouteId(QString::fromUtf8(p.route));
 
-			// Note: if the routing table was changed, there's a chance the request
-			// might get a different route id this time around. This could confuse
-			// stats processors tracking route+connection mappings.
-			rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin, req.jsonpCallback, req.jsonpExtendedResponse, req.unreportedTime, p.retrySeq);
+            // Note: if the routing table was changed, there's a chance the request
+            // might get a different route id this time around. This could confuse
+            // stats processors tracking route+connection mappings.
+            rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin, req.jsonpCallback,
+                           req.jsonpExtendedResponse, req.unreportedTime, p.retrySeq);
 
-			doProxy(rs, p.haveInspectInfo ? &idata : 0);
-		}
-	}
+            doProxy(rs, p.haveInspectInfo ? &idata : 0);
+        }
+    }
 
-	void stats_connMax(const StatsPacket &packet)
-	{
-		if(accept->canWriteImmediately())
-		{
-			ZrpcRequestPacket p;
-			p.method = "conn-max";
-			p.args["conn-max"] = VariantList() << packet.toVariant();
+    void stats_connMax(const StatsPacket &packet) {
+        if (accept->canWriteImmediately()) {
+            ZrpcRequestPacket p;
+            p.method = "conn-max";
+            p.args["conn-max"] = VariantList() << packet.toVariant();
 
-			accept->write(p);
-		}
-	}
+            accept->write(p);
+        }
+    }
 
-	void command_requestReady()
-	{
-		ZrpcRequest *req = command->takeNext();
-		if(req->method() == "conncheck")
-		{
-			if(!stats)
-			{
-				req->respondError("service-unavailable");
-				delete req;
-				return;
-			}
+    void command_requestReady() {
+        ZrpcRequest *req = command->takeNext();
+        if (req->method() == "conncheck") {
+            if (!stats) {
+                req->respondError("service-unavailable");
+                delete req;
+                return;
+            }
 
-			VariantHash args = req->args();
-			if(!args.contains("ids") || typeId(args["ids"]) != VariantType::List)
-			{
-				req->respondError("bad-format");
-				delete req;
-				return;
-			}
+            VariantHash args = req->args();
+            if (!args.contains("ids") || typeId(args["ids"]) != VariantType::List) {
+                req->respondError("bad-format");
+                delete req;
+                return;
+            }
 
-			VariantList vids = args["ids"].toList();
+            VariantList vids = args["ids"].toList();
 
-			bool ok = true;
-			QList<QByteArray> ids;
-			for(const Variant &vid : vids)
-			{
-				if(typeId(vid) != VariantType::ByteArray)
-				{
-					ok = false;
-					break;
-				}
+            bool ok = true;
+            QList<QByteArray> ids;
+            for (const Variant &vid : vids) {
+                if (typeId(vid) != VariantType::ByteArray) {
+                    ok = false;
+                    break;
+                }
 
-				ids += vid.toByteArray();
-			}
-			if(!ok)
-			{
-				req->respondError("bad-format");
-				delete req;
-				return;
-			}
+                ids += vid.toByteArray();
+            }
+            if (!ok) {
+                req->respondError("bad-format");
+                delete req;
+                return;
+            }
 
-			VariantList out;
-			foreach(const QByteArray &id, ids)
-			{
-				if(stats->checkConnection(id))
-					out += id;
-			}
+            VariantList out;
+            foreach (const QByteArray &id, ids) {
+                if (stats->checkConnection(id))
+                    out += id;
+            }
 
-			req->respond(out);
-		}
-		else if(req->method() == "refresh")
-		{
-			VariantHash args = req->args();
-			if(!args.contains("cid") || typeId(args["cid"]) != VariantType::ByteArray)
-			{
-				req->respondError("bad-format");
-				delete req;
-				return;
-			}
+            req->respond(out);
+        } else if (req->method() == "refresh") {
+            VariantHash args = req->args();
+            if (!args.contains("cid") || typeId(args["cid"]) != VariantType::ByteArray) {
+                req->respondError("bad-format");
+                delete req;
+                return;
+            }
 
-			QByteArray cid = args["cid"].toByteArray();
+            QByteArray cid = args["cid"].toByteArray();
 
-			WsProxySession *ps = connectionManager.getProxyForConnection(cid);
-			if(!ps)
-			{
-				req->respondError("item-not-found");
-				delete req;
-				return;
-			}
+            WsProxySession *ps = connectionManager.getProxyForConnection(cid);
+            if (!ps) {
+                req->respondError("item-not-found");
+                delete req;
+                return;
+            }
 
-			WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp*>(ps->outSocket());
-			if(woh)
-				woh->refresh();
+            WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp *>(ps->outSocket());
+            if (woh)
+                woh->refresh();
 
-			req->respond();
-		}
-		else
-		{
-			req->respondError("method-not-found");
-		}
+            req->respond();
+        } else {
+            req->respondError("method-not-found");
+        }
 
-		delete req;
-	}
+        delete req;
+    }
 };
 
-Engine::Engine(DomainMap *domainMap)
-{
-	d = new Private(this, domainMap);
-}
+Engine::Engine(DomainMap *domainMap) { d = new Private(this, domainMap); }
 
-Engine::~Engine()
-{
-	delete d;
-}
+Engine::~Engine() { delete d; }
 
-StatsManager *Engine::statsManager() const
-{
-	return d->stats.get();
-}
+StatsManager *Engine::statsManager() const { return d->stats.get(); }
 
-bool Engine::start(const Configuration &config)
-{
-	return d->start(config);
-}
+bool Engine::start(const Configuration &config) { return d->start(config); }
 
-void Engine::routesChanged()
-{
-	d->routesChanged();
-}
+void Engine::routesChanged() { d->routesChanged(); }

--- a/src/proxy/proxyengine.h
+++ b/src/proxy/proxyengine.h
@@ -24,12 +24,12 @@
 #ifndef PROXYENGINE_H
 #define PROXYENGINE_H
 
-#include <map>
-#include <QStringList>
-#include <QHostAddress>
-#include <boost/signals2.hpp>
 #include "jwt.h"
 #include "xffrule.h"
+#include <QHostAddress>
+#include <QStringList>
+#include <boost/signals2.hpp>
+#include <map>
 
 // Each session can have a bunch of timers:
 // 2 per incoming zhttprequest/zwebsocket
@@ -60,91 +60,87 @@ class DomainMap;
 /// - Creates and manages proxy sessions for backend connections
 /// - Processes retry requests
 /// - Coordinates statistics tracking
-class Engine
-{
+class Engine {
 public:
-	class Configuration
-	{
-	public:
-		int id;
-		QString appVersion;
-		QByteArray clientId;
-		QStringList serverInSpecs;
-		QStringList serverInStreamSpecs;
-		QStringList serverOutSpecs;
-		QStringList clientOutSpecs;
-		QStringList clientOutStreamSpecs;
-		QStringList clientInSpecs;
-		QString inspectSpec;
-		QString acceptSpec;
-		QString retryInSpec;
-		QStringList wsControlInitSpecs;
-		QStringList wsControlStreamSpecs;
-		QString statsSpec;
-		QString commandSpec;
-		QStringList intServerInSpecs;
-		QStringList intServerInStreamSpecs;
-		QStringList intServerOutSpecs;
-		int ipcFileMode;
-		int sessionsMax;
-		int inspectTimeout;
-		int inspectPrefetch;
-		bool debug;
-		bool autoCrossOrigin;
-		bool acceptXForwardedProto;
-		bool setXForwardedProto;
-		bool setXForwardedProtocol;
-		XffRule xffUntrustedRule;
-		XffRule xffTrustedRule;
-		QList<QByteArray> origHeadersNeedMark;
-		bool acceptPushpinRoute;
-		QByteArray cdnLoop;
-		bool logFrom;
-		bool logUserAgent;
-		QByteArray sigIss;
-		Jwt::EncodingKey sigKey;
-		Jwt::DecodingKey upstreamKey;
-		QString sockJsUrl;
-		bool statsConnectionSend;
-		int statsConnectionTtl;
-		int statsConnectionsMaxTtl;
-		int statsReportInterval;
-		QString prometheusPort;
-		QString prometheusPrefix;
+    class Configuration {
+    public:
+        int id;
+        QString appVersion;
+        QByteArray clientId;
+        QStringList serverInSpecs;
+        QStringList serverInStreamSpecs;
+        QStringList serverOutSpecs;
+        QStringList clientOutSpecs;
+        QStringList clientOutStreamSpecs;
+        QStringList clientInSpecs;
+        QString inspectSpec;
+        QString acceptSpec;
+        QString retryInSpec;
+        QStringList wsControlInitSpecs;
+        QStringList wsControlStreamSpecs;
+        QString statsSpec;
+        QString commandSpec;
+        QStringList intServerInSpecs;
+        QStringList intServerInStreamSpecs;
+        QStringList intServerOutSpecs;
+        int ipcFileMode;
+        int sessionsMax;
+        int inspectTimeout;
+        int inspectPrefetch;
+        bool debug;
+        bool autoCrossOrigin;
+        bool acceptXForwardedProto;
+        bool setXForwardedProto;
+        bool setXForwardedProtocol;
+        XffRule xffUntrustedRule;
+        XffRule xffTrustedRule;
+        QList<QByteArray> origHeadersNeedMark;
+        bool acceptPushpinRoute;
+        QByteArray cdnLoop;
+        bool logFrom;
+        bool logUserAgent;
+        QByteArray sigIss;
+        Jwt::EncodingKey sigKey;
+        Jwt::DecodingKey upstreamKey;
+        QString sockJsUrl;
+        bool statsConnectionSend;
+        int statsConnectionTtl;
+        int statsConnectionsMaxTtl;
+        int statsReportInterval;
+        QString prometheusPort;
+        QString prometheusPrefix;
 
-		Configuration() :
-			id(0),
-			ipcFileMode(-1),
-			sessionsMax(-1),
-			inspectTimeout(8000),
-			inspectPrefetch(10000),
-			debug(false),
-			autoCrossOrigin(false),
-			acceptXForwardedProto(false),
-			setXForwardedProto(false),
-			setXForwardedProtocol(false),
-			acceptPushpinRoute(false),
-			logFrom(false),
-			logUserAgent(false),
-			statsConnectionSend(false),
-			statsConnectionTtl(-1),
-			statsConnectionsMaxTtl(-1),
-			statsReportInterval(-1)
-		{
-		}
-	};
+        Configuration()
+            : id(0),
+              ipcFileMode(-1),
+              sessionsMax(-1),
+              inspectTimeout(8000),
+              inspectPrefetch(10000),
+              debug(false),
+              autoCrossOrigin(false),
+              acceptXForwardedProto(false),
+              setXForwardedProto(false),
+              setXForwardedProtocol(false),
+              acceptPushpinRoute(false),
+              logFrom(false),
+              logUserAgent(false),
+              statsConnectionSend(false),
+              statsConnectionTtl(-1),
+              statsConnectionsMaxTtl(-1),
+              statsReportInterval(-1) {}
+    };
 
-	Engine(DomainMap *domainMap);
-	~Engine();
+    Engine(DomainMap *domainMap);
+    ~Engine();
 
-	StatsManager *statsManager() const;
+    StatsManager *statsManager() const;
 
-	bool start(const Configuration &config);
-	void routesChanged();
+    bool start(const Configuration &config);
+    void routesChanged();
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -21,31 +21,31 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <unistd.h>
-#include <chrono>
-#include <thread>
-#include <boost/signals2.hpp>
-#include <QDir>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include "test.h"
+#include "proxyengine.h"
 #include "cowstring.h"
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "zmqreqmessage.h"
+#include "domainmap.h"
+#include "eventloop.h"
 #include "log.h"
-#include "tnetstring.h"
-#include "variant.h"
-#include "zhttprequestpacket.h"
-#include "zhttpresponsepacket.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "packet/statspacket.h"
-#include "eventloop.h"
-#include "zhttpmanager.h"
 #include "statsmanager.h"
-#include "domainmap.h"
-#include "proxyengine.h"
+#include "test.h"
+#include "tnetstring.h"
+#include "variant.h"
+#include "zhttpmanager.h"
+#include "zhttprequestpacket.h"
+#include "zhttpresponsepacket.h"
+#include "zmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <boost/signals2.hpp>
+#include <chrono>
+#include <thread>
+#include <unistd.h>
 
 using namespace std::chrono_literals;
 
@@ -56,1398 +56,1406 @@ Q_DECLARE_METATYPE(QList<StatsPacket>);
 
 namespace {
 
-class Wrapper
-{
+class Wrapper {
 public:
-	std::unique_ptr<ZmqSocket> zhttpClientOutSock;
-	std::unique_ptr<ZmqSocket> zhttpClientOutStreamSock;
-	std::unique_ptr<ZmqValve> zhttpClientOutStreamValve;
-	std::unique_ptr<ZmqSocket> zhttpClientInSock;
-	std::unique_ptr<ZmqValve> zhttpClientInValve;
-	std::unique_ptr<ZmqSocket> zhttpServerInSock;
-	std::unique_ptr<ZmqValve> zhttpServerInValve;
-	std::unique_ptr<ZmqSocket> zhttpServerInStreamSock;
-	std::unique_ptr<ZmqValve> zhttpServerInStreamValve;
-	std::unique_ptr<ZmqSocket> zhttpServerOutSock;
+    std::unique_ptr<ZmqSocket> zhttpClientOutSock;
+    std::unique_ptr<ZmqSocket> zhttpClientOutStreamSock;
+    std::unique_ptr<ZmqValve> zhttpClientOutStreamValve;
+    std::unique_ptr<ZmqSocket> zhttpClientInSock;
+    std::unique_ptr<ZmqValve> zhttpClientInValve;
+    std::unique_ptr<ZmqSocket> zhttpServerInSock;
+    std::unique_ptr<ZmqValve> zhttpServerInValve;
+    std::unique_ptr<ZmqSocket> zhttpServerInStreamSock;
+    std::unique_ptr<ZmqValve> zhttpServerInStreamValve;
+    std::unique_ptr<ZmqSocket> zhttpServerOutSock;
 
-	std::unique_ptr<ZmqSocket> handlerInspectSock;
-	std::unique_ptr<ZmqValve> handlerInspectValve;
-	std::unique_ptr<ZmqSocket> handlerAcceptSock;
-	std::unique_ptr<ZmqValve> handlerAcceptValve;
-	std::unique_ptr<ZmqSocket> handlerRetryOutSock;
+    std::unique_ptr<ZmqSocket> handlerInspectSock;
+    std::unique_ptr<ZmqValve> handlerInspectValve;
+    std::unique_ptr<ZmqSocket> handlerAcceptSock;
+    std::unique_ptr<ZmqValve> handlerAcceptValve;
+    std::unique_ptr<ZmqSocket> handlerRetryOutSock;
 
-	QDir workDir;
-	QHash<QByteArray, HttpRequestData> serverReqs;
-	bool isWs;
-	bool serverFailed;
-	bool inspectEnabled;
-	bool inspected;
-	QByteArray sharingKey;
-	QByteArray in;
-	HttpHeaders acceptHeaders;
-	QByteArray acceptIn;
-	bool retried;
-	bool finished;
-	int serverOutSeq;
-	int clientReqsFinished;
-	QByteArray requestBody;
-	QHash<QByteArray, HttpResponseData> responses;
-	Connection zhttpClientInValveConnection;
-	Connection zhttpClientOutStreamValveConnection;
-	Connection zhttpServerInValveConnection;
-	Connection zhttpServerInStreamValveConnection;
-	Connection handlerAcceptValveConnection;
-	Connection handlerInspectValveConnection;
+    QDir workDir;
+    QHash<QByteArray, HttpRequestData> serverReqs;
+    bool isWs;
+    bool serverFailed;
+    bool inspectEnabled;
+    bool inspected;
+    QByteArray sharingKey;
+    QByteArray in;
+    HttpHeaders acceptHeaders;
+    QByteArray acceptIn;
+    bool retried;
+    bool finished;
+    int serverOutSeq;
+    int clientReqsFinished;
+    QByteArray requestBody;
+    QHash<QByteArray, HttpResponseData> responses;
+    Connection zhttpClientInValveConnection;
+    Connection zhttpClientOutStreamValveConnection;
+    Connection zhttpServerInValveConnection;
+    Connection zhttpServerInStreamValveConnection;
+    Connection handlerAcceptValveConnection;
+    Connection handlerInspectValveConnection;
 
-	boost::signals2::signal<void()> connected;
+    boost::signals2::signal<void()> connected;
 
-	Wrapper(QDir _workDir) :
-		workDir(_workDir),
-		isWs(false),
-		serverFailed(false),
-		inspectEnabled(true),
-		inspected(false),
-		retried(false),
-		finished(false),
-		serverOutSeq(0),
-		clientReqsFinished(0)
-	{
-		// Http sockets
+    Wrapper(QDir _workDir)
+        : workDir(_workDir),
+          isWs(false),
+          serverFailed(false),
+          inspectEnabled(true),
+          inspected(false),
+          retried(false),
+          finished(false),
+          serverOutSeq(0),
+          clientReqsFinished(0) {
+        // Http sockets
 
-		zhttpClientOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
+        zhttpClientOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
 
-		zhttpClientOutStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		zhttpClientOutStreamValve = std::make_unique<ZmqValve>(zhttpClientOutStreamSock.get());
-		zhttpClientOutStreamValveConnection = zhttpClientOutStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientOutStream_readyRead, this, boost::placeholders::_1));
+        zhttpClientOutStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        zhttpClientOutStreamValve = std::make_unique<ZmqValve>(zhttpClientOutStreamSock.get());
+        zhttpClientOutStreamValveConnection = zhttpClientOutStreamValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpClientOutStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpClientInSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
-		zhttpClientInValve = std::make_unique<ZmqValve>(zhttpClientInSock.get());
-		zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
+        zhttpClientInSock = std::make_unique<ZmqSocket>(ZmqSocket::Sub);
+        zhttpClientInValve = std::make_unique<ZmqValve>(zhttpClientInSock.get());
+        zhttpClientInValveConnection = zhttpClientInValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpClientIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
-		zhttpServerInValve = std::make_unique<ZmqValve>(zhttpServerInSock.get());
-		zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
+        zhttpServerInSock = std::make_unique<ZmqSocket>(ZmqSocket::Pull);
+        zhttpServerInValve = std::make_unique<ZmqValve>(zhttpServerInSock.get());
+        zhttpServerInValveConnection = zhttpServerInValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpServerIn_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerInStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		zhttpServerInStreamSock->setIdentity("test-server");
-		zhttpServerInStreamValve = std::make_unique<ZmqValve>(zhttpServerInStreamSock.get());
-		zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
+        zhttpServerInStreamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        zhttpServerInStreamSock->setIdentity("test-server");
+        zhttpServerInStreamValve = std::make_unique<ZmqValve>(zhttpServerInStreamSock.get());
+        zhttpServerInStreamValveConnection = zhttpServerInStreamValve->readyRead.connect(
+            boost::bind(&Wrapper::zhttpServerInStream_readyRead, this, boost::placeholders::_1));
 
-		zhttpServerOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
+        zhttpServerOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Pub);
 
-		// Handler sockets
+        // Handler sockets
 
-		handlerInspectSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        handlerInspectSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 
-		handlerAcceptSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-		handlerAcceptValve = std::make_unique<ZmqValve>(handlerAcceptSock.get());
-		handlerAcceptValveConnection = handlerAcceptValve->readyRead.connect(boost::bind(&Wrapper::handlerAccept_readyRead, this, boost::placeholders::_1));
+        handlerAcceptSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        handlerAcceptValve = std::make_unique<ZmqValve>(handlerAcceptSock.get());
+        handlerAcceptValveConnection = handlerAcceptValve->readyRead.connect(
+            boost::bind(&Wrapper::handlerAccept_readyRead, this, boost::placeholders::_1));
 
-		handlerInspectValve = std::make_unique<ZmqValve>(handlerInspectSock.get());
-		handlerInspectValveConnection = handlerInspectValve->readyRead.connect(boost::bind(&Wrapper::handlerInspect_readyRead, this, boost::placeholders::_1));
+        handlerInspectValve = std::make_unique<ZmqValve>(handlerInspectSock.get());
+        handlerInspectValveConnection = handlerInspectValve->readyRead.connect(
+            boost::bind(&Wrapper::handlerInspect_readyRead, this, boost::placeholders::_1));
 
-		handlerRetryOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
-	}
+        handlerRetryOutSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+    }
 
-	void startHttp()
-	{
-		zhttpClientOutStreamSock->setIdentity("test-client");
-		zhttpClientOutStreamSock->setProbeRouterEnabled(true);
+    void startHttp() {
+        zhttpClientOutStreamSock->setIdentity("test-client");
+        zhttpClientOutStreamSock->setProbeRouterEnabled(true);
 
-		zhttpClientOutSock->bind("ipc://" + workDir.filePath("prxtst-client-out"));
-		zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("prxtst-client-out-stream"));
-		zhttpClientInSock->bind("ipc://" + workDir.filePath("prxtst-client-in"));
-		zhttpServerInSock->bind("ipc://" + workDir.filePath("prxtst-server-in"));
-		zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("prxtst-server-in-stream"));
-		zhttpServerOutSock->bind("ipc://" + workDir.filePath("prxtst-server-out"));
+        zhttpClientOutSock->bind("ipc://" + workDir.filePath("prxtst-client-out"));
+        zhttpClientOutStreamSock->bind("ipc://" + workDir.filePath("prxtst-client-out-stream"));
+        zhttpClientInSock->bind("ipc://" + workDir.filePath("prxtst-client-in"));
+        zhttpServerInSock->bind("ipc://" + workDir.filePath("prxtst-server-in"));
+        zhttpServerInStreamSock->bind("ipc://" + workDir.filePath("prxtst-server-in-stream"));
+        zhttpServerOutSock->bind("ipc://" + workDir.filePath("prxtst-server-out"));
 
-		zhttpClientInSock->subscribe("test-client ");
+        zhttpClientInSock->subscribe("test-client ");
 
-		zhttpClientInValve->open();
-		zhttpClientOutStreamValve->open();
-		zhttpServerInValve->open();
-		zhttpServerInStreamValve->open();
-	}
+        zhttpClientInValve->open();
+        zhttpClientOutStreamValve->open();
+        zhttpServerInValve->open();
+        zhttpServerInStreamValve->open();
+    }
 
-	void startHandler()
-	{
-		handlerInspectSock->connectToAddress("ipc://" + workDir.filePath("prxtst-inspect"));
-		handlerAcceptSock->connectToAddress("ipc://" + workDir.filePath("prxtst-accept"));
-		handlerRetryOutSock->connectToAddress("ipc://" + workDir.filePath("prxtst-retry-in"));
+    void startHandler() {
+        handlerInspectSock->connectToAddress("ipc://" + workDir.filePath("prxtst-inspect"));
+        handlerAcceptSock->connectToAddress("ipc://" + workDir.filePath("prxtst-accept"));
+        handlerRetryOutSock->connectToAddress("ipc://" + workDir.filePath("prxtst-retry-in"));
 
-		handlerInspectValve->open();
-		handlerAcceptValve->open();
-	}
+        handlerInspectValve->open();
+        handlerAcceptValve->open();
+    }
 
-	void reset()
-	{
-		serverReqs.clear();
-		isWs = false;
-		serverFailed = false;
-		inspectEnabled = true;
-		inspected = false;
-		sharingKey.clear();
-		in.clear();
-		acceptHeaders.clear();
-		acceptIn.clear();
-		retried = false;
-		finished = false;
-		serverOutSeq = 0;
-		clientReqsFinished = 0;
-		requestBody.clear();
-		responses.clear();
-	}
+    void reset() {
+        serverReqs.clear();
+        isWs = false;
+        serverFailed = false;
+        inspectEnabled = true;
+        inspected = false;
+        sharingKey.clear();
+        in.clear();
+        acceptHeaders.clear();
+        acceptIn.clear();
+        retried = false;
+        finished = false;
+        serverOutSeq = 0;
+        clientReqsFinished = 0;
+        requestBody.clear();
+        responses.clear();
+    }
 
 private:
-	void processClientIn(const CowByteArray &message)
-	{
-		log_debug("client in");
-		Variant v = TnetString::toVariant(message);
-		ZhttpResponsePacket zresp;
-		zresp.fromVariant(v);
-		if(zresp.type == ZhttpResponsePacket::Data)
-		{
-			if(!responses.contains(zresp.ids.first().id.asQByteArray()))
-			{
-				HttpResponseData rd;
-				rd.code = zresp.code;
-				rd.reason = zresp.reason.asQByteArray();
-				rd.headers = zresp.headers;
-				responses[zresp.ids.first().id.asQByteArray()] = rd;
-			}
+    void processClientIn(const CowByteArray &message) {
+        log_debug("client in");
+        Variant v = TnetString::toVariant(message);
+        ZhttpResponsePacket zresp;
+        zresp.fromVariant(v);
+        if (zresp.type == ZhttpResponsePacket::Data) {
+            if (!responses.contains(zresp.ids.first().id.asQByteArray())) {
+                HttpResponseData rd;
+                rd.code = zresp.code;
+                rd.reason = zresp.reason.asQByteArray();
+                rd.headers = zresp.headers;
+                responses[zresp.ids.first().id.asQByteArray()] = rd;
+            }
 
-			responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
-			in += zresp.body.asQByteArray();
+            responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
+            in += zresp.body.asQByteArray();
 
-			if(!isWs && !zresp.more)
-			{
-				finished = true;
-				++clientReqsFinished;
-			}
-		}
-		else if(zresp.type == ZhttpResponsePacket::HandoffStart)
-		{
-			ZhttpRequestPacket zreq;
-			zreq.from = "test-client";
-			zreq.ids += ZhttpRequestPacket::Id(zresp.ids.first().id, 1);
-			zreq.type = ZhttpRequestPacket::HandoffProceed;
-			QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-			log_debug("writing: %s", buf.data());
-			QList<QByteArray> msg;
-			msg.append("proxy");
-			msg.append(QByteArray());
-			msg.append(buf);
-			zhttpClientOutStreamSock->write(msg);
-		}
-		else if(zresp.type == ZhttpResponsePacket::Close)
-		{
-			finished = true;
-			++clientReqsFinished;
-		}
-	}
+            if (!isWs && !zresp.more) {
+                finished = true;
+                ++clientReqsFinished;
+            }
+        } else if (zresp.type == ZhttpResponsePacket::HandoffStart) {
+            ZhttpRequestPacket zreq;
+            zreq.from = "test-client";
+            zreq.ids += ZhttpRequestPacket::Id(zresp.ids.first().id, 1);
+            zreq.type = ZhttpRequestPacket::HandoffProceed;
+            QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+            log_debug("writing: %s", buf.data());
+            QList<QByteArray> msg;
+            msg.append("proxy");
+            msg.append(QByteArray());
+            msg.append(buf);
+            zhttpClientOutStreamSock->write(msg);
+        } else if (zresp.type == ZhttpResponsePacket::Close) {
+            finished = true;
+            ++clientReqsFinished;
+        }
+    }
 
-	void zhttpClientIn_readyRead(const CowByteArrayList &message)
-	{
-		int at = message[0].indexOf(' ');
+    void zhttpClientIn_readyRead(const CowByteArrayList &message) {
+        int at = message[0].indexOf(' ');
 
-		processClientIn(message[0].mid(at + 2));
-	}
+        processClientIn(message[0].mid(at + 2));
+    }
 
-	void zhttpClientOutStream_readyRead(const CowByteArrayList &message)
-	{
-		if(message[2] == "probe-ack")
-		{
-			connected();
-			return;
-		}
+    void zhttpClientOutStream_readyRead(const CowByteArrayList &message) {
+        if (message[2] == "probe-ack") {
+            connected();
+            return;
+        }
 
-		processClientIn(message[2].mid(1));
-	}
+        processClientIn(message[2].mid(1));
+    }
 
-	void zhttpServerIn_readyRead(const CowByteArrayList &message)
-	{
-		log_debug("server in");
-		Variant v = TnetString::toVariant(message[0].mid(1));
-		ZhttpRequestPacket zreq;
-		zreq.fromVariant(v);
+    void zhttpServerIn_readyRead(const CowByteArrayList &message) {
+        log_debug("server in");
+        Variant v = TnetString::toVariant(message[0].mid(1));
+        ZhttpRequestPacket zreq;
+        zreq.fromVariant(v);
 
-		HttpRequestData rd;
-		rd.method = zreq.method.asQString();
-		rd.uri = zreq.uri;
-		rd.headers = zreq.headers;
-		serverReqs[zreq.ids[0].id.asQByteArray()] = rd;
+        HttpRequestData rd;
+        rd.method = zreq.method.asQString();
+        rd.uri = zreq.uri;
+        rd.headers = zreq.headers;
+        serverReqs[zreq.ids[0].id.asQByteArray()] = rd;
 
-		handleServerIn(zreq);
-	}
+        handleServerIn(zreq);
+    }
 
-	void zhttpServerInStream_readyRead(const CowByteArrayList &message)
-	{
-		log_debug("server stream in");
-		Variant v = TnetString::toVariant(message[2].mid(1));
-		ZhttpRequestPacket zreq;
-		zreq.fromVariant(v);
+    void zhttpServerInStream_readyRead(const CowByteArrayList &message) {
+        log_debug("server stream in");
+        Variant v = TnetString::toVariant(message[2].mid(1));
+        ZhttpRequestPacket zreq;
+        zreq.fromVariant(v);
 
-		handleServerIn(zreq);
-	}
+        handleServerIn(zreq);
+    }
 
-	void handleServerIn(const ZhttpRequestPacket &zreq)
-	{
-		if(zreq.type == ZhttpRequestPacket::Close || zreq.type == ZhttpRequestPacket::Credit)
-		{
-			return;
-		}
+    void handleServerIn(const ZhttpRequestPacket &zreq) {
+        if (zreq.type == ZhttpRequestPacket::Close || zreq.type == ZhttpRequestPacket::Credit) {
+            return;
+        }
 
-		if(zreq.type == ZhttpRequestPacket::Cancel)
-		{
-			serverFailed = true;
-			return;
-		}
+        if (zreq.type == ZhttpRequestPacket::Cancel) {
+            serverFailed = true;
+            return;
+        }
 
-		serverReqs[zreq.ids[0].id.asQByteArray()].body += zreq.body.asQByteArray();
+        serverReqs[zreq.ids[0].id.asQByteArray()].body += zreq.body.asQByteArray();
 
-		if(zreq.type == ZhttpRequestPacket::Data)
-			requestBody += zreq.body.asQByteArray();
+        if (zreq.type == ZhttpRequestPacket::Data)
+            requestBody += zreq.body.asQByteArray();
 
-		if(zreq.more)
-		{
-			// Ack
-			if(serverOutSeq == 0)
-			{
-				ZhttpResponsePacket zresp;
-				zresp.from = "test-server";
-				zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
-				zresp.type = ZhttpResponsePacket::Credit;
-				zresp.credits = 200000;
-				QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-				zhttpServerOutSock->write(QList<QByteArray>() << buf);
-			}
+        if (zreq.more) {
+            // Ack
+            if (serverOutSeq == 0) {
+                ZhttpResponsePacket zresp;
+                zresp.from = "test-server";
+                zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
+                zresp.type = ZhttpResponsePacket::Credit;
+                zresp.credits = 200000;
+                QByteArray buf =
+                    zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+                zhttpServerOutSock->write(QList<QByteArray>() << buf);
+            }
 
-			return;
-		}
+            return;
+        }
 
-		ZhttpResponsePacket zresp;
-		zresp.from = "test-server";
-		zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
-		zresp.type = ZhttpResponsePacket::Data;
+        ZhttpResponsePacket zresp;
+        zresp.from = "test-server";
+        zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
+        zresp.type = ZhttpResponsePacket::Data;
 
-		if(!isWs && zreq.uri.scheme() == "ws")
-		{
-			isWs = true;
+        if (!isWs && zreq.uri.scheme() == "ws") {
+            isWs = true;
 
-			// Accept websocket
-			zresp.code = 101;
-			zresp.reason = "Switching Protocols";
-			zresp.credits = 200000;
-			QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-			zhttpServerOutSock->write(QList<QByteArray>() << buf);
+            // Accept websocket
+            zresp.code = 101;
+            zresp.reason = "Switching Protocols";
+            zresp.credits = 200000;
+            QByteArray buf =
+                zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+            zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
-			// Send message
-			zresp.ids[0].seq = serverOutSeq++;
-			zresp.credits = -1;
-			zresp.code = -1;
-			zresp.reason.clear();
-			zresp.body = "hello world";
-			buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-			zhttpServerOutSock->write(QList<QByteArray>() << buf);
+            // Send message
+            zresp.ids[0].seq = serverOutSeq++;
+            zresp.credits = -1;
+            zresp.code = -1;
+            zresp.reason.clear();
+            zresp.body = "hello world";
+            buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+            zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
-			return;
-		}
+            return;
+        }
 
-		if(isWs)
-		{
-			// Close
-			zresp.type = ZhttpResponsePacket::Close;
-			QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-			zhttpServerOutSock->write(QList<QByteArray>() << buf);
+        if (isWs) {
+            // Close
+            zresp.type = ZhttpResponsePacket::Close;
+            QByteArray buf =
+                zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+            zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
-			return;
-		}
+            return;
+        }
 
-		zresp.code = 200;
-		zresp.reason = "OK";
+        zresp.code = 200;
+        zresp.reason = "OK";
 
-		QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
 
-		QUrlQuery query(zreq.uri.query());
-		QString hold = query.queryItemValue("hold");
-		bool bodyInstruct = (query.queryItemValue("body-instruct") == "true");
-		bool large = (query.queryItemValue("large") == "true");
+        QUrlQuery query(zreq.uri.query());
+        QString hold = query.queryItemValue("hold");
+        bool bodyInstruct = (query.queryItemValue("body-instruct") == "true");
+        bool large = (query.queryItemValue("large") == "true");
 
-		if(!retried && (hold == "response" || hold == "stream"))
-		{
-			if(encPath == "/path2")
-			{
-				if(bodyInstruct)
-				{
-					zresp.headers += HttpHeader("Content-Type", "application/grip-instruct");
-					zresp.body = "{ \"hold\": { \"mode\": \"response\", \"channels\": [ { \"name\": \"test-channel\", \"prev-id\": \"1\" } ] } }";
-				}
-				else
-				{
-					zresp.headers += HttpHeader("Grip-Hold", "response");
-					zresp.headers += HttpHeader("Grip-Channel", "test-channel; prev-id=1");
-				}
-			}
-			else
-			{
-				if(bodyInstruct)
-				{
-					zresp.headers += HttpHeader("Content-Type", "application/grip-instruct");
-					zresp.body = "{ \"hold\": { \"mode\": \"response\", \"channels\": [ { \"name\": \"test-channel\" } ] } }";
-				}
-				else
-				{
-					if(hold == "stream")
-					{
-						zresp.headers += HttpHeader("Grip-Hold", "stream");
-						zresp.headers += HttpHeader("Grip-Channel", "test-channel");
-						if(large)
-							zresp.body = QByteArray(PROXY_MAX_ACCEPT_RESPONSE_BODY + 10000, 'a') + '\n';
-						else
-							zresp.body = "stream open\n";
-					}
-					else
-					{
-						zresp.headers += HttpHeader("Grip-Hold", "response");
-						zresp.headers += HttpHeader("Grip-Channel", "test-channel");
-					}
-				}
-			}
-		}
-		else
-		{
-			if(encPath.startsWith("/jsonp"))
-			{
-				zresp.headers += HttpHeader("Content-Type", "application/json");
-				zresp.body = "{\"hello\": \"world\"}";
-			}
-			else if(encPath == "/path3")
-			{
-				zresp.headers += HttpHeader("Content-Type", "text/plain");
-				zresp.body = "next page";
-			}
-			else
-			{
-				if(hold == "none")
-				{
-					if(bodyInstruct)
-					{
-						zresp.headers += HttpHeader("Content-Type", "application/grip-instruct");
-						zresp.body = "{ \"response\": { \"body\": \"hello world\" } }";
-					}
-					else
-					{
-						zresp.headers += HttpHeader("Content-Type", "text/plain");
-						if(large)
-						{
-							// Grip-Link required to trigger accept after
-							// sending large response. Note that the link
-							// won't be followed in this test since that's
-							// not a proxy issue
-							zresp.headers += HttpHeader("Grip-Link", "</path3>; rel=next");
-							zresp.body = QByteArray(PROXY_MAX_ACCEPT_RESPONSE_BODY + 10000, 'a') + '\n';
-						}
-						else
-						{
-							zresp.headers += HttpHeader("Grip-Foo", "bar"); // Something to trigger accept
-							zresp.body = "hello world";
-						}
-					}
-				}
-				else
-				{
-					zresp.headers += HttpHeader("Content-Type", "text/plain");
-					zresp.body = "hello world";
-				}
-			}
-		}
-		zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
-		QByteArray buf = zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
-		zhttpServerOutSock->write(QList<QByteArray>() << buf);
+        if (!retried && (hold == "response" || hold == "stream")) {
+            if (encPath == "/path2") {
+                if (bodyInstruct) {
+                    zresp.headers += HttpHeader("Content-Type", "application/grip-instruct");
+                    zresp.body = "{ \"hold\": { \"mode\": \"response\", \"channels\": [ { "
+                                 "\"name\": \"test-channel\", \"prev-id\": \"1\" } ] } }";
+                } else {
+                    zresp.headers += HttpHeader("Grip-Hold", "response");
+                    zresp.headers += HttpHeader("Grip-Channel", "test-channel; prev-id=1");
+                }
+            } else {
+                if (bodyInstruct) {
+                    zresp.headers += HttpHeader("Content-Type", "application/grip-instruct");
+                    zresp.body = "{ \"hold\": { \"mode\": \"response\", \"channels\": [ "
+                                 "{ \"name\": \"test-channel\" } ] } }";
+                } else {
+                    if (hold == "stream") {
+                        zresp.headers += HttpHeader("Grip-Hold", "stream");
+                        zresp.headers += HttpHeader("Grip-Channel", "test-channel");
+                        if (large)
+                            zresp.body =
+                                QByteArray(PROXY_MAX_ACCEPT_RESPONSE_BODY + 10000, 'a') + '\n';
+                        else
+                            zresp.body = "stream open\n";
+                    } else {
+                        zresp.headers += HttpHeader("Grip-Hold", "response");
+                        zresp.headers += HttpHeader("Grip-Channel", "test-channel");
+                    }
+                }
+            }
+        } else {
+            if (encPath.startsWith("/jsonp")) {
+                zresp.headers += HttpHeader("Content-Type", "application/json");
+                zresp.body = "{\"hello\": \"world\"}";
+            } else if (encPath == "/path3") {
+                zresp.headers += HttpHeader("Content-Type", "text/plain");
+                zresp.body = "next page";
+            } else {
+                if (hold == "none") {
+                    if (bodyInstruct) {
+                        zresp.headers += HttpHeader("Content-Type", "application/grip-instruct");
+                        zresp.body = "{ \"response\": { \"body\": \"hello world\" } }";
+                    } else {
+                        zresp.headers += HttpHeader("Content-Type", "text/plain");
+                        if (large) {
+                            // Grip-Link required to trigger accept after
+                            // sending large response. Note that the link
+                            // won't be followed in this test since that's
+                            // not a proxy issue
+                            zresp.headers += HttpHeader("Grip-Link", "</path3>; rel=next");
+                            zresp.body =
+                                QByteArray(PROXY_MAX_ACCEPT_RESPONSE_BODY + 10000, 'a') + '\n';
+                        } else {
+                            zresp.headers +=
+                                HttpHeader("Grip-Foo", "bar"); // Something to trigger accept
+                            zresp.body = "hello world";
+                        }
+                    }
+                } else {
+                    zresp.headers += HttpHeader("Content-Type", "text/plain");
+                    zresp.body = "hello world";
+                }
+            }
+        }
+        zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
+        QByteArray buf =
+            zreq.from.asQByteArray() + " T" + TnetString::fromVariant(zresp.toVariant());
+        zhttpServerOutSock->write(QList<QByteArray>() << buf);
 
-		// Zero out so we can accept another request
-		serverOutSeq = 0;
-	}
+        // Zero out so we can accept another request
+        serverOutSeq = 0;
+    }
 
-	void handlerInspect_readyRead(const CowByteArrayList &_message)
-	{
-		ZmqReqMessage message(_message);
-		Variant v = TnetString::toVariant(message.content()[0]);
-		log_debug("inspect: %s", qPrintable(TnetString::variantToString(v, -1)));
+    void handlerInspect_readyRead(const CowByteArrayList &_message) {
+        ZmqReqMessage message(_message);
+        Variant v = TnetString::toVariant(message.content()[0]);
+        log_debug("inspect: %s", qPrintable(TnetString::variantToString(v, -1)));
 
-		inspected = true;
+        inspected = true;
 
-		if(inspectEnabled)
-		{
-			VariantHash vreq = v.toHash();
-			VariantHash args = vreq["args"].toHash();
-			VariantHash respValue;
-			respValue["no-proxy"] = false;
-			if(!sharingKey.isEmpty())
-				respValue["sharing-key"] = sharingKey;
-			VariantHash vresp;
-			vresp["id"] = vreq["id"];
-			vresp["success"] = true;
-			vresp["value"] = respValue;
-			log_debug("inspect response: %s", qPrintable(TnetString::variantToString(vresp, -1)));
-			handlerInspectSock->write(message.createReply(QList<QByteArray>() << TnetString::fromVariant(vresp)).toRawMessage());
-		}
-	}
+        if (inspectEnabled) {
+            VariantHash vreq = v.toHash();
+            VariantHash args = vreq["args"].toHash();
+            VariantHash respValue;
+            respValue["no-proxy"] = false;
+            if (!sharingKey.isEmpty())
+                respValue["sharing-key"] = sharingKey;
+            VariantHash vresp;
+            vresp["id"] = vreq["id"];
+            vresp["success"] = true;
+            vresp["value"] = respValue;
+            log_debug("inspect response: %s", qPrintable(TnetString::variantToString(vresp, -1)));
+            handlerInspectSock->write(
+                message.createReply(QList<QByteArray>() << TnetString::fromVariant(vresp))
+                    .toRawMessage());
+        }
+    }
 
-	void handlerAccept_readyRead(const CowByteArrayList &_message)
-	{
-		ZmqReqMessage message(_message);
-		Variant v = TnetString::toVariant(message.content()[0]);
-		log_debug("accept: %s", qPrintable(TnetString::variantToString(v, -1)));
+    void handlerAccept_readyRead(const CowByteArrayList &_message) {
+        ZmqReqMessage message(_message);
+        Variant v = TnetString::toVariant(message.content()[0]);
+        log_debug("accept: %s", qPrintable(TnetString::variantToString(v, -1)));
 
-		VariantHash vreq = v.toHash();
+        VariantHash vreq = v.toHash();
 
-		if(vreq["method"].toString() != "accept")
-			return;
+        if (vreq["method"].toString() != "accept")
+            return;
 
-		VariantHash vaccept = vreq["args"].toHash();
-		VariantHash vresponse = vaccept["response"].toHash();
+        VariantHash vaccept = vreq["args"].toHash();
+        VariantHash vresponse = vaccept["response"].toHash();
 
-		acceptHeaders.clear();
-		for(const Variant &vheader : vresponse["headers"].toList())
-		{
-			VariantList h = vheader.toList();
-			acceptHeaders += HttpHeader(h[0].toByteArray(), h[1].toByteArray());
-		}
+        acceptHeaders.clear();
+        for (const Variant &vheader : vresponse["headers"].toList()) {
+            VariantList h = vheader.toList();
+            acceptHeaders += HttpHeader(h[0].toByteArray(), h[1].toByteArray());
+        }
 
-		acceptIn = vresponse["body"].toByteArray();
+        acceptIn = vresponse["body"].toByteArray();
 
-		VariantMap jsonInstruct;
-		QByteArray hold;
+        VariantMap jsonInstruct;
+        QByteArray hold;
 
-		if(acceptHeaders.get("Content-Type") == "application/grip-instruct")
-		{
-			QJsonParseError e;
-			QJsonDocument doc = QJsonDocument::fromJson(acceptIn, &e);
-			TEST_ASSERT(e.error == QJsonParseError::NoError);
-			TEST_ASSERT(doc.isObject());
+        if (acceptHeaders.get("Content-Type") == "application/grip-instruct") {
+            QJsonParseError e;
+            QJsonDocument doc = QJsonDocument::fromJson(acceptIn, &e);
+            TEST_ASSERT(e.error == QJsonParseError::NoError);
+            TEST_ASSERT(doc.isObject());
 
-			jsonInstruct = doc.object().toVariantMap();
+            jsonInstruct = doc.object().toVariantMap();
 
-			if(jsonInstruct.contains("hold"))
-				hold = jsonInstruct["hold"].toMap().value("mode").toString().toUtf8();
-		}
-		else
-		{
-			hold = acceptHeaders.get("Grip-Hold").asQByteArray();
-		}
+            if (jsonInstruct.contains("hold"))
+                hold = jsonInstruct["hold"].toMap().value("mode").toString().toUtf8();
+        } else {
+            hold = acceptHeaders.get("Grip-Hold").asQByteArray();
+        }
 
-		VariantList vheaders = vresponse["headers"].toList();
-		for(int n = 0; n < vheaders.count(); ++n)
-		{
-			VariantList h = vheaders[n].toList();
-			if(h[0].toByteArray().startsWith("Grip-"))
-			{
-				vheaders.removeAt(n);
-				--n; // Adjust position
-			}
-		}
-		vresponse["headers"] = vheaders;
+        VariantList vheaders = vresponse["headers"].toList();
+        for (int n = 0; n < vheaders.count(); ++n) {
+            VariantList h = vheaders[n].toList();
+            if (h[0].toByteArray().startsWith("Grip-")) {
+                vheaders.removeAt(n);
+                --n; // Adjust position
+            }
+        }
+        vresponse["headers"] = vheaders;
 
-		VariantHash vresp;
-		vresp["id"] = vreq["id"];
-		vresp["success"] = true;
-		VariantHash respValue;
-		if(!hold.isEmpty())
-			respValue["accepted"] = true;
-		else if(!vaccept.value("response-sent").toBool())
-			respValue["response"] = vresponse;
-		vresp["value"] = respValue;
-		handlerAcceptSock->write(message.createReply(QList<QByteArray>() << TnetString::fromVariant(vresp)).toRawMessage());
+        VariantHash vresp;
+        vresp["id"] = vreq["id"];
+        vresp["success"] = true;
+        VariantHash respValue;
+        if (!hold.isEmpty())
+            respValue["accepted"] = true;
+        else if (!vaccept.value("response-sent").toBool())
+            respValue["response"] = vresponse;
+        vresp["value"] = respValue;
+        handlerAcceptSock->write(
+            message.createReply(QList<QByteArray>() << TnetString::fromVariant(vresp))
+                .toRawMessage());
 
-		log_debug("instruct: [%s]", acceptIn.data());
+        log_debug("instruct: [%s]", acceptIn.data());
 
-		if(acceptHeaders.get("Content-Type") == "application/grip-instruct")
-		{
-			if(jsonInstruct.contains("hold") && jsonInstruct["hold"].toMap()["channels"].toList()[0].toMap().contains("prev-id"))
-			{
-				retried = true;
-				VariantHash vretry;
-				vretry["requests"] = vaccept["requests"];
-				vretry["request-data"] = vaccept["request-data"];
-				QByteArray buf = TnetString::fromVariant(vretry);
-				log_debug("retrying: %s", qPrintable(TnetString::variantToString(vretry, -1)));
+        if (acceptHeaders.get("Content-Type") == "application/grip-instruct") {
+            if (jsonInstruct.contains("hold") &&
+                jsonInstruct["hold"].toMap()["channels"].toList()[0].toMap().contains("prev-id")) {
+                retried = true;
+                VariantHash vretry;
+                vretry["requests"] = vaccept["requests"];
+                vretry["request-data"] = vaccept["request-data"];
+                QByteArray buf = TnetString::fromVariant(vretry);
+                log_debug("retrying: %s", qPrintable(TnetString::variantToString(vretry, -1)));
 
-				QList<QByteArray> msg;
-				msg.append("proxy");
-				msg.append(QByteArray());
-				msg.append(buf);
-				handlerRetryOutSock->write(msg);
-				return;
-			}
-		}
+                QList<QByteArray> msg;
+                msg.append("proxy");
+                msg.append(QByteArray());
+                msg.append(buf);
+                handlerRetryOutSock->write(msg);
+                return;
+            }
+        }
 
-		if(!hold.isEmpty())
-			finished = true;
-	}
+        if (!hold.isEmpty())
+            finished = true;
+    }
 };
 
-class TestState
-{
+class TestState {
 public:
-	DomainMap *domainMap;
-	Engine *engine;
-	Wrapper *wrapper;
-	QList<StatsPacket> trackedPackets;
+    DomainMap *domainMap;
+    Engine *engine;
+    Wrapper *wrapper;
+    QList<StatsPacket> trackedPackets;
 
-	TestState(std::function<void (int)> loop_wait)
-	{
-		qRegisterMetaType<QList<StatsPacket>>();
+    TestState(std::function<void(int)> loop_wait) {
+        qRegisterMetaType<QList<StatsPacket>>();
 
-		log_setOutputLevel(LOG_LEVEL_WARNING);
-		//log_setOutputLevel(LOG_LEVEL_DEBUG);
+        log_setOutputLevel(LOG_LEVEL_WARNING);
+        // log_setOutputLevel(LOG_LEVEL_DEBUG);
 
-		QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
-		QDir configDir(rootDir.filePath("src/proxy"));
-		QDir outDir(qgetenv("OUT_DIR"));
-		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+        QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
+        QDir configDir(rootDir.filePath("src/proxy"));
+        QDir outDir(qgetenv("OUT_DIR"));
+        QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
-		wrapper = new Wrapper(workDir);
+        wrapper = new Wrapper(workDir);
 
-		bool connected = false;
-		wrapper->connected.connect([&] {
-			connected = true;
-		});
+        bool connected = false;
+        wrapper->connected.connect([&] { connected = true; });
 
-		wrapper->startHttp();
+        wrapper->startHttp();
 
-		domainMap = new DomainMap(configDir.filePath("routes.test"));
+        domainMap = new DomainMap(configDir.filePath("routes.test"));
 
-		engine = new Engine(domainMap);
+        engine = new Engine(domainMap);
 
-		Engine::Configuration config;
-		config.clientId = "proxy";
-		config.serverInSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-out"));
-		config.serverInStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-out-stream"));
-		config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-in"));
-		config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-in"));
-		config.clientOutStreamSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-in-stream"));
-		config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-out"));
-		config.inspectSpec = ("ipc://" + workDir.filePath("prxtst-inspect"));
-		config.acceptSpec = ("ipc://" + workDir.filePath("prxtst-accept"));
-		config.retryInSpec = ("ipc://" + workDir.filePath("prxtst-retry-in"));
-		config.statsSpec = ("ipc://" + workDir.filePath("prxtst-stats"));
-		config.sessionsMax = 20;
-		config.inspectTimeout = 500;
-		config.inspectPrefetch = 5;
-		config.sigIss = "pushpin";
-		config.sigKey = Jwt::EncodingKey::fromSecret("changeme");
-		config.statsConnectionTtl = 120;
-		config.statsReportInterval = 1000; // Set a large interval so there's only one working report
-		TEST_ASSERT(engine->start(config));
+        Engine::Configuration config;
+        config.clientId = "proxy";
+        config.serverInSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-out"));
+        config.serverInStreamSpecs = QStringList()
+                                     << ("ipc://" + workDir.filePath("prxtst-client-out-stream"));
+        config.serverOutSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-client-in"));
+        config.clientOutSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-in"));
+        config.clientOutStreamSpecs = QStringList()
+                                      << ("ipc://" + workDir.filePath("prxtst-server-in-stream"));
+        config.clientInSpecs = QStringList() << ("ipc://" + workDir.filePath("prxtst-server-out"));
+        config.inspectSpec = ("ipc://" + workDir.filePath("prxtst-inspect"));
+        config.acceptSpec = ("ipc://" + workDir.filePath("prxtst-accept"));
+        config.retryInSpec = ("ipc://" + workDir.filePath("prxtst-retry-in"));
+        config.statsSpec = ("ipc://" + workDir.filePath("prxtst-stats"));
+        config.sessionsMax = 20;
+        config.inspectTimeout = 500;
+        config.inspectPrefetch = 5;
+        config.sigIss = "pushpin";
+        config.sigKey = Jwt::EncodingKey::fromSecret("changeme");
+        config.statsConnectionTtl = 120;
+        config.statsReportInterval =
+            1000; // Set a large interval so there's only one working report
+        TEST_ASSERT(engine->start(config));
 
-		wrapper->startHandler();
+        wrapper->startHandler();
 
-		engine->statsManager()->reported.connect([=](const QList<StatsPacket>& packets) {
-			trackedPackets.append(packets);
-		});
+        engine->statsManager()->reported.connect(
+            [=](const QList<StatsPacket> &packets) { trackedPackets.append(packets); });
 
-		while(!connected)
-			loop_wait(10);
-	}
+        while (!connected)
+            loop_wait(10);
+    }
 
-	~TestState()
-	{
-		delete engine;
-		delete domainMap;
-		delete wrapper;
-	}
+    ~TestState() {
+        delete engine;
+        delete domainMap;
+        delete wrapper;
+    }
 };
 
+} // namespace
+
+static void runWithEventLoop(std::function<void(TestState &, std::function<void(int)>)> f) {
+    EventLoop loop(100);
+
+    auto loop_wait = [&](int ms) {
+        for (int i = ms; i > 0; i -= 10) {
+            std::this_thread::sleep_for(10ms);
+            loop.step();
+        }
+    };
+
+    {
+        TestState state(loop_wait);
+
+        f(state, loop_wait);
+    }
 }
 
-static void runWithEventLoop(std::function<void (TestState &, std::function<void (int)>)> f)
-{
-	EventLoop loop(100);
+static void passthrough(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	auto loop_wait = [&](int ms) {
-		for(int i = ms; i > 0; i -= 10)
-		{
-			std::this_thread::sleep_for(10ms);
-			loop.step();
-		}
-	};
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("1", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?a=b";
+    zreq.method = "GET";
+    zreq.headers += HttpHeader("Host", "example");
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	{
-		TestState state(loop_wait);
+    engine->statsManager()->flushReport(QByteArray());
 
-		f(state, loop_wait);
-	}
+    TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
+    TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
+
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   23); // "GET" + "/path?a=b" + "Host" + "example"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
+                                                  // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   43); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
 }
 
-static void passthrough(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void passthroughWithoutInspect(TestState &state, std::function<void(int)> loop_wait) {
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("1", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?a=b";
-	zreq.method = "GET";
-	zreq.headers += HttpHeader("Host", "example");
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    wrapper->inspectEnabled = false;
 
-	engine->statsManager()->flushReport(QByteArray());
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("2", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
-	TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
-
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
-
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 23); // "GET" + "/path?a=b" + "Host" + "example"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
+    TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
 }
 
-static void passthroughWithoutInspect(TestState &state, std::function<void (int)> loop_wait)
-{
-	Wrapper *wrapper = state.wrapper;
+static void passthroughJsonp(TestState &state, std::function<void(int)> loop_wait) {
+    Wrapper *wrapper = state.wrapper;
 
-	wrapper->inspectEnabled = false;
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("3", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/jsonp?callback=jpcb";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("2", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    TEST_ASSERT(wrapper->in.startsWith("/**/jpcb({"));
+    TEST_ASSERT(wrapper->in.endsWith("});\n"));
+    QByteArray dataRaw = wrapper->in.mid(9, wrapper->in.size() - 9 - 3);
 
-	TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
+    QJsonParseError e;
+    QJsonDocument doc = QJsonDocument::fromJson(dataRaw, &e);
+    TEST_ASSERT(e.error == QJsonParseError::NoError);
+    TEST_ASSERT(doc.isObject());
+
+    VariantMap data = doc.object().toVariantMap();
+
+    TEST_ASSERT_EQ(data["code"].toInt(), 200);
+    TEST_ASSERT_EQ(data["body"].toByteArray(), QByteArray("{\"hello\": \"world\"}"));
 }
 
-static void passthroughJsonp(TestState &state, std::function<void (int)> loop_wait)
-{
-	Wrapper *wrapper = state.wrapper;
+static void passthroughJsonpBasic(TestState &state, std::function<void(int)> loop_wait) {
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("3", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/jsonp?callback=jpcb";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("4", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/jsonp-basic?bparam={}";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	TEST_ASSERT(wrapper->in.startsWith("/**/jpcb({"));
-	TEST_ASSERT(wrapper->in.endsWith("});\n"));
-	QByteArray dataRaw = wrapper->in.mid(9, wrapper->in.size() - 9 - 3);
-
-	QJsonParseError e;
-	QJsonDocument doc = QJsonDocument::fromJson(dataRaw, &e);
-	TEST_ASSERT(e.error == QJsonParseError::NoError);
-	TEST_ASSERT(doc.isObject());
-
-	VariantMap data = doc.object().toVariantMap();
-
-	TEST_ASSERT_EQ(data["code"].toInt(), 200);
-	TEST_ASSERT_EQ(data["body"].toByteArray(), QByteArray("{\"hello\": \"world\"}"));
+    TEST_ASSERT_EQ(wrapper->in, QByteArray("/**/jpcb({\"hello\": \"world\"});\n"));
 }
 
-static void passthroughJsonpBasic(TestState &state, std::function<void (int)> loop_wait)
-{
-	Wrapper *wrapper = state.wrapper;
+static void passthroughPostStream(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("4", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/jsonp-basic?bparam={}";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("5", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path";
+    zreq.method = "POST";
+    zreq.stream = true;
+    zreq.body = "hello"; // Enough to hit the prefetch amount
+    zreq.more = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
 
-	TEST_ASSERT_EQ(wrapper->in, QByteArray("/**/jpcb({\"hello\": \"world\"});\n"));
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+
+    // Ensure the server gets hit without finishing the request
+    while (wrapper->serverReqs.count() < 1)
+        loop_wait(10);
+
+    // Now finish the request
+    zreq = ZhttpRequestPacket();
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("5", 1);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.body = " world";
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    QList<QByteArray> msg;
+    msg.append("proxy");
+    msg.append(QByteArray());
+    msg.append(buf);
+    wrapper->zhttpClientOutStreamSock->write(msg);
+
+    while (!wrapper->finished)
+        loop_wait(10);
+
+    engine->statsManager()->flushReport(QByteArray());
+
+    TEST_ASSERT_EQ(wrapper->requestBody, QByteArray("hello world"));
+    TEST_ASSERT_EQ(wrapper->responses["5"].body, QByteArray("hello world"));
+
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 9);   // "POST" + "/path"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 11); // "hello world"
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
+                                                  // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 11);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   43); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
 }
 
-static void passthroughPostStream(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void passthroughPostStreamFail(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("5", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path";
-	zreq.method = "POST";
-	zreq.stream = true;
-	zreq.body = "hello"; // Enough to hit the prefetch amount
-	zreq.more = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("6", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path";
+    zreq.method = "POST";
+    zreq.stream = true;
+    zreq.body = "hello"; // Enough to hit the prefetch amount
+    zreq.more = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
 
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
 
-	// Ensure the server gets hit without finishing the request
-	while(wrapper->serverReqs.count() < 1)
-		loop_wait(10);
+    // Ensure the server gets hit without finishing the request
+    while (wrapper->serverReqs.count() < 1)
+        loop_wait(10);
 
-	// Now finish the request
-	zreq = ZhttpRequestPacket();
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("5", 1);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.body = " world";
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	QList<QByteArray> msg;
-	msg.append("proxy");
-	msg.append(QByteArray());
-	msg.append(buf);
-	wrapper->zhttpClientOutStreamSock->write(msg);
+    // Now cancel the request
+    zreq = ZhttpRequestPacket();
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("6", 1);
+    zreq.type = ZhttpRequestPacket::Cancel;
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    QList<QByteArray> msg;
+    msg.append("proxy");
+    msg.append(QByteArray());
+    msg.append(buf);
+    wrapper->zhttpClientOutStreamSock->write(msg);
 
-	while(!wrapper->finished)
-		loop_wait(10);
+    // Wait for server side to receive error
+    while (!wrapper->serverFailed)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
+    engine->statsManager()->flushReport(QByteArray());
 
-	TEST_ASSERT_EQ(wrapper->requestBody, QByteArray("hello world"));
-	TEST_ASSERT_EQ(wrapper->responses["5"].body, QByteArray("hello world"));
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
 
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
 
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 9); // "POST" + "/path"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 11); // "hello world"
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 11);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 9);  // "POST" + "/path"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 5); // "hello"
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 5); // "hello"
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 0);
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 0);
 }
 
-static void passthroughPostStreamFail(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void acceptResponse(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("6", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path";
-	zreq.method = "POST";
-	zreq.stream = true;
-	zreq.body = "hello"; // Enough to hit the prefetch amount
-	zreq.more = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("7", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=response";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    engine->statsManager()->flushReport(QByteArray());
 
-	// Ensure the server gets hit without finishing the request
-	while(wrapper->serverReqs.count() < 1)
-		loop_wait(10);
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Hold"), CowByteArray("response"));
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Channel"), CowByteArray("test-channel"));
+    TEST_ASSERT(wrapper->acceptIn.isEmpty());
 
-	// Now cancel the request
-	zreq = ZhttpRequestPacket();
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("6", 1);
-	zreq.type = ZhttpRequestPacket::Cancel;
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	QList<QByteArray> msg;
-	msg.append("proxy");
-	msg.append(QByteArray());
-	msg.append(buf);
-	wrapper->zhttpClientOutStreamSock->write(msg);
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
 
-	// Wait for server side to receive error
-	while(!wrapper->serverFailed)
-		loop_wait(10);
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
 
-	engine->statsManager()->flushReport(QByteArray());
-
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
-
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 9); // "POST" + "/path"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 5); // "hello"
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 5); // "hello"
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 0);
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 0);
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   22); // "GET" + "/path?hold=response"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   61); // "200" + "OK" + "Grip-Hold" + "response" + "Grip-Channel" +
+                        // "test-channel" + "Content-Length" + "0"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 0);
 }
 
-static void acceptResponse(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void acceptStream(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("7", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=response";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("8", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=stream";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
+    engine->statsManager()->flushReport(QByteArray());
 
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Hold"), CowByteArray("response"));
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Channel"), CowByteArray("test-channel"));
-	TEST_ASSERT(wrapper->acceptIn.isEmpty());
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Hold"), CowByteArray("stream"));
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Channel"), CowByteArray("test-channel"));
+    TEST_ASSERT_EQ(wrapper->acceptIn, QByteArray("stream open\n"));
+    TEST_ASSERT(wrapper->in.isEmpty());
 
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
 
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
 
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 22); // "GET" + "/path?hold=response"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 61); // "200" + "OK" + "Grip-Hold" + "response" + "Grip-Channel" + "test-channel" + "Content-Length" + "0"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 0);
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   20); // "GET" + "/path?hold=stream"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   60); // "200" + "OK" + "Grip-Hold" + "stream" + "Grip-Channel"
+                        // + "test-channel" + "Content-Length" + "12"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 12); // "stream open\n"
 }
 
-static void acceptStream(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void acceptResponseBodyInstruct(TestState &state, std::function<void(int)> loop_wait) {
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("8", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=stream";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("9", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=response&body-instruct=true";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
-
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Hold"), CowByteArray("stream"));
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Channel"), CowByteArray("test-channel"));
-	TEST_ASSERT_EQ(wrapper->acceptIn, QByteArray("stream open\n"));
-	TEST_ASSERT(wrapper->in.isEmpty());
-
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
-
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 20); // "GET" + "/path?hold=stream"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 60); // "200" + "OK" + "Grip-Hold" + "stream" + "Grip-Channel" + "test-channel" + "Content-Length" + "12"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 12); // "stream open\n"
+    TEST_ASSERT_EQ(wrapper->acceptIn,
+                   QByteArray("{ \"hold\": { \"mode\": \"response\", \"channels\": [ { "
+                              "\"name\": \"test-channel\" } ] } }"));
 }
 
-static void acceptResponseBodyInstruct(TestState &state, std::function<void (int)> loop_wait)
-{
-	Wrapper *wrapper = state.wrapper;
+static void acceptNoHold(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("9", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=response&body-instruct=true";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("10", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=none";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	TEST_ASSERT_EQ(wrapper->acceptIn, QByteArray("{ \"hold\": { \"mode\": \"response\", \"channels\": [ { \"name\": \"test-channel\" } ] } }"));
+    engine->statsManager()->flushReport(QByteArray());
+
+    TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
+
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 18); // "GET" + "/path?hold=none"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
+                                                  // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   54); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Grip-Foo" + "bar" + "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
 }
 
-static void acceptNoHold(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void acceptNoHoldBodyInstruct(TestState &state, std::function<void(int)> loop_wait) {
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("10", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=none";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("11", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=none&body-instruct=true";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
-
-	TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
-
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
-
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 18); // "GET" + "/path?hold=none"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 54); // "200" + "OK" + "Content-Type" + "text/plain" + "Grip-Foo" + "bar" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
+    TEST_ASSERT_EQ(wrapper->acceptIn,
+                   QByteArray("{ \"response\": { \"body\": \"hello world\" } }"));
 }
 
-static void acceptNoHoldBodyInstruct(TestState &state, std::function<void (int)> loop_wait)
-{
-	Wrapper *wrapper = state.wrapper;
+static void passthroughThenAcceptStream(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("11", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=none&body-instruct=true";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("12", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=stream&large=true";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	TEST_ASSERT_EQ(wrapper->acceptIn, QByteArray("{ \"response\": { \"body\": \"hello world\" } }"));
+    engine->statsManager()->flushReport(QByteArray());
+
+    TEST_ASSERT_EQ(wrapper->in.size(), 110001);
+    TEST_ASSERT_EQ(wrapper->in.mid(wrapper->in.size() - 2), QByteArray("a\n"));
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Hold"), CowByteArray("stream"));
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Channel"), CowByteArray("test-channel"));
+    TEST_ASSERT(wrapper->acceptIn.isEmpty());
+
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   31); // "GET" + "/path?hold=stream&large=true"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent, 5); // "200" + "OK"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 110001);
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   64); // "200" + "OK" + "Grip-Hold" + "stream" + "Grip-Channel"
+                        // + "test-channel" + "Content-Length" + "110001"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 110001);
 }
 
-static void passthroughThenAcceptStream(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void passthroughThenAcceptNext(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("12", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=stream&large=true";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("13", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path?hold=none&large=true";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
+    engine->statsManager()->flushReport(QByteArray());
 
-	TEST_ASSERT_EQ(wrapper->in.size(), 110001);
-	TEST_ASSERT_EQ(wrapper->in.mid(wrapper->in.size() - 2), QByteArray("a\n"));
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Hold"), CowByteArray("stream"));
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Channel"), CowByteArray("test-channel"));
-	TEST_ASSERT(wrapper->acceptIn.isEmpty());
+    TEST_ASSERT_EQ(wrapper->in.size(), 110001);
+    TEST_ASSERT_EQ(wrapper->in.mid(wrapper->in.size() - 2), QByteArray("a\n"));
+    TEST_ASSERT(wrapper->acceptIn.isEmpty());
+    TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Link"), CowByteArray("</path3>; rel=next"));
 
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
 
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
 
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 31); // "GET" + "/path?hold=stream&large=true"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 5); // "200" + "OK"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 110001);
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 64); // "200" + "OK" + "Grip-Hold" + "stream" + "Grip-Channel" + "test-channel" + "Content-Length" + "110001"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 110001);
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   29); // "GET" + "/path?hold=none&large=true"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   27); // "200" + "OK" + "Content-Type" + "text/plain"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 110001);
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   74); // "200" + "OK" + "Content-Type" + "text/plain" + "Grip-Link" +
+                        // "</path3>; rel=next" + "Content-Length" + "110001"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 110001);
 }
 
-static void passthroughThenAcceptNext(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void acceptWithRetry(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("13", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path?hold=none&large=true";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("14", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path2?hold=response&body-instruct=true";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
+    engine->statsManager()->flushReport(QByteArray());
 
-	TEST_ASSERT_EQ(wrapper->in.size(), 110001);
-	TEST_ASSERT_EQ(wrapper->in.mid(wrapper->in.size() - 2), QByteArray("a\n"));
-	TEST_ASSERT(wrapper->acceptIn.isEmpty());
-	TEST_ASSERT_EQ(wrapper->acceptHeaders.get("Grip-Link"), CowByteArray("</path3>; rel=next"));
+    TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
 
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+    TEST_ASSERT_EQ(wrapper->serverReqs.count(), 2);
 
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+    QHashIterator<QByteArray, HttpRequestData> it(wrapper->serverReqs);
+    HttpRequestData req1Data = it.next().value();
+    HttpRequestData req2Data = it.next().value();
 
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 29); // "GET" + "/path?hold=none&large=true"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 27); // "200" + "OK" + "Content-Type" + "text/plain"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 110001);
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 74); // "200" + "OK" + "Content-Type" + "text/plain" + "Grip-Link" + "</path3>; rel=next" + "Content-Length" + "110001"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 110001);
+    int headerBytes = 0;
+    int contentBytes = 0;
+
+    headerBytes +=
+        ZhttpManager::estimateRequestHeaderBytes(req1Data.method, req1Data.uri, req1Data.headers);
+    contentBytes += req1Data.body.size();
+
+    headerBytes +=
+        ZhttpManager::estimateRequestHeaderBytes(req2Data.method, req2Data.uri, req2Data.headers);
+    contentBytes += req2Data.body.size();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   42); // "GET" + "/path2?hold=response&body-instruct=true"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
+                                                  // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, headerBytes);
+    TEST_ASSERT_EQ(p.serverContentBytesSent, contentBytes);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   101); // "200" + "OK + "Content-Type" + "application/grip-instruct" +
+                         // "Content-Length": "94" + "200" + "OK" + "Content-Type" +
+                         // "text/plain" + "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived,
+                   105); // "{ \"hold\": { \"mode\": \"response\", \"channels\": [
+                         // { \"name\": \"test-channel\", \"prev-id\": \"1\" } ] }
+                         // }" + "hello world"
 }
 
-static void acceptWithRetry(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void passthroughShared(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("14", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path2?hold=response&body-instruct=true";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->finished)
-		loop_wait(10);
+    wrapper->sharingKey = "test";
 
-	engine->statsManager()->flushReport(QByteArray());
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path";
+    zreq.method = "GET";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
 
-	TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
+    QByteArray buf;
 
-	TEST_ASSERT_EQ(wrapper->serverReqs.count(), 2);
+    // Send two requests
 
-	QHashIterator<QByteArray, HttpRequestData> it(wrapper->serverReqs);
-	HttpRequestData req1Data = it.next().value();
-	HttpRequestData req2Data = it.next().value();
+    QByteArray id1 = "15";
+    QByteArray id2 = "16";
 
-	int headerBytes = 0;
-	int contentBytes = 0;
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id1, 0);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
 
-	headerBytes += ZhttpManager::estimateRequestHeaderBytes(req1Data.method, req1Data.uri, req1Data.headers);
-	contentBytes += req1Data.body.size();
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id2, 0);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
 
-	headerBytes += ZhttpManager::estimateRequestHeaderBytes(req2Data.method, req2Data.uri, req2Data.headers);
-	contentBytes += req2Data.body.size();
+    while (wrapper->clientReqsFinished < 2)
+        loop_wait(10);
 
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+    engine->statsManager()->flushReport(QByteArray());
 
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 42); // "GET" + "/path2?hold=response&body-instruct=true"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, headerBytes);
-	TEST_ASSERT_EQ(p.serverContentBytesSent, contentBytes);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 101); // "200" + "OK + "Content-Type" + "application/grip-instruct" + "Content-Length": "94" + "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 105); // "{ \"hold\": { \"mode\": \"response\", \"channels\": [ { \"name\": \"test-channel\", \"prev-id\": \"1\" } ] } }" + "hello world"
+    // There should have only been 1 request to the server
+    TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
+
+    TEST_ASSERT_EQ(wrapper->responses[id1].body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(wrapper->responses[id2].body, QByteArray("hello world"));
+
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   16); // "GET" + "/path" + "GET" + "/path"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   86); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11" + "200" + "OK" + "Content-Type"
+                        // + "text/plain" + "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   43); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
 }
 
-static void passthroughShared(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void passthroughSharedPost(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	wrapper->sharingKey = "test";
+    wrapper->sharingKey = "test";
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path";
-	zreq.method = "GET";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "http://example/path";
+    zreq.method = "POST";
+    zreq.stream = true;
+    zreq.body = "hello"; // Enough to hit the prefetch amount
+    zreq.more = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
 
-	QByteArray buf;
+    QByteArray buf;
 
-	// Send two requests
+    // Send two requests
 
-	QByteArray id1 = "15";
-	QByteArray id2 = "16";
+    QByteArray id1 = "17";
+    QByteArray id2 = "18";
 
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id1, 0);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id1, 0);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
 
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id2, 0);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id2, 0);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
 
-	while(wrapper->clientReqsFinished < 2)
-		loop_wait(10);
+    // We've hit prefetch, wait for inspect
+    while (!wrapper->inspected)
+        loop_wait(10);
 
-	engine->statsManager()->flushReport(QByteArray());
+    // Finish the requests
 
-	// There should have only been 1 request to the server
-	TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
+    zreq = ZhttpRequestPacket();
+    zreq.from = "test-client";
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.body = " world";
 
-	TEST_ASSERT_EQ(wrapper->responses[id1].body, QByteArray("hello world"));
-	TEST_ASSERT_EQ(wrapper->responses[id2].body, QByteArray("hello world"));
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id1, 1);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    QList<QByteArray> msg;
+    msg.append("proxy");
+    msg.append(QByteArray());
+    msg.append(buf);
+    wrapper->zhttpClientOutStreamSock->write(msg);
 
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id2, 1);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    msg.clear();
+    msg.append("proxy");
+    msg.append(QByteArray());
+    msg.append(buf);
+    wrapper->zhttpClientOutStreamSock->write(msg);
 
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+    while (wrapper->clientReqsFinished < 2)
+        loop_wait(10);
 
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 16); // "GET" + "/path" + "GET" + "/path"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 86); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11" + "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
+    engine->statsManager()->flushReport(QByteArray());
+
+    // There should have only been 1 request to the server
+    TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
+
+    TEST_ASSERT_EQ(wrapper->responses[id1].body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(wrapper->responses[id2].body, QByteArray("hello world"));
+
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
+
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
+
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived,
+                   18); // "POST" + "/path" + "POST" + "/path"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived,
+                   22); // "hello world" + "hello world"
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent,
+                   86); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11" + "200" + "OK" + "Content-Type"
+                        // + "text/plain" + "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 11); // "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   43); // "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
 }
 
-static void passthroughSharedPost(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+static void passthroughWs(TestState &state, std::function<void(int)> loop_wait) {
+    Engine *engine = state.engine;
+    Wrapper *wrapper = state.wrapper;
 
-	wrapper->sharingKey = "test";
+    ZhttpRequestPacket zreq;
+    zreq.from = "test-client";
+    zreq.ids += ZhttpRequestPacket::Id("19", 0);
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.uri = "ws://example/path";
+    zreq.stream = true;
+    zreq.credits = 200000;
+    zreq.routerResp = true;
+    QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    while (!wrapper->isWs)
+        loop_wait(10);
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "http://example/path";
-	zreq.method = "POST";
-	zreq.stream = true;
-	zreq.body = "hello"; // Enough to hit the prefetch amount
-	zreq.more = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
+    zreq = ZhttpRequestPacket();
+    zreq.from = "test-client";
+    zreq.type = ZhttpRequestPacket::Data;
+    zreq.body = "hello";
 
-	QByteArray buf;
+    zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id("19", 1);
+    buf = 'T' + TnetString::fromVariant(zreq.toVariant());
+    log_debug("writing: %s", buf.data());
+    QList<QByteArray> msg;
+    msg.append("proxy");
+    msg.append(QByteArray());
+    msg.append(buf);
+    wrapper->zhttpClientOutStreamSock->write(msg);
+    while (!wrapper->finished)
+        loop_wait(10);
 
-	// Send two requests
+    engine->statsManager()->flushReport(QByteArray());
 
-	QByteArray id1 = "17";
-	QByteArray id2 = "18";
+    TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
+    TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
 
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id1, 0);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    HttpRequestData reqData =
+        QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
 
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id2, 0);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
+    TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
 
-	// We've hit prefetch, wait for inspect
-	while(!wrapper->inspected)
-		loop_wait(10);
-
-	// Finish the requests
-
-	zreq = ZhttpRequestPacket();
-	zreq.from = "test-client";
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.body = " world";
-
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id1, 1);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	QList<QByteArray> msg;
-	msg.append("proxy");
-	msg.append(QByteArray());
-	msg.append(buf);
-	wrapper->zhttpClientOutStreamSock->write(msg);
-
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id(id2, 1);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	msg.clear();
-	msg.append("proxy");
-	msg.append(QByteArray());
-	msg.append(buf);
-	wrapper->zhttpClientOutStreamSock->write(msg);
-
-	while(wrapper->clientReqsFinished < 2)
-		loop_wait(10);
-
-	engine->statsManager()->flushReport(QByteArray());
-
-	// There should have only been 1 request to the server
-	TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
-
-	TEST_ASSERT_EQ(wrapper->responses[id1].body, QByteArray("hello world"));
-	TEST_ASSERT_EQ(wrapper->responses[id2].body, QByteArray("hello world"));
-
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
-
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 18); // "POST" + "/path" + "POST" + "/path"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 22); // "hello world" + "hello world"
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 86); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11" + "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(reqData.method, reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 11); // "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 43); // "200" + "OK" + "Content-Type" + "text/plain" + "Content-Length" + "11"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
+    StatsPacket p = state.trackedPackets.takeFirst();
+    TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 8); // "GET" + "/path"
+    TEST_ASSERT_EQ(p.clientContentBytesReceived, 5);
+    TEST_ASSERT_EQ(p.clientHeaderBytesSent, 22);  // "101" + "Switching Protocols"
+    TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes("GET", reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverContentBytesSent, 5);
+    TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
+                   22);                               // "101" + "Switching Protocols"
+    TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
 }
 
-static void passthroughWs(TestState &state, std::function<void (int)> loop_wait)
-{
-	Engine *engine = state.engine;
-	Wrapper *wrapper = state.wrapper;
+extern "C" int proxyengine_test(ffi::TestException *out_ex) {
+    TEST_CATCH(runWithEventLoop(passthrough));
+    TEST_CATCH(runWithEventLoop(passthroughWithoutInspect));
+    TEST_CATCH(runWithEventLoop(passthroughJsonp));
+    TEST_CATCH(runWithEventLoop(passthroughJsonpBasic));
+    TEST_CATCH(runWithEventLoop(passthroughPostStream));
+    TEST_CATCH(runWithEventLoop(passthroughPostStreamFail));
+    TEST_CATCH(runWithEventLoop(acceptResponse));
+    TEST_CATCH(runWithEventLoop(acceptStream));
+    TEST_CATCH(runWithEventLoop(acceptResponseBodyInstruct));
+    TEST_CATCH(runWithEventLoop(acceptNoHold));
+    TEST_CATCH(runWithEventLoop(acceptNoHoldBodyInstruct));
+    TEST_CATCH(runWithEventLoop(passthroughThenAcceptStream));
+    TEST_CATCH(runWithEventLoop(passthroughThenAcceptNext));
+    TEST_CATCH(runWithEventLoop(acceptWithRetry));
+    TEST_CATCH(runWithEventLoop(passthroughShared));
+    TEST_CATCH(runWithEventLoop(passthroughSharedPost));
+    TEST_CATCH(runWithEventLoop(passthroughWs));
 
-	ZhttpRequestPacket zreq;
-	zreq.from = "test-client";
-	zreq.ids += ZhttpRequestPacket::Id("19", 0);
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.uri = "ws://example/path";
-	zreq.stream = true;
-	zreq.credits = 200000;
-	zreq.routerResp = true;
-	QByteArray buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	wrapper->zhttpClientOutSock->write(QList<QByteArray>() << buf);
-	while(!wrapper->isWs)
-		loop_wait(10);
-
-	zreq = ZhttpRequestPacket();
-	zreq.from = "test-client";
-	zreq.type = ZhttpRequestPacket::Data;
-	zreq.body = "hello";
-
-	zreq.ids = QList<ZhttpRequestPacket::Id>() << ZhttpRequestPacket::Id("19", 1);
-	buf = 'T' + TnetString::fromVariant(zreq.toVariant());
-	log_debug("writing: %s", buf.data());
-	QList<QByteArray> msg;
-	msg.append("proxy");
-	msg.append(QByteArray());
-	msg.append(buf);
-	wrapper->zhttpClientOutStreamSock->write(msg);
-	while(!wrapper->finished)
-		loop_wait(10);
-
-	engine->statsManager()->flushReport(QByteArray());
-
-	TEST_ASSERT_EQ(wrapper->serverReqs.count(), 1);
-	TEST_ASSERT_EQ(wrapper->in, QByteArray("hello world"));
-
-	HttpRequestData reqData = QHashIterator<QByteArray, HttpRequestData>(wrapper->serverReqs).next().value();
-
-	TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
-
-	StatsPacket p = state.trackedPackets.takeFirst();
-	TEST_ASSERT_EQ(p.clientHeaderBytesReceived, 8); // "GET" + "/path"
-	TEST_ASSERT_EQ(p.clientContentBytesReceived, 5);
-	TEST_ASSERT_EQ(p.clientHeaderBytesSent, 22); // "101" + "Switching Protocols"
-	TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-	TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes("GET", reqData.uri, reqData.headers));
-	TEST_ASSERT_EQ(p.serverContentBytesSent, 5);
-	TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 22); // "101" + "Switching Protocols"
-	TEST_ASSERT_EQ(p.serverContentBytesReceived, 11); // "hello world"
-}
-
-extern "C" int proxyengine_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(runWithEventLoop(passthrough));
-	TEST_CATCH(runWithEventLoop(passthroughWithoutInspect));
-	TEST_CATCH(runWithEventLoop(passthroughJsonp));
-	TEST_CATCH(runWithEventLoop(passthroughJsonpBasic));
-	TEST_CATCH(runWithEventLoop(passthroughPostStream));
-	TEST_CATCH(runWithEventLoop(passthroughPostStreamFail));
-	TEST_CATCH(runWithEventLoop(acceptResponse));
-	TEST_CATCH(runWithEventLoop(acceptStream));
-	TEST_CATCH(runWithEventLoop(acceptResponseBodyInstruct));
-	TEST_CATCH(runWithEventLoop(acceptNoHold));
-	TEST_CATCH(runWithEventLoop(acceptNoHoldBodyInstruct));
-	TEST_CATCH(runWithEventLoop(passthroughThenAcceptStream));
-	TEST_CATCH(runWithEventLoop(passthroughThenAcceptNext));
-	TEST_CATCH(runWithEventLoop(acceptWithRetry));
-	TEST_CATCH(runWithEventLoop(passthroughShared));
-	TEST_CATCH(runWithEventLoop(passthroughSharedPost));
-	TEST_CATCH(runWithEventLoop(passthroughWs));
-
-	return 0;
+    return 0;
 }

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -23,30 +23,30 @@
 
 #include "proxysession.h"
 
-#include <assert.h>
-#include <QSet>
-#include "url.h"
-#include <QHostAddress>
-#include "packet/statspacket.h"
+#include "acceptdata.h"
+#include "acceptrequest.h"
+#include "bufferlist.h"
+#include "inspectdata.h"
+#include "jwt.h"
+#include "log.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
+#include "packet/statspacket.h"
+#include "proxyutil.h"
 #include "qtcompat.h"
+#include "requestsession.h"
+#include "statsmanager.h"
+#include "statusreasons.h"
+#include "testhttprequest.h"
+#include "url.h"
 #include "variant.h"
-#include "bufferlist.h"
-#include "log.h"
-#include "jwt.h"
-#include "inspectdata.h"
-#include "acceptdata.h"
+#include "xffrule.h"
 #include "zhttpmanager.h"
 #include "zhttprequest.h"
 #include "zroutes.h"
-#include "statusreasons.h"
-#include "xffrule.h"
-#include "requestsession.h"
-#include "proxyutil.h"
-#include "statsmanager.h"
-#include "acceptrequest.h"
-#include "testhttprequest.h"
+#include <QHostAddress>
+#include <QSet>
+#include <assert.h>
 
 using std::map;
 
@@ -58,1492 +58,1321 @@ using std::map;
 #define MAX_INITIAL_BUFFER 100000
 #define MAX_STREAM_BUFFER 100000
 
-class ProxySession::Private
-{
+class ProxySession::Private {
 public:
-	enum State
-	{
-		Stopped,
-		Requesting,
-		Accepting,
-		Responding,
-		Responded
-	};
-
-	class SessionItem
-	{
-	public:
-		enum State
-		{
-			WaitingForResponse,
-			Responding,
-			Responded,
-			Errored,
-			Pausing,
-			Paused
-		};
-
-		RequestSession *rs;
-		State state;
-		bool startedResponse;
-		bool unclean;
-		int bytesToWrite;
-		bool countClientReceivedBytes;
-		bool countClientSentBytes;
-
-		SessionItem() :
-			rs(0),
-			state(WaitingForResponse),
-			startedResponse(false),
-			unclean(false),
-			bytesToWrite(0),
-			countClientReceivedBytes(true),
-			countClientSentBytes(true)
-		{
-		}
-	};
-
-	struct RequestSessionConnections {
-		Connection bytesWrittenConnection;
-		Connection errorRespondingConnection;
-		Connection pausedConnection;
-		Connection finishedConnection;
-		Connection headerBytesSentConnection;
-		Connection bodyBytesSentConnection;
-	};
-
-	struct ZhttpReqConnections {
-		Connection readyReadConnection;
-		Connection writeBytesChangedConnection;
-		Connection errorConnection;
-	};
-
-	ProxySession *q;
-	State state;
-	ZRoutes *zroutes;
-	ZhttpManager *zhttpManager;
-	RequestSession *inRequest;
-	ZrpcManager *acceptManager;
-	bool isHttps;
-	DomainMap::Entry route;
-	QList<DomainMap::Target> targets;
-	DomainMap::Target target;
-	std::unique_ptr<HttpRequest> zhttpRequest;
-	bool addAllowed;
-	bool haveInspectData;
-	InspectData idata;
-	QSet<QByteArray> acceptHeaderPrefixes;
-	QSet<QByteArray> acceptContentTypes;
-	QSet<SessionItem*> sessionItems;
-	bool shared;
-	HttpRequestData requestData;
-	HttpRequestData origRequestData;
-	HttpResponseData responseData;
-	HttpResponseData acceptResponseData;
-	BufferList requestBody;
-	BufferList responseBody;
-	QHash<RequestSession*, SessionItem*> sessionItemsBySession;
-	QByteArray initialRequestBody;
-	bool requestBodySent;
-	int total;
-	bool buffering;
-	QByteArray defaultSigIss;
-	Jwt::EncodingKey defaultSigKey;
-	bool trustedClient;
-	bool intReq;
-	bool passthrough;
-	bool acceptXForwardedProtocol;
-	bool useXForwardedProto;
-	bool useXForwardedProtocol;
-	XffRule xffRule;
-	XffRule xffTrustedRule;
-	QList<QByteArray> origHeadersNeedMark;
-	bool acceptPushpinRoute;
-	QByteArray cdnLoop;
-	bool proxyInitialResponse;
-	bool acceptAfterResponding;
-	std::unique_ptr<AcceptRequest> acceptRequest;
-	LogUtil::Config logConfig;
-	StatsManager *statsManager;
-	Connection inReqReadyReadConnection;
-	Connection inReqErrorConnection;
-	ZhttpReqConnections zhttpReqConnections;
-	Connection finishedConnection;
-	map<RequestSession*, RequestSessionConnections> reqSessionConnectionMap;
-
-	Private(ProxySession *_q, ZRoutes *_zroutes, ZrpcManager *_acceptManager, const LogUtil::Config &_logConfig, StatsManager *_statsManager) :
-		q(_q),
-		state(Stopped),
-		zroutes(_zroutes),
-		zhttpManager(0),
-		inRequest(0),
-		acceptManager(_acceptManager),
-		isHttps(false),
-		addAllowed(true),
-		haveInspectData(false),
-		shared(false),
-		requestBodySent(false),
-		total(0),
-		trustedClient(false),
-		intReq(false),
-		passthrough(false),
-		acceptXForwardedProtocol(false),
-		useXForwardedProto(false),
-		useXForwardedProtocol(false),
-		acceptPushpinRoute(false),
-		proxyInitialResponse(false),
-		acceptAfterResponding(false),
-		logConfig(_logConfig),
-		statsManager(_statsManager)
-	{
-		acceptHeaderPrefixes += "Grip-";
-		acceptContentTypes += "application/grip-instruct";
-	}
-
-	~Private()
-	{
-		cleanup();
-	}
-
-	void cleanup()
-	{
-		foreach(SessionItem *si, sessionItems)
-		{
-			// Emitting a signal here is gross, but this way the engine cleans up the request sessions
-			q->requestSessionDestroyed(si->rs, false);
-			delete si->rs;
-			delete si;
-		}
-
-		sessionItems.clear();
-		sessionItemsBySession.clear();
-
-		if(zhttpManager)
-		{
-			zroutes->removeRef(zhttpManager);
-			zhttpManager = 0;
-		}
-	}
-
-	void add(RequestSession *rs)
-	{
-		assert(addAllowed);
-		assert(!route.isNull());
-
-		SessionItem *si = new SessionItem;
-		si->rs = rs;
-
-		// A retried request already had its received bytes counted earlier
-		if(rs->isRetry())
-			si->countClientReceivedBytes = false;
-
-		// Internal requests originate internally and should not have client bytes counted
-		if(rs->request()->passthroughData().isValid())
-		{
-			si->countClientReceivedBytes = false;
-			si->countClientSentBytes = false;
-		}
-
-		if(!sessionItems.isEmpty())
-			shared = true;
-
-		sessionItems += si;
-		sessionItemsBySession.insert(rs, si);
-		reqSessionConnectionMap[rs] = {
-			rs->bytesWritten.connect(boost::bind(&Private::rs_bytesWritten, this, boost::placeholders::_1, rs)),
-			rs->errorResponding.connect(boost::bind(&Private::rs_errorResponding, this, rs)),
-			rs->paused.connect(boost::bind(&Private::rs_paused, this, rs)),
-			rs->finished.connect(boost::bind(&Private::rs_finished, this, rs)),
-			rs->headerBytesSent.connect(boost::bind(&Private::rs_headerBytesSent, this, boost::placeholders::_1, rs)),
-			rs->bodyBytesSent.connect(boost::bind(&Private::rs_bodyBytesSent, this, boost::placeholders::_1, rs))
-		};
-
-		HttpRequestData rsRequestData = rs->requestData();
-
-		if(si->countClientReceivedBytes)
-		{
-			incCounter(Stats::ClientHeaderBytesReceived, ZhttpManager::estimateRequestHeaderBytes(rsRequestData.method, rsRequestData.uri, rsRequestData.headers));
-			incCounter(Stats::ClientContentBytesReceived, rsRequestData.body.size());
-		}
-
-		if(state == Stopped)
-		{
-			isHttps = rs->isHttps();
-
-			requestData = rsRequestData;
-			requestBody += requestData.body;
-			requestData.body.clear();
-
-			origRequestData = requestData;
-
-			if(!route.asHost.isEmpty())
-				ProxyUtil::applyHost(&requestData.uri, route.asHost);
-
-			QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
-
-			if(route.pathRemove > 0)
-				path = path.mid(route.pathRemove);
-
-			if(!route.pathPrepend.isEmpty())
-				path = route.pathPrepend + path;
-
-			requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
-
-			QByteArray sigIss = defaultSigIss;
-			Jwt::EncodingKey sigKey = defaultSigKey;
-
-			if(!route.sigIss.isEmpty())
-				sigIss = route.sigIss;
-
-			if(!route.sigKey.isNull())
-				sigKey = route.sigKey;
-
-			targets = route.targets;
-
-			foreach(const HttpHeader &h, route.headers)
-			{
-				requestData.headers.removeAll(h.first);
-				if(!h.second.isEmpty())
-					requestData.headers += HttpHeader(h.first, h.second);
-			}
-
-			if(!rs->isRetry())
-			{
-				inRequest = rs;
-
-				ZhttpRequest *req = inRequest->request();
-
-				inReqReadyReadConnection = req->readyRead.connect(boost::bind(&Private::inRequest_readyRead, this));
-				inReqErrorConnection = req->error.connect(boost::bind(&Private::inRequest_error, this));
-
-				requestBody += req->readBody();
-
-				intReq = req->passthroughData().isValid();
-			}
-
-			trustedClient = rs->trusted();
-			QHostAddress clientAddress = rs->request()->peerAddress();
-
-			ProxyUtil::manipulateRequestHeaders("proxysession", q, &requestData, trustedClient, route, sigIss, sigKey, acceptXForwardedProtocol, useXForwardedProto, useXForwardedProtocol, xffTrustedRule, xffRule, origHeadersNeedMark, acceptPushpinRoute, cdnLoop, clientAddress, idata, route.grip, intReq);
-
-			state = Requesting;
-			buffering = true;
-
-			if(trustedClient || !route.grip || intReq)
-				passthrough = true;
-
-			initialRequestBody = requestBody.toByteArray();
-
-			if(requestBody.size() > MAX_ACCEPT_REQUEST_BODY)
-			{
-				requestBody.clear();
-				buffering = false;
-			}
-
-			tryNextTarget();
-		}
-		else if(state == Requesting)
-		{
-			// Nothing to do, just wait around until a response comes
-		}
-		else if(state == Responding)
-		{
-			// Get the session caught up with where we're at
-
-			si->state = SessionItem::Responding;
-			si->startedResponse = true;
-			rs->startResponse(responseData.code, responseData.reason, responseData.headers);
-
-			if(!responseBody.isEmpty())
-			{
-				si->bytesToWrite += responseBody.size();
-				rs->writeResponseBody(responseBody.toByteArray());
-			}
-		}
-	}
-
-	bool pendingWrites()
-	{
-		foreach(SessionItem *si, sessionItems)
-		{
-			if(si->bytesToWrite != -1 && si->bytesToWrite > 0)
-				return true;
-		}
-
-		return false;
-	}
-
-	void tryNextTarget()
-	{
-		if(targets.isEmpty())
-		{
-			QString msg = "Error while proxying to origin.";
-
-			QStringList targetStrs;
-			foreach(const DomainMap::Target &t, route.targets)
-				targetStrs += ProxyUtil::targetToString(t);
-			QString dmsg = QString("Unable to connect to any targets. Tried: %1").arg(targetStrs.join(", "));
-
-			rejectAll(502, "Bad Gateway", msg, dmsg);
-			return;
-		}
-
-		target = targets.takeFirst();
-
-		if(target.overHttp)
-		{
-			// Don't forward WOH requests from client unless trusted
-
-			QByteArray contentType = requestData.headers.get("Content-Type").asQByteArray();
-			int at = contentType.indexOf(';');
-			if(at != -1)
-				contentType.truncate(at);
-
-			if(contentType == "application/websocket-events" && !trustedClient)
-			{
-				rejectAll(403, "Forbidden", "Client not allowed to send WebSocket events directly.");
-				return;
-			}
-		}
-
-		Url uri = requestData.uri;
-		if(target.ssl)
-			uri.setScheme("https");
-		else
-			uri.setScheme("http");
-
-		if(!target.host.isEmpty())
-			ProxyUtil::applyHost(&uri, target.host);
-
-		if(zhttpManager)
-		{
-			zroutes->removeRef(zhttpManager);
-			zhttpManager = 0;
-		}
-
-		if(target.type == DomainMap::Target::Test)
-		{
-			// For test route, auto-adjust path
-			if(!route.pathBeg.isEmpty())
-			{
-				int pathRemove = route.pathBeg.length();
-				if(route.pathBeg.endsWith('/'))
-					--pathRemove;
-
-				if(pathRemove > 0)
-					uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
-			}
-
-			zhttpRequest = std::make_unique<TestHttpRequest>();
-		}
-		else
-		{
-			if(target.type == DomainMap::Target::Custom)
-			{
-				zhttpManager = zroutes->managerForRoute(target.zhttpRoute);
-				log_debug("proxysession: %p forwarding to %s", q, qPrintable(target.zhttpRoute.baseSpec));
-			}
-			else // Default
-			{
-				zhttpManager = zroutes->defaultManager();
-				log_debug("proxysession: %p forwarding to %s:%d", q, qPrintable(target.connectHost), target.connectPort);
-			}
-
-			zroutes->addRef(zhttpManager);
-
-			zhttpRequest = std::unique_ptr<HttpRequest>(zhttpManager->createRequest());
-		}
-
-		zhttpReqConnections = {
-			zhttpRequest->readyRead.connect(boost::bind(&Private::zhttpRequest_readyRead, this)),
-			zhttpRequest->writeBytesChanged.connect(boost::bind(&Private::zhttpRequest_writeBytesChanged, this)),
-			zhttpRequest->error.connect(boost::bind(&Private::zhttpRequest_error, this))
-		};
-
-		if(target.trusted)
-			zhttpRequest->setIgnorePolicies(true);
-
-		if(target.trustConnectHost)
-			zhttpRequest->setTrustConnectHost(true);
-
-		if(target.insecure)
-			zhttpRequest->setIgnoreTlsErrors(true);
-
-		if(target.type == DomainMap::Target::Default)
-		{
-			zhttpRequest->setConnectHost(target.connectHost);
-			zhttpRequest->setConnectPort(target.connectPort);
-		}
-
-		if(!target.clientCert.isEmpty())
-			zhttpRequest->setClientCert(target.clientCert, target.clientKey);
-
-		ProxyUtil::applyHostHeader(&requestData.headers, uri);
-
-		incCounter(Stats::ServerHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(requestData.method, uri, requestData.headers));
-
-		zhttpRequest->start(requestData.method, uri, requestData.headers);
-
-		requestBodySent = false;
-
-		if(!initialRequestBody.isEmpty())
-		{
-			incCounter(Stats::ServerContentBytesSent, initialRequestBody.size());
-
-			zhttpRequest->writeBody(initialRequestBody);
-		}
-
-		if(!inRequest || (inRequest->request()->isInputFinished() && inRequest->request()->bytesAvailable() == 0))
-		{
-			// No need to track the primary request anymore
-			if(inRequest)
-			{
-				inReqReadyReadConnection.disconnect();
-				inReqErrorConnection.disconnect();
-				inRequest = 0;
-			}
-
-			requestBodySent = true;
-			zhttpRequest->endBody();
-		}
-	}
-
-	void tryRequestRead()
-	{
-		// If the state changed before input finished, then
-		// stop reading input
-		if(state != Requesting)
-			return;
-
-		int maxBytes = buffering ? MAX_STREAM_BUFFER : zhttpRequest->writeBytesAvailable();
-
-		// If we're not buffering, then sync to speed of server
-		if(maxBytes == 0)
-			return;
-
-		QByteArray buf = inRequest->request()->readBody(maxBytes);
-		if(!buf.isEmpty())
-		{
-			log_debug("proxysession: %p input chunk: %d", q, buf.size());
-
-			SessionItem *si = sessionItemsBySession.value(inRequest);
-			assert(si);
-
-			if(si->countClientReceivedBytes)
-				incCounter(Stats::ClientContentBytesReceived, buf.size());
-
-			if(buffering)
-			{
-				if(requestBody.size() + buf.size() > MAX_ACCEPT_REQUEST_BODY)
-				{
-					requestBody.clear();
-					buffering = false;
-				}
-				else
-					requestBody += buf;
-			}
-
-			incCounter(Stats::ServerContentBytesSent, buf.size());
-
-			zhttpRequest->writeBody(buf);
-		}
-
-		if(!requestBodySent && inRequest->request()->isInputFinished() && inRequest->request()->bytesAvailable() == 0)
-		{
-			// No need to track the primary request anymore
-			inReqReadyReadConnection.disconnect();
-			inReqErrorConnection.disconnect();
-			inRequest = 0;
-
-			requestBodySent = true;
-			zhttpRequest->endBody();
-		}
-	}
-
-	void cannotAcceptAll()
-	{
-		assert(state != Responding);
-		assert(state != Responded);
-
-		state = Responded;
-
-		foreach(SessionItem *si, sessionItems)
-		{
-			if(si->state != SessionItem::Errored)
-			{
-				if(si->state == SessionItem::Paused)
-				{
-					if(si->startedResponse)
-						si->state = SessionItem::Responding;
-					else
-						si->state = SessionItem::WaitingForResponse;
-
-					si->rs->resume();
-				}
-
-				assert(si->state == SessionItem::WaitingForResponse || si->state == SessionItem::Responding);
-
-				if(si->state == SessionItem::WaitingForResponse)
-				{
-					si->state = SessionItem::Responded;
-					si->bytesToWrite = -1;
-
-					si->rs->respondCannotAccept();
-				}
-				else
-				{
-					// If we already started responding, then only provide an
-					// error message in debug mode
-
-					if(si->rs->debugEnabled())
-					{
-						// If debug enabled, append the message at the end.
-						// this may ruin the content, but hey it's debug
-						// mode
-						QByteArray buf = "\n\nAccept service unavailable\n";
-
-						si->bytesToWrite += buf.size();
-						si->rs->writeResponseBody(buf);
-						si->rs->endResponseBody();
-					}
-					else
-					{
-						// If debug not enabled, then the best we can do is
-						// disconnect
-						si->state = SessionItem::Responded;
-						si->unclean = true;
-						si->bytesToWrite = -1;
-						si->rs->endResponseBody();
-					}
-				}
-			}
-		}
-	}
-
-	void rejectAll(int code, const QString &reason, const QString &errorMessage, const QString &debugErrorMessage)
-	{
-		zhttpReqConnections = ZhttpReqConnections();
-		// Kill the active target request, if any
-		zhttpRequest.reset();
-
-		assert(state != Responding);
-		assert(state != Responded);
-
-		state = Responded;
-
-		foreach(SessionItem *si, sessionItems)
-		{
-			if(si->state != SessionItem::Errored)
-			{
-				if(si->state == SessionItem::Paused)
-				{
-					if(si->startedResponse)
-						si->state = SessionItem::Responding;
-					else
-						si->state = SessionItem::WaitingForResponse;
-
-					si->rs->resume();
-				}
-
-				assert(si->state == SessionItem::WaitingForResponse || si->state == SessionItem::Responding);
-
-				if(si->state == SessionItem::WaitingForResponse)
-				{
-					si->state = SessionItem::Responded;
-					si->bytesToWrite = -1;
-
-					si->rs->respondError(code, reason, si->rs->debugEnabled() ? debugErrorMessage : errorMessage);
-				}
-				else // Responding
-				{
-					// If we already started responding, then only provide a
-					// rejection message in debug mode
-
-					if(si->rs->debugEnabled())
-					{
-						// If debug enabled, append the message at the end.
-						// this may ruin the content, but hey it's debug
-						// mode
-						QByteArray buf = "\n\n" + debugErrorMessage.toUtf8() + '\n';
-
-						si->bytesToWrite += buf.size();
-						si->rs->writeResponseBody(buf);
-						si->rs->endResponseBody();
-					}
-					else
-					{
-						// If debug not enabled, then the best we can do is
-						// disconnect
-						si->state = SessionItem::Responded;
-						si->unclean = true;
-						si->bytesToWrite = -1;
-						si->rs->endResponseBody();
-					}
-				}
-			}
-		}
-	}
-
-	void rejectAll(int code, const QString &reason, const QString &errorMessage)
-	{
-		rejectAll(code, reason, errorMessage, errorMessage);
-	}
-
-	void respondAll(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		assert(state != Responding);
-		assert(state != Responded);
-
-		state = Responded;
-
-		foreach(SessionItem *si, sessionItems)
-		{
-			if(si->state != SessionItem::Errored)
-			{
-				assert(si->state == SessionItem::WaitingForResponse);
-
-				si->state = SessionItem::Responded;
-				si->bytesToWrite = -1;
-				si->rs->respond(code, reason, headers, body);
-			}
-		}
-	}
-
-	void destroyAll()
-	{
-		assert(state == Accepting || state == Responding);
-
-		state = Responded;
-
-		foreach(SessionItem *si, sessionItems)
-		{
-			if(si->state == SessionItem::Paused)
-			{
-				si->state = SessionItem::Responding;
-				si->rs->resume();
-			}
-
-			if(si->state == SessionItem::WaitingForResponse || si->state == SessionItem::Responding)
-			{
-				si->state = SessionItem::Responded;
-				si->unclean = true;
-				si->bytesToWrite = -1;
-				si->rs->endResponseBody();
-			}
-		}
-	}
-
-	// This method emits signals
-	void tryResponseRead()
-	{
-		// If we're not buffering, then don't read (instead, sync to slowest
-		// receiver before reading again)
-		if(!buffering && pendingWrites())
-			return;
-
-		std::weak_ptr<Private> self = q->d;
-
-		bool wasAllowed = addAllowed;
-
-		if(state == Accepting)
-		{
-			if(responseBody.size() + zhttpRequest->bytesAvailable() > MAX_ACCEPT_RESPONSE_BODY)
-			{
-				QByteArray gripHold = responseData.headers.get("Grip-Hold").asQByteArray();
-
-				QByteArray gripNextLinkParam;
-				foreach(const HttpHeaderParameters &params, responseData.headers.getAllAsParameters("Grip-Link"))
-				{
-					if(params.count() >= 2 && params.get("rel") == "next")
-						gripNextLinkParam = params[0].first.asQByteArray();
-				}
-
-				bool usingBuildIdFilter = false;
-				foreach(const HttpHeaderParameters &params, responseData.headers.getAllAsParameters("Grip-Channel"))
-				{
-					if(params.count() >= 2)
-					{
-						bool found = false;
-						for(int n = 1; n < params.count(); ++n)
-						{
-							if(params[n].first == "filter" && params[n].second == "build-id")
-							{
-								found = true;
-								break;
-							}
-						}
-						if(found)
-						{
-							usingBuildIdFilter = true;
-							break;
-						}
-					}
-				}
-
-				if(proxyInitialResponse && (gripHold == "stream" || (gripHold.isEmpty() && !gripNextLinkParam.isEmpty())) && !usingBuildIdFilter)
-				{
-					// Sending the initial response from the proxy means
-					// we need to do some of the handler's job here
-
-					// NOTE: if we ever need to do more than what's
-					// below, we should consider querying the handler
-					// to perform these things while still letting
-					// the proxy send the response body
-
-					// No content length
-					responseData.headers.removeAll("Content-Length");
-
-					// Interpret grip-status
-					QByteArray statusHeader = responseData.headers.get("Grip-Status").asQByteArray();
-					if(!statusHeader.isEmpty())
-					{
-						QByteArray codeStr;
-						QByteArray reason;
-
-						int at = statusHeader.indexOf(' ');
-						if(at != -1)
-						{
-							codeStr = statusHeader.mid(0, at);
-							reason = statusHeader.mid(at + 1);
-						}
-						else
-						{
-							codeStr = statusHeader;
-						}
-
-						bool _ok;
-						responseData.code = codeStr.toInt(&_ok);
-						if(!_ok || responseData.code < 0 || responseData.code > 999)
-						{
-							// This may output a misleading error message
-							cannotAcceptAll();
-							return;
-						}
-
-						if(reason.isEmpty())
-							reason = StatusReasons::getReason(responseData.code);
-
-						responseData.reason = reason;
-					}
-
-					// Strip any grip headers
-					for(int n = 0; n < responseData.headers.count(); ++n)
-					{
-						const HttpHeader &h = responseData.headers[n];
-
-						bool prefixed = false;
-						foreach(const QByteArray &hp, acceptHeaderPrefixes)
-						{
-							if(qstrnicmp(h.first.data(), hp.data(), hp.length()) == 0)
-							{
-								prefixed = true;
-								break;
-							}
-						}
-
-						if(prefixed)
-						{
-							responseData.headers.removeAt(n);
-							--n; // Adjust position
-						}
-					}
-
-					// We'll let the proxy send normally, then accept afterwards
-					acceptAfterResponding = true;
-				}
-				else
-				{
-					QString msg = "Error while proxying to origin.";
-					QString dmsg = QString("GRIP instruct response too large from %1").arg(ProxyUtil::targetToString(target));
-
-					rejectAll(502, "Bad Gateway", msg, dmsg);
-					return;
-				}
-			}
-		}
-		else if(state == Responding)
-		{
-			if(buffering && responseBody.size() + zhttpRequest->bytesAvailable() > MAX_INITIAL_BUFFER)
-			{
-				responseBody.clear();
-				buffering = false;
-				addAllowed = false;
-			}
-		}
-
-		QByteArray buf;
-		int maxBytes = (buffering ? MAX_INITIAL_BUFFER - responseBody.size() : MAX_STREAM_BUFFER);
-		if(maxBytes > 0)
-			buf = zhttpRequest->readBody(maxBytes);
-
-		if(!buf.isEmpty())
-		{
-			incCounter(Stats::ServerContentBytesReceived, buf.size());
-
-			total += buf.size();
-			log_debug("proxysession: %p recv=%d, total=%d, avail=%d", q, buf.size(), total, zhttpRequest->bytesAvailable());
-
-			if(buffering)
-				responseBody += buf;
-		}
-
-		if(state == Accepting)
-		{
-			if(acceptAfterResponding)
-				startResponse();
-		}
-		else if(state == Responding)
-		{
-			log_debug("proxysession: %p writing %d to clients", q, buf.size());
-
-			foreach(SessionItem *si, sessionItems)
-			{
-				assert(si->state != SessionItem::WaitingForResponse);
-
-				if(si->state == SessionItem::Responding)
-				{
-					si->bytesToWrite += buf.size();
-					si->rs->writeResponseBody(buf);
-				}
-			}
-
-			if(wasAllowed && !addAllowed)
-			{
-				q->addNotAllowed();
-				if(self.expired())
-					return;
-			}
-		}
-
-		checkIncomingResponseFinished();
-	}
-
-	// This method emits signals
-	void checkIncomingResponseFinished()
-	{
-		std::weak_ptr<Private> self = q->d;
-
-		if(zhttpRequest->isFinished() && zhttpRequest->bytesAvailable() == 0)
-		{
-			log_debug("proxysession: %p response from target finished", q);
-
-			if(!buffering && pendingWrites())
-			{
-				log_debug("proxysession: %p still stuff left to write, though. we'll wait.", q);
-				return;
-			}
-
-			zhttpReqConnections = ZhttpReqConnections();			
-			zhttpRequest.reset();
-
-			// Once the entire response has been received, cut off any new adds
-			if(addAllowed)
-			{
-				addAllowed = false;
-				q->addNotAllowed();
-				if(self.expired())
-					return;
-			}
-
-			if(state == Accepting || (state == Responding && acceptAfterResponding))
-			{
-				state = Accepting;
-
-				if(acceptManager)
-				{
-					log_debug("we have an acceptmanager");
-					foreach(SessionItem *si, sessionItems)
-					{
-						si->state = SessionItem::Pausing;
-						si->rs->pause();
-					}
-				}
-				else
-				{
-					cannotAcceptAll();
-				}
-			}
-			else if(state == Responding)
-			{
-				foreach(SessionItem *si, sessionItems)
-				{
-					assert(si->state != SessionItem::WaitingForResponse);
-
-					if(si->state == SessionItem::Responding)
-					{
-						si->state = SessionItem::Responded;
-						si->rs->endResponseBody();
-					}
-				}
-			}
-		}
-	}
-
-	void startResponse()
-	{
-		state = Responding;
-
-		// Don't relay these headers. Their meaning is handled by
-		// zurl and they only apply to the outgoing hop.
-		responseData.headers.removeAll("Connection");
-		responseData.headers.removeAll("Keep-Alive");
-		responseData.headers.removeAll("Content-Encoding");
-		responseData.headers.removeAll("Transfer-Encoding");
-
-		foreach(SessionItem *si, sessionItems)
-		{
-			si->state = SessionItem::Responding;
-			si->startedResponse = true;
-			si->rs->startResponse(responseData.code, responseData.reason, responseData.headers);
-
-			if(!responseBody.isEmpty())
-			{
-				si->bytesToWrite += responseBody.size();
-				si->rs->writeResponseBody(responseBody.toByteArray());
-			}
-		}
-	}
-
-	void logFinished(SessionItem *si, bool accepted = false)
-	{
-		RequestSession *rs = si->rs;
-
-		HttpResponseData resp = rs->responseData();
-
-		LogUtil::RequestData rd;
-
-		// Only log route id if explicitly set
-		if(route.separateStats)
-			rd.routeId = route.id;
-
-		if(accepted)
-		{
-			rd.status = LogUtil::Accept;
-		}
-		else if(resp.code != -1 && !si->unclean)
-		{
-			rd.status = LogUtil::Response;
-			rd.responseData = resp;
-			rd.responseBodySize = rs->responseBodySize();
-		}
-		else
-		{
-			rd.status = LogUtil::Error;
-		}
-
-		rd.requestData = rs->requestData();
-
-		rd.targetStr = ProxyUtil::targetToString(target);
-		rd.targetOverHttp = target.overHttp;
-
-		rd.retry = rs->isRetry();
-		if(shared)
-			rd.sharedBy = this;
-
-		rd.fromAddress = rs->peerAddress();
-
-		LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
-	}
-
-	void incCounter(Stats::Counter c, int count = 1)
-	{
-		if(statsManager)
-			statsManager->incCounter(route.statsRoute(), c, count);
-	}
+    enum State { Stopped, Requesting, Accepting, Responding, Responded };
+
+    class SessionItem {
+    public:
+        enum State { WaitingForResponse, Responding, Responded, Errored, Pausing, Paused };
+
+        RequestSession *rs;
+        State state;
+        bool startedResponse;
+        bool unclean;
+        int bytesToWrite;
+        bool countClientReceivedBytes;
+        bool countClientSentBytes;
+
+        SessionItem()
+            : rs(0),
+              state(WaitingForResponse),
+              startedResponse(false),
+              unclean(false),
+              bytesToWrite(0),
+              countClientReceivedBytes(true),
+              countClientSentBytes(true) {}
+    };
+
+    struct RequestSessionConnections {
+        Connection bytesWrittenConnection;
+        Connection errorRespondingConnection;
+        Connection pausedConnection;
+        Connection finishedConnection;
+        Connection headerBytesSentConnection;
+        Connection bodyBytesSentConnection;
+    };
+
+    struct ZhttpReqConnections {
+        Connection readyReadConnection;
+        Connection writeBytesChangedConnection;
+        Connection errorConnection;
+    };
+
+    ProxySession *q;
+    State state;
+    ZRoutes *zroutes;
+    ZhttpManager *zhttpManager;
+    RequestSession *inRequest;
+    ZrpcManager *acceptManager;
+    bool isHttps;
+    DomainMap::Entry route;
+    QList<DomainMap::Target> targets;
+    DomainMap::Target target;
+    std::unique_ptr<HttpRequest> zhttpRequest;
+    bool addAllowed;
+    bool haveInspectData;
+    InspectData idata;
+    QSet<QByteArray> acceptHeaderPrefixes;
+    QSet<QByteArray> acceptContentTypes;
+    QSet<SessionItem *> sessionItems;
+    bool shared;
+    HttpRequestData requestData;
+    HttpRequestData origRequestData;
+    HttpResponseData responseData;
+    HttpResponseData acceptResponseData;
+    BufferList requestBody;
+    BufferList responseBody;
+    QHash<RequestSession *, SessionItem *> sessionItemsBySession;
+    QByteArray initialRequestBody;
+    bool requestBodySent;
+    int total;
+    bool buffering;
+    QByteArray defaultSigIss;
+    Jwt::EncodingKey defaultSigKey;
+    bool trustedClient;
+    bool intReq;
+    bool passthrough;
+    bool acceptXForwardedProtocol;
+    bool useXForwardedProto;
+    bool useXForwardedProtocol;
+    XffRule xffRule;
+    XffRule xffTrustedRule;
+    QList<QByteArray> origHeadersNeedMark;
+    bool acceptPushpinRoute;
+    QByteArray cdnLoop;
+    bool proxyInitialResponse;
+    bool acceptAfterResponding;
+    std::unique_ptr<AcceptRequest> acceptRequest;
+    LogUtil::Config logConfig;
+    StatsManager *statsManager;
+    Connection inReqReadyReadConnection;
+    Connection inReqErrorConnection;
+    ZhttpReqConnections zhttpReqConnections;
+    Connection finishedConnection;
+    map<RequestSession *, RequestSessionConnections> reqSessionConnectionMap;
+
+    Private(ProxySession *_q, ZRoutes *_zroutes, ZrpcManager *_acceptManager,
+            const LogUtil::Config &_logConfig, StatsManager *_statsManager)
+        : q(_q),
+          state(Stopped),
+          zroutes(_zroutes),
+          zhttpManager(0),
+          inRequest(0),
+          acceptManager(_acceptManager),
+          isHttps(false),
+          addAllowed(true),
+          haveInspectData(false),
+          shared(false),
+          requestBodySent(false),
+          total(0),
+          trustedClient(false),
+          intReq(false),
+          passthrough(false),
+          acceptXForwardedProtocol(false),
+          useXForwardedProto(false),
+          useXForwardedProtocol(false),
+          acceptPushpinRoute(false),
+          proxyInitialResponse(false),
+          acceptAfterResponding(false),
+          logConfig(_logConfig),
+          statsManager(_statsManager) {
+        acceptHeaderPrefixes += "Grip-";
+        acceptContentTypes += "application/grip-instruct";
+    }
+
+    ~Private() { cleanup(); }
+
+    void cleanup() {
+        foreach (SessionItem *si, sessionItems) {
+            // Emitting a signal here is gross, but this way the engine cleans up the
+            // request sessions
+            q->requestSessionDestroyed(si->rs, false);
+            delete si->rs;
+            delete si;
+        }
+
+        sessionItems.clear();
+        sessionItemsBySession.clear();
+
+        if (zhttpManager) {
+            zroutes->removeRef(zhttpManager);
+            zhttpManager = 0;
+        }
+    }
+
+    void add(RequestSession *rs) {
+        assert(addAllowed);
+        assert(!route.isNull());
+
+        SessionItem *si = new SessionItem;
+        si->rs = rs;
+
+        // A retried request already had its received bytes counted earlier
+        if (rs->isRetry())
+            si->countClientReceivedBytes = false;
+
+        // Internal requests originate internally and should not have client bytes
+        // counted
+        if (rs->request()->passthroughData().isValid()) {
+            si->countClientReceivedBytes = false;
+            si->countClientSentBytes = false;
+        }
+
+        if (!sessionItems.isEmpty())
+            shared = true;
+
+        sessionItems += si;
+        sessionItemsBySession.insert(rs, si);
+        reqSessionConnectionMap[rs] = {
+            rs->bytesWritten.connect(
+                boost::bind(&Private::rs_bytesWritten, this, boost::placeholders::_1, rs)),
+            rs->errorResponding.connect(boost::bind(&Private::rs_errorResponding, this, rs)),
+            rs->paused.connect(boost::bind(&Private::rs_paused, this, rs)),
+            rs->finished.connect(boost::bind(&Private::rs_finished, this, rs)),
+            rs->headerBytesSent.connect(
+                boost::bind(&Private::rs_headerBytesSent, this, boost::placeholders::_1, rs)),
+            rs->bodyBytesSent.connect(
+                boost::bind(&Private::rs_bodyBytesSent, this, boost::placeholders::_1, rs))};
+
+        HttpRequestData rsRequestData = rs->requestData();
+
+        if (si->countClientReceivedBytes) {
+            incCounter(Stats::ClientHeaderBytesReceived,
+                       ZhttpManager::estimateRequestHeaderBytes(
+                           rsRequestData.method, rsRequestData.uri, rsRequestData.headers));
+            incCounter(Stats::ClientContentBytesReceived, rsRequestData.body.size());
+        }
+
+        if (state == Stopped) {
+            isHttps = rs->isHttps();
+
+            requestData = rsRequestData;
+            requestBody += requestData.body;
+            requestData.body.clear();
+
+            origRequestData = requestData;
+
+            if (!route.asHost.isEmpty())
+                ProxyUtil::applyHost(&requestData.uri, route.asHost);
+
+            QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
+
+            if (route.pathRemove > 0)
+                path = path.mid(route.pathRemove);
+
+            if (!route.pathPrepend.isEmpty())
+                path = route.pathPrepend + path;
+
+            requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
+
+            QByteArray sigIss = defaultSigIss;
+            Jwt::EncodingKey sigKey = defaultSigKey;
+
+            if (!route.sigIss.isEmpty())
+                sigIss = route.sigIss;
+
+            if (!route.sigKey.isNull())
+                sigKey = route.sigKey;
+
+            targets = route.targets;
+
+            foreach (const HttpHeader &h, route.headers) {
+                requestData.headers.removeAll(h.first);
+                if (!h.second.isEmpty())
+                    requestData.headers += HttpHeader(h.first, h.second);
+            }
+
+            if (!rs->isRetry()) {
+                inRequest = rs;
+
+                ZhttpRequest *req = inRequest->request();
+
+                inReqReadyReadConnection =
+                    req->readyRead.connect(boost::bind(&Private::inRequest_readyRead, this));
+                inReqErrorConnection =
+                    req->error.connect(boost::bind(&Private::inRequest_error, this));
+
+                requestBody += req->readBody();
+
+                intReq = req->passthroughData().isValid();
+            }
+
+            trustedClient = rs->trusted();
+            QHostAddress clientAddress = rs->request()->peerAddress();
+
+            ProxyUtil::manipulateRequestHeaders(
+                "proxysession", q, &requestData, trustedClient, route, sigIss, sigKey,
+                acceptXForwardedProtocol, useXForwardedProto, useXForwardedProtocol, xffTrustedRule,
+                xffRule, origHeadersNeedMark, acceptPushpinRoute, cdnLoop, clientAddress, idata,
+                route.grip, intReq);
+
+            state = Requesting;
+            buffering = true;
+
+            if (trustedClient || !route.grip || intReq)
+                passthrough = true;
+
+            initialRequestBody = requestBody.toByteArray();
+
+            if (requestBody.size() > MAX_ACCEPT_REQUEST_BODY) {
+                requestBody.clear();
+                buffering = false;
+            }
+
+            tryNextTarget();
+        } else if (state == Requesting) {
+            // Nothing to do, just wait around until a response comes
+        } else if (state == Responding) {
+            // Get the session caught up with where we're at
+
+            si->state = SessionItem::Responding;
+            si->startedResponse = true;
+            rs->startResponse(responseData.code, responseData.reason, responseData.headers);
+
+            if (!responseBody.isEmpty()) {
+                si->bytesToWrite += responseBody.size();
+                rs->writeResponseBody(responseBody.toByteArray());
+            }
+        }
+    }
+
+    bool pendingWrites() {
+        foreach (SessionItem *si, sessionItems) {
+            if (si->bytesToWrite != -1 && si->bytesToWrite > 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    void tryNextTarget() {
+        if (targets.isEmpty()) {
+            QString msg = "Error while proxying to origin.";
+
+            QStringList targetStrs;
+            foreach (const DomainMap::Target &t, route.targets)
+                targetStrs += ProxyUtil::targetToString(t);
+            QString dmsg =
+                QString("Unable to connect to any targets. Tried: %1").arg(targetStrs.join(", "));
+
+            rejectAll(502, "Bad Gateway", msg, dmsg);
+            return;
+        }
+
+        target = targets.takeFirst();
+
+        if (target.overHttp) {
+            // Don't forward WOH requests from client unless trusted
+
+            QByteArray contentType = requestData.headers.get("Content-Type").asQByteArray();
+            int at = contentType.indexOf(';');
+            if (at != -1)
+                contentType.truncate(at);
+
+            if (contentType == "application/websocket-events" && !trustedClient) {
+                rejectAll(403, "Forbidden",
+                          "Client not allowed to send WebSocket events directly.");
+                return;
+            }
+        }
+
+        Url uri = requestData.uri;
+        if (target.ssl)
+            uri.setScheme("https");
+        else
+            uri.setScheme("http");
+
+        if (!target.host.isEmpty())
+            ProxyUtil::applyHost(&uri, target.host);
+
+        if (zhttpManager) {
+            zroutes->removeRef(zhttpManager);
+            zhttpManager = 0;
+        }
+
+        if (target.type == DomainMap::Target::Test) {
+            // For test route, auto-adjust path
+            if (!route.pathBeg.isEmpty()) {
+                int pathRemove = route.pathBeg.length();
+                if (route.pathBeg.endsWith('/'))
+                    --pathRemove;
+
+                if (pathRemove > 0)
+                    uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
+            }
+
+            zhttpRequest = std::make_unique<TestHttpRequest>();
+        } else {
+            if (target.type == DomainMap::Target::Custom) {
+                zhttpManager = zroutes->managerForRoute(target.zhttpRoute);
+                log_debug("proxysession: %p forwarding to %s", q,
+                          qPrintable(target.zhttpRoute.baseSpec));
+            } else // Default
+            {
+                zhttpManager = zroutes->defaultManager();
+                log_debug("proxysession: %p forwarding to %s:%d", q, qPrintable(target.connectHost),
+                          target.connectPort);
+            }
+
+            zroutes->addRef(zhttpManager);
+
+            zhttpRequest = std::unique_ptr<HttpRequest>(zhttpManager->createRequest());
+        }
+
+        zhttpReqConnections = {
+            zhttpRequest->readyRead.connect(boost::bind(&Private::zhttpRequest_readyRead, this)),
+            zhttpRequest->writeBytesChanged.connect(
+                boost::bind(&Private::zhttpRequest_writeBytesChanged, this)),
+            zhttpRequest->error.connect(boost::bind(&Private::zhttpRequest_error, this))};
+
+        if (target.trusted)
+            zhttpRequest->setIgnorePolicies(true);
+
+        if (target.trustConnectHost)
+            zhttpRequest->setTrustConnectHost(true);
+
+        if (target.insecure)
+            zhttpRequest->setIgnoreTlsErrors(true);
+
+        if (target.type == DomainMap::Target::Default) {
+            zhttpRequest->setConnectHost(target.connectHost);
+            zhttpRequest->setConnectPort(target.connectPort);
+        }
+
+        if (!target.clientCert.isEmpty())
+            zhttpRequest->setClientCert(target.clientCert, target.clientKey);
+
+        ProxyUtil::applyHostHeader(&requestData.headers, uri);
+
+        incCounter(Stats::ServerHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
+                                                     requestData.method, uri, requestData.headers));
+
+        zhttpRequest->start(requestData.method, uri, requestData.headers);
+
+        requestBodySent = false;
+
+        if (!initialRequestBody.isEmpty()) {
+            incCounter(Stats::ServerContentBytesSent, initialRequestBody.size());
+
+            zhttpRequest->writeBody(initialRequestBody);
+        }
+
+        if (!inRequest || (inRequest->request()->isInputFinished() &&
+                           inRequest->request()->bytesAvailable() == 0)) {
+            // No need to track the primary request anymore
+            if (inRequest) {
+                inReqReadyReadConnection.disconnect();
+                inReqErrorConnection.disconnect();
+                inRequest = 0;
+            }
+
+            requestBodySent = true;
+            zhttpRequest->endBody();
+        }
+    }
+
+    void tryRequestRead() {
+        // If the state changed before input finished, then
+        // stop reading input
+        if (state != Requesting)
+            return;
+
+        int maxBytes = buffering ? MAX_STREAM_BUFFER : zhttpRequest->writeBytesAvailable();
+
+        // If we're not buffering, then sync to speed of server
+        if (maxBytes == 0)
+            return;
+
+        QByteArray buf = inRequest->request()->readBody(maxBytes);
+        if (!buf.isEmpty()) {
+            log_debug("proxysession: %p input chunk: %d", q, buf.size());
+
+            SessionItem *si = sessionItemsBySession.value(inRequest);
+            assert(si);
+
+            if (si->countClientReceivedBytes)
+                incCounter(Stats::ClientContentBytesReceived, buf.size());
+
+            if (buffering) {
+                if (requestBody.size() + buf.size() > MAX_ACCEPT_REQUEST_BODY) {
+                    requestBody.clear();
+                    buffering = false;
+                } else
+                    requestBody += buf;
+            }
+
+            incCounter(Stats::ServerContentBytesSent, buf.size());
+
+            zhttpRequest->writeBody(buf);
+        }
+
+        if (!requestBodySent && inRequest->request()->isInputFinished() &&
+            inRequest->request()->bytesAvailable() == 0) {
+            // No need to track the primary request anymore
+            inReqReadyReadConnection.disconnect();
+            inReqErrorConnection.disconnect();
+            inRequest = 0;
+
+            requestBodySent = true;
+            zhttpRequest->endBody();
+        }
+    }
+
+    void cannotAcceptAll() {
+        assert(state != Responding);
+        assert(state != Responded);
+
+        state = Responded;
+
+        foreach (SessionItem *si, sessionItems) {
+            if (si->state != SessionItem::Errored) {
+                if (si->state == SessionItem::Paused) {
+                    if (si->startedResponse)
+                        si->state = SessionItem::Responding;
+                    else
+                        si->state = SessionItem::WaitingForResponse;
+
+                    si->rs->resume();
+                }
+
+                assert(si->state == SessionItem::WaitingForResponse ||
+                       si->state == SessionItem::Responding);
+
+                if (si->state == SessionItem::WaitingForResponse) {
+                    si->state = SessionItem::Responded;
+                    si->bytesToWrite = -1;
+
+                    si->rs->respondCannotAccept();
+                } else {
+                    // If we already started responding, then only provide an
+                    // error message in debug mode
+
+                    if (si->rs->debugEnabled()) {
+                        // If debug enabled, append the message at the end.
+                        // this may ruin the content, but hey it's debug
+                        // mode
+                        QByteArray buf = "\n\nAccept service unavailable\n";
+
+                        si->bytesToWrite += buf.size();
+                        si->rs->writeResponseBody(buf);
+                        si->rs->endResponseBody();
+                    } else {
+                        // If debug not enabled, then the best we can do is
+                        // disconnect
+                        si->state = SessionItem::Responded;
+                        si->unclean = true;
+                        si->bytesToWrite = -1;
+                        si->rs->endResponseBody();
+                    }
+                }
+            }
+        }
+    }
+
+    void rejectAll(int code, const QString &reason, const QString &errorMessage,
+                   const QString &debugErrorMessage) {
+        zhttpReqConnections = ZhttpReqConnections();
+        // Kill the active target request, if any
+        zhttpRequest.reset();
+
+        assert(state != Responding);
+        assert(state != Responded);
+
+        state = Responded;
+
+        foreach (SessionItem *si, sessionItems) {
+            if (si->state != SessionItem::Errored) {
+                if (si->state == SessionItem::Paused) {
+                    if (si->startedResponse)
+                        si->state = SessionItem::Responding;
+                    else
+                        si->state = SessionItem::WaitingForResponse;
+
+                    si->rs->resume();
+                }
+
+                assert(si->state == SessionItem::WaitingForResponse ||
+                       si->state == SessionItem::Responding);
+
+                if (si->state == SessionItem::WaitingForResponse) {
+                    si->state = SessionItem::Responded;
+                    si->bytesToWrite = -1;
+
+                    si->rs->respondError(code, reason,
+                                         si->rs->debugEnabled() ? debugErrorMessage : errorMessage);
+                } else // Responding
+                {
+                    // If we already started responding, then only provide a
+                    // rejection message in debug mode
+
+                    if (si->rs->debugEnabled()) {
+                        // If debug enabled, append the message at the end.
+                        // this may ruin the content, but hey it's debug
+                        // mode
+                        QByteArray buf = "\n\n" + debugErrorMessage.toUtf8() + '\n';
+
+                        si->bytesToWrite += buf.size();
+                        si->rs->writeResponseBody(buf);
+                        si->rs->endResponseBody();
+                    } else {
+                        // If debug not enabled, then the best we can do is
+                        // disconnect
+                        si->state = SessionItem::Responded;
+                        si->unclean = true;
+                        si->bytesToWrite = -1;
+                        si->rs->endResponseBody();
+                    }
+                }
+            }
+        }
+    }
+
+    void rejectAll(int code, const QString &reason, const QString &errorMessage) {
+        rejectAll(code, reason, errorMessage, errorMessage);
+    }
+
+    void respondAll(int code, const QByteArray &reason, const HttpHeaders &headers,
+                    const QByteArray &body) {
+        assert(state != Responding);
+        assert(state != Responded);
+
+        state = Responded;
+
+        foreach (SessionItem *si, sessionItems) {
+            if (si->state != SessionItem::Errored) {
+                assert(si->state == SessionItem::WaitingForResponse);
+
+                si->state = SessionItem::Responded;
+                si->bytesToWrite = -1;
+                si->rs->respond(code, reason, headers, body);
+            }
+        }
+    }
+
+    void destroyAll() {
+        assert(state == Accepting || state == Responding);
+
+        state = Responded;
+
+        foreach (SessionItem *si, sessionItems) {
+            if (si->state == SessionItem::Paused) {
+                si->state = SessionItem::Responding;
+                si->rs->resume();
+            }
+
+            if (si->state == SessionItem::WaitingForResponse ||
+                si->state == SessionItem::Responding) {
+                si->state = SessionItem::Responded;
+                si->unclean = true;
+                si->bytesToWrite = -1;
+                si->rs->endResponseBody();
+            }
+        }
+    }
+
+    // This method emits signals
+    void tryResponseRead() {
+        // If we're not buffering, then don't read (instead, sync to slowest
+        // receiver before reading again)
+        if (!buffering && pendingWrites())
+            return;
+
+        std::weak_ptr<Private> self = q->d;
+
+        bool wasAllowed = addAllowed;
+
+        if (state == Accepting) {
+            if (responseBody.size() + zhttpRequest->bytesAvailable() > MAX_ACCEPT_RESPONSE_BODY) {
+                QByteArray gripHold = responseData.headers.get("Grip-Hold").asQByteArray();
+
+                QByteArray gripNextLinkParam;
+                foreach (const HttpHeaderParameters &params,
+                         responseData.headers.getAllAsParameters("Grip-Link")) {
+                    if (params.count() >= 2 && params.get("rel") == "next")
+                        gripNextLinkParam = params[0].first.asQByteArray();
+                }
+
+                bool usingBuildIdFilter = false;
+                foreach (const HttpHeaderParameters &params,
+                         responseData.headers.getAllAsParameters("Grip-Channel")) {
+                    if (params.count() >= 2) {
+                        bool found = false;
+                        for (int n = 1; n < params.count(); ++n) {
+                            if (params[n].first == "filter" && params[n].second == "build-id") {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (found) {
+                            usingBuildIdFilter = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (proxyInitialResponse &&
+                    (gripHold == "stream" ||
+                     (gripHold.isEmpty() && !gripNextLinkParam.isEmpty())) &&
+                    !usingBuildIdFilter) {
+                    // Sending the initial response from the proxy means
+                    // we need to do some of the handler's job here
+
+                    // NOTE: if we ever need to do more than what's
+                    // below, we should consider querying the handler
+                    // to perform these things while still letting
+                    // the proxy send the response body
+
+                    // No content length
+                    responseData.headers.removeAll("Content-Length");
+
+                    // Interpret grip-status
+                    QByteArray statusHeader =
+                        responseData.headers.get("Grip-Status").asQByteArray();
+                    if (!statusHeader.isEmpty()) {
+                        QByteArray codeStr;
+                        QByteArray reason;
+
+                        int at = statusHeader.indexOf(' ');
+                        if (at != -1) {
+                            codeStr = statusHeader.mid(0, at);
+                            reason = statusHeader.mid(at + 1);
+                        } else {
+                            codeStr = statusHeader;
+                        }
+
+                        bool _ok;
+                        responseData.code = codeStr.toInt(&_ok);
+                        if (!_ok || responseData.code < 0 || responseData.code > 999) {
+                            // This may output a misleading error message
+                            cannotAcceptAll();
+                            return;
+                        }
+
+                        if (reason.isEmpty())
+                            reason = StatusReasons::getReason(responseData.code);
+
+                        responseData.reason = reason;
+                    }
+
+                    // Strip any grip headers
+                    for (int n = 0; n < responseData.headers.count(); ++n) {
+                        const HttpHeader &h = responseData.headers[n];
+
+                        bool prefixed = false;
+                        foreach (const QByteArray &hp, acceptHeaderPrefixes) {
+                            if (qstrnicmp(h.first.data(), hp.data(), hp.length()) == 0) {
+                                prefixed = true;
+                                break;
+                            }
+                        }
+
+                        if (prefixed) {
+                            responseData.headers.removeAt(n);
+                            --n; // Adjust position
+                        }
+                    }
+
+                    // We'll let the proxy send normally, then accept afterwards
+                    acceptAfterResponding = true;
+                } else {
+                    QString msg = "Error while proxying to origin.";
+                    QString dmsg = QString("GRIP instruct response too large from %1")
+                                       .arg(ProxyUtil::targetToString(target));
+
+                    rejectAll(502, "Bad Gateway", msg, dmsg);
+                    return;
+                }
+            }
+        } else if (state == Responding) {
+            if (buffering &&
+                responseBody.size() + zhttpRequest->bytesAvailable() > MAX_INITIAL_BUFFER) {
+                responseBody.clear();
+                buffering = false;
+                addAllowed = false;
+            }
+        }
+
+        QByteArray buf;
+        int maxBytes = (buffering ? MAX_INITIAL_BUFFER - responseBody.size() : MAX_STREAM_BUFFER);
+        if (maxBytes > 0)
+            buf = zhttpRequest->readBody(maxBytes);
+
+        if (!buf.isEmpty()) {
+            incCounter(Stats::ServerContentBytesReceived, buf.size());
+
+            total += buf.size();
+            log_debug("proxysession: %p recv=%d, total=%d, avail=%d", q, buf.size(), total,
+                      zhttpRequest->bytesAvailable());
+
+            if (buffering)
+                responseBody += buf;
+        }
+
+        if (state == Accepting) {
+            if (acceptAfterResponding)
+                startResponse();
+        } else if (state == Responding) {
+            log_debug("proxysession: %p writing %d to clients", q, buf.size());
+
+            foreach (SessionItem *si, sessionItems) {
+                assert(si->state != SessionItem::WaitingForResponse);
+
+                if (si->state == SessionItem::Responding) {
+                    si->bytesToWrite += buf.size();
+                    si->rs->writeResponseBody(buf);
+                }
+            }
+
+            if (wasAllowed && !addAllowed) {
+                q->addNotAllowed();
+                if (self.expired())
+                    return;
+            }
+        }
+
+        checkIncomingResponseFinished();
+    }
+
+    // This method emits signals
+    void checkIncomingResponseFinished() {
+        std::weak_ptr<Private> self = q->d;
+
+        if (zhttpRequest->isFinished() && zhttpRequest->bytesAvailable() == 0) {
+            log_debug("proxysession: %p response from target finished", q);
+
+            if (!buffering && pendingWrites()) {
+                log_debug("proxysession: %p still stuff left to write, though. we'll wait.", q);
+                return;
+            }
+
+            zhttpReqConnections = ZhttpReqConnections();
+            zhttpRequest.reset();
+
+            // Once the entire response has been received, cut off any new adds
+            if (addAllowed) {
+                addAllowed = false;
+                q->addNotAllowed();
+                if (self.expired())
+                    return;
+            }
+
+            if (state == Accepting || (state == Responding && acceptAfterResponding)) {
+                state = Accepting;
+
+                if (acceptManager) {
+                    log_debug("we have an acceptmanager");
+                    foreach (SessionItem *si, sessionItems) {
+                        si->state = SessionItem::Pausing;
+                        si->rs->pause();
+                    }
+                } else {
+                    cannotAcceptAll();
+                }
+            } else if (state == Responding) {
+                foreach (SessionItem *si, sessionItems) {
+                    assert(si->state != SessionItem::WaitingForResponse);
+
+                    if (si->state == SessionItem::Responding) {
+                        si->state = SessionItem::Responded;
+                        si->rs->endResponseBody();
+                    }
+                }
+            }
+        }
+    }
+
+    void startResponse() {
+        state = Responding;
+
+        // Don't relay these headers. Their meaning is handled by
+        // zurl and they only apply to the outgoing hop.
+        responseData.headers.removeAll("Connection");
+        responseData.headers.removeAll("Keep-Alive");
+        responseData.headers.removeAll("Content-Encoding");
+        responseData.headers.removeAll("Transfer-Encoding");
+
+        foreach (SessionItem *si, sessionItems) {
+            si->state = SessionItem::Responding;
+            si->startedResponse = true;
+            si->rs->startResponse(responseData.code, responseData.reason, responseData.headers);
+
+            if (!responseBody.isEmpty()) {
+                si->bytesToWrite += responseBody.size();
+                si->rs->writeResponseBody(responseBody.toByteArray());
+            }
+        }
+    }
+
+    void logFinished(SessionItem *si, bool accepted = false) {
+        RequestSession *rs = si->rs;
+
+        HttpResponseData resp = rs->responseData();
+
+        LogUtil::RequestData rd;
+
+        // Only log route id if explicitly set
+        if (route.separateStats)
+            rd.routeId = route.id;
+
+        if (accepted) {
+            rd.status = LogUtil::Accept;
+        } else if (resp.code != -1 && !si->unclean) {
+            rd.status = LogUtil::Response;
+            rd.responseData = resp;
+            rd.responseBodySize = rs->responseBodySize();
+        } else {
+            rd.status = LogUtil::Error;
+        }
+
+        rd.requestData = rs->requestData();
+
+        rd.targetStr = ProxyUtil::targetToString(target);
+        rd.targetOverHttp = target.overHttp;
+
+        rd.retry = rs->isRetry();
+        if (shared)
+            rd.sharedBy = this;
+
+        rd.fromAddress = rs->peerAddress();
+
+        LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
+    }
+
+    void incCounter(Stats::Counter c, int count = 1) {
+        if (statsManager)
+            statsManager->incCounter(route.statsRoute(), c, count);
+    }
 
 public:
-	void inRequest_readyRead()
-	{
-		tryRequestRead();
-	}
-
-	void inRequest_error()
-	{
-		log_warning("proxysession: %p error reading request", q);
-
-		// don't take action here. do that in rs_finished
-	}
-
-	void zhttpRequest_readyRead()
-	{
-		log_debug("proxysession: %p data from target", q);
-
-		if(state == Requesting)
-		{
-			responseData.code = zhttpRequest->responseCode();
-			responseData.reason = zhttpRequest->responseReason();
-			responseData.headers = zhttpRequest->responseHeaders();
-
-			QByteArray buf = zhttpRequest->readBody(MAX_INITIAL_BUFFER);
-
-			incCounter(Stats::ServerHeaderBytesReceived, ZhttpManager::estimateResponseHeaderBytes(responseData.code, responseData.reason, responseData.headers));
-			incCounter(Stats::ServerContentBytesReceived, buf.size());
-
-			responseBody += buf;
-			total += buf.size();
-
-			acceptResponseData = responseData;
-
-			log_debug("proxysession: %p recv total: %d", q, total);
-
-			bool doAccept = false;
-			if(!passthrough)
-			{
-				QByteArray contentType = responseData.headers.get("Content-Type").asQByteArray();
-				int at = contentType.indexOf(';');
-				if(at != -1)
-					contentType = contentType.mid(0, at);
-
-				if(acceptContentTypes.contains(contentType))
-				{
-					doAccept = true;
-				}
-				else
-				{
-					foreach(const HttpHeader &h, responseData.headers)
-					{
-						foreach(const QByteArray &hp, acceptHeaderPrefixes)
-						{
-							if(qstrnicmp(h.first.data(), hp.data(), hp.length()) == 0)
-							{
-								doAccept = true;
-								break;
-							}
-						}
-
-						if(doAccept)
-							break;
-					}
-				}
-			}
-
-			if(doAccept)
-			{
-				if(!buffering)
-				{
-					rejectAll(400, "Bad Request", "Request too large to accept GRIP instruct.");
-					return;
-				}
-
-				state = Accepting;
-			}
-			else
-			{
-				startResponse();
-			}
-		}
-
-		assert(state == Accepting || state == Responding);
-
-		tryResponseRead();
-	}
-
-	void zhttpRequest_writeBytesChanged()
-	{
-		if(inRequest)
-			tryRequestRead();
-	}
-
-	void zhttpRequest_error()
-	{
-		ZhttpRequest::ErrorCondition e = zhttpRequest->errorCondition();
-		log_debug("proxysession: %p target error state=%d, condition=%d", q, (int)state, (int)e);
-
-		if(state == Requesting || state == Accepting)
-		{
-			bool tryAgain = false;
-
-			switch(e)
-			{
-				case ZhttpRequest::ErrorLengthRequired:
-					rejectAll(411, "Length Required", "Must provide Content-Length header.");
-					break;
-				case ZhttpRequest::ErrorPolicy:
-					rejectAll(502, "Bad Gateway", "Error while proxying to origin.", "Error: Origin host/IP blocked.");
-					break;
-				case ZhttpRequest::ErrorConnect:
-				case ZhttpRequest::ErrorConnectTimeout:
-				case ZhttpRequest::ErrorTls:
-					// It should not be possible to get one of these errors while accepting
-					assert(state == Requesting);
-					tryAgain = true;
-					break;
-				case ZhttpRequest::ErrorTimeout:
-					rejectAll(502, "Bad Gateway", "Error while proxying to origin.", "Error: zhttp service for route is unreachable.");
-					break;
-				default:
-					rejectAll(502, "Bad Gateway", "Error while proxying to origin.");
-					break;
-			}
-
-			if(tryAgain)
-				tryNextTarget();
-		}
-		else if(state == Responding)
-		{
-			// If we're already responding, then we can't reply with an error
-			destroyAll();
-		}
-	}
-
-	void rs_bytesWritten(int count, RequestSession *rs)
-	{
-		log_debug("proxysession: %p response bytes written id=%s: %d", q, rs->rid().second.data(), count);
-
-		SessionItem *si = sessionItemsBySession.value(rs);
-		assert(si);
-
-		if(si->bytesToWrite != -1)
-		{
-			si->bytesToWrite -= count;
-			assert(si->bytesToWrite >= 0);
-		}
-
-		if(zhttpRequest)
-			tryResponseRead();
-	}
-
-	void rs_finished(RequestSession *rs)
-	{
-		log_debug("proxysession: %p response finished id=%s", q, rs->rid().second.data());
-
-		SessionItem *si = sessionItemsBySession.value(rs);
-		assert(si);
-
-		if(!intReq)
-			logFinished(si);
-
-		std::weak_ptr<Private> self = q->d;
-		q->requestSessionDestroyed(si->rs, false);
-		if(self.expired())
-			return;
-
-		ZhttpRequest *req = rs->request();
-		bool wasInputRequest = (req && inRequest && req == inRequest->request());
-
-		sessionItemsBySession.remove(rs);
-		sessionItems.remove(si);
-		reqSessionConnectionMap.erase(rs);
-		delete rs;
-
-		delete si;
-
-		if(sessionItems.isEmpty())
-		{
-			log_debug("proxysession: %p finished by passthrough", q);
-			q->finished();
-		}
-		else if(wasInputRequest)
-		{
-			// This should never happen. For there to be more than
-			// one SessionItem, inRequest must be 0.
-			assert(0);
-
-			rejectAll(500, "Internal Server Error", "Input request failed.");
-		}
-	}
-
-	void rs_paused(RequestSession *rs)
-	{
-		log_debug("proxysession: %p response paused id=%s", q, rs->rid().second.data());
-
-		SessionItem *si = sessionItemsBySession.value(rs);
-		assert(si);
-
-		assert(si->state == SessionItem::Pausing);
-		si->state = SessionItem::Paused;
-
-		bool allPaused = true;
-		foreach(SessionItem *si, sessionItems)
-		{
-			if(si->state != SessionItem::Paused)
-			{
-				allPaused = false;
-				break;
-			}
-		}
-
-		if(allPaused)
-		{
-			assert(!acceptRequest);
-
-			QByteArray sigIss = defaultSigIss;
-			Jwt::EncodingKey sigKey = defaultSigKey;
-
-			if(!route.sigIss.isEmpty())
-				sigIss = route.sigIss;
-
-			if(!route.sigKey.isNull())
-				sigKey = route.sigKey;
-
-			acceptResponseData.body = responseBody.take();
-
-			AcceptData adata;
-
-			foreach(SessionItem *si, sessionItems)
-			{
-				int unreportedTime = -1;
-
-				if(!statsManager->connectionSendEnabled())
-					unreportedTime = si->rs->unregisterConnection();
-
-				ZhttpRequest::ServerState ss = si->rs->request()->serverState();
-
-				AcceptData::Request areq;
-				areq.rid = si->rs->rid();
-				areq.https = si->rs->isHttps();
-				areq.peerAddress = si->rs->peerAddress();
-				areq.logicalPeerAddress = si->rs->logicalPeerAddress();
-				areq.debug = si->rs->debugEnabled();
-				areq.isRetry = si->rs->isRetry();
-				areq.autoCrossOrigin = si->rs->autoCrossOrigin();
-				areq.jsonpCallback = si->rs->jsonpCallback();
-				areq.jsonpExtendedResponse = si->rs->jsonpExtendedResponse();
-				areq.unreportedTime = unreportedTime;
-				areq.responseCode = ss.responseCode;
-				areq.inSeq = ss.inSeq;
-				areq.outSeq = ss.outSeq;
-				areq.outCredits = ss.outCredits;
-				areq.routerResp = ss.routerResp;
-				areq.userData = ss.userData;
-				adata.requests += areq;
-			}
-
-			adata.requestData = requestData;
-			adata.requestData.body = requestBody.take();
-			adata.origRequestData = origRequestData;
-			adata.origRequestData.body = adata.requestData.body;
-
-			adata.haveResponse = true;
-			adata.response = acceptResponseData;
-
-			if(haveInspectData)
-			{
-				adata.haveInspectData = true;
-				adata.inspectData = idata;
-			}
-
-			adata.route = route.id;
-			adata.separateStats = route.separateStats;
-			adata.channelPrefix = route.prefix;
-			adata.logLevel = route.logLevel;
-			foreach(const QString &s, target.subscriptions)
-				adata.channels += s.toUtf8();
-			adata.trusted = target.trusted;
-			adata.useSession = route.session;
-			adata.responseSent = acceptAfterResponding;
-
-			if(!statsManager->connectionSendEnabled())
-			{
-				// Flush max. The count will include the connections we just unregistered
-				adata.connMaxPackets += statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
-
-				// Flush max again to get the count without the connections
-				adata.connMaxPackets += statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
-			}
-
-			acceptRequest = std::make_unique<AcceptRequest>(acceptManager);
-			finishedConnection = acceptRequest->finished.connect(boost::bind(&Private::acceptRequest_finished, this));
-			acceptRequest->start(adata);
-		}
-	}
-
-	void rs_errorResponding(RequestSession *rs)
-	{
-		log_debug("proxysession: %p response error id=%s", q, rs->rid().second.data());
-
-		SessionItem *si = sessionItemsBySession.value(rs);
-		assert(si);
-
-		assert(si->state != SessionItem::Errored);
-
-		// Flag that we should stop attempting to respond
-		si->state = SessionItem::Errored;
-		si->bytesToWrite = -1;
-
-		// Don't destroy the RequestSession here. A finished signal will arrive next.
-	}
-
-	void rs_headerBytesSent(int count, RequestSession *rs)
-	{
-		SessionItem *si = sessionItemsBySession.value(rs);
-		assert(si);
-
-		if(si->countClientSentBytes)
-			incCounter(Stats::ClientHeaderBytesSent, count);
-	}
-
-	void rs_bodyBytesSent(int count, RequestSession *rs)
-	{
-		SessionItem *si = sessionItemsBySession.value(rs);
-		assert(si);
-
-		if(si->countClientSentBytes)
-			incCounter(Stats::ClientContentBytesSent, count);
-	}
-
-	void acceptRequest_finished()
-	{
-		if(acceptRequest->success())
-		{
-			AcceptRequest::ResponseData rdata = acceptRequest->result();
-
-			finishedConnection.disconnect();
-			acceptRequest.reset();
-
-			if(rdata.accepted)
-			{
-				foreach(SessionItem *si, sessionItems)
-					logFinished(si, true);
-
-				// The requests were paused, so deleting them will leave the peer sessions active
-
-				QList<RequestSession*> toDestroy;
-				foreach(SessionItem *si, sessionItems)
-				{
-					toDestroy += si->rs;
-					delete si;
-				}
-
-				sessionItems.clear();
-				sessionItemsBySession.clear();
-
-				std::weak_ptr<Private> self = q->d;
-				foreach(RequestSession *rs, toDestroy)
-				{
-					q->requestSessionDestroyed(rs, true);
-					reqSessionConnectionMap.erase(rs);
-					delete rs;
-					if(self.expired())
-						return;
-				}
-
-				log_debug("proxysession: %p finished for accept", q);
-				cleanup();
-				q->finished();
-			}
-			else
-			{
-				if(acceptAfterResponding)
-				{
-					// Wake up receivers and append
-					foreach(SessionItem *si, sessionItems)
-					{
-						si->state = SessionItem::Responded;
-						si->rs->resume();
-
-						if(rdata.response.code != -1)
-							si->rs->writeResponseBody(rdata.response.body);
-
-						si->bytesToWrite = -1;
-						si->rs->endResponseBody();
-					}
-				}
-				else
-				{
-					if(rdata.response.code != -1)
-					{
-						// Wake up receivers
-						foreach(SessionItem *si, sessionItems)
-						{
-							si->state = SessionItem::WaitingForResponse;
-							si->rs->resume();
-						}
-
-						respondAll(rdata.response.code, rdata.response.reason, rdata.response.headers, rdata.response.body);
-					}
-					else
-					{
-						cannotAcceptAll();
-					}
-				}
-			}
-		}
-		else
-		{
-			// Wake up receivers and reject
-
-			if(acceptRequest->errorCondition() == ZrpcRequest::ErrorFormat && typeId(((ZrpcRequest *)acceptRequest.get())->result()) == VariantType::ByteArray)
-			{
-				QString errorString = QString::fromUtf8(((ZrpcRequest *)acceptRequest.get())->result().toByteArray());
-				QString msg = "Error while proxying to origin.";
-				QString dmsg = QString("Failed to parse accept instructions: %1").arg(errorString);
-
-				rejectAll(502, "Bad Gateway", msg, dmsg);
-			}
-			else
-			{
-				cannotAcceptAll();
-			}
-
-			finishedConnection.disconnect();
-			acceptRequest.reset();
-		}
-	}
+    void inRequest_readyRead() { tryRequestRead(); }
+
+    void inRequest_error() {
+        log_warning("proxysession: %p error reading request", q);
+
+        // don't take action here. do that in rs_finished
+    }
+
+    void zhttpRequest_readyRead() {
+        log_debug("proxysession: %p data from target", q);
+
+        if (state == Requesting) {
+            responseData.code = zhttpRequest->responseCode();
+            responseData.reason = zhttpRequest->responseReason();
+            responseData.headers = zhttpRequest->responseHeaders();
+
+            QByteArray buf = zhttpRequest->readBody(MAX_INITIAL_BUFFER);
+
+            incCounter(Stats::ServerHeaderBytesReceived,
+                       ZhttpManager::estimateResponseHeaderBytes(
+                           responseData.code, responseData.reason, responseData.headers));
+            incCounter(Stats::ServerContentBytesReceived, buf.size());
+
+            responseBody += buf;
+            total += buf.size();
+
+            acceptResponseData = responseData;
+
+            log_debug("proxysession: %p recv total: %d", q, total);
+
+            bool doAccept = false;
+            if (!passthrough) {
+                QByteArray contentType = responseData.headers.get("Content-Type").asQByteArray();
+                int at = contentType.indexOf(';');
+                if (at != -1)
+                    contentType = contentType.mid(0, at);
+
+                if (acceptContentTypes.contains(contentType)) {
+                    doAccept = true;
+                } else {
+                    foreach (const HttpHeader &h, responseData.headers) {
+                        foreach (const QByteArray &hp, acceptHeaderPrefixes) {
+                            if (qstrnicmp(h.first.data(), hp.data(), hp.length()) == 0) {
+                                doAccept = true;
+                                break;
+                            }
+                        }
+
+                        if (doAccept)
+                            break;
+                    }
+                }
+            }
+
+            if (doAccept) {
+                if (!buffering) {
+                    rejectAll(400, "Bad Request", "Request too large to accept GRIP instruct.");
+                    return;
+                }
+
+                state = Accepting;
+            } else {
+                startResponse();
+            }
+        }
+
+        assert(state == Accepting || state == Responding);
+
+        tryResponseRead();
+    }
+
+    void zhttpRequest_writeBytesChanged() {
+        if (inRequest)
+            tryRequestRead();
+    }
+
+    void zhttpRequest_error() {
+        ZhttpRequest::ErrorCondition e = zhttpRequest->errorCondition();
+        log_debug("proxysession: %p target error state=%d, condition=%d", q, (int)state, (int)e);
+
+        if (state == Requesting || state == Accepting) {
+            bool tryAgain = false;
+
+            switch (e) {
+            case ZhttpRequest::ErrorLengthRequired:
+                rejectAll(411, "Length Required", "Must provide Content-Length header.");
+                break;
+            case ZhttpRequest::ErrorPolicy:
+                rejectAll(502, "Bad Gateway", "Error while proxying to origin.",
+                          "Error: Origin host/IP blocked.");
+                break;
+            case ZhttpRequest::ErrorConnect:
+            case ZhttpRequest::ErrorConnectTimeout:
+            case ZhttpRequest::ErrorTls:
+                // It should not be possible to get one of these errors while accepting
+                assert(state == Requesting);
+                tryAgain = true;
+                break;
+            case ZhttpRequest::ErrorTimeout:
+                rejectAll(502, "Bad Gateway", "Error while proxying to origin.",
+                          "Error: zhttp service for route is unreachable.");
+                break;
+            default:
+                rejectAll(502, "Bad Gateway", "Error while proxying to origin.");
+                break;
+            }
+
+            if (tryAgain)
+                tryNextTarget();
+        } else if (state == Responding) {
+            // If we're already responding, then we can't reply with an error
+            destroyAll();
+        }
+    }
+
+    void rs_bytesWritten(int count, RequestSession *rs) {
+        log_debug("proxysession: %p response bytes written id=%s: %d", q, rs->rid().second.data(),
+                  count);
+
+        SessionItem *si = sessionItemsBySession.value(rs);
+        assert(si);
+
+        if (si->bytesToWrite != -1) {
+            si->bytesToWrite -= count;
+            assert(si->bytesToWrite >= 0);
+        }
+
+        if (zhttpRequest)
+            tryResponseRead();
+    }
+
+    void rs_finished(RequestSession *rs) {
+        log_debug("proxysession: %p response finished id=%s", q, rs->rid().second.data());
+
+        SessionItem *si = sessionItemsBySession.value(rs);
+        assert(si);
+
+        if (!intReq)
+            logFinished(si);
+
+        std::weak_ptr<Private> self = q->d;
+        q->requestSessionDestroyed(si->rs, false);
+        if (self.expired())
+            return;
+
+        ZhttpRequest *req = rs->request();
+        bool wasInputRequest = (req && inRequest && req == inRequest->request());
+
+        sessionItemsBySession.remove(rs);
+        sessionItems.remove(si);
+        reqSessionConnectionMap.erase(rs);
+        delete rs;
+
+        delete si;
+
+        if (sessionItems.isEmpty()) {
+            log_debug("proxysession: %p finished by passthrough", q);
+            q->finished();
+        } else if (wasInputRequest) {
+            // This should never happen. For there to be more than
+            // one SessionItem, inRequest must be 0.
+            assert(0);
+
+            rejectAll(500, "Internal Server Error", "Input request failed.");
+        }
+    }
+
+    void rs_paused(RequestSession *rs) {
+        log_debug("proxysession: %p response paused id=%s", q, rs->rid().second.data());
+
+        SessionItem *si = sessionItemsBySession.value(rs);
+        assert(si);
+
+        assert(si->state == SessionItem::Pausing);
+        si->state = SessionItem::Paused;
+
+        bool allPaused = true;
+        foreach (SessionItem *si, sessionItems) {
+            if (si->state != SessionItem::Paused) {
+                allPaused = false;
+                break;
+            }
+        }
+
+        if (allPaused) {
+            assert(!acceptRequest);
+
+            QByteArray sigIss = defaultSigIss;
+            Jwt::EncodingKey sigKey = defaultSigKey;
+
+            if (!route.sigIss.isEmpty())
+                sigIss = route.sigIss;
+
+            if (!route.sigKey.isNull())
+                sigKey = route.sigKey;
+
+            acceptResponseData.body = responseBody.take();
+
+            AcceptData adata;
+
+            foreach (SessionItem *si, sessionItems) {
+                int unreportedTime = -1;
+
+                if (!statsManager->connectionSendEnabled())
+                    unreportedTime = si->rs->unregisterConnection();
+
+                ZhttpRequest::ServerState ss = si->rs->request()->serverState();
+
+                AcceptData::Request areq;
+                areq.rid = si->rs->rid();
+                areq.https = si->rs->isHttps();
+                areq.peerAddress = si->rs->peerAddress();
+                areq.logicalPeerAddress = si->rs->logicalPeerAddress();
+                areq.debug = si->rs->debugEnabled();
+                areq.isRetry = si->rs->isRetry();
+                areq.autoCrossOrigin = si->rs->autoCrossOrigin();
+                areq.jsonpCallback = si->rs->jsonpCallback();
+                areq.jsonpExtendedResponse = si->rs->jsonpExtendedResponse();
+                areq.unreportedTime = unreportedTime;
+                areq.responseCode = ss.responseCode;
+                areq.inSeq = ss.inSeq;
+                areq.outSeq = ss.outSeq;
+                areq.outCredits = ss.outCredits;
+                areq.routerResp = ss.routerResp;
+                areq.userData = ss.userData;
+                adata.requests += areq;
+            }
+
+            adata.requestData = requestData;
+            adata.requestData.body = requestBody.take();
+            adata.origRequestData = origRequestData;
+            adata.origRequestData.body = adata.requestData.body;
+
+            adata.haveResponse = true;
+            adata.response = acceptResponseData;
+
+            if (haveInspectData) {
+                adata.haveInspectData = true;
+                adata.inspectData = idata;
+            }
+
+            adata.route = route.id;
+            adata.separateStats = route.separateStats;
+            adata.channelPrefix = route.prefix;
+            adata.logLevel = route.logLevel;
+            foreach (const QString &s, target.subscriptions)
+                adata.channels += s.toUtf8();
+            adata.trusted = target.trusted;
+            adata.useSession = route.session;
+            adata.responseSent = acceptAfterResponding;
+
+            if (!statsManager->connectionSendEnabled()) {
+                // Flush max. The count will include the connections we just
+                // unregistered
+                adata.connMaxPackets +=
+                    statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
+
+                // Flush max again to get the count without the connections
+                adata.connMaxPackets +=
+                    statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
+            }
+
+            acceptRequest = std::make_unique<AcceptRequest>(acceptManager);
+            finishedConnection = acceptRequest->finished.connect(
+                boost::bind(&Private::acceptRequest_finished, this));
+            acceptRequest->start(adata);
+        }
+    }
+
+    void rs_errorResponding(RequestSession *rs) {
+        log_debug("proxysession: %p response error id=%s", q, rs->rid().second.data());
+
+        SessionItem *si = sessionItemsBySession.value(rs);
+        assert(si);
+
+        assert(si->state != SessionItem::Errored);
+
+        // Flag that we should stop attempting to respond
+        si->state = SessionItem::Errored;
+        si->bytesToWrite = -1;
+
+        // Don't destroy the RequestSession here. A finished signal will arrive
+        // next.
+    }
+
+    void rs_headerBytesSent(int count, RequestSession *rs) {
+        SessionItem *si = sessionItemsBySession.value(rs);
+        assert(si);
+
+        if (si->countClientSentBytes)
+            incCounter(Stats::ClientHeaderBytesSent, count);
+    }
+
+    void rs_bodyBytesSent(int count, RequestSession *rs) {
+        SessionItem *si = sessionItemsBySession.value(rs);
+        assert(si);
+
+        if (si->countClientSentBytes)
+            incCounter(Stats::ClientContentBytesSent, count);
+    }
+
+    void acceptRequest_finished() {
+        if (acceptRequest->success()) {
+            AcceptRequest::ResponseData rdata = acceptRequest->result();
+
+            finishedConnection.disconnect();
+            acceptRequest.reset();
+
+            if (rdata.accepted) {
+                foreach (SessionItem *si, sessionItems)
+                    logFinished(si, true);
+
+                // The requests were paused, so deleting them will leave the peer
+                // sessions active
+
+                QList<RequestSession *> toDestroy;
+                foreach (SessionItem *si, sessionItems) {
+                    toDestroy += si->rs;
+                    delete si;
+                }
+
+                sessionItems.clear();
+                sessionItemsBySession.clear();
+
+                std::weak_ptr<Private> self = q->d;
+                foreach (RequestSession *rs, toDestroy) {
+                    q->requestSessionDestroyed(rs, true);
+                    reqSessionConnectionMap.erase(rs);
+                    delete rs;
+                    if (self.expired())
+                        return;
+                }
+
+                log_debug("proxysession: %p finished for accept", q);
+                cleanup();
+                q->finished();
+            } else {
+                if (acceptAfterResponding) {
+                    // Wake up receivers and append
+                    foreach (SessionItem *si, sessionItems) {
+                        si->state = SessionItem::Responded;
+                        si->rs->resume();
+
+                        if (rdata.response.code != -1)
+                            si->rs->writeResponseBody(rdata.response.body);
+
+                        si->bytesToWrite = -1;
+                        si->rs->endResponseBody();
+                    }
+                } else {
+                    if (rdata.response.code != -1) {
+                        // Wake up receivers
+                        foreach (SessionItem *si, sessionItems) {
+                            si->state = SessionItem::WaitingForResponse;
+                            si->rs->resume();
+                        }
+
+                        respondAll(rdata.response.code, rdata.response.reason,
+                                   rdata.response.headers, rdata.response.body);
+                    } else {
+                        cannotAcceptAll();
+                    }
+                }
+            }
+        } else {
+            // Wake up receivers and reject
+
+            if (acceptRequest->errorCondition() == ZrpcRequest::ErrorFormat &&
+                typeId(((ZrpcRequest *)acceptRequest.get())->result()) == VariantType::ByteArray) {
+                QString errorString =
+                    QString::fromUtf8(((ZrpcRequest *)acceptRequest.get())->result().toByteArray());
+                QString msg = "Error while proxying to origin.";
+                QString dmsg = QString("Failed to parse accept instructions: %1").arg(errorString);
+
+                rejectAll(502, "Bad Gateway", msg, dmsg);
+            } else {
+                cannotAcceptAll();
+            }
+
+            finishedConnection.disconnect();
+            acceptRequest.reset();
+        }
+    }
 };
 
-ProxySession::ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig, StatsManager *statsManager)
-{
-	d = std::make_shared<Private>(this, zroutes, acceptManager, logConfig, statsManager);
+ProxySession::ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager,
+                           const LogUtil::Config &logConfig, StatsManager *statsManager) {
+    d = std::make_shared<Private>(this, zroutes, acceptManager, logConfig, statsManager);
 }
 
 ProxySession::~ProxySession() = default;
 
-void ProxySession::setRoute(const DomainMap::Entry &route)
-{
-	d->route = route;
+void ProxySession::setRoute(const DomainMap::Entry &route) { d->route = route; }
+
+void ProxySession::setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key) {
+    d->defaultSigIss = iss;
+    d->defaultSigKey = key;
 }
 
-void ProxySession::setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key)
-{
-	d->defaultSigIss = iss;
-	d->defaultSigKey = key;
+void ProxySession::setAcceptXForwardedProtocol(bool enabled) {
+    d->acceptXForwardedProtocol = enabled;
 }
 
-void ProxySession::setAcceptXForwardedProtocol(bool enabled)
-{
-	d->acceptXForwardedProtocol = enabled;
+void ProxySession::setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled) {
+    d->useXForwardedProto = protoEnabled;
+    d->useXForwardedProtocol = protocolEnabled;
 }
 
-void ProxySession::setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled)
-{
-	d->useXForwardedProto = protoEnabled;
-	d->useXForwardedProtocol = protocolEnabled;
+void ProxySession::setXffRules(const XffRule &untrusted, const XffRule &trusted) {
+    d->xffRule = untrusted;
+    d->xffTrustedRule = trusted;
 }
 
-void ProxySession::setXffRules(const XffRule &untrusted, const XffRule &trusted)
-{
-	d->xffRule = untrusted;
-	d->xffTrustedRule = trusted;
+void ProxySession::setOrigHeadersNeedMark(const QList<QByteArray> &names) {
+    d->origHeadersNeedMark = names;
 }
 
-void ProxySession::setOrigHeadersNeedMark(const QList<QByteArray> &names)
-{
-	d->origHeadersNeedMark = names;
+void ProxySession::setAcceptPushpinRoute(bool enabled) { d->acceptPushpinRoute = enabled; }
+
+void ProxySession::setCdnLoop(const QByteArray &value) { d->cdnLoop = value; }
+
+void ProxySession::setProxyInitialResponseEnabled(bool enabled) {
+    d->proxyInitialResponse = enabled;
 }
 
-void ProxySession::setAcceptPushpinRoute(bool enabled)
-{
-	d->acceptPushpinRoute = enabled;
+void ProxySession::setInspectData(const InspectData &idata) {
+    d->haveInspectData = true;
+    d->idata = idata;
 }
 
-void ProxySession::setCdnLoop(const QByteArray &value)
-{
-	d->cdnLoop = value;
-}
-
-void ProxySession::setProxyInitialResponseEnabled(bool enabled)
-{
-	d->proxyInitialResponse = enabled;
-}
-
-void ProxySession::setInspectData(const InspectData &idata)
-{
-	d->haveInspectData = true;
-	d->idata = idata;
-}
-
-void ProxySession::add(RequestSession *rs)
-{
-	d->add(rs);
-}
+void ProxySession::add(RequestSession *rs) { d->add(rs); }

--- a/src/proxy/proxysession.h
+++ b/src/proxy/proxysession.h
@@ -24,12 +24,12 @@
 #ifndef PROXYSESSION_H
 #define PROXYSESSION_H
 
-#include <boost/signals2.hpp>
-#include "logutil.h"
 #include "domainmap.h"
+#include "logutil.h"
+#include <boost/signals2.hpp>
 
 namespace Jwt {
-	class EncodingKey;
+class EncodingKey;
 }
 
 class InspectData;
@@ -44,35 +44,35 @@ using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
 /// Proxies HTTP requests to backends with GRIP streaming and request sharing
-class ProxySession
-{
+class ProxySession {
 public:
-	ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig, StatsManager *stats = 0);
-	~ProxySession();
+    ProxySession(ZRoutes *zroutes, ZrpcManager *acceptManager, const LogUtil::Config &logConfig,
+                 StatsManager *stats = 0);
+    ~ProxySession();
 
-	void setRoute(const DomainMap::Entry &route);
-	void setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key);
-	void setAcceptXForwardedProtocol(bool enabled);
-	void setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled);
-	void setXffRules(const XffRule &untrusted, const XffRule &trusted);
-	void setOrigHeadersNeedMark(const QList<QByteArray> &names);
-	void setAcceptPushpinRoute(bool enabled);
-	void setCdnLoop(const QByteArray &value);
-	void setProxyInitialResponseEnabled(bool enabled);
+    void setRoute(const DomainMap::Entry &route);
+    void setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key);
+    void setAcceptXForwardedProtocol(bool enabled);
+    void setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled);
+    void setXffRules(const XffRule &untrusted, const XffRule &trusted);
+    void setOrigHeadersNeedMark(const QList<QByteArray> &names);
+    void setAcceptPushpinRoute(bool enabled);
+    void setCdnLoop(const QByteArray &value);
+    void setProxyInitialResponseEnabled(bool enabled);
 
-	void setInspectData(const InspectData &idata);
+    void setInspectData(const InspectData &idata);
 
-	// Takes ownership
-	void add(RequestSession *rs);
+    // Takes ownership
+    void add(RequestSession *rs);
 
-	Signal addNotAllowed; // No more sharing, for whatever reason
-	Signal finished;
-	boost::signals2::signal<void(RequestSession*, bool)> requestSessionDestroyed;
+    Signal addNotAllowed; // No more sharing, for whatever reason
+    Signal finished;
+    boost::signals2::signal<void(RequestSession *, bool)> requestSessionDestroyed;
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -23,295 +23,266 @@
 
 #include "proxyutil.h"
 
+#include "inspectdata.h"
+#include "jwt.h"
+#include "log.h"
+#include "qtcompat.h"
+#include "variant.h"
 #include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include "qtcompat.h"
-#include "variant.h"
-#include "log.h"
-#include "jwt.h"
-#include "inspectdata.h"
 
-static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key)
-{
-	VariantMap claim;
-	claim["iss"] = QString::fromUtf8(iss);
-	claim["exp"] = QDateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600;
-	return Jwt::encode(claim, key);
+static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key) {
+    VariantMap claim;
+    claim["iss"] = QString::fromUtf8(iss);
+    claim["exp"] = QDateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600;
+    return Jwt::encode(claim, key);
 }
 
-static bool validate_token(const QByteArray &token, const Jwt::DecodingKey &key)
-{
-	Variant claimObj = Jwt::decode(token, key);
-	if(!claimObj.isValid() || typeId(claimObj) != VariantType::Map)
-		return false;
+static bool validate_token(const QByteArray &token, const Jwt::DecodingKey &key) {
+    Variant claimObj = Jwt::decode(token, key);
+    if (!claimObj.isValid() || typeId(claimObj) != VariantType::Map)
+        return false;
 
-	VariantMap claim = claimObj.toMap();
+    VariantMap claim = claimObj.toMap();
 
-	int exp = claim.value("exp").toInt();
-	if(exp <= 0 || (int)QDateTime::currentDateTimeUtc().toSecsSinceEpoch() >= exp)
-		return false;
+    int exp = claim.value("exp").toInt();
+    if (exp <= 0 || (int)QDateTime::currentDateTimeUtc().toSecsSinceEpoch() >= exp)
+        return false;
 
-	return true;
+    return true;
 }
 
 namespace ProxyUtil {
 
 // Check if the request is coming from a grip proxy already
-bool checkTrustedClient(const char *logprefix, void *object, const HttpRequestData &requestData, const Jwt::DecodingKey &defaultUpstreamKey)
-{
-	if(!defaultUpstreamKey.isNull())
-	{
-		QByteArray token = requestData.headers.get("Grip-Sig").asQByteArray();
-		if(!token.isEmpty())
-		{
-			if(validate_token(token, defaultUpstreamKey))
-				return true;
+bool checkTrustedClient(const char *logprefix, void *object, const HttpRequestData &requestData,
+                        const Jwt::DecodingKey &defaultUpstreamKey) {
+    if (!defaultUpstreamKey.isNull()) {
+        QByteArray token = requestData.headers.get("Grip-Sig").asQByteArray();
+        if (!token.isEmpty()) {
+            if (validate_token(token, defaultUpstreamKey))
+                return true;
 
-			log_debug("%s: %p signature present but invalid: %s", logprefix, object, token.data());
-		}
-	}
+            log_debug("%s: %p signature present but invalid: %s", logprefix, object, token.data());
+        }
+    }
 
-	return false;
+    return false;
 }
 
-void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestData *requestData, bool trustedClient, const DomainMap::Entry &entry, const QByteArray &sigIss, const Jwt::EncodingKey &sigKey, bool acceptXForwardedProtocol, bool useXForwardedProto, bool useXForwardedProtocol, const XffRule &xffTrustedRule, const XffRule &xffRule, const QList<QByteArray> &origHeadersNeedMark, bool acceptPushpinRoute, const QByteArray &cdnLoop, const QHostAddress &peerAddress, const InspectData &idata, bool gripEnabled, bool intReq)
-{
-	if(trustedClient)
-		log_debug("%s: %p passing to upstream", logprefix, object);
+void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestData *requestData,
+                              bool trustedClient, const DomainMap::Entry &entry,
+                              const QByteArray &sigIss, const Jwt::EncodingKey &sigKey,
+                              bool acceptXForwardedProtocol, bool useXForwardedProto,
+                              bool useXForwardedProtocol, const XffRule &xffTrustedRule,
+                              const XffRule &xffRule, const QList<QByteArray> &origHeadersNeedMark,
+                              bool acceptPushpinRoute, const QByteArray &cdnLoop,
+                              const QHostAddress &peerAddress, const InspectData &idata,
+                              bool gripEnabled, bool intReq) {
+    if (trustedClient)
+        log_debug("%s: %p passing to upstream", logprefix, object);
 
-	if(!trustedClient && entry.origHeaders)
-	{
-		// Copy headers to include magic prefix, so that the original
-		// headers may be recovered later. If the client is trusted,
-		// then we assume this has been done already.
+    if (!trustedClient && entry.origHeaders) {
+        // Copy headers to include magic prefix, so that the original
+        // headers may be recovered later. If the client is trusted,
+        // then we assume this has been done already.
 
-		HttpHeaders origHeaders;
-		for(int n = 0; n < requestData->headers.count(); ++n)
-		{
-			const HttpHeader &h = requestData->headers[n];
+        HttpHeaders origHeaders;
+        for (int n = 0; n < requestData->headers.count(); ++n) {
+            const HttpHeader &h = requestData->headers[n];
 
-			if(qstrnicmp(h.first.data(), "eb9bf0f5-", 9) == 0)
-			{
-				// If it's already marked, take it
-				origHeaders += h;
+            if (qstrnicmp(h.first.data(), "eb9bf0f5-", 9) == 0) {
+                // If it's already marked, take it
+                origHeaders += h;
 
-				// Remove where it lives now. We'll put it back later
-				requestData->headers.removeAt(n);
-				--n; // Adjust position
-			}
-			else
-			{
-				// See if we require it to be marked already
-				bool found = false;
-				foreach(const QByteArray &i, origHeadersNeedMark)
-				{
-					if(qstricmp(h.first.data(), i.data()) == 0)
-					{
-						found = true;
-						break;
-					}
-				}
+                // Remove where it lives now. We'll put it back later
+                requestData->headers.removeAt(n);
+                --n; // Adjust position
+            } else {
+                // See if we require it to be marked already
+                bool found = false;
+                foreach (const QByteArray &i, origHeadersNeedMark) {
+                    if (qstricmp(h.first.data(), i.data()) == 0) {
+                        found = true;
+                        break;
+                    }
+                }
 
-				// If not, then add as marked
-				if(!found)
-					origHeaders += HttpHeader("eb9bf0f5-" + h.first, h.second);
-			}
-		}
+                // If not, then add as marked
+                if (!found)
+                    origHeaders += HttpHeader("eb9bf0f5-" + h.first, h.second);
+            }
+        }
 
-		// Now append all the orig headers to the end
-		foreach(const HttpHeader &h, origHeaders)
-			requestData->headers += h;
-	}
-	else if(!entry.origHeaders)
-	{
-		// If we don't want original headers, then filter them out
-		// before proxying
-		for(int n = 0; n < requestData->headers.count(); ++n)
-		{
-			const HttpHeader &h = requestData->headers[n];
+        // Now append all the orig headers to the end
+        foreach (const HttpHeader &h, origHeaders)
+            requestData->headers += h;
+    } else if (!entry.origHeaders) {
+        // If we don't want original headers, then filter them out
+        // before proxying
+        for (int n = 0; n < requestData->headers.count(); ++n) {
+            const HttpHeader &h = requestData->headers[n];
 
-			if(qstrnicmp(h.first.data(), "eb9bf0f5-", 9) == 0)
-			{
-				requestData->headers.removeAt(n);
-				--n; // Adjust position
-			}
-		}
-	}
+            if (qstrnicmp(h.first.data(), "eb9bf0f5-", 9) == 0) {
+                requestData->headers.removeAt(n);
+                --n; // Adjust position
+            }
+        }
+    }
 
-	// Don't relay these headers. Their meaning is handled by
-	// mongrel2 and they only apply to the incoming hop.
-	requestData->headers.removeAll("Connection");
-	requestData->headers.removeAll("Keep-Alive");
-	requestData->headers.removeAll("Accept-Encoding");
-	requestData->headers.removeAll("Content-Encoding");
-	requestData->headers.removeAll("Transfer-Encoding");
-	requestData->headers.removeAll("Expect");
+    // Don't relay these headers. Their meaning is handled by
+    // mongrel2 and they only apply to the incoming hop.
+    requestData->headers.removeAll("Connection");
+    requestData->headers.removeAll("Keep-Alive");
+    requestData->headers.removeAll("Accept-Encoding");
+    requestData->headers.removeAll("Content-Encoding");
+    requestData->headers.removeAll("Transfer-Encoding");
+    requestData->headers.removeAll("Expect");
 
-	if(acceptPushpinRoute)
-		requestData->headers.removeAll("Pushpin-Route");
+    if (acceptPushpinRoute)
+        requestData->headers.removeAll("Pushpin-Route");
 
-	if(!cdnLoop.isEmpty())
-	{
-		QList<QByteArray> values = requestData->headers.takeAll("CDN-Loop", true).asQByteArrayList();
-		values += cdnLoop;
+    if (!cdnLoop.isEmpty()) {
+        QList<QByteArray> values =
+            requestData->headers.takeAll("CDN-Loop", true).asQByteArrayList();
+        values += cdnLoop;
 
-		requestData->headers += HttpHeader("CDN-Loop", values.join(", "));
-	}
+        requestData->headers += HttpHeader("CDN-Loop", values.join(", "));
+    }
 
-	if(!trustedClient && !intReq)
-	{
-		// Remove all Grip- headers
-		for(int n = 0; n < requestData->headers.count(); ++n)
-		{
-			if(qstrnicmp(requestData->headers[n].first.data(), "Grip-", 5) == 0)
-			{
-				requestData->headers.removeAt(n);
-				--n; // Adjust position
-			}
-		}
-	}
+    if (!trustedClient && !intReq) {
+        // Remove all Grip- headers
+        for (int n = 0; n < requestData->headers.count(); ++n) {
+            if (qstrnicmp(requestData->headers[n].first.data(), "Grip-", 5) == 0) {
+                requestData->headers.removeAt(n);
+                --n; // Adjust position
+            }
+        }
+    }
 
-	if(!trustedClient && gripEnabled)
-	{
-		applyGripSig(logprefix, object, &requestData->headers, sigIss, sigKey);
+    if (!trustedClient && gripEnabled) {
+        applyGripSig(logprefix, object, &requestData->headers, sigIss, sigKey);
 
-		requestData->headers.removeAll("Grip-Feature");
-		requestData->headers += HttpHeader("Grip-Feature",
-			"status, session, link:next, link:gone, filter:skip-self, filter:skip-users, filter:require-sub, filter:build-id, filter:var-subst, filter:http-check, filter:http-modify");
+        requestData->headers.removeAll("Grip-Feature");
+        requestData->headers +=
+            HttpHeader("Grip-Feature", "status, session, link:next, link:gone, filter:skip-self, "
+                                       "filter:skip-users, filter:require-sub, filter:build-id, "
+                                       "filter:var-subst, filter:http-check, filter:http-modify");
 
-		if(!idata.sid.isEmpty())
-		{
-			requestData->headers.removeAll("Grip-Session-Id");
-			requestData->headers += HttpHeader("Grip-Session-Id", idata.sid);
-		}
+        if (!idata.sid.isEmpty()) {
+            requestData->headers.removeAll("Grip-Session-Id");
+            requestData->headers += HttpHeader("Grip-Session-Id", idata.sid);
+        }
 
-		if(!idata.lastIds.isEmpty())
-		{
-			QHashIterator<QByteArray, QByteArray> it(idata.lastIds);
-			while(it.hasNext())
-			{
-				it.next();
-				requestData->headers += HttpHeader("Grip-Last", it.key() + "; last-id=" + it.value());
-			}
-		}
-	}
+        if (!idata.lastIds.isEmpty()) {
+            QHashIterator<QByteArray, QByteArray> it(idata.lastIds);
+            while (it.hasNext()) {
+                it.next();
+                requestData->headers +=
+                    HttpHeader("Grip-Last", it.key() + "; last-id=" + it.value());
+            }
+        }
+    }
 
-	if(acceptXForwardedProtocol || useXForwardedProto || useXForwardedProtocol)
-	{
-		requestData->headers.removeAll("X-Forwarded-Proto");
+    if (acceptXForwardedProtocol || useXForwardedProto || useXForwardedProtocol) {
+        requestData->headers.removeAll("X-Forwarded-Proto");
 
-		// TODO: deprecate
-		requestData->headers.removeAll("X-Forwarded-Protocol");
-	}
+        // TODO: deprecate
+        requestData->headers.removeAll("X-Forwarded-Protocol");
+    }
 
-	if(useXForwardedProto || useXForwardedProtocol)
-	{
-		QString scheme = requestData->uri.scheme();
-		if(scheme == "https" || scheme == "wss")
-		{
-			QByteArray schemeVal = scheme.toUtf8();
+    if (useXForwardedProto || useXForwardedProtocol) {
+        QString scheme = requestData->uri.scheme();
+        if (scheme == "https" || scheme == "wss") {
+            QByteArray schemeVal = scheme.toUtf8();
 
-			if(useXForwardedProto)
-				requestData->headers += HttpHeader("X-Forwarded-Proto", schemeVal);
+            if (useXForwardedProto)
+                requestData->headers += HttpHeader("X-Forwarded-Proto", schemeVal);
 
-			// TODO: deprecate
-			if(useXForwardedProtocol)
-				requestData->headers += HttpHeader("X-Forwarded-Protocol", schemeVal);
-		}
-	}
+            // TODO: deprecate
+            if (useXForwardedProtocol)
+                requestData->headers += HttpHeader("X-Forwarded-Protocol", schemeVal);
+        }
+    }
 
-	const XffRule *xr;
-	if(trustedClient)
-		xr = &xffTrustedRule;
-	else
-		xr = &xffRule;
+    const XffRule *xr;
+    if (trustedClient)
+        xr = &xffTrustedRule;
+    else
+        xr = &xffRule;
 
-	QList<QByteArray> xffValues = requestData->headers.takeAll("X-Forwarded-For").asQByteArrayList();
-	if(xr->truncate >= 0)
-		xffValues = xffValues.mid(qMax(xffValues.count() - xr->truncate, 0));
-	if(xr->append)
-		xffValues += peerAddress.toString().toUtf8();
-	if(!xffValues.isEmpty())
-		requestData->headers += HttpHeader("X-Forwarded-For", HttpHeaders::join(xffValues));
+    QList<QByteArray> xffValues =
+        requestData->headers.takeAll("X-Forwarded-For").asQByteArrayList();
+    if (xr->truncate >= 0)
+        xffValues = xffValues.mid(qMax(xffValues.count() - xr->truncate, 0));
+    if (xr->append)
+        xffValues += peerAddress.toString().toUtf8();
+    if (!xffValues.isEmpty())
+        requestData->headers += HttpHeader("X-Forwarded-For", HttpHeaders::join(xffValues));
 }
 
-void applyHost(Url *url, const QString &host)
-{
-	int at = host.indexOf(':');
-	if(at != -1)
-	{
-		url->setHost(host.mid(0, at));
-		url->setPort(host.mid(at + 1).toInt());
-	}
-	else
-	{
-		url->setHost(host);
-		url->setPort(-1);
-	}
+void applyHost(Url *url, const QString &host) {
+    int at = host.indexOf(':');
+    if (at != -1) {
+        url->setHost(host.mid(0, at));
+        url->setPort(host.mid(at + 1).toInt());
+    } else {
+        url->setHost(host);
+        url->setPort(-1);
+    }
 }
 
-void applyHostHeader(HttpHeaders *headers, const Url &uri)
-{
-	QByteArray hostHeader = uri.host().toUtf8();
-	if(uri.port() != -1)
-		hostHeader += ':' + QByteArray::number(uri.port());
+void applyHostHeader(HttpHeaders *headers, const Url &uri) {
+    QByteArray hostHeader = uri.host().toUtf8();
+    if (uri.port() != -1)
+        hostHeader += ':' + QByteArray::number(uri.port());
 
-	if(headers->get("Host").asQByteArray() != hostHeader)
-	{
-		headers->removeAll("Host");
-		headers->append(HttpHeader("Host", hostHeader));
-	}
+    if (headers->get("Host").asQByteArray() != hostHeader) {
+        headers->removeAll("Host");
+        headers->append(HttpHeader("Host", hostHeader));
+    }
 }
 
-void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers, const QByteArray &sigIss, const Jwt::EncodingKey &sigKey)
-{
-	if(!sigIss.isEmpty() && !sigKey.isNull())
-	{
-		QByteArray token = make_token(sigIss, sigKey);
-		if(!token.isEmpty())
-		{
-			headers->removeAll("Grip-Sig");
-			headers->append(HttpHeader("Grip-Sig", token));
-		}
-		else
-			log_error("%s: %p failed to sign request", logprefix, object);
-	}
+void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers,
+                  const QByteArray &sigIss, const Jwt::EncodingKey &sigKey) {
+    if (!sigIss.isEmpty() && !sigKey.isNull()) {
+        QByteArray token = make_token(sigIss, sigKey);
+        if (!token.isEmpty()) {
+            headers->removeAll("Grip-Sig");
+            headers->append(HttpHeader("Grip-Sig", token));
+        } else
+            log_error("%s: %p failed to sign request", logprefix, object);
+    }
 }
 
-QString targetToString(const DomainMap::Target &target)
-{
-	if(target.type == DomainMap::Target::Test)
-	{
-		return "test";
-	}
-	else if(target.type == DomainMap::Target::Custom)
-	{
-		return(target.zhttpRoute.req ? "zhttpreq/" : "zhttp/") + target.zhttpRoute.baseSpec;
-	}
-	else // Default
-	{
-		QString host;
-		if(QHostAddress(target.connectHost).protocol() == QAbstractSocket::IPv6Protocol)
-			host = '[' + target.connectHost + ']';
-		else
-			host = target.connectHost;
+QString targetToString(const DomainMap::Target &target) {
+    if (target.type == DomainMap::Target::Test) {
+        return "test";
+    } else if (target.type == DomainMap::Target::Custom) {
+        return (target.zhttpRoute.req ? "zhttpreq/" : "zhttp/") + target.zhttpRoute.baseSpec;
+    } else // Default
+    {
+        QString host;
+        if (QHostAddress(target.connectHost).protocol() == QAbstractSocket::IPv6Protocol)
+            host = '[' + target.connectHost + ']';
+        else
+            host = target.connectHost;
 
-		return host + ':' + QString::number(target.connectPort);
-	}
+        return host + ':' + QString::number(target.connectPort);
+    }
 }
 
-QHostAddress getLogicalAddress(const HttpHeaders &headers, const XffRule &xffRule, const QHostAddress &peerAddress)
-{
-	QList<QByteArray> xffValues = headers.getAll("X-Forwarded-For").asQByteArrayList();
-	if(!xffValues.isEmpty() && xffRule.truncate != 0)
-	{
-		QHostAddress addr;
-		if(addr.setAddress(QString::fromUtf8(xffValues.first())))
-			return addr;
-	}
+QHostAddress getLogicalAddress(const HttpHeaders &headers, const XffRule &xffRule,
+                               const QHostAddress &peerAddress) {
+    QList<QByteArray> xffValues = headers.getAll("X-Forwarded-For").asQByteArrayList();
+    if (!xffValues.isEmpty() && xffRule.truncate != 0) {
+        QHostAddress addr;
+        if (addr.setAddress(QString::fromUtf8(xffValues.first())))
+            return addr;
+    }
 
-	return peerAddress;
+    return peerAddress;
 }
 
-}
+} // namespace ProxyUtil

--- a/src/proxy/proxyutil.h
+++ b/src/proxy/proxyutil.h
@@ -23,36 +23,47 @@
 #ifndef PROXYUTIL_H
 #define PROXYUTIL_H
 
-#include <QByteArray>
-#include <QList>
-#include <QHostAddress>
-#include "packet/httprequestdata.h"
 #include "domainmap.h"
-#include "xffrule.h"
+#include "packet/httprequestdata.h"
 #include "url.h"
+#include "xffrule.h"
+#include <QByteArray>
+#include <QHostAddress>
+#include <QList>
 
 namespace Jwt {
-    class EncodingKey;
-    class DecodingKey;
-}
+class EncodingKey;
+class DecodingKey;
+} // namespace Jwt
 
 class InspectData;
 
 namespace ProxyUtil {
 
-bool checkTrustedClient(const char *logprefix, void *object, const HttpRequestData &requestData, const Jwt::DecodingKey &defaultUpstreamKey);
+bool checkTrustedClient(const char *logprefix, void *object, const HttpRequestData &requestData,
+                        const Jwt::DecodingKey &defaultUpstreamKey);
 
-void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestData *requestData, bool trustedClient, const DomainMap::Entry &entry, const QByteArray &sigIss, const Jwt::EncodingKey &sigKey, bool acceptXForwardedProtocol, bool useXForwardedProto, bool useXForwardedProtocol, const XffRule &xffTrustedRule, const XffRule &xffRule, const QList<QByteArray> &origHeadersNeedMark, bool acceptPushpinRoute, const QByteArray &cdnLoop, const QHostAddress &peerAddress, const InspectData &idata, bool gripEnabled, bool intReq);
+void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestData *requestData,
+                              bool trustedClient, const DomainMap::Entry &entry,
+                              const QByteArray &sigIss, const Jwt::EncodingKey &sigKey,
+                              bool acceptXForwardedProtocol, bool useXForwardedProto,
+                              bool useXForwardedProtocol, const XffRule &xffTrustedRule,
+                              const XffRule &xffRule, const QList<QByteArray> &origHeadersNeedMark,
+                              bool acceptPushpinRoute, const QByteArray &cdnLoop,
+                              const QHostAddress &peerAddress, const InspectData &idata,
+                              bool gripEnabled, bool intReq);
 
 void applyHost(Url *url, const QString &host);
 
 void applyHostHeader(HttpHeaders *headers, const Url &uri);
-void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers, const QByteArray &sigIss, const Jwt::EncodingKey &sigKey);
+void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers,
+                  const QByteArray &sigIss, const Jwt::EncodingKey &sigKey);
 
 QString targetToString(const DomainMap::Target &target);
 
-QHostAddress getLogicalAddress(const HttpHeaders &headers, const XffRule &xffRule, const QHostAddress &peerAddress);
+QHostAddress getLogicalAddress(const HttpHeaders &headers, const XffRule &xffRule,
+                               const QHostAddress &peerAddress);
 
-}
+} // namespace ProxyUtil
 
 #endif

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -23,1390 +23,1221 @@
 
 #include "requestsession.h"
 
-#include <assert.h>
-#include "url.h"
-#include <QHostAddress>
-#include <QUrlQuery>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
+#include "acceptdata.h"
+#include "acceptrequest.h"
+#include "bufferlist.h"
+#include "cors.h"
+#include "defercall.h"
+#include "inspectdata.h"
+#include "inspectrequest.h"
+#include "layertracker.h"
+#include "log.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
-#include "qtcompat.h"
-#include "variant.h"
-#include "bufferlist.h"
-#include "log.h"
-#include "defercall.h"
-#include "layertracker.h"
-#include "sockjsmanager.h"
-#include "inspectdata.h"
-#include "acceptdata.h"
-#include "zhttpmanager.h"
-#include "zrpcmanager.h"
-#include "zrpcchecker.h"
-#include "inspectrequest.h"
-#include "acceptrequest.h"
-#include "statsmanager.h"
-#include "cors.h"
 #include "proxyutil.h"
+#include "qtcompat.h"
+#include "sockjsmanager.h"
+#include "statsmanager.h"
+#include "url.h"
+#include "variant.h"
 #include "xffrule.h"
+#include "zhttpmanager.h"
+#include "zrpcchecker.h"
+#include "zrpcmanager.h"
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrlQuery>
+#include <assert.h>
 
 #define MAX_SHARED_REQUEST_BODY 100000
 #define MAX_ACCEPT_REQUEST_BODY 100000
 
-static int fromHex(char c)
-{
-	if(c >= '0' && c <= '9')
-		return c - '0';
-	else if(c >= 'a' && c <= 'f')
-		return c - 'a' + 10;
-	else if(c >= 'A' && c <= 'F')
-		return c - 'A' + 10;
-	else
-		return -1;
+static int fromHex(char c) {
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    else if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    else
+        return -1;
 }
 
-static QByteArray parsePercentEncoding(const QByteArray &in)
-{
-	QByteArray out;
+static QByteArray parsePercentEncoding(const QByteArray &in) {
+    QByteArray out;
 
-	for(int n = 0; n < in.size(); ++n)
-	{
-		char c = in[n];
+    for (int n = 0; n < in.size(); ++n) {
+        char c = in[n];
 
-		if(c == '%')
-		{
-			if(n + 2 >= in.size())
-				return QByteArray();
+        if (c == '%') {
+            if (n + 2 >= in.size())
+                return QByteArray();
 
-			int hi = fromHex(in[n + 1]);
-			if(hi == -1)
-				return QByteArray();
+            int hi = fromHex(in[n + 1]);
+            if (hi == -1)
+                return QByteArray();
 
-			int lo = fromHex(in[n + 2]);
-			if(lo == -1)
-				return QByteArray();
+            int lo = fromHex(in[n + 2]);
+            if (lo == -1)
+                return QByteArray();
 
-			unsigned char val = (hi << 4) + lo;
-			out += val;
+            unsigned char val = (hi << 4) + lo;
+            out += val;
 
-			n += 2; // Adjust position
-		}
-		else
-			out += c;
-	}
+            n += 2; // Adjust position
+        } else
+            out += c;
+    }
 
-	return out;
+    return out;
 }
 
-static bool validMethod(const QString &in)
-{
-	if(in.isEmpty())
-		return false;
+static bool validMethod(const QString &in) {
+    if (in.isEmpty())
+        return false;
 
-	for(int n = 0; n < in.size(); ++n)
-	{
-		if(!in[n].isPrint())
-			return false;
-	}
+    for (int n = 0; n < in.size(); ++n) {
+        if (!in[n].isPrint())
+            return false;
+    }
 
-	return true;
+    return true;
 }
 
-static QByteArray serializeJsonString(const QString &s)
-{
-	QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s)).toJson(QJsonDocument::Compact);
+static QByteArray serializeJsonString(const QString &s) {
+    QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s))
+                         .toJson(QJsonDocument::Compact);
 
-	assert(tmp.length() >= 4);
-	assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
-	assert(tmp[1] == '"' && tmp[tmp.length() - 2] == '"');
+    assert(tmp.length() >= 4);
+    assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
+    assert(tmp[1] == '"' && tmp[tmp.length() - 2] == '"');
 
-	return tmp.mid(1, tmp.length() - 2);
+    return tmp.mid(1, tmp.length() - 2);
 }
 
-static QByteArray ridToString(const QPair<QByteArray, QByteArray> &rid)
-{
-	return rid.first + ':' + rid.second;
+static QByteArray ridToString(const QPair<QByteArray, QByteArray> &rid) {
+    return rid.first + ':' + rid.second;
 }
 
-class RequestSession::Private
-{
+class RequestSession::Private {
 public:
-	enum State
-	{
-		Stopped,
-		Prefetching,
-		Inspecting,
-		Receiving,
-		ReceivingForAccept,
-		Accepting,
-		WaitingForResponse,
-		RespondingStart,
-		Responding,
-		RespondingInternal
-	};
-
-	struct ZhttpReqConnections {
-		Connection readyReadConnection;
-		Connection pausedConnection;
-		Connection errorConnection;
-		Connection bytesWrittenConnection;
-	};
-
-	RequestSession *q;
-	int workerId;
-	State state;
-	ZhttpRequest::Rid rid;
-	DomainMap *domainMap;
-	SockJsManager *sockJsManager;
-	ZrpcManager *inspectManager;
-	ZrpcChecker *inspectChecker;
-	ZrpcManager *acceptManager;
-	StatsManager *stats;
-	ZhttpRequest *zhttpRequest;
-	HttpRequestData requestData;
-	Jwt::DecodingKey defaultUpstreamKey;
-	bool trusted;
-	QHostAddress peerAddress;
-	QHostAddress logicalPeerAddress;
-	DomainMap::Entry route;
-	QString routeId;
-	bool debug;
-	bool autoCrossOrigin;
-	std::unique_ptr<InspectRequest> inspectRequest;
-	InspectData idata;
-	std::unique_ptr<AcceptRequest> acceptRequest;
-	BufferList in;
-	QByteArray jsonpCallback;
-	bool jsonpExtendedResponse;
-	HttpResponseData responseData;
-	int responseBodySize;
-	BufferList out;
-	bool responseBodyFinished;
-	bool pendingResponseUpdate;
-	LayerTracker jsonpTracker;
-	bool isRetry;
-	QList<QByteArray> jsonpExtractableHeaders;
-	int prefetchSize;
-	bool needPause;
-	bool connectionRegistered;
-	bool accepted;
-	bool passthrough;
-	bool autoShare;
-	XffRule xffRule;
-	XffRule xffTrustedRule;
-	bool isSockJs;
-	ZhttpReqConnections zhttpReqConnections;
-	Connection inspectFinishedConnection;
-	Connection acceptFinishedConnection;
-	DeferCall deferCall;
-
-	Private(RequestSession *_q, int _workerId, DomainMap *_domainMap = 0, SockJsManager *_sockJsManager = 0, ZrpcManager *_inspectManager = 0, ZrpcChecker *_inspectChecker = 0, ZrpcManager *_acceptManager = 0, StatsManager *_stats = 0) :
-		q(_q),
-		workerId(_workerId),
-		state(Stopped),
-		domainMap(_domainMap),
-		sockJsManager(_sockJsManager),
-		inspectManager(_inspectManager),
-		inspectChecker(_inspectChecker),
-		acceptManager(_acceptManager),
-		stats(_stats),
-		zhttpRequest(0),
-		trusted(false),
-		debug(false),
-		autoCrossOrigin(false),
-		jsonpExtendedResponse(false),
-		responseBodySize(0),
-		responseBodyFinished(false),
-		pendingResponseUpdate(false),
-		isRetry(false),
-		prefetchSize(0),
-		needPause(false),
-		connectionRegistered(false),
-		accepted(false),
-		passthrough(false),
-		autoShare(false),
-		isSockJs(false)
-	{
-		jsonpExtractableHeaders += "Cache-Control";
-	}
-
-	~Private()
-	{
-		cleanup();
-	}
-
-	void cleanup()
-	{
-		if(zhttpRequest)
-		{
-			zhttpReqConnections = ZhttpReqConnections();
-			delete zhttpRequest;
-			zhttpRequest = 0;
-		}
-
-		if(inspectRequest)
-		{
-			inspectFinishedConnection.disconnect();
-			inspectChecker->give(inspectRequest.release());
-		}
-
-		if(stats && connectionRegistered)
-		{
-			connectionRegistered = false;
-
-			QByteArray cid = ridToString(rid);
-
-			// Refresh before remove, to ensure transition
-			if(accepted)
-				stats->refreshConnection(cid);
-
-			// Linger if accepted
-			bool linger = accepted && stats->connectionSendEnabled();
-			stats->removeConnection(cid, linger);
-		}
-
-		state = Stopped;
-	}
-
-	void start(ZhttpRequest *req)
-	{
-		zhttpRequest = req;
-		rid = req->rid();
-		passthrough = req->passthroughData().isValid();
-
-		requestData.method = req->requestMethod();
-		requestData.uri = req->requestUri();
-		requestData.headers = req->requestHeaders();
-
-		trusted = ProxyUtil::checkTrustedClient("requestsession", q, requestData, defaultUpstreamKey);
-
-		peerAddress = req->peerAddress();
-		logicalPeerAddress = ProxyUtil::getLogicalAddress(requestData.headers, trusted ? xffTrustedRule : xffRule, peerAddress);
-
-		log_debug("worker %d: IN id=%s, %s %s", workerId, rid.second.data(), qPrintable(requestData.method), requestData.uri.toEncoded().data());
-
-		bool isHttps = (requestData.uri.scheme() == "https");
-		QString host = requestData.uri.host();
-
-		if(route.isNull() && domainMap)
-		{
-			QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
-
-			// Look up the route
-			if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-				route = domainMap->entry(routeId);
-			else
-				route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
-
-			// Before we do anything else, see if this is a sockjs request
-			if(!route.isNull() && !route.sockJsPath.isEmpty() && encPath.startsWith(route.sockJsPath))
-			{
-				isSockJs = true;
-				sockJsManager->giveRequest(zhttpRequest, route.sockJsPath.length(), route.sockJsAsPath, route);
-				zhttpRequest = 0;
-				deferCall.defer([=] { doFinished(); });
-				return;
-			}
-		}
-
-		zhttpReqConnections.pausedConnection = zhttpRequest->paused.connect(boost::bind(&Private::zhttpRequest_paused, this));
-		zhttpReqConnections.errorConnection = zhttpRequest->error.connect(boost::bind(&Private::zhttpRequest_error, this));
-
-		if(!route.isNull())
-		{
-			if(route.debug)
-				debug = true;
-
-			if(route.autoCrossOrigin)
-				autoCrossOrigin = true;
-		}
-
-		if(autoCrossOrigin)
-		{
-			DomainMap::JsonpConfig config;
-			if(!route.isNull())
-				config = route.jsonpConfig;
-
-			bool ok = false;
-			QString str;
-			tryApplyJsonp(config, &ok, &str);
-			if(!ok)
-			{
-				state = WaitingForResponse;
-				respondBadRequest(str);
-				return;
-			}
-		}
-
-		// NOTE: per the license, this functionality may not be removed as it
-		// is the interface for the copyright notice
-		if(requestData.headers.contains("Pushpin-Check"))
-		{
-			QString str =
-			"Copyright (C) 2012-2023 Fanout, Inc.\n"
-			"Copyright (C) 2023 Fastly, Inc.\n"
-			"\n"
-			"Pushpin is licensed under the Apache License, Version 2.0 (the \"License\");\n"
-			"you may not use this software except in compliance with the License.\n"
-			"You may obtain a copy of the License at\n"
-			"\n"
-			"    http://www.apache.org/licenses/LICENSE-2.0\n"
-			"\n"
-			"Unless required by applicable law or agreed to in writing, software\n"
-			"distributed under the License is distributed on an \"AS IS\" BASIS,\n"
-			"WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n"
-			"See the License for the specific language governing permissions and\n"
-			"limitations under the License.\n";
-
-			state = WaitingForResponse;
-			respondSuccess(str);
-			return;
-		}
-
-		log_debug("requestsession: %p %s has %d routes", q, qPrintable(host), route.targets.count());
-
-		if(route.isNull())
-		{
-			state = WaitingForResponse;
-			respondError(502, "Bad Gateway", QString("No route for host: %1").arg(host));
-			return;
-		}
-
-		if(stats && !passthrough)
-		{
-			connectionRegistered = true;
-
-			stats->addConnection(ridToString(rid), route.statsRoute(), StatsManager::Http, logicalPeerAddress, isHttps, false);
-			stats->addActivity(route.statsRoute());
-			stats->addRequestsReceived(1);
-		}
-
-		state = Prefetching;
-
-		zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(boost::bind(&Private::zhttpRequest_readyRead, this));
-		processIncomingRequest();
-	}
-
-	void startRetry(int unreportedTime, int retrySeq)
-	{
-		trusted = ProxyUtil::checkTrustedClient("requestsession", q, requestData, defaultUpstreamKey);
-
-		peerAddress = zhttpRequest->peerAddress();
-		logicalPeerAddress = ProxyUtil::getLogicalAddress(requestData.headers, trusted ? xffTrustedRule : xffRule, peerAddress);
-
-		zhttpReqConnections.pausedConnection = zhttpRequest->paused.connect(boost::bind(&Private::zhttpRequest_paused, this));
-		zhttpReqConnections.errorConnection = zhttpRequest->error.connect(boost::bind(&Private::zhttpRequest_error, this));
-
-		state = WaitingForResponse;
-
-		bool isHttps = (requestData.uri.scheme() == "https");
-		QString host = requestData.uri.host();
-
-		QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
-
-		// Look up the route
-		if(!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-			route = domainMap->entry(routeId);
-		else
-			route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
-
-		log_debug("requestsession: %p %s has %d routes", q, qPrintable(host), route.targets.count());
-
-		if(route.isNull())
-		{
-			state = WaitingForResponse;
-			respondError(502, "Bad Gateway", QString("No route for host: %1").arg(host));
-			return;
-		}
-
-		if(stats)
-		{
-			if(retrySeq >= 0)
-				stats->setRetrySeq(route.statsRoute(), retrySeq);
-
-			connectionRegistered = true;
-
-			int reportOffset = stats->connectionSendEnabled() ? -1 : qMax(unreportedTime, 0);
-
-			stats->addConnection(ridToString(rid), route.statsRoute(), StatsManager::Http, logicalPeerAddress, isHttps, false, reportOffset);
-			stats->addActivity(route.statsRoute());
-
-			// Note: we don't call addRequestsReceived here, because we're acting for an existing request
-		}
-	}
-
-	void processIncomingRequest()
-	{
-		if(state == Prefetching)
-		{
-			if(prefetchSize > 0)
-				in += zhttpRequest->readBody(prefetchSize - in.size());
-
-			if(in.size() >= prefetchSize || zhttpRequest->isInputFinished())
-			{
-				// We've read enough body to start inspection
-
-				zhttpReqConnections.readyReadConnection.disconnect();
-
-				state = Inspecting;
-				requestData.body = in.toByteArray();
-				bool truncated = (!zhttpRequest->isInputFinished() || zhttpRequest->bytesAvailable() > 0);
-
-				assert(!inspectRequest);
-
-				if(inspectManager)
-				{
-					inspectRequest = std::make_unique<InspectRequest>(inspectManager);
-
-					if(inspectChecker->isInterfaceAvailable())
-					{
-						inspectFinishedConnection = inspectRequest->finished.connect(boost::bind(&Private::inspectRequest_finished, this));
-						inspectChecker->watch(inspectRequest.get());
-						inspectRequest->start(requestData, truncated, route.session, autoShare);
-					}
-					else
-					{
-						inspectChecker->watch(inspectRequest.get());
-						inspectChecker->give(inspectRequest.get());
-						inspectRequest->start(requestData, truncated, route.session, autoShare);
-						inspectRequest.release();
-					}
-				}
-
-				if(!inspectRequest)
-				{
-					log_debug("inspect not available");
-					deferCall.defer([=] { doInspectError(); });
-				}
-			}
-		}
-		else if(state == Receiving)
-		{
-			in += zhttpRequest->readBody(MAX_SHARED_REQUEST_BODY - in.size());
-
-			if(in.size() >= MAX_SHARED_REQUEST_BODY || zhttpRequest->isInputFinished())
-			{
-				// We've read as much as we can for now. If there is still
-				// more to read, then the engine will notice this and
-				// disallow sharing before passing to proxysession. At that
-				// point, proxysession will read the remainder of the data
-
-				zhttpReqConnections.readyReadConnection.disconnect();
-
-				state = WaitingForResponse;
-				requestData.body = in.take();
-				q->inspected(idata);
-			}
-		}
-		else if(state == ReceivingForAccept)
-		{
-			QByteArray buf = zhttpRequest->readBody();
-			if(in.size() + buf.size() > MAX_ACCEPT_REQUEST_BODY)
-			{
-				respondError(413, "Request Entity Too Large", QString("Body must not exceed %1 bytes").arg(MAX_ACCEPT_REQUEST_BODY));
-				return;
-			}
-
-			in += buf;
-
-			if(zhttpRequest->isInputFinished())
-			{
-				if(acceptManager)
-					zhttpRequest->pause();
-				else
-					respondCannotAccept();
-			}
-		}
-	}
-
-	void respond(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		q->startResponse(code, reason, headers);
-		q->writeResponseBody(body);
-		q->endResponseBody();
-	}
-
-	void respond(int code, const QString &status, const QByteArray &body)
-	{
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "text/plain");
-		headers += HttpHeader("Content-Length", QByteArray::number(body.size()));
-
-		respond(code, status.toUtf8(), headers, body);
-	}
-
-	void respondError(int code, const QString &status, const QString &errorString)
-	{
-		respond(code, status, errorString.toUtf8() + '\n');
-	}
-
-	void respondBadRequest(const QString &errorString)
-	{
-		respondError(400, "Bad Request", errorString);
-	}
-
-	void respondCannotAccept()
-	{
-		respondError(500, "Internal Server Error", "Accept service unavailable.");
-	}
-
-	void responseUpdate()
-	{
-		if(!pendingResponseUpdate)
-		{
-			pendingResponseUpdate = true;
-			deferCall.defer([=] { doResponseUpdate(); });
-		}
-	}
-
-	// Returns null array on error
-	QByteArray makeJsonpStart(int code, const QByteArray &reason, const HttpHeaders &headers)
-	{
-		QByteArray out = "/**/" + jsonpCallback + "(";
-
-		if(jsonpExtendedResponse)
-		{
-			QByteArray reasonJson = serializeJsonString(QString::fromUtf8(reason));
-			if(reasonJson.isNull())
-				return QByteArray();
-
-			VariantMap vheaders;
-			foreach(const HttpHeader h, headers)
-			{
-				if(!vheaders.contains(h.first.asQByteArray()))
-					vheaders[h.first.asQByteArray()] = h.second.asQByteArray();
-			}
-
-			QByteArray headersJson = QJsonDocument(QJsonObject::fromVariantMap(vheaders)).toJson(QJsonDocument::Compact);
-			if(headersJson.isNull())
-				return QByteArray();
-
-			out += "{\"code\": " + QByteArray::number(code) + ", \"reason\": " + reasonJson + ", \"headers\": " + headersJson + ", \"body\": \"";
-		}
-
-		return out;
-	}
-
-	QByteArray makeJsonpBody(const QByteArray &buf)
-	{
-		if(jsonpExtendedResponse)
-		{
-			// FIXME: this assumes there isn't a partial character encoding
-			QByteArray bodyJson = serializeJsonString(QString::fromUtf8(buf));
-			if(bodyJson.isNull())
-				return QByteArray();
-
-			assert(bodyJson.size() >= 2);
-
-			return bodyJson.mid(1, bodyJson.size() - 2);
-		}
-		else
-			return buf;
-	}
-
-	QByteArray makeJsonpEnd()
-	{
-		if(jsonpExtendedResponse)
-			return QByteArray("\"});\n");
-		else
-			return QByteArray(");\n");
-	}
-
-	// Return true if jsonp applied
-	bool tryApplyJsonp(const DomainMap::JsonpConfig &config, bool *ok, QString *errorMessage)
-	{
-		*ok = true;
-
-		// Must be a GET
-		if(requestData.method != "GET")
-			return false;
-
-		QString callbackParam = QString::fromUtf8(config.callbackParam);
-		if(callbackParam.isEmpty())
-			callbackParam = "callback";
-
-		QString bodyParam;
-		if(!config.bodyParam.isEmpty())
-			bodyParam = QString::fromUtf8(config.bodyParam);
-
-		Url uri = requestData.uri;
-		QUrlQuery query(uri);
-
-		// Two ways to activate JSON-P:
-		// 1) callback param present
-		// 2) default callback specified in configuration and body param present
-		if(!query.hasQueryItem(callbackParam) &&
-			(config.defaultCallback.isEmpty() || bodyParam.isEmpty() || !query.hasQueryItem(bodyParam)))
-		{
-			return false;
-		}
-
-		QByteArray callback;
-		if(query.hasQueryItem(callbackParam))
-		{
-			callback = parsePercentEncoding(query.queryItemValue(callbackParam, Url::FullyEncoded).toUtf8());
-			if(callback.isEmpty())
-			{
-				log_debug("requestsession: id=%s invalid callback parameter, rejecting", rid.second.data());
-				*ok = false;
-				*errorMessage = "Invalid callback parameter.";
-				return false;
-			}
-
-			query.removeAllQueryItems(callbackParam);
-		}
-		else
-			callback = config.defaultCallback;
-
-		QString method;
-		if(query.hasQueryItem("_method"))
-		{
-			method = QString::fromLatin1(parsePercentEncoding(query.queryItemValue("_method", Url::FullyEncoded).toUtf8()));
-			if(!validMethod(method))
-			{
-				log_debug("requestsession: id=%s invalid _method parameter, rejecting", rid.second.data());
-				*ok = false;
-				*errorMessage = "Invalid _method parameter.";
-				return false;
-			}
-
-			query.removeAllQueryItems("_method");
-		}
-
-		HttpHeaders headers;
-		if(query.hasQueryItem("_headers"))
-		{
-			QJsonParseError e;
-			QJsonDocument doc = QJsonDocument::fromJson(parsePercentEncoding(query.queryItemValue("_headers", Url::FullyEncoded).toUtf8()), &e);
-			if(e.error != QJsonParseError::NoError || !doc.isObject())
-			{
-				log_debug("requestsession: id=%s invalid _headers parameter, rejecting", rid.second.data());
-				*ok = false;
-				*errorMessage = "Invalid _headers parameter.";
-				return false;
-			}
-
-			VariantMap headersMap = doc.object().toVariantMap();
-
-			for(auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit)
-			{
-				if(typeId(vit.value()) != VariantType::String)
-				{
-					log_debug("requestsession: id=%s invalid _headers parameter, rejecting", rid.second.data());
-					*ok = false;
-					*errorMessage = "Invalid _headers parameter.";
-					return false;
-				}
-
-				QByteArray key = vit.key().toUtf8();
-
-				// Ignore some headers that we explicitly set later on
-				if(qstricmp(key.data(), "host") == 0)
-					continue;
-				if(qstricmp(key.data(), "accept") == 0)
-					continue;
-
-				headers += HttpHeader(key, vit.value().toString().toUtf8());
-			}
-
-			query.removeAllQueryItems("_headers");
-		}
-
-		QByteArray body;
-		if(!bodyParam.isEmpty())
-		{
-			if(query.hasQueryItem(bodyParam))
-			{
-				body = parsePercentEncoding(query.queryItemValue(bodyParam, Url::FullyEncoded).toUtf8());
-				if(body.isNull())
-				{
-					log_debug("requestsession: id=%s invalid body parameter, rejecting", rid.second.data());
-					*ok = false;
-					*errorMessage = "Invalid body parameter.";
-					return false;
-				}
-
-				headers.removeAll("Content-Type");
-				headers += HttpHeader("Content-Type", "application/json");
-
-				query.removeAllQueryItems(bodyParam);
-			}
-		}
-		else
-		{
-			if(query.hasQueryItem("_body"))
-			{
-				body = parsePercentEncoding(query.queryItemValue("_body").toUtf8());
-				if(body.isNull())
-				{
-					log_debug("requestsession: id=%s invalid _body parameter, rejecting", rid.second.data());
-					*ok = false;
-					*errorMessage = "Invalid _body parameter.";
-					return false;
-				}
-
-				query.removeAllQueryItems("_body");
-			}
-		}
-
-		uri.setQuery(query);
-
-		// If we have no query items anymore, strip the '?'
-		if(query.isEmpty())
-		{
-			QByteArray tmp = uri.toEncoded();
-			if(tmp.length() > 0 && tmp[tmp.length() - 1] == '?')
-			{
-				tmp.truncate(tmp.length() - 1);
-				uri = Url::fromEncoded(tmp, Url::StrictMode);
-			}
-		}
-
-		if(method.isEmpty())
-			method = config.defaultMethod;
-
-		requestData.method = method;
-
-		requestData.uri = uri;
-
-		QByteArray hostHeader = uri.host().toUtf8();
-		if(uri.port() != -1)
-			hostHeader += ':' + QByteArray::number(uri.port());
-		headers += HttpHeader("Host", hostHeader);
-
-		headers += HttpHeader("Accept", "*/*");
-
-		// Carry over the rest of the headers
-		foreach(const HttpHeader &h, requestData.headers)
-		{
-			if(qstricmp(h.first.data(), "host") == 0)
-				continue;
-			if(qstricmp(h.first.data(), "accept") == 0)
-				continue;
-
-			headers += h;
-		}
-
-		requestData.headers = headers;
-		in += body;
-
-		jsonpCallback = callback;
-		jsonpExtendedResponse = (config.mode == DomainMap::JsonpConfig::Extended);
-
-		return true;
-	}
+    enum State {
+        Stopped,
+        Prefetching,
+        Inspecting,
+        Receiving,
+        ReceivingForAccept,
+        Accepting,
+        WaitingForResponse,
+        RespondingStart,
+        Responding,
+        RespondingInternal
+    };
+
+    struct ZhttpReqConnections {
+        Connection readyReadConnection;
+        Connection pausedConnection;
+        Connection errorConnection;
+        Connection bytesWrittenConnection;
+    };
+
+    RequestSession *q;
+    int workerId;
+    State state;
+    ZhttpRequest::Rid rid;
+    DomainMap *domainMap;
+    SockJsManager *sockJsManager;
+    ZrpcManager *inspectManager;
+    ZrpcChecker *inspectChecker;
+    ZrpcManager *acceptManager;
+    StatsManager *stats;
+    ZhttpRequest *zhttpRequest;
+    HttpRequestData requestData;
+    Jwt::DecodingKey defaultUpstreamKey;
+    bool trusted;
+    QHostAddress peerAddress;
+    QHostAddress logicalPeerAddress;
+    DomainMap::Entry route;
+    QString routeId;
+    bool debug;
+    bool autoCrossOrigin;
+    std::unique_ptr<InspectRequest> inspectRequest;
+    InspectData idata;
+    std::unique_ptr<AcceptRequest> acceptRequest;
+    BufferList in;
+    QByteArray jsonpCallback;
+    bool jsonpExtendedResponse;
+    HttpResponseData responseData;
+    int responseBodySize;
+    BufferList out;
+    bool responseBodyFinished;
+    bool pendingResponseUpdate;
+    LayerTracker jsonpTracker;
+    bool isRetry;
+    QList<QByteArray> jsonpExtractableHeaders;
+    int prefetchSize;
+    bool needPause;
+    bool connectionRegistered;
+    bool accepted;
+    bool passthrough;
+    bool autoShare;
+    XffRule xffRule;
+    XffRule xffTrustedRule;
+    bool isSockJs;
+    ZhttpReqConnections zhttpReqConnections;
+    Connection inspectFinishedConnection;
+    Connection acceptFinishedConnection;
+    DeferCall deferCall;
+
+    Private(RequestSession *_q, int _workerId, DomainMap *_domainMap = 0,
+            SockJsManager *_sockJsManager = 0, ZrpcManager *_inspectManager = 0,
+            ZrpcChecker *_inspectChecker = 0, ZrpcManager *_acceptManager = 0,
+            StatsManager *_stats = 0)
+        : q(_q),
+          workerId(_workerId),
+          state(Stopped),
+          domainMap(_domainMap),
+          sockJsManager(_sockJsManager),
+          inspectManager(_inspectManager),
+          inspectChecker(_inspectChecker),
+          acceptManager(_acceptManager),
+          stats(_stats),
+          zhttpRequest(0),
+          trusted(false),
+          debug(false),
+          autoCrossOrigin(false),
+          jsonpExtendedResponse(false),
+          responseBodySize(0),
+          responseBodyFinished(false),
+          pendingResponseUpdate(false),
+          isRetry(false),
+          prefetchSize(0),
+          needPause(false),
+          connectionRegistered(false),
+          accepted(false),
+          passthrough(false),
+          autoShare(false),
+          isSockJs(false) {
+        jsonpExtractableHeaders += "Cache-Control";
+    }
+
+    ~Private() { cleanup(); }
+
+    void cleanup() {
+        if (zhttpRequest) {
+            zhttpReqConnections = ZhttpReqConnections();
+            delete zhttpRequest;
+            zhttpRequest = 0;
+        }
+
+        if (inspectRequest) {
+            inspectFinishedConnection.disconnect();
+            inspectChecker->give(inspectRequest.release());
+        }
+
+        if (stats && connectionRegistered) {
+            connectionRegistered = false;
+
+            QByteArray cid = ridToString(rid);
+
+            // Refresh before remove, to ensure transition
+            if (accepted)
+                stats->refreshConnection(cid);
+
+            // Linger if accepted
+            bool linger = accepted && stats->connectionSendEnabled();
+            stats->removeConnection(cid, linger);
+        }
+
+        state = Stopped;
+    }
+
+    void start(ZhttpRequest *req) {
+        zhttpRequest = req;
+        rid = req->rid();
+        passthrough = req->passthroughData().isValid();
+
+        requestData.method = req->requestMethod();
+        requestData.uri = req->requestUri();
+        requestData.headers = req->requestHeaders();
+
+        trusted =
+            ProxyUtil::checkTrustedClient("requestsession", q, requestData, defaultUpstreamKey);
+
+        peerAddress = req->peerAddress();
+        logicalPeerAddress = ProxyUtil::getLogicalAddress(
+            requestData.headers, trusted ? xffTrustedRule : xffRule, peerAddress);
+
+        log_debug("worker %d: IN id=%s, %s %s", workerId, rid.second.data(),
+                  qPrintable(requestData.method), requestData.uri.toEncoded().data());
+
+        bool isHttps = (requestData.uri.scheme() == "https");
+        QString host = requestData.uri.host();
+
+        if (route.isNull() && domainMap) {
+            QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
+
+            // Look up the route
+            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
+                route = domainMap->entry(routeId);
+            else
+                route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
+
+            // Before we do anything else, see if this is a sockjs request
+            if (!route.isNull() && !route.sockJsPath.isEmpty() &&
+                encPath.startsWith(route.sockJsPath)) {
+                isSockJs = true;
+                sockJsManager->giveRequest(zhttpRequest, route.sockJsPath.length(),
+                                           route.sockJsAsPath, route);
+                zhttpRequest = 0;
+                deferCall.defer([=] { doFinished(); });
+                return;
+            }
+        }
+
+        zhttpReqConnections.pausedConnection =
+            zhttpRequest->paused.connect(boost::bind(&Private::zhttpRequest_paused, this));
+        zhttpReqConnections.errorConnection =
+            zhttpRequest->error.connect(boost::bind(&Private::zhttpRequest_error, this));
+
+        if (!route.isNull()) {
+            if (route.debug)
+                debug = true;
+
+            if (route.autoCrossOrigin)
+                autoCrossOrigin = true;
+        }
+
+        if (autoCrossOrigin) {
+            DomainMap::JsonpConfig config;
+            if (!route.isNull())
+                config = route.jsonpConfig;
+
+            bool ok = false;
+            QString str;
+            tryApplyJsonp(config, &ok, &str);
+            if (!ok) {
+                state = WaitingForResponse;
+                respondBadRequest(str);
+                return;
+            }
+        }
+
+        // NOTE: per the license, this functionality may not be removed as it
+        // is the interface for the copyright notice
+        if (requestData.headers.contains("Pushpin-Check")) {
+            QString str = "Copyright (C) 2012-2023 Fanout, Inc.\n"
+                          "Copyright (C) 2023 Fastly, Inc.\n"
+                          "\n"
+                          "Pushpin is licensed under the Apache License, Version 2.0 "
+                          "(the \"License\");\n"
+                          "you may not use this software except in compliance with "
+                          "the License.\n"
+                          "You may obtain a copy of the License at\n"
+                          "\n"
+                          "    http://www.apache.org/licenses/LICENSE-2.0\n"
+                          "\n"
+                          "Unless required by applicable law or agreed to in "
+                          "writing, software\n"
+                          "distributed under the License is distributed on an \"AS "
+                          "IS\" BASIS,\n"
+                          "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either "
+                          "express or implied.\n"
+                          "See the License for the specific language governing "
+                          "permissions and\n"
+                          "limitations under the License.\n";
+
+            state = WaitingForResponse;
+            respondSuccess(str);
+            return;
+        }
+
+        log_debug("requestsession: %p %s has %d routes", q, qPrintable(host),
+                  route.targets.count());
+
+        if (route.isNull()) {
+            state = WaitingForResponse;
+            respondError(502, "Bad Gateway", QString("No route for host: %1").arg(host));
+            return;
+        }
+
+        if (stats && !passthrough) {
+            connectionRegistered = true;
+
+            stats->addConnection(ridToString(rid), route.statsRoute(), StatsManager::Http,
+                                 logicalPeerAddress, isHttps, false);
+            stats->addActivity(route.statsRoute());
+            stats->addRequestsReceived(1);
+        }
+
+        state = Prefetching;
+
+        zhttpReqConnections.readyReadConnection =
+            zhttpRequest->readyRead.connect(boost::bind(&Private::zhttpRequest_readyRead, this));
+        processIncomingRequest();
+    }
+
+    void startRetry(int unreportedTime, int retrySeq) {
+        trusted =
+            ProxyUtil::checkTrustedClient("requestsession", q, requestData, defaultUpstreamKey);
+
+        peerAddress = zhttpRequest->peerAddress();
+        logicalPeerAddress = ProxyUtil::getLogicalAddress(
+            requestData.headers, trusted ? xffTrustedRule : xffRule, peerAddress);
+
+        zhttpReqConnections.pausedConnection =
+            zhttpRequest->paused.connect(boost::bind(&Private::zhttpRequest_paused, this));
+        zhttpReqConnections.errorConnection =
+            zhttpRequest->error.connect(boost::bind(&Private::zhttpRequest_error, this));
+
+        state = WaitingForResponse;
+
+        bool isHttps = (requestData.uri.scheme() == "https");
+        QString host = requestData.uri.host();
+
+        QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
+
+        // Look up the route
+        if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
+            route = domainMap->entry(routeId);
+        else
+            route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
+
+        log_debug("requestsession: %p %s has %d routes", q, qPrintable(host),
+                  route.targets.count());
+
+        if (route.isNull()) {
+            state = WaitingForResponse;
+            respondError(502, "Bad Gateway", QString("No route for host: %1").arg(host));
+            return;
+        }
+
+        if (stats) {
+            if (retrySeq >= 0)
+                stats->setRetrySeq(route.statsRoute(), retrySeq);
+
+            connectionRegistered = true;
+
+            int reportOffset = stats->connectionSendEnabled() ? -1 : qMax(unreportedTime, 0);
+
+            stats->addConnection(ridToString(rid), route.statsRoute(), StatsManager::Http,
+                                 logicalPeerAddress, isHttps, false, reportOffset);
+            stats->addActivity(route.statsRoute());
+
+            // Note: we don't call addRequestsReceived here, because we're acting for
+            // an existing request
+        }
+    }
+
+    void processIncomingRequest() {
+        if (state == Prefetching) {
+            if (prefetchSize > 0)
+                in += zhttpRequest->readBody(prefetchSize - in.size());
+
+            if (in.size() >= prefetchSize || zhttpRequest->isInputFinished()) {
+                // We've read enough body to start inspection
+
+                zhttpReqConnections.readyReadConnection.disconnect();
+
+                state = Inspecting;
+                requestData.body = in.toByteArray();
+                bool truncated =
+                    (!zhttpRequest->isInputFinished() || zhttpRequest->bytesAvailable() > 0);
+
+                assert(!inspectRequest);
+
+                if (inspectManager) {
+                    inspectRequest = std::make_unique<InspectRequest>(inspectManager);
+
+                    if (inspectChecker->isInterfaceAvailable()) {
+                        inspectFinishedConnection = inspectRequest->finished.connect(
+                            boost::bind(&Private::inspectRequest_finished, this));
+                        inspectChecker->watch(inspectRequest.get());
+                        inspectRequest->start(requestData, truncated, route.session, autoShare);
+                    } else {
+                        inspectChecker->watch(inspectRequest.get());
+                        inspectChecker->give(inspectRequest.get());
+                        inspectRequest->start(requestData, truncated, route.session, autoShare);
+                        inspectRequest.release();
+                    }
+                }
+
+                if (!inspectRequest) {
+                    log_debug("inspect not available");
+                    deferCall.defer([=] { doInspectError(); });
+                }
+            }
+        } else if (state == Receiving) {
+            in += zhttpRequest->readBody(MAX_SHARED_REQUEST_BODY - in.size());
+
+            if (in.size() >= MAX_SHARED_REQUEST_BODY || zhttpRequest->isInputFinished()) {
+                // We've read as much as we can for now. If there is still
+                // more to read, then the engine will notice this and
+                // disallow sharing before passing to proxysession. At that
+                // point, proxysession will read the remainder of the data
+
+                zhttpReqConnections.readyReadConnection.disconnect();
+
+                state = WaitingForResponse;
+                requestData.body = in.take();
+                q->inspected(idata);
+            }
+        } else if (state == ReceivingForAccept) {
+            QByteArray buf = zhttpRequest->readBody();
+            if (in.size() + buf.size() > MAX_ACCEPT_REQUEST_BODY) {
+                respondError(413, "Request Entity Too Large",
+                             QString("Body must not exceed %1 bytes").arg(MAX_ACCEPT_REQUEST_BODY));
+                return;
+            }
+
+            in += buf;
+
+            if (zhttpRequest->isInputFinished()) {
+                if (acceptManager)
+                    zhttpRequest->pause();
+                else
+                    respondCannotAccept();
+            }
+        }
+    }
+
+    void respond(int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body) {
+        q->startResponse(code, reason, headers);
+        q->writeResponseBody(body);
+        q->endResponseBody();
+    }
+
+    void respond(int code, const QString &status, const QByteArray &body) {
+        HttpHeaders headers;
+        headers += HttpHeader("Content-Type", "text/plain");
+        headers += HttpHeader("Content-Length", QByteArray::number(body.size()));
+
+        respond(code, status.toUtf8(), headers, body);
+    }
+
+    void respondError(int code, const QString &status, const QString &errorString) {
+        respond(code, status, errorString.toUtf8() + '\n');
+    }
+
+    void respondBadRequest(const QString &errorString) {
+        respondError(400, "Bad Request", errorString);
+    }
+
+    void respondCannotAccept() {
+        respondError(500, "Internal Server Error", "Accept service unavailable.");
+    }
+
+    void responseUpdate() {
+        if (!pendingResponseUpdate) {
+            pendingResponseUpdate = true;
+            deferCall.defer([=] { doResponseUpdate(); });
+        }
+    }
+
+    // Returns null array on error
+    QByteArray makeJsonpStart(int code, const QByteArray &reason, const HttpHeaders &headers) {
+        QByteArray out = "/**/" + jsonpCallback + "(";
+
+        if (jsonpExtendedResponse) {
+            QByteArray reasonJson = serializeJsonString(QString::fromUtf8(reason));
+            if (reasonJson.isNull())
+                return QByteArray();
+
+            VariantMap vheaders;
+            foreach (const HttpHeader h, headers) {
+                if (!vheaders.contains(h.first.asQByteArray()))
+                    vheaders[h.first.asQByteArray()] = h.second.asQByteArray();
+            }
+
+            QByteArray headersJson =
+                QJsonDocument(QJsonObject::fromVariantMap(vheaders)).toJson(QJsonDocument::Compact);
+            if (headersJson.isNull())
+                return QByteArray();
+
+            out += "{\"code\": " + QByteArray::number(code) + ", \"reason\": " + reasonJson +
+                   ", \"headers\": " + headersJson + ", \"body\": \"";
+        }
+
+        return out;
+    }
+
+    QByteArray makeJsonpBody(const QByteArray &buf) {
+        if (jsonpExtendedResponse) {
+            // FIXME: this assumes there isn't a partial character encoding
+            QByteArray bodyJson = serializeJsonString(QString::fromUtf8(buf));
+            if (bodyJson.isNull())
+                return QByteArray();
+
+            assert(bodyJson.size() >= 2);
+
+            return bodyJson.mid(1, bodyJson.size() - 2);
+        } else
+            return buf;
+    }
+
+    QByteArray makeJsonpEnd() {
+        if (jsonpExtendedResponse)
+            return QByteArray("\"});\n");
+        else
+            return QByteArray(");\n");
+    }
+
+    // Return true if jsonp applied
+    bool tryApplyJsonp(const DomainMap::JsonpConfig &config, bool *ok, QString *errorMessage) {
+        *ok = true;
+
+        // Must be a GET
+        if (requestData.method != "GET")
+            return false;
+
+        QString callbackParam = QString::fromUtf8(config.callbackParam);
+        if (callbackParam.isEmpty())
+            callbackParam = "callback";
+
+        QString bodyParam;
+        if (!config.bodyParam.isEmpty())
+            bodyParam = QString::fromUtf8(config.bodyParam);
+
+        Url uri = requestData.uri;
+        QUrlQuery query(uri);
+
+        // Two ways to activate JSON-P:
+        // 1) callback param present
+        // 2) default callback specified in configuration and body param present
+        if (!query.hasQueryItem(callbackParam) &&
+            (config.defaultCallback.isEmpty() || bodyParam.isEmpty() ||
+             !query.hasQueryItem(bodyParam))) {
+            return false;
+        }
+
+        QByteArray callback;
+        if (query.hasQueryItem(callbackParam)) {
+            callback = parsePercentEncoding(
+                query.queryItemValue(callbackParam, Url::FullyEncoded).toUtf8());
+            if (callback.isEmpty()) {
+                log_debug("requestsession: id=%s invalid callback parameter, rejecting",
+                          rid.second.data());
+                *ok = false;
+                *errorMessage = "Invalid callback parameter.";
+                return false;
+            }
+
+            query.removeAllQueryItems(callbackParam);
+        } else
+            callback = config.defaultCallback;
+
+        QString method;
+        if (query.hasQueryItem("_method")) {
+            method = QString::fromLatin1(
+                parsePercentEncoding(query.queryItemValue("_method", Url::FullyEncoded).toUtf8()));
+            if (!validMethod(method)) {
+                log_debug("requestsession: id=%s invalid _method parameter, rejecting",
+                          rid.second.data());
+                *ok = false;
+                *errorMessage = "Invalid _method parameter.";
+                return false;
+            }
+
+            query.removeAllQueryItems("_method");
+        }
+
+        HttpHeaders headers;
+        if (query.hasQueryItem("_headers")) {
+            QJsonParseError e;
+            QJsonDocument doc = QJsonDocument::fromJson(
+                parsePercentEncoding(query.queryItemValue("_headers", Url::FullyEncoded).toUtf8()),
+                &e);
+            if (e.error != QJsonParseError::NoError || !doc.isObject()) {
+                log_debug("requestsession: id=%s invalid _headers parameter, rejecting",
+                          rid.second.data());
+                *ok = false;
+                *errorMessage = "Invalid _headers parameter.";
+                return false;
+            }
+
+            VariantMap headersMap = doc.object().toVariantMap();
+
+            for (auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit) {
+                if (typeId(vit.value()) != VariantType::String) {
+                    log_debug("requestsession: id=%s invalid _headers parameter, rejecting",
+                              rid.second.data());
+                    *ok = false;
+                    *errorMessage = "Invalid _headers parameter.";
+                    return false;
+                }
+
+                QByteArray key = vit.key().toUtf8();
+
+                // Ignore some headers that we explicitly set later on
+                if (qstricmp(key.data(), "host") == 0)
+                    continue;
+                if (qstricmp(key.data(), "accept") == 0)
+                    continue;
+
+                headers += HttpHeader(key, vit.value().toString().toUtf8());
+            }
+
+            query.removeAllQueryItems("_headers");
+        }
+
+        QByteArray body;
+        if (!bodyParam.isEmpty()) {
+            if (query.hasQueryItem(bodyParam)) {
+                body = parsePercentEncoding(
+                    query.queryItemValue(bodyParam, Url::FullyEncoded).toUtf8());
+                if (body.isNull()) {
+                    log_debug("requestsession: id=%s invalid body parameter, rejecting",
+                              rid.second.data());
+                    *ok = false;
+                    *errorMessage = "Invalid body parameter.";
+                    return false;
+                }
+
+                headers.removeAll("Content-Type");
+                headers += HttpHeader("Content-Type", "application/json");
+
+                query.removeAllQueryItems(bodyParam);
+            }
+        } else {
+            if (query.hasQueryItem("_body")) {
+                body = parsePercentEncoding(query.queryItemValue("_body").toUtf8());
+                if (body.isNull()) {
+                    log_debug("requestsession: id=%s invalid _body parameter, rejecting",
+                              rid.second.data());
+                    *ok = false;
+                    *errorMessage = "Invalid _body parameter.";
+                    return false;
+                }
+
+                query.removeAllQueryItems("_body");
+            }
+        }
+
+        uri.setQuery(query);
+
+        // If we have no query items anymore, strip the '?'
+        if (query.isEmpty()) {
+            QByteArray tmp = uri.toEncoded();
+            if (tmp.length() > 0 && tmp[tmp.length() - 1] == '?') {
+                tmp.truncate(tmp.length() - 1);
+                uri = Url::fromEncoded(tmp, Url::StrictMode);
+            }
+        }
+
+        if (method.isEmpty())
+            method = config.defaultMethod;
+
+        requestData.method = method;
+
+        requestData.uri = uri;
+
+        QByteArray hostHeader = uri.host().toUtf8();
+        if (uri.port() != -1)
+            hostHeader += ':' + QByteArray::number(uri.port());
+        headers += HttpHeader("Host", hostHeader);
+
+        headers += HttpHeader("Accept", "*/*");
+
+        // Carry over the rest of the headers
+        foreach (const HttpHeader &h, requestData.headers) {
+            if (qstricmp(h.first.data(), "host") == 0)
+                continue;
+            if (qstricmp(h.first.data(), "accept") == 0)
+                continue;
+
+            headers += h;
+        }
+
+        requestData.headers = headers;
+        in += body;
+
+        jsonpCallback = callback;
+        jsonpExtendedResponse = (config.mode == DomainMap::JsonpConfig::Extended);
+
+        return true;
+    }
 
 public:
-	void zhttpRequest_readyRead()
-	{
-		processIncomingRequest();
-	}
+    void zhttpRequest_readyRead() { processIncomingRequest(); }
 
-	void zhttpRequest_bytesWritten(int count)
-	{
-		std::weak_ptr<Private> self = q->d;
+    void zhttpRequest_bytesWritten(int count) {
+        std::weak_ptr<Private> self = q->d;
 
-		if(!jsonpCallback.isEmpty())
-		{
-			int actual = jsonpTracker.finished(count);
-			if(actual > 0)
-				q->bytesWritten(actual);
-		}
-		else
-			q->bytesWritten(count);
+        if (!jsonpCallback.isEmpty()) {
+            int actual = jsonpTracker.finished(count);
+            if (actual > 0)
+                q->bytesWritten(actual);
+        } else
+            q->bytesWritten(count);
 
-		if(self.expired())
-			return;
+        if (self.expired())
+            return;
 
-		if(zhttpRequest->isFinished())
-		{
-			cleanup();
-			q->finished();
-		}
-	}
+        if (zhttpRequest->isFinished()) {
+            cleanup();
+            q->finished();
+        }
+    }
 
-	void zhttpRequest_paused()
-	{
-		if(state == ReceivingForAccept)
-		{
-			ZhttpRequest::ServerState ss = zhttpRequest->serverState();
+    void zhttpRequest_paused() {
+        if (state == ReceivingForAccept) {
+            ZhttpRequest::ServerState ss = zhttpRequest->serverState();
 
-			AcceptData adata;
+            AcceptData adata;
 
-			AcceptData::Request areq;
-			areq.rid = rid;
-			areq.https = requestData.uri.scheme() == "https";
-			areq.peerAddress = peerAddress;
-			areq.logicalPeerAddress = logicalPeerAddress;
-			areq.debug = debug;
-			areq.autoCrossOrigin = autoCrossOrigin;
-			areq.jsonpCallback = jsonpCallback;
-			areq.jsonpExtendedResponse = jsonpExtendedResponse;
-			areq.inSeq = ss.inSeq;
-			areq.outSeq = ss.outSeq;
-			areq.outCredits = ss.outCredits;
-			areq.userData = ss.userData;
-			adata.requests += areq;
+            AcceptData::Request areq;
+            areq.rid = rid;
+            areq.https = requestData.uri.scheme() == "https";
+            areq.peerAddress = peerAddress;
+            areq.logicalPeerAddress = logicalPeerAddress;
+            areq.debug = debug;
+            areq.autoCrossOrigin = autoCrossOrigin;
+            areq.jsonpCallback = jsonpCallback;
+            areq.jsonpExtendedResponse = jsonpExtendedResponse;
+            areq.inSeq = ss.inSeq;
+            areq.outSeq = ss.outSeq;
+            areq.outCredits = ss.outCredits;
+            areq.userData = ss.userData;
+            adata.requests += areq;
 
-			adata.requestData = requestData;
-			adata.requestData.body = in.take();
+            adata.requestData = requestData;
+            adata.requestData.body = in.take();
 
-			adata.haveInspectData = true;
-			adata.inspectData = idata;
+            adata.haveInspectData = true;
+            adata.inspectData = idata;
 
-			adata.route = route.id;
-			adata.channelPrefix = route.prefix;
+            adata.route = route.id;
+            adata.channelPrefix = route.prefix;
 
-			acceptRequest = std::make_unique<AcceptRequest>(acceptManager);
-			acceptFinishedConnection = acceptRequest->finished.connect(boost::bind(&Private::acceptRequest_finished, this));
-			acceptRequest->start(adata);
-		}
-		else
-		{
-			q->paused();
-		}
-	}
+            acceptRequest = std::make_unique<AcceptRequest>(acceptManager);
+            acceptFinishedConnection = acceptRequest->finished.connect(
+                boost::bind(&Private::acceptRequest_finished, this));
+            acceptRequest->start(adata);
+        } else {
+            q->paused();
+        }
+    }
 
-	void zhttpRequest_error()
-	{
-		log_debug("requestsession: request error id=%s", rid.second.data());
-		cleanup();
-		q->finished();
-	}
+    void zhttpRequest_error() {
+        log_debug("requestsession: request error id=%s", rid.second.data());
+        cleanup();
+        q->finished();
+    }
 
-	void inspectRequest_finished()
-	{
-		if(!inspectRequest->success())
-		{
-			inspectFinishedConnection.disconnect();
-			inspectChecker->give(inspectRequest.release());
+    void inspectRequest_finished() {
+        if (!inspectRequest->success()) {
+            inspectFinishedConnection.disconnect();
+            inspectChecker->give(inspectRequest.release());
 
-			doInspectError();
-			return;
-		}
+            doInspectError();
+            return;
+        }
 
-		idata = inspectRequest->result();
+        idata = inspectRequest->result();
 
-		inspectFinishedConnection.disconnect();
-		inspectChecker->give(inspectRequest.release());
+        inspectFinishedConnection.disconnect();
+        inspectChecker->give(inspectRequest.release());
 
-		if(!idata.doProxy)
-		{
-			state = ReceivingForAccept;
+        if (!idata.doProxy) {
+            state = ReceivingForAccept;
 
-			// Successful inspect indicated we should not proxy. In that case,
-			// collect the body and accept
-			zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(boost::bind(&Private::zhttpRequest_readyRead, this));
-			processIncomingRequest();
-		}
-		else
-		{
-			if(!idata.sharingKey.isEmpty())
-			{
-				// A request can only be shared if we've read the entire
-				// request body, so let's try to read it now
-				state = Receiving;
+            // Successful inspect indicated we should not proxy. In that case,
+            // collect the body and accept
+            zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(
+                boost::bind(&Private::zhttpRequest_readyRead, this));
+            processIncomingRequest();
+        } else {
+            if (!idata.sharingKey.isEmpty()) {
+                // A request can only be shared if we've read the entire
+                // request body, so let's try to read it now
+                state = Receiving;
 
-				zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(boost::bind(&Private::zhttpRequest_readyRead, this));
-				processIncomingRequest();
-			}
-			else
-			{
-				state = WaitingForResponse;
-				requestData.body = in.take();
-				q->inspected(idata);
-			}
-		}
-	}
+                zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(
+                    boost::bind(&Private::zhttpRequest_readyRead, this));
+                processIncomingRequest();
+            } else {
+                state = WaitingForResponse;
+                requestData.body = in.take();
+                q->inspected(idata);
+            }
+        }
+    }
 
-	void acceptRequest_finished()
-	{
-		if(acceptRequest->success())
-		{
-			AcceptRequest::ResponseData rdata = acceptRequest->result();
+    void acceptRequest_finished() {
+        if (acceptRequest->success()) {
+            AcceptRequest::ResponseData rdata = acceptRequest->result();
 
-			acceptFinishedConnection.disconnect();
-			acceptRequest.reset();
+            acceptFinishedConnection.disconnect();
+            acceptRequest.reset();
 
-			if(rdata.accepted)
-			{
-				accepted = true;
+            if (rdata.accepted) {
+                accepted = true;
 
-				// The request was paused, so deleting it will leave the peer session active
-				zhttpReqConnections = ZhttpReqConnections();
-				delete zhttpRequest;
-				zhttpRequest = 0;
+                // The request was paused, so deleting it will leave the peer session
+                // active
+                zhttpReqConnections = ZhttpReqConnections();
+                delete zhttpRequest;
+                zhttpRequest = 0;
 
-				cleanup();
-				q->finishedByAccept();
-			}
-			else
-			{
-				if(rdata.response.code != -1)
-				{
-					zhttpRequest->resume();
-					respond(rdata.response.code, rdata.response.reason, rdata.response.headers, rdata.response.body);
-				}
-				else
-				{
-					zhttpRequest->resume();
-					respondCannotAccept();
-				}
-			}
-		}
-		else
-		{
-			acceptFinishedConnection.disconnect();
-			acceptRequest.reset();
+                cleanup();
+                q->finishedByAccept();
+            } else {
+                if (rdata.response.code != -1) {
+                    zhttpRequest->resume();
+                    respond(rdata.response.code, rdata.response.reason, rdata.response.headers,
+                            rdata.response.body);
+                } else {
+                    zhttpRequest->resume();
+                    respondCannotAccept();
+                }
+            }
+        } else {
+            acceptFinishedConnection.disconnect();
+            acceptRequest.reset();
 
-			zhttpRequest->resume();
-			respondCannotAccept();
-		}
-	}
+            zhttpRequest->resume();
+            respondCannotAccept();
+        }
+    }
 
-	void doResponseUpdate()
-	{
-		pendingResponseUpdate = false;
+    void doResponseUpdate() {
+        pendingResponseUpdate = false;
 
-		if(state == RespondingStart)
-		{
-			state = Responding;
+        if (state == RespondingStart) {
+            state = Responding;
 
-			if(!jsonpCallback.isEmpty())
-			{
-				HttpHeaders headers;
+            if (!jsonpCallback.isEmpty()) {
+                HttpHeaders headers;
 
-				if(responseBodyFinished)
-				{
-					QByteArray bodyRawBuf = out.take();
+                if (responseBodyFinished) {
+                    QByteArray bodyRawBuf = out.take();
 
-					if(!jsonpExtendedResponse)
-					{
-						// Trim any trailing newline before we wrap in a function call
-						if(bodyRawBuf.endsWith("\r\n"))
-							bodyRawBuf.truncate(bodyRawBuf.size() - 2);
-						else if(bodyRawBuf.endsWith("\n"))
-							bodyRawBuf.truncate(bodyRawBuf.size() - 1);
-					}
+                    if (!jsonpExtendedResponse) {
+                        // Trim any trailing newline before we wrap in a function call
+                        if (bodyRawBuf.endsWith("\r\n"))
+                            bodyRawBuf.truncate(bodyRawBuf.size() - 2);
+                        else if (bodyRawBuf.endsWith("\n"))
+                            bodyRawBuf.truncate(bodyRawBuf.size() - 1);
+                    }
 
-					QByteArray startBuf = makeJsonpStart(responseData.code, responseData.reason, responseData.headers);
-					QByteArray bodyBuf;
-					QByteArray endBuf = makeJsonpEnd();
-					if(!startBuf.isNull())
-						bodyBuf = makeJsonpBody(bodyRawBuf);
+                    QByteArray startBuf = makeJsonpStart(responseData.code, responseData.reason,
+                                                         responseData.headers);
+                    QByteArray bodyBuf;
+                    QByteArray endBuf = makeJsonpEnd();
+                    if (!startBuf.isNull())
+                        bodyBuf = makeJsonpBody(bodyRawBuf);
 
-					if(startBuf.isNull() || bodyBuf.isNull())
-					{
-						state = RespondingInternal;
+                    if (startBuf.isNull() || bodyBuf.isNull()) {
+                        state = RespondingInternal;
 
-						QByteArray body = "Upstream response could not be JSON-P encoded.\n";
-						headers += HttpHeader("Content-Type", "text/plain");
-						headers += HttpHeader("Content-Length", QByteArray::number(body.size()));
-						zhttpRequest->beginResponse(500, "Internal Server Error", headers);
-						zhttpRequest->writeBody(body);
-						responseBodySize += body.size();
-						zhttpRequest->endBody();
-						q->errorResponding();
-						return;
-					}
+                        QByteArray body = "Upstream response could not be JSON-P encoded.\n";
+                        headers += HttpHeader("Content-Type", "text/plain");
+                        headers += HttpHeader("Content-Length", QByteArray::number(body.size()));
+                        zhttpRequest->beginResponse(500, "Internal Server Error", headers);
+                        zhttpRequest->writeBody(body);
+                        responseBodySize += body.size();
+                        zhttpRequest->endBody();
+                        q->errorResponding();
+                        return;
+                    }
 
-					QByteArray buf = startBuf + bodyBuf + endBuf;
+                    QByteArray buf = startBuf + bodyBuf + endBuf;
 
-					headers += HttpHeader("Content-Type", "application/javascript");
-					headers += HttpHeader("Content-Length", QByteArray::number(buf.size()));
+                    headers += HttpHeader("Content-Type", "application/javascript");
+                    headers += HttpHeader("Content-Length", QByteArray::number(buf.size()));
 
-					// Mirror headers in the wrapping response
-					foreach(const HttpHeader &h, responseData.headers)
-					{
-						foreach(const QByteArray &eh, jsonpExtractableHeaders)
-						{
-							if(qstricmp(h.first.data(), eh.data()) == 0)
-							{
-								headers += h;
-								break;
-							}
-						}
-					}
+                    // Mirror headers in the wrapping response
+                    foreach (const HttpHeader &h, responseData.headers) {
+                        foreach (const QByteArray &eh, jsonpExtractableHeaders) {
+                            if (qstricmp(h.first.data(), eh.data()) == 0) {
+                                headers += h;
+                                break;
+                            }
+                        }
+                    }
 
-					zhttpReqConnections.bytesWrittenConnection = zhttpRequest->bytesWritten.connect(boost::bind(&Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
+                    zhttpReqConnections.bytesWrittenConnection =
+                        zhttpRequest->bytesWritten.connect(boost::bind(
+                            &Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
 
-					zhttpRequest->beginResponse(200, "OK", headers);
+                    zhttpRequest->beginResponse(200, "OK", headers);
 
-					jsonpTracker.addPlain(bodyRawBuf.size());
-					jsonpTracker.specifyEncoded(buf.size(), bodyRawBuf.size());
+                    jsonpTracker.addPlain(bodyRawBuf.size());
+                    jsonpTracker.specifyEncoded(buf.size(), bodyRawBuf.size());
 
-					zhttpRequest->writeBody(buf);
-					responseBodySize += buf.size();
-					zhttpRequest->endBody();
-					return;
-				}
+                    zhttpRequest->writeBody(buf);
+                    responseBodySize += buf.size();
+                    zhttpRequest->endBody();
+                    return;
+                }
 
-				QByteArray buf = makeJsonpStart(responseData.code, responseData.reason, responseData.headers);
-				if(buf.isNull())
-				{
-					state = RespondingInternal;
+                QByteArray buf =
+                    makeJsonpStart(responseData.code, responseData.reason, responseData.headers);
+                if (buf.isNull()) {
+                    state = RespondingInternal;
 
-					QByteArray body = "Upstream response could not be JSON-P encoded.\n";
-					headers += HttpHeader("Content-Type", "text/plain");
-					headers += HttpHeader("Content-Length", QByteArray::number(body.size()));
-					zhttpRequest->beginResponse(500, "Internal Server Error", headers);
-					zhttpRequest->writeBody(body);
-					responseBodySize += body.size();
-					zhttpRequest->endBody();
-					q->errorResponding();
-					return;
-				}
+                    QByteArray body = "Upstream response could not be JSON-P encoded.\n";
+                    headers += HttpHeader("Content-Type", "text/plain");
+                    headers += HttpHeader("Content-Length", QByteArray::number(body.size()));
+                    zhttpRequest->beginResponse(500, "Internal Server Error", headers);
+                    zhttpRequest->writeBody(body);
+                    responseBodySize += body.size();
+                    zhttpRequest->endBody();
+                    q->errorResponding();
+                    return;
+                }
 
-				headers += HttpHeader("Content-Type", "application/javascript");
-				headers += HttpHeader("Transfer-Encoding", "chunked");
+                headers += HttpHeader("Content-Type", "application/javascript");
+                headers += HttpHeader("Transfer-Encoding", "chunked");
 
-				zhttpReqConnections.bytesWrittenConnection = zhttpRequest->bytesWritten.connect(boost::bind(&Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
+                zhttpReqConnections.bytesWrittenConnection =
+                    zhttpRequest->bytesWritten.connect(boost::bind(
+                        &Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
 
-				zhttpRequest->beginResponse(200, "OK", headers);
+                zhttpRequest->beginResponse(200, "OK", headers);
 
-				jsonpTracker.specifyEncoded(buf.size(), 0);
+                jsonpTracker.specifyEncoded(buf.size(), 0);
 
-				zhttpRequest->writeBody(buf);
-				responseBodySize += buf.size();
-			}
-			else
-			{
-				if(autoCrossOrigin)
-					Cors::applyCorsHeaders(requestData.headers, &responseData.headers);
+                zhttpRequest->writeBody(buf);
+                responseBodySize += buf.size();
+            } else {
+                if (autoCrossOrigin)
+                    Cors::applyCorsHeaders(requestData.headers, &responseData.headers);
 
-				zhttpReqConnections.bytesWrittenConnection = zhttpRequest->bytesWritten.connect(boost::bind(&Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
+                zhttpReqConnections.bytesWrittenConnection =
+                    zhttpRequest->bytesWritten.connect(boost::bind(
+                        &Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
 
-				zhttpRequest->beginResponse(responseData.code, responseData.reason, responseData.headers);
-			}
-		}
+                zhttpRequest->beginResponse(responseData.code, responseData.reason,
+                                            responseData.headers);
+            }
+        }
 
-		if(!out.isEmpty())
-		{
-			if(!jsonpCallback.isEmpty())
-			{
-				QByteArray bodyRawBuf = out.take();
+        if (!out.isEmpty()) {
+            if (!jsonpCallback.isEmpty()) {
+                QByteArray bodyRawBuf = out.take();
 
-				if(!jsonpExtendedResponse)
-				{
-					if(responseBodyFinished)
-					{
-						// Trim any trailing newline before we wrap in a function call
-						if(bodyRawBuf.endsWith("\r\n"))
-							bodyRawBuf.truncate(bodyRawBuf.size() - 2);
-						else if(bodyRawBuf.endsWith("\n"))
-							bodyRawBuf.truncate(bodyRawBuf.size() - 1);
-					}
-					else
-					{
-						// Response isn't finished. Keep any trailing newline in the output buffer
-						if(bodyRawBuf.endsWith("\r\n"))
-						{
-							bodyRawBuf.truncate(bodyRawBuf.size() - 2);
-							out += QByteArray("\r\n");
-						}
-						else if(bodyRawBuf.endsWith("\n"))
-						{
-							bodyRawBuf.truncate(bodyRawBuf.size() - 1);
-							out += QByteArray("\n");
-						}
-					}
-				}
+                if (!jsonpExtendedResponse) {
+                    if (responseBodyFinished) {
+                        // Trim any trailing newline before we wrap in a function call
+                        if (bodyRawBuf.endsWith("\r\n"))
+                            bodyRawBuf.truncate(bodyRawBuf.size() - 2);
+                        else if (bodyRawBuf.endsWith("\n"))
+                            bodyRawBuf.truncate(bodyRawBuf.size() - 1);
+                    } else {
+                        // Response isn't finished. Keep any trailing newline in the output
+                        // buffer
+                        if (bodyRawBuf.endsWith("\r\n")) {
+                            bodyRawBuf.truncate(bodyRawBuf.size() - 2);
+                            out += QByteArray("\r\n");
+                        } else if (bodyRawBuf.endsWith("\n")) {
+                            bodyRawBuf.truncate(bodyRawBuf.size() - 1);
+                            out += QByteArray("\n");
+                        }
+                    }
+                }
 
-				QByteArray buf = makeJsonpBody(bodyRawBuf);
-				if(buf.isNull())
-				{
-					state = RespondingInternal;
+                QByteArray buf = makeJsonpBody(bodyRawBuf);
+                if (buf.isNull()) {
+                    state = RespondingInternal;
 
-					log_warning("requestsession: id=%s upstream response could not be JSON-P encoded", rid.second.data());
+                    log_warning("requestsession: id=%s upstream response could not be "
+                                "JSON-P encoded",
+                                rid.second.data());
 
-					// If we error while streaming, all we can do is give up
-					zhttpRequest->endBody();
-					q->errorResponding();
-					return;
-				}
+                    // If we error while streaming, all we can do is give up
+                    zhttpRequest->endBody();
+                    q->errorResponding();
+                    return;
+                }
 
-				jsonpTracker.addPlain(bodyRawBuf.size());
-				jsonpTracker.specifyEncoded(buf.size(), bodyRawBuf.size());
+                jsonpTracker.addPlain(bodyRawBuf.size());
+                jsonpTracker.specifyEncoded(buf.size(), bodyRawBuf.size());
 
-				zhttpRequest->writeBody(buf);
-				responseBodySize += buf.size();
-			}
-			else
-			{
-				QByteArray buf = out.take();
-				zhttpRequest->writeBody(buf);
-				responseBodySize += buf.size();
-			}
-		}
+                zhttpRequest->writeBody(buf);
+                responseBodySize += buf.size();
+            } else {
+                QByteArray buf = out.take();
+                zhttpRequest->writeBody(buf);
+                responseBodySize += buf.size();
+            }
+        }
 
-		if(responseBodyFinished)
-		{
-			assert(!needPause);
+        if (responseBodyFinished) {
+            assert(!needPause);
 
-			if(!jsonpCallback.isEmpty())
-			{
-				QByteArray buf = makeJsonpEnd();
-				jsonpTracker.specifyEncoded(buf.size(), 0);
-				zhttpRequest->writeBody(buf);
-				responseBodySize += buf.size();
-			}
+            if (!jsonpCallback.isEmpty()) {
+                QByteArray buf = makeJsonpEnd();
+                jsonpTracker.specifyEncoded(buf.size(), 0);
+                zhttpRequest->writeBody(buf);
+                responseBodySize += buf.size();
+            }
 
-			zhttpRequest->endBody();
-		}
-		else if(needPause)
-		{
-			needPause = false;
-			zhttpRequest->pause();
-		}
-	}
+            zhttpRequest->endBody();
+        } else if (needPause) {
+            needPause = false;
+            zhttpRequest->pause();
+        }
+    }
 
-	void respondSuccess(const QString &message)
-	{
-		respond(200, "OK", message.toUtf8() + '\n');
-	}
+    void respondSuccess(const QString &message) { respond(200, "OK", message.toUtf8() + '\n'); }
 
-	void doInspectError()
-	{
-		state = WaitingForResponse;
-		q->inspectError();
-	}
+    void doInspectError() {
+        state = WaitingForResponse;
+        q->inspectError();
+    }
 
-	void doFinished()
-	{
-		q->finished();
-	}
+    void doFinished() { q->finished(); }
 };
 
-RequestSession::RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *acceptManager, StatsManager *stats)
-{
-	d = std::make_shared<Private>(this, workerId, domainMap, sockJsManager, inspectManager, inspectChecker, acceptManager, stats);
+RequestSession::RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager,
+                               ZrpcManager *inspectManager, ZrpcChecker *inspectChecker,
+                               ZrpcManager *acceptManager, StatsManager *stats) {
+    d = std::make_shared<Private>(this, workerId, domainMap, sockJsManager, inspectManager,
+                                  inspectChecker, acceptManager, stats);
 }
 
 RequestSession::~RequestSession() = default;
 
-bool RequestSession::isRetry() const
-{
-	return d->isRetry;
+bool RequestSession::isRetry() const { return d->isRetry; }
+
+bool RequestSession::isHttps() const { return d->requestData.uri.scheme() == "https"; }
+
+bool RequestSession::isSockJs() const { return d->isSockJs; };
+
+bool RequestSession::trusted() const { return d->trusted; }
+
+QHostAddress RequestSession::peerAddress() const { return d->peerAddress; }
+
+QHostAddress RequestSession::logicalPeerAddress() const { return d->logicalPeerAddress; }
+
+ZhttpRequest::Rid RequestSession::rid() const { return d->rid; }
+
+HttpRequestData RequestSession::requestData() const { return d->requestData; }
+
+HttpResponseData RequestSession::responseData() const { return d->responseData; }
+
+int RequestSession::responseBodySize() const { return d->responseBodySize; }
+
+bool RequestSession::debugEnabled() const { return d->debug; }
+
+bool RequestSession::autoCrossOrigin() const { return d->autoCrossOrigin; }
+
+QByteArray RequestSession::jsonpCallback() const { return d->jsonpCallback; }
+
+bool RequestSession::jsonpExtendedResponse() const { return d->jsonpExtendedResponse; }
+
+bool RequestSession::haveCompleteRequestBody() const {
+    return (d->zhttpRequest->isInputFinished() && d->zhttpRequest->bytesAvailable() == 0);
 }
 
-bool RequestSession::isHttps() const
-{
-	return d->requestData.uri.scheme() == "https";
+DomainMap::Entry RequestSession::route() const { return d->route; }
+
+ZhttpRequest *RequestSession::request() { return d->zhttpRequest; }
+
+void RequestSession::setDebugEnabled(bool enabled) { d->debug = enabled; }
+
+void RequestSession::setAutoCrossOrigin(bool enabled) { d->autoCrossOrigin = enabled; }
+
+void RequestSession::setPrefetchSize(int size) { d->prefetchSize = size; }
+
+void RequestSession::setRoute(const DomainMap::Entry &route) { d->route = route; }
+
+void RequestSession::setRouteId(const QString &routeId) { d->routeId = routeId; }
+
+void RequestSession::setAutoShare(bool enabled) { d->autoShare = enabled; }
+
+void RequestSession::setAccepted(bool enabled) { d->accepted = enabled; }
+
+void RequestSession::setDefaultUpstreamKey(const Jwt::DecodingKey &key) {
+    d->defaultUpstreamKey = key;
 }
 
-bool RequestSession::isSockJs() const
-{
-	return d->isSockJs;
-};
-
-bool RequestSession::trusted() const
-{
-	return d->trusted;
+void RequestSession::setXffRules(const XffRule &untrusted, const XffRule &trusted) {
+    d->xffRule = untrusted;
+    d->xffTrustedRule = trusted;
 }
 
-QHostAddress RequestSession::peerAddress() const
-{
-	return d->peerAddress;
+void RequestSession::start(ZhttpRequest *req) { d->start(req); }
+
+void RequestSession::startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin,
+                                const QByteArray &jsonpCallback, bool jsonpExtendedResponse,
+                                int unreportedTime, int retrySeq) {
+    d->isRetry = true;
+    d->zhttpRequest = req;
+    d->rid = req->rid();
+    d->debug = debug;
+    d->autoCrossOrigin = autoCrossOrigin;
+    d->jsonpCallback = jsonpCallback;
+    d->jsonpExtendedResponse = jsonpExtendedResponse;
+    d->requestData.method = req->requestMethod();
+    d->requestData.uri = req->requestUri();
+    d->requestData.headers = req->requestHeaders();
+    d->requestData.body = req->readBody();
+
+    d->startRetry(unreportedTime, retrySeq);
 }
 
-QHostAddress RequestSession::logicalPeerAddress() const
-{
-	return d->logicalPeerAddress;
+void RequestSession::pause() {
+    assert(!d->responseBodyFinished);
+    d->needPause = true;
+
+    d->responseUpdate();
 }
 
-ZhttpRequest::Rid RequestSession::rid() const
-{
-	return d->rid;
+void RequestSession::resume() { d->zhttpRequest->resume(); }
+
+void RequestSession::startResponse(int code, const QByteArray &reason, const HttpHeaders &headers) {
+    assert(d->state == Private::ReceivingForAccept || d->state == Private::WaitingForResponse);
+
+    headerBytesSent(ZhttpManager::estimateResponseHeaderBytes(code, reason, headers));
+
+    d->state = Private::RespondingStart;
+    d->responseData.code = code;
+    d->responseData.reason = reason;
+    d->responseData.headers = headers;
+
+    d->responseUpdate();
 }
 
-HttpRequestData RequestSession::requestData() const
-{
-	return d->requestData;
+void RequestSession::writeResponseBody(const QByteArray &body) {
+    assert(d->state == Private::RespondingStart || d->state == Private::Responding);
+    assert(!d->responseBodyFinished);
+
+    bodyBytesSent(body.size());
+
+    d->out += body;
+    d->responseUpdate();
 }
 
-HttpResponseData RequestSession::responseData() const
-{
-	return d->responseData;
+void RequestSession::endResponseBody() {
+    assert(d->state == Private::RespondingStart || d->state == Private::Responding);
+    assert(!d->responseBodyFinished);
+
+    d->responseBodyFinished = true;
+    d->responseUpdate();
 }
 
-int RequestSession::responseBodySize() const
-{
-	return d->responseBodySize;
+void RequestSession::respond(int code, const QByteArray &reason, const HttpHeaders &headers,
+                             const QByteArray &body) {
+    d->respond(code, reason, headers, body);
 }
 
-bool RequestSession::debugEnabled() const
-{
-	return d->debug;
+void RequestSession::respondError(int code, const QString &reason, const QString &errorString) {
+    d->respondError(code, reason, errorString);
 }
 
-bool RequestSession::autoCrossOrigin() const
-{
-	return d->autoCrossOrigin;
-}
+void RequestSession::respondCannotAccept() { d->respondCannotAccept(); }
 
-QByteArray RequestSession::jsonpCallback() const
-{
-	return d->jsonpCallback;
-}
+int RequestSession::unregisterConnection() {
+    if (!d->connectionRegistered)
+        return 0;
 
-bool RequestSession::jsonpExtendedResponse() const
-{
-	return d->jsonpExtendedResponse;
-}
+    d->connectionRegistered = false;
 
-bool RequestSession::haveCompleteRequestBody() const
-{
-	return (d->zhttpRequest->isInputFinished() && d->zhttpRequest->bytesAvailable() == 0);
-}
-
-DomainMap::Entry RequestSession::route() const
-{
-	return d->route;
-}
-
-ZhttpRequest *RequestSession::request()
-{
-	return d->zhttpRequest;
-}
-
-void RequestSession::setDebugEnabled(bool enabled)
-{
-	d->debug = enabled;
-}
-
-void RequestSession::setAutoCrossOrigin(bool enabled)
-{
-	d->autoCrossOrigin = enabled;
-}
-
-void RequestSession::setPrefetchSize(int size)
-{
-	d->prefetchSize = size;
-}
-
-void RequestSession::setRoute(const DomainMap::Entry &route)
-{
-	d->route = route;
-}
-
-void RequestSession::setRouteId(const QString &routeId)
-{
-	d->routeId = routeId;
-}
-
-void RequestSession::setAutoShare(bool enabled)
-{
-	d->autoShare = enabled;
-}
-
-void RequestSession::setAccepted(bool enabled)
-{
-	d->accepted = enabled;
-}
-
-void RequestSession::setDefaultUpstreamKey(const Jwt::DecodingKey &key)
-{
-	d->defaultUpstreamKey = key;
-}
-
-void RequestSession::setXffRules(const XffRule &untrusted, const XffRule &trusted)
-{
-	d->xffRule = untrusted;
-	d->xffTrustedRule = trusted;
-}
-
-void RequestSession::start(ZhttpRequest *req)
-{
-	d->start(req);
-}
-
-void RequestSession::startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin, const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime, int retrySeq)
-{
-	d->isRetry = true;
-	d->zhttpRequest = req;
-	d->rid = req->rid();
-	d->debug = debug;
-	d->autoCrossOrigin = autoCrossOrigin;
-	d->jsonpCallback = jsonpCallback;
-	d->jsonpExtendedResponse = jsonpExtendedResponse;
-	d->requestData.method = req->requestMethod();
-	d->requestData.uri = req->requestUri();
-	d->requestData.headers = req->requestHeaders();
-	d->requestData.body = req->readBody();
-
-	d->startRetry(unreportedTime, retrySeq);
-}
-
-void RequestSession::pause()
-{
-	assert(!d->responseBodyFinished);
-	d->needPause = true;
-
-	d->responseUpdate();
-}
-
-void RequestSession::resume()
-{
-	d->zhttpRequest->resume();
-}
-
-void RequestSession::startResponse(int code, const QByteArray &reason, const HttpHeaders &headers)
-{
-	assert(d->state == Private::ReceivingForAccept || d->state == Private::WaitingForResponse);
-
-	headerBytesSent(ZhttpManager::estimateResponseHeaderBytes(code, reason, headers));
-
-	d->state = Private::RespondingStart;
-	d->responseData.code = code;
-	d->responseData.reason = reason;
-	d->responseData.headers = headers;
-
-	d->responseUpdate();
-}
-
-void RequestSession::writeResponseBody(const QByteArray &body)
-{
-	assert(d->state == Private::RespondingStart || d->state == Private::Responding);
-	assert(!d->responseBodyFinished);
-
-	bodyBytesSent(body.size());
-
-	d->out += body;
-	d->responseUpdate();
-}
-
-void RequestSession::endResponseBody()
-{
-	assert(d->state == Private::RespondingStart || d->state == Private::Responding);
-	assert(!d->responseBodyFinished);
-
-	d->responseBodyFinished = true;
-	d->responseUpdate();
-}
-
-void RequestSession::respond(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	d->respond(code, reason, headers, body);
-}
-
-void RequestSession::respondError(int code, const QString &reason, const QString &errorString)
-{
-	d->respondError(code, reason, errorString);
-}
-
-void RequestSession::respondCannotAccept()
-{
-	d->respondCannotAccept();
-}
-
-int RequestSession::unregisterConnection()
-{
-	if(!d->connectionRegistered)
-		return 0;
-
-	d->connectionRegistered = false;
-
-	QByteArray cid = ridToString(d->rid);
-	return d->stats->removeConnection(cid, false);
+    QByteArray cid = ridToString(d->rid);
+    return d->stats->removeConnection(cid, false);
 }

--- a/src/proxy/requestsession.h
+++ b/src/proxy/requestsession.h
@@ -24,9 +24,9 @@
 #ifndef REQUESTSESSION_H
 #define REQUESTSESSION_H
 
-#include <boost/signals2.hpp>
-#include "zhttprequest.h"
 #include "domainmap.h"
+#include "zhttprequest.h"
+#include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 using SignalInt = boost::signals2::signal<void(int)>;
@@ -35,7 +35,7 @@ using Connection = boost::signals2::scoped_connection;
 class QHostAddress;
 
 namespace Jwt {
-	class DecodingKey;
+class DecodingKey;
 }
 
 class HttpRequestData;
@@ -50,76 +50,80 @@ class XffRule;
 
 /// Manages the lifecycle of an individual HTTP request including
 /// inspection, acceptance, and response handling
-class RequestSession
-{
+class RequestSession {
 public:
-	RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager, ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats);
-	~RequestSession();
+    RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager,
+                   ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept,
+                   StatsManager *stats);
+    ~RequestSession();
 
-	bool isRetry() const;
-	bool isHttps() const;
-	bool isSockJs() const;
-	bool trusted() const;
-	QHostAddress peerAddress() const;
-	QHostAddress logicalPeerAddress() const;
-	ZhttpRequest::Rid rid() const;
-	HttpRequestData requestData() const;
-	HttpResponseData responseData() const;
-	int responseBodySize() const;
-	bool debugEnabled() const;
-	bool autoCrossOrigin() const;
-	QByteArray jsonpCallback() const; // Non-empty if JSON-P is used
-	bool jsonpExtendedResponse() const;
-	bool haveCompleteRequestBody() const;
-	DomainMap::Entry route() const;
+    bool isRetry() const;
+    bool isHttps() const;
+    bool isSockJs() const;
+    bool trusted() const;
+    QHostAddress peerAddress() const;
+    QHostAddress logicalPeerAddress() const;
+    ZhttpRequest::Rid rid() const;
+    HttpRequestData requestData() const;
+    HttpResponseData responseData() const;
+    int responseBodySize() const;
+    bool debugEnabled() const;
+    bool autoCrossOrigin() const;
+    QByteArray jsonpCallback() const; // Non-empty if JSON-P is used
+    bool jsonpExtendedResponse() const;
+    bool haveCompleteRequestBody() const;
+    DomainMap::Entry route() const;
 
-	ZhttpRequest *request();
+    ZhttpRequest *request();
 
-	void setDebugEnabled(bool enabled);
-	void setAutoCrossOrigin(bool enabled);
-	void setPrefetchSize(int size);
-	void setRoute(const DomainMap::Entry &route);
-	void setRouteId(const QString &routeId);
-	void setAutoShare(bool enabled);
-	void setAccepted(bool enabled);
-	void setDefaultUpstreamKey(const Jwt::DecodingKey &key);
-	void setXffRules(const XffRule &untrusted, const XffRule &trusted);
+    void setDebugEnabled(bool enabled);
+    void setAutoCrossOrigin(bool enabled);
+    void setPrefetchSize(int size);
+    void setRoute(const DomainMap::Entry &route);
+    void setRouteId(const QString &routeId);
+    void setAutoShare(bool enabled);
+    void setAccepted(bool enabled);
+    void setDefaultUpstreamKey(const Jwt::DecodingKey &key);
+    void setXffRules(const XffRule &untrusted, const XffRule &trusted);
 
-	// Takes ownership
-	void start(ZhttpRequest *req);
-	void startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin, const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime, int retrySeq);
+    // Takes ownership
+    void start(ZhttpRequest *req);
+    void startRetry(ZhttpRequest *req, bool debug, bool autoCrossOrigin,
+                    const QByteArray &jsonpCallback, bool jsonpExtendedResponse, int unreportedTime,
+                    int retrySeq);
 
-	void pause();
-	void resume();
+    void pause();
+    void resume();
 
-	void startResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
-	void writeResponseBody(const QByteArray &body);
-	void endResponseBody();
+    void startResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
+    void writeResponseBody(const QByteArray &body);
+    void endResponseBody();
 
-	void respond(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
-	void respondError(int code, const QString &reason, const QString &errorString);
-	void respondCannotAccept();
+    void respond(int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body);
+    void respondError(int code, const QString &reason, const QString &errorString);
+    void respondCannotAccept();
 
-	int unregisterConnection(); // Return unreported time
+    int unregisterConnection(); // Return unreported time
 
-	Signal inspectError;
-	boost::signals2::signal<void(const InspectData&)> inspected;
-	Signal finishedByAccept;
-	SignalInt bytesWritten;
-	Signal paused;
-	SignalInt headerBytesSent;
-	SignalInt bodyBytesSent;
-	// This signal means some error was encountered while responding and
-	// that you should not attempt to call further response-related
-	// methods. The object remains in an active state though, and so you
-	// should still wait for finished()
-	Signal errorResponding;
-	Signal finished;
+    Signal inspectError;
+    boost::signals2::signal<void(const InspectData &)> inspected;
+    Signal finishedByAccept;
+    SignalInt bytesWritten;
+    Signal paused;
+    SignalInt headerBytesSent;
+    SignalInt bodyBytesSent;
+    // This signal means some error was encountered while responding and
+    // that you should not attempt to call further response-related
+    // methods. The object remains in an active state though, and so you
+    // should still wait for finished()
+    Signal errorResponding;
+    Signal finished;
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 };
 
 #endif

--- a/src/proxy/routesfile.cpp
+++ b/src/proxy/routesfile.cpp
@@ -22,260 +22,205 @@
 
 #include "routesfile.h"
 
-#include <assert.h>
 #include "log.h"
+#include <assert.h>
 
 namespace RoutesFile {
 
-static int findNext(const QString &str, const QString &chars, int offset = 0)
-{
-	for(int n = offset; n < str.length(); ++n)
-	{
-		if(chars.contains(str[n]))
-			return n;
-	}
+static int findNext(const QString &str, const QString &chars, int offset = 0) {
+    for (int n = offset; n < str.length(); ++n) {
+        if (chars.contains(str[n]))
+            return n;
+    }
 
-	return -1;
+    return -1;
 }
 
-class LineParser
-{
+class LineParser {
 public:
-	class Token
-	{
-	public:
-		enum Type
-		{
-			Error,
-			InitialValue,
-			Prop,
-			EndOfLine
-		};
+    class Token {
+    public:
+        enum Type { Error, InitialValue, Prop, EndOfLine };
 
-		Type type;
-		QString value; // Error, initialvalue, prop
-		QString name; // Prop;
+        Type type;
+        QString value; // Error, initialvalue, prop
+        QString name;  // Prop;
 
-		Token() :
-			type((Type)-1)
-		{
-		}
+        Token() : type((Type)-1) {}
 
-		Token(Type _type) :
-			type(_type)
-		{
-		}
-	};
+        Token(Type _type) : type(_type) {}
+    };
 
-	enum State
-	{
-		ReadSeparator,
-		ReadInitialValue,
-		ReadProp
-	};
+    enum State { ReadSeparator, ReadInitialValue, ReadProp };
 
-	State state_;
-	QString str_;
-	int index_;
+    State state_;
+    QString str_;
+    int index_;
 
-	LineParser(const QString &line) :
-		state_(ReadSeparator),
-		str_(line),
-		index_(0)
-	{
-	}
+    LineParser(const QString &line) : state_(ReadSeparator), str_(line), index_(0) {}
 
-	Token nextToken()
-	{
-		int start = index_;
-		QString part;
+    Token nextToken() {
+        int start = index_;
+        QString part;
 
-		while(true)
-		{
-			//log_debug("%d [%s] %d", (int)state_, qPrintable(str_), index_);
+        while (true) {
+            // log_debug("%d [%s] %d", (int)state_, qPrintable(str_), index_);
 
-			if(state_ == ReadSeparator)
-			{
-				for(; index_ < str_.length(); ++index_)
-				{
-					if(str_[index_] != ' ')
-						break;
-				}
+            if (state_ == ReadSeparator) {
+                for (; index_ < str_.length(); ++index_) {
+                    if (str_[index_] != ' ')
+                        break;
+                }
 
-				if(index_ >= str_.length() || str_[index_] == '#')
-					return Token(Token::EndOfLine);
+                if (index_ >= str_.length() || str_[index_] == '#')
+                    return Token(Token::EndOfLine);
 
-				state_ = ReadInitialValue;
-				continue;
-			}
-			else // ReadInitialValue, ReadProp
-			{
-				int at = findNext(str_, "\", #", index_);
+                state_ = ReadInitialValue;
+                continue;
+            } else // ReadInitialValue, ReadProp
+            {
+                int at = findNext(str_, "\", #", index_);
 
-				// Quoted section?
-				if(at != -1 && str_[at] == '\"')
-				{
-					part += str_.mid(index_, at - index_);
-					++at;
+                // Quoted section?
+                if (at != -1 && str_[at] == '\"') {
+                    part += str_.mid(index_, at - index_);
+                    ++at;
 
-					// Decode inner string
-					for(; at < str_.length(); ++at)
-					{
-						if(str_[at] == '\\')
-						{
-							++at;
-							if(at >= str_.length())
-							{
-								Token token(Token::Error);
-								token.value = "unterminated escape sequence";
-								return token;
-							}
+                    // Decode inner string
+                    for (; at < str_.length(); ++at) {
+                        if (str_[at] == '\\') {
+                            ++at;
+                            if (at >= str_.length()) {
+                                Token token(Token::Error);
+                                token.value = "unterminated escape sequence";
+                                return token;
+                            }
 
-							if(str_[at] == '\\')
-								part += '\\';
-							else if(str_[at] == '\"')
-								part += '\"';
-							else
-							{
-								Token token(Token::Error);
-								token.value = QString("unexpected escape character: ") + str_[at];
-								return token;
-							}
-						}
-						else if(str_[at] == '\"')
-						{
-							break;
-						}
-						else
-						{
-							part += str_[at];
-						}
-					}
-					if(at >= str_.length())
-					{
-						Token token(Token::Error);
-						token.value = "unterminated quoted section";
-						return token;
-					}
+                            if (str_[at] == '\\')
+                                part += '\\';
+                            else if (str_[at] == '\"')
+                                part += '\"';
+                            else {
+                                Token token(Token::Error);
+                                token.value = QString("unexpected escape character: ") + str_[at];
+                                return token;
+                            }
+                        } else if (str_[at] == '\"') {
+                            break;
+                        } else {
+                            part += str_[at];
+                        }
+                    }
+                    if (at >= str_.length()) {
+                        Token token(Token::Error);
+                        token.value = "unterminated quoted section";
+                        return token;
+                    }
 
-					index_ = at + 1;
-					continue;
-				}
+                    index_ = at + 1;
+                    continue;
+                }
 
-				// All other chars, or end of string, means end of initial value or prop
+                // All other chars, or end of string, means end of initial value or prop
 
-				if(at == -1)
-					at = str_.length();
+                if (at == -1)
+                    at = str_.length();
 
-				part += str_.mid(index_, at - index_);
+                part += str_.mid(index_, at - index_);
 
-				Token token;
+                Token token;
 
-				if(state_ == ReadInitialValue)
-				{
-					int n = part.indexOf('=');
+                if (state_ == ReadInitialValue) {
+                    int n = part.indexOf('=');
 
-					// '=' in initial value?
-					if(n != -1)
-					{
-						// Return empty initial value, re-read as a prop
-						index_ = start;
-						state_ = ReadProp;
-						return Token(Token::InitialValue);
-					}
+                    // '=' in initial value?
+                    if (n != -1) {
+                        // Return empty initial value, re-read as a prop
+                        index_ = start;
+                        state_ = ReadProp;
+                        return Token(Token::InitialValue);
+                    }
 
-					token.type = Token::InitialValue;
-					token.value = part;
-				}
-				else // ReadProp
-				{
-					if(part.isEmpty())
-					{
-						Token token(Token::Error);
-						token.value = "expecting prop";
-						return token;
-					}
+                    token.type = Token::InitialValue;
+                    token.value = part;
+                } else // ReadProp
+                {
+                    if (part.isEmpty()) {
+                        Token token(Token::Error);
+                        token.value = "expecting prop";
+                        return token;
+                    }
 
-					QString name;
-					QString value;
+                    QString name;
+                    QString value;
 
-					int n = part.indexOf('=');
-					if(n != -1)
-					{
-						name = part.mid(0, n);
-						value = part.mid(n + 1);
-					}
-					else
-						name = part;
+                    int n = part.indexOf('=');
+                    if (n != -1) {
+                        name = part.mid(0, n);
+                        value = part.mid(n + 1);
+                    } else
+                        name = part;
 
-					if(name.isEmpty())
-					{
-						token.type = Token::Error;
-						token.value = "empty prop name";
-						return token;
-					}
+                    if (name.isEmpty()) {
+                        token.type = Token::Error;
+                        token.value = "empty prop name";
+                        return token;
+                    }
 
-					token.type = Token::Prop;
-					token.name = name;
-					token.value = value;
-				}
+                    token.type = Token::Prop;
+                    token.name = name;
+                    token.value = value;
+                }
 
-				if(at < str_.length() && str_[at] == ',')
-				{
-					++at;
-					state_ = ReadProp;
-				}
-				else // Space, #, or end of line
-				{
-					state_ = ReadSeparator;
-				}
+                if (at < str_.length() && str_[at] == ',') {
+                    ++at;
+                    state_ = ReadProp;
+                } else // Space, #, or end of line
+                {
+                    state_ = ReadSeparator;
+                }
 
-				index_ = at;
+                index_ = at;
 
-				return token;
-			}
-		}
-	}
+                return token;
+            }
+        }
+    }
 };
 
-QList<RouteSection> parseLine(const QString &line, bool *ok, QString *errorMessage)
-{
-	QList<RouteSection> out;
+QList<RouteSection> parseLine(const QString &line, bool *ok, QString *errorMessage) {
+    QList<RouteSection> out;
 
-	LineParser parser(line);
-	bool done = false;
-	while(!done)
-	{
-		LineParser::Token t = parser.nextToken();
-		//log_debug("token: %d [%s]", (int)t.type, qPrintable(t.value));
-		switch(t.type)
-		{
-			case LineParser::Token::Error:
-				if(ok)
-					*ok = false;
-				if(errorMessage)
-					*errorMessage = t.value;
-				return QList<RouteSection>();
-			case LineParser::Token::InitialValue:
-				{
-					RouteSection s;
-					s.value = t.value;
-					out += s;
-				}
-				break;
-			case LineParser::Token::Prop:
-				assert(!out.isEmpty());
-				out.last().props.insert(t.name, t.value);
-				break;
-			case LineParser::Token::EndOfLine:
-				done = true;
-				break;
-		}
-	}
+    LineParser parser(line);
+    bool done = false;
+    while (!done) {
+        LineParser::Token t = parser.nextToken();
+        // log_debug("token: %d [%s]", (int)t.type, qPrintable(t.value));
+        switch (t.type) {
+        case LineParser::Token::Error:
+            if (ok)
+                *ok = false;
+            if (errorMessage)
+                *errorMessage = t.value;
+            return QList<RouteSection>();
+        case LineParser::Token::InitialValue: {
+            RouteSection s;
+            s.value = t.value;
+            out += s;
+        } break;
+        case LineParser::Token::Prop:
+            assert(!out.isEmpty());
+            out.last().props.insert(t.name, t.value);
+            break;
+        case LineParser::Token::EndOfLine:
+            done = true;
+            break;
+        }
+    }
 
-	if(ok)
-		*ok = true;
-	return out;
+    if (ok)
+        *ok = true;
+    return out;
 }
 
-}
+} // namespace RoutesFile

--- a/src/proxy/routesfile.h
+++ b/src/proxy/routesfile.h
@@ -23,22 +23,21 @@
 #ifndef ROUTESFILE_H
 #define ROUTESFILE_H
 
-#include <QString>
 #include <QList>
 #include <QMultiHash>
+#include <QString>
 
 namespace RoutesFile {
 
-/// Single space-separated element from a route line 
-class RouteSection
-{
+/// Single space-separated element from a route line
+class RouteSection {
 public:
-	QString value;
-	QMultiHash<QString, QString> props;
+    QString value;
+    QMultiHash<QString, QString> props;
 };
 
 QList<RouteSection> parseLine(const QString &line, bool *ok = 0, QString *errorMessage = 0);
 
-}
+} // namespace RoutesFile
 
 #endif

--- a/src/proxy/routesfiletest.cpp
+++ b/src/proxy/routesfiletest.cpp
@@ -21,90 +21,88 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include "test.h"
 #include "routesfile.h"
+#include "test.h"
 
-static void lineTests()
-{
-	QList<RoutesFile::RouteSection> r;
-	bool ok;
+static void lineTests() {
+    QList<RoutesFile::RouteSection> r;
+    bool ok;
 
-	r = RoutesFile::parseLine("apple", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 1);
-	TEST_ASSERT_EQ(r[0].value, QString("apple"));
-	TEST_ASSERT(r[0].props.isEmpty());
+    r = RoutesFile::parseLine("apple", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 1);
+    TEST_ASSERT_EQ(r[0].value, QString("apple"));
+    TEST_ASSERT(r[0].props.isEmpty());
 
-	r = RoutesFile::parseLine("apple banana", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 2);
-	TEST_ASSERT_EQ(r[0].value, QString("apple"));
-	TEST_ASSERT(r[0].props.isEmpty());
-	TEST_ASSERT_EQ(r[1].value, QString("banana"));
-	TEST_ASSERT(r[1].props.isEmpty());
+    r = RoutesFile::parseLine("apple banana", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 2);
+    TEST_ASSERT_EQ(r[0].value, QString("apple"));
+    TEST_ASSERT(r[0].props.isEmpty());
+    TEST_ASSERT_EQ(r[1].value, QString("banana"));
+    TEST_ASSERT(r[1].props.isEmpty());
 
-	r = RoutesFile::parseLine("  apple   banana  # comment", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 2);
-	TEST_ASSERT_EQ(r[0].value, QString("apple"));
-	TEST_ASSERT(r[0].props.isEmpty());
-	TEST_ASSERT_EQ(r[1].value, QString("banana"));
-	TEST_ASSERT(r[1].props.isEmpty());
+    r = RoutesFile::parseLine("  apple   banana  # comment", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 2);
+    TEST_ASSERT_EQ(r[0].value, QString("apple"));
+    TEST_ASSERT(r[0].props.isEmpty());
+    TEST_ASSERT_EQ(r[1].value, QString("banana"));
+    TEST_ASSERT(r[1].props.isEmpty());
 
-	r = RoutesFile::parseLine("apple,organic,type=gala,from=\"washington, \\\"usa\\\"\"", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 1);
-	TEST_ASSERT_EQ(r[0].value, QString("apple"));
-	TEST_ASSERT_EQ(r[0].props.count(), 3);
-	TEST_ASSERT(r[0].props.contains("organic"));
-	TEST_ASSERT(r[0].props.value("organic").isEmpty());
-	TEST_ASSERT_EQ(r[0].props.value("type"), QString("gala"));
-	TEST_ASSERT_EQ(r[0].props.value("from"), QString("washington, \"usa\""));
+    r = RoutesFile::parseLine("apple,organic,type=gala,from=\"washington, \\\"usa\\\"\"", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 1);
+    TEST_ASSERT_EQ(r[0].value, QString("apple"));
+    TEST_ASSERT_EQ(r[0].props.count(), 3);
+    TEST_ASSERT(r[0].props.contains("organic"));
+    TEST_ASSERT(r[0].props.value("organic").isEmpty());
+    TEST_ASSERT_EQ(r[0].props.value("type"), QString("gala"));
+    TEST_ASSERT_EQ(r[0].props.value("from"), QString("washington, \"usa\""));
 
-	r = RoutesFile::parseLine("apple,organic banana cherry,type=bing", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 3);
-	TEST_ASSERT_EQ(r[0].value, QString("apple"));
-	TEST_ASSERT_EQ(r[0].props.count(), 1);
-	TEST_ASSERT(r[0].props.contains("organic"));
-	TEST_ASSERT(r[0].props.value("organic").isEmpty());
-	TEST_ASSERT_EQ(r[1].value, QString("banana"));
-	TEST_ASSERT(r[1].props.isEmpty());
-	TEST_ASSERT_EQ(r[2].value, QString("cherry"));
-	TEST_ASSERT_EQ(r[2].props.value("type"), QString("bing"));
+    r = RoutesFile::parseLine("apple,organic banana cherry,type=bing", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 3);
+    TEST_ASSERT_EQ(r[0].value, QString("apple"));
+    TEST_ASSERT_EQ(r[0].props.count(), 1);
+    TEST_ASSERT(r[0].props.contains("organic"));
+    TEST_ASSERT(r[0].props.value("organic").isEmpty());
+    TEST_ASSERT_EQ(r[1].value, QString("banana"));
+    TEST_ASSERT(r[1].props.isEmpty());
+    TEST_ASSERT_EQ(r[2].value, QString("cherry"));
+    TEST_ASSERT_EQ(r[2].props.value("type"), QString("bing"));
 
-	r = RoutesFile::parseLine(",organic", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 1);
-	TEST_ASSERT_EQ(r[0].value, QString(""));
-	TEST_ASSERT_EQ(r[0].props.count(), 1);
-	TEST_ASSERT(r[0].props.contains("organic"));
-	TEST_ASSERT(r[0].props.value("organic").isEmpty());
+    r = RoutesFile::parseLine(",organic", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 1);
+    TEST_ASSERT_EQ(r[0].value, QString(""));
+    TEST_ASSERT_EQ(r[0].props.count(), 1);
+    TEST_ASSERT(r[0].props.contains("organic"));
+    TEST_ASSERT(r[0].props.value("organic").isEmpty());
 
-	r = RoutesFile::parseLine("type=gala", &ok);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(r.count(), 1);
-	TEST_ASSERT_EQ(r[0].value, QString(""));
-	TEST_ASSERT_EQ(r[0].props.count(), 1);
-	TEST_ASSERT(r[0].props.contains("type"));
-	TEST_ASSERT_EQ(r[0].props.value("type"), QString("gala"));
+    r = RoutesFile::parseLine("type=gala", &ok);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(r.count(), 1);
+    TEST_ASSERT_EQ(r[0].value, QString(""));
+    TEST_ASSERT_EQ(r[0].props.count(), 1);
+    TEST_ASSERT(r[0].props.contains("type"));
+    TEST_ASSERT_EQ(r[0].props.value("type"), QString("gala"));
 
-	// Unterminated quote
-	r = RoutesFile::parseLine("apple,organic,type=\"gala", &ok);
-	TEST_ASSERT(!ok);
+    // Unterminated quote
+    r = RoutesFile::parseLine("apple,organic,type=\"gala", &ok);
+    TEST_ASSERT(!ok);
 
-	// Empty prop name
-	r = RoutesFile::parseLine("apple,organic,", &ok);
-	TEST_ASSERT(!ok);
+    // Empty prop name
+    r = RoutesFile::parseLine("apple,organic,", &ok);
+    TEST_ASSERT(!ok);
 
-	// Empty prop name
-	r = RoutesFile::parseLine("apple,organic,=gala", &ok);
-	TEST_ASSERT(!ok);
+    // Empty prop name
+    r = RoutesFile::parseLine("apple,organic,=gala", &ok);
+    TEST_ASSERT(!ok);
 }
 
-extern "C" int routesfile_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(lineTests());
+extern "C" int routesfile_test(ffi::TestException *out_ex) {
+    TEST_CATCH(lineTests());
 
-	return 0;
+    return 0;
 }

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -23,716 +23,631 @@
 
 #include "sockjsmanager.h"
 
-#include <assert.h>
-#include <QtGlobal>
-#include <QUrlQuery>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QCryptographicHash>
-#include <QRandomGenerator>
-#include "qtcompat.h"
-#include "variant.h"
-#include "log.h"
 #include "bufferlist.h"
+#include "log.h"
+#include "qtcompat.h"
+#include "sockjssession.h"
 #include "timer.h"
+#include "variant.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
-#include "sockjssession.h"
+#include <QCryptographicHash>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRandomGenerator>
+#include <QUrlQuery>
+#include <QtGlobal>
+#include <assert.h>
 
 using std::map;
 
 #define MAX_REQUEST_BODY 100000
 
 const char *iframeHtmlTemplate =
-"<!DOCTYPE html>\n"
-"<html>\n"
-"<head>\n"
-"  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />\n"
-"  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n"
-"  <script src=\"%1\"></script>\n"
-"  <script>\n"
-"    document.domain = document.domain;\n"
-"    SockJS.bootstrap_iframe();\n"
-"  </script>\n"
-"</head>\n"
-"<body>\n"
-"  <h2>Don't panic!</h2>\n"
-"  <p>This is a SockJS hidden iframe. It's used for cross domain magic.</p>\n"
-"</body>\n"
-"</html>\n";
+    "<!DOCTYPE html>\n"
+    "<html>\n"
+    "<head>\n"
+    "  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />\n"
+    "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" "
+    "/>\n"
+    "  <script src=\"%1\"></script>\n"
+    "  <script>\n"
+    "    document.domain = document.domain;\n"
+    "    SockJS.bootstrap_iframe();\n"
+    "  </script>\n"
+    "</head>\n"
+    "<body>\n"
+    "  <h2>Don't panic!</h2>\n"
+    "  <p>This is a SockJS hidden iframe. It's used for cross domain "
+    "magic.</p>\n"
+    "</body>\n"
+    "</html>\n";
 
-static QByteArray serializeJsonString(const QString &s)
-{
-	QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s)).toJson(QJsonDocument::Compact);
+static QByteArray serializeJsonString(const QString &s) {
+    QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s))
+                         .toJson(QJsonDocument::Compact);
 
-	assert(tmp.length() >= 4);
-	assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
-	assert(tmp[1] == '"' && tmp[tmp.length() - 2] == '"');
+    assert(tmp.length() >= 4);
+    assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
+    assert(tmp[1] == '"' && tmp[tmp.length() - 2] == '"');
 
-	return tmp.mid(1, tmp.length() - 2);
+    return tmp.mid(1, tmp.length() - 2);
 }
 
-class SockJsManager::Private
-{
+class SockJsManager::Private {
 public:
-	class Session
-	{
-	public:
-		enum Type
-		{
-			Http,
-			WebSocket
-		};
-
-		Private *owner;
-		Type type;
-		ZhttpRequest *req;
-		ZWebSocket *sock;
-		BufferList reqBody;
-		QByteArray path;
-		QByteArray jsonpCallback;
-		Url asUri;
-		DomainMap::Entry route;
-		QByteArray sid;
-		QByteArray lastPart;
-		bool pending;
-		SockJsSession *ext;
-		std::unique_ptr<Timer> timer;
-		Variant closeValue;
-		Connection timerConnection;
-
-		Session(Private *_owner) :
-			owner(_owner),
-			req(0),
-			sock(0),
-			pending(false),
-			ext(0)
-		{
-		}
-
-		~Session()
-		{
-			if(req)
-			{
-				owner->reqConnectionMap.erase(req);
-				delete req;
-			}
-			owner->wsConnectionMap.erase(sock);
-			delete sock;
-		}
-	};
-
-	struct WSConnections {
-		Connection closedConnection;
-		Connection errorConnection;
-	};
-
-	struct ZhttpReqConnections{
-		Connection readyReadConnection;
-		Connection bytesWrittenConnection;
-		Connection errorConnection;
-	};
-
-	SockJsManager *q;
-	QSet<Session*> sessions;
-	QHash<ZhttpRequest*, Session*> sessionsByRequest;
-	QHash<ZWebSocket*, Session*> sessionsBySocket;
-	QHash<QByteArray, Session*> sessionsById;
-	QHash<SockJsSession*, Session*> sessionsByExt;
-	QHash<Timer*, Session*> sessionsByTimer;
-	QList<Session*> pendingSessions;
-	QByteArray iframeHtml;
-	QByteArray iframeHtmlEtag;
-	QSet<ZhttpRequest*> discardedRequests;
-	map<ZhttpRequest*, ZhttpReqConnections> reqConnectionMap;
-	map<ZWebSocket*, WSConnections> wsConnectionMap;
-
-	Private(SockJsManager *_q, const QString &sockJsUrl) :
-		q(_q)
-	{
-		iframeHtml = QString(iframeHtmlTemplate).arg(sockJsUrl).toUtf8();
-		iframeHtmlEtag = '\"' + QCryptographicHash::hash(iframeHtml, QCryptographicHash::Md5).toHex() + '\"';
-	}
-
-	~Private()
-	{
-		qDeleteAll(discardedRequests);
-
-		while(!pendingSessions.isEmpty())
-			removeSession(pendingSessions.takeFirst());
-
-		assert(sessions.isEmpty());
-	}
-
-	void removeSession(Session *s)
-	{
-		// Can't remove unless unlinked
-		assert(!s->ext);
-
-		// Note: this method assumes the session has already been removed
-		// from pendingSessions if needed
-		if(s->req)
-			sessionsByRequest.remove(s->req);
-		if(s->sock)
-			sessionsBySocket.remove(s->sock);
-		if(!s->sid.isEmpty())
-			sessionsById.remove(s->sid);
-		if(s->ext)
-			sessionsByExt.remove(s->ext);
-		if(s->timer)
-			sessionsByTimer.remove(s->timer.get());
-		sessions.remove(s);
-		delete s;
-	}
-
-	void unlink(SockJsSession *ext)
-	{
-		Session *s = sessionsByExt.value(ext);
-		assert(s);
-
-		sessionsByExt.remove(s->ext);
-		s->ext = 0;
-
-		if(s->closeValue.isValid())
-		{
-			// If there's a close value, hang around for a little bit
-			s->timer = std::make_unique<Timer>();
-			s->timerConnection = s->timer->timeout.connect(boost::bind(&Private::timer_timeout, this, s->timer.get()));
-			s->timer->setSingleShot(true);
-			sessionsByTimer.insert(s->timer.get(), s);
-			s->timer->start(5000);
-		}
-		else
-			removeSession(s);
-	}
-
-	void setLinger(SockJsSession *ext, const Variant &closeValue)
-	{
-		Session *s = sessionsByExt.value(ext);
-		assert(s);
-
-		s->closeValue = closeValue;
-	}
-
-	void startHandleRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath, const DomainMap::Entry &route)
-	{
-		Session *s = new Session(this);
-		s->req = req;
-
-		Url uri = req->requestUri();
-
-		QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
-		s->path = encPath.mid(basePathStart);
-
-		QUrlQuery query(uri);
-
-		QList<QByteArray> parts = s->path.split('/');
-		if(!parts.isEmpty() && parts.last().startsWith("jsonp"))
-		{
-			if(query.hasQueryItem("callback"))
-			{
-				s->jsonpCallback = query.queryItemValue("callback").toUtf8();
-				query.removeAllQueryItems("callback");
-			}
-			else if(query.hasQueryItem("c"))
-			{
-				s->jsonpCallback = query.queryItemValue("c").toUtf8();
-				query.removeAllQueryItems("c");
-			}
-		}
-
-		s->asUri = uri;
-		s->asUri.setScheme((s->asUri.scheme() == "https") ? "wss" : "ws");
-		if(!asPath.isEmpty())
-			s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
-		else
-			s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart)), Url::StrictMode);
-
-		s->route = route;
-
-		reqConnectionMap[req] = {
-			req->readyRead.connect(boost::bind(&Private::req_readyRead, this, req)),
-			req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, req)),
-			req->error.connect(boost::bind(&Private::req_error, this, req))
-		};
-
-		sessions += s;
-		sessionsByRequest.insert(s->req, s);
-
-		processRequestInput(s);
-	}
-
-	void startHandleSocket(ZWebSocket *sock, int basePathStart, const QByteArray &asPath, const DomainMap::Entry &route)
-	{
-		Session *s = new Session(this);
-		s->sock = sock;
-
-		QByteArray encPath = sock->requestUri().path(Url::FullyEncoded).toUtf8();
-		s->path = encPath.mid(basePathStart);
-		s->asUri = sock->requestUri();
-		if(!asPath.isEmpty())
-			s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
-		else
-			s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart) + "/websocket"), Url::StrictMode);
-		s->route = route;
-
-		wsConnectionMap[sock] = {
-			sock->closed.connect(boost::bind(&Private::sock_closed, this, sock)),
-			sock->error.connect(boost::bind(&Private::sock_error, this, sock))
-		};
-
-		sessions += s;
-		sessionsBySocket.insert(s->sock, s);
-
-		handleSocket(s);
-	}
-
-	void applyHeaders(const HttpHeaders &in, HttpHeaders *out)
-	{
-		*out += HttpHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
-
-		QByteArray origin;
-		if(in.contains("Origin"))
-			origin = in.get("Origin").asQByteArray();
-		else
-			origin = "*";
-		*out += HttpHeader("Access-Control-Allow-Origin", origin);
-		*out += HttpHeader("Access-Control-Allow-Credentials", "true");
-	}
-
-	void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		HttpHeaders outHeaders = headers;
-		applyHeaders(req->requestHeaders(), &outHeaders);
-
-		req->beginResponse(code, reason, outHeaders);
-		req->writeBody(body);
-		req->endBody();
-	}
-
-	void respondEmpty(ZhttpRequest *req)
-	{
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "text/plain"); // Workaround FF issue. See sockjs spec.
-		respond(req, 204, "No Content", headers, QByteArray());
-	}
-
-	void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray())
-	{
-		HttpHeaders headers;
-		if(!jsonpCallback.isEmpty())
-			headers += HttpHeader("Content-Type", "application/javascript");
-		else
-			headers += HttpHeader("Content-Type", "text/plain");
-
-		QByteArray body;
-		if(data.isValid())
-		{
-			QJsonDocument doc;
-			if(typeId(data) == VariantType::Map)
-				doc = QJsonDocument(QJsonObject::fromVariantMap(data.toMap()));
-			else // List
-				doc = QJsonDocument(QJsonArray::fromVariantList(data.toList()));
-
-			body = doc.toJson(QJsonDocument::Compact);
-		}
-		if(!prefix.isEmpty())
-			body.prepend(prefix);
-
-		if(!jsonpCallback.isEmpty())
-		{
-			QByteArray encBody = serializeJsonString(QString::fromUtf8(body));
-			body = "/**/" + jsonpCallback + '(' + encBody + ");\n";
-		}
-		else if(!body.isEmpty())
-			body += "\n"; // Newline is required
-
-		respond(req, 200, "OK", headers, body);
-	}
-
-	void respondOk(ZhttpRequest *req, const QString &str, const QByteArray &jsonpCallback = QByteArray())
-	{
-		HttpHeaders headers;
-		if(!jsonpCallback.isEmpty())
-			headers += HttpHeader("Content-Type", "application/javascript");
-		else
-			headers += HttpHeader("Content-Type", "text/plain");
-
-		QByteArray body;
-		if(!jsonpCallback.isEmpty())
-		{
-			QByteArray encBody = serializeJsonString(str);
-			body = "/**/" + jsonpCallback + '(' + encBody + ");\n";
-		}
-		else
-			body = str.toUtf8();
-
-		respond(req, 200, "OK", headers, body);
-	}
-
-	void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message, bool discard = false)
-	{
-		// If discarded, manager takes ownership of req to handle sending
-		if(discard)
-		{
-			discardedRequests += req;
-
-			reqConnectionMap[req] = {
-				req->readyRead.connect(boost::bind(&Private::req_readyRead, this, req)),
-				req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, req)),
-				req->error.connect(boost::bind(&Private::req_error, this, req))
-			};
-		}
-
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "text/plain");
-		respond(req, code, reason, headers, message.toUtf8() + '\n');
-	}
-
-	void respondError(ZWebSocket *sock, int code, const QByteArray &reason, const QString &message)
-	{
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "text/plain");
-		sock->respondError(code, reason, headers, message.toUtf8() + '\n');
-	}
-
-	void processRequestInput(Session *s)
-	{
-		s->reqBody += s->req->readBody(MAX_REQUEST_BODY - s->reqBody.size() + 1);
-		if(s->reqBody.size() > MAX_REQUEST_BODY)
-		{
-			respondError(s->req, 400, "Bad Request", "Request too large.");
-			return;
-		}
-
-		if(s->req->isInputFinished())
-			handleRequest(s);
-	}
-
-	void handleRequest(Session *s)
-	{
-		QString method = s->req->requestMethod();
-		log_debug("sockjs request: path=[%s], asUri=[%s]", s->path.data(), s->asUri.toEncoded().data());
-
-		if(method == "OPTIONS")
-		{
-			respondEmpty(s->req);
-		}
-		else if(method == "GET" && s->path == "/info")
-		{
-			uint32_t x = QRandomGenerator::global()->generate();
-
-			VariantMap out;
-			out["websocket"] = true;
-			out["origins"] = VariantList() << QString("*:*");
-			out["cookie_needed"] = false;
-			out["entropy"] = x;
-			respondOk(s->req, out);
-		}
-		else if(method == "GET" && s->path.startsWith("/iframe") && s->path.endsWith(".html"))
-		{
-			HttpHeaders headers;
-			headers += HttpHeader("ETag", iframeHtmlEtag);
-
-			QByteArray ifNoneMatch = s->req->requestHeaders().get("If-None-Match").asQByteArray();
-			if(ifNoneMatch == iframeHtmlEtag)
-			{
-				respond(s->req, 304, "Not Modified", headers, QByteArray());
-			}
-			else
-			{
-				headers += HttpHeader("Content-Type", "text/html; charset=UTF-8");
-				headers += HttpHeader("Cache-Control", "public, max-age=31536000");
-				respond(s->req, 200, "OK", headers, iframeHtml);
-			}
-		}
-		else
-		{
-			QList<QByteArray> parts = s->path.mid(1).split('/');
-			if(parts.count() == 3)
-			{
-				QByteArray sid = parts[1];
-				QByteArray lastPart = parts[2];
-
-				Session *existing = sessionsById.value(sid);
-				if(existing)
-				{
-					if(existing->ext)
-					{
-						// Give to external session
-						ZhttpRequest *req = s->req;
-						QByteArray body = s->reqBody.toByteArray();
-						QByteArray jsonpCallback = s->jsonpCallback;
-						reqConnectionMap.erase(req);
-						s->req = 0;
-						removeSession(s);
-
-						existing->ext->handleRequest(req, jsonpCallback, lastPart, body);
-					}
-					else
-					{
-						if(existing->closeValue.isValid())
-						{
-							respondOk(s->req, existing->closeValue, "c", s->jsonpCallback);
-						}
-						else
-						{
-							VariantList out;
-							out += 2010;
-							out += QString("Another connection still open");
-							respondOk(s->req, out, "c", s->jsonpCallback);
-						}
-					}
-					return;
-				}
-
-				if((method == "POST" && lastPart == "xhr") || ((method == "GET" || method == "POST") && lastPart == "jsonp"))
-				{
-					if(lastPart == "jsonp" && s->jsonpCallback.isEmpty())
-					{
-						respondError(s->req, 400, "Bad Request", "Bad Request");
-						return;
-					}
-
-					s->sid = sid;
-					s->lastPart = lastPart;
-					sessionsById.insert(s->sid, s);
-					s->pending = true;
-					pendingSessions += s;
-					q->sessionReady();
-					return;
-				}
-			}
-
-			respondError(s->req, 404, "Not Found", "Not Found");
-		}
-	}
-
-	void handleSocket(Session *s)
-	{
-		if(s->path == "/websocket")
-		{
-			s->pending = true;
-			pendingSessions += s;
-			q->sessionReady();
-			return;
-		}
-		else
-		{
-			QList<QByteArray> parts = s->path.mid(1).split('/');
-			if(parts.count() == 3)
-			{
-				QByteArray sid = parts[1];
-				QByteArray lastPart = parts[2];
-
-				s->sid = sid;
-				s->lastPart = lastPart;
-				s->pending = true;
-				pendingSessions += s;
-				q->sessionReady();
-				return;
-			}
-
-			respondError(s->sock, 404, "Not Found", "Not Found");
-		}
-	}
-
-	SockJsSession *takeNext()
-	{
-		Session *s = 0;
-
-		while(!s)
-		{
-			if(pendingSessions.isEmpty())
-				return 0;
-
-			s = pendingSessions.takeFirst();
-			s->pending = false;
-			if(!s->req && !s->sock)
-			{
-				// This means the object was a zombie. Clean up and take next
-				removeSession(s);
-				s = 0;
-				continue;
-			}
-		}
-
-		s->ext = new SockJsSession;
-
-		if(s->req)
-		{
-			assert(!s->sid.isEmpty());
-			assert(!s->lastPart.isEmpty());
-
-			s->ext->setupServer(q, s->req, s->jsonpCallback, s->asUri, s->sid, s->lastPart, s->reqBody.toByteArray(), s->route);
-
-			reqConnectionMap.erase(s->req);
-			sessionsByRequest.remove(s->req);
-			s->req = 0;
-		}
-		else // S->sock
-		{
-			if(!s->sid.isEmpty())
-			{
-				assert(!s->lastPart.isEmpty());
-				s->ext->setupServer(q, s->sock, s->asUri, s->sid, s->lastPart, s->route);
-			}
-			else
-				s->ext->setupServer(q, s->sock, s->asUri, s->route);
-
-			wsConnectionMap.erase(s->sock);
-			sessionsBySocket.remove(s->sock);
-			s->sock = 0;
-		}
-
-		sessionsByExt.insert(s->ext, s);
-		s->ext->startServer();
-		return s->ext;
-	}
+    class Session {
+    public:
+        enum Type { Http, WebSocket };
+
+        Private *owner;
+        Type type;
+        ZhttpRequest *req;
+        ZWebSocket *sock;
+        BufferList reqBody;
+        QByteArray path;
+        QByteArray jsonpCallback;
+        Url asUri;
+        DomainMap::Entry route;
+        QByteArray sid;
+        QByteArray lastPart;
+        bool pending;
+        SockJsSession *ext;
+        std::unique_ptr<Timer> timer;
+        Variant closeValue;
+        Connection timerConnection;
+
+        Session(Private *_owner) : owner(_owner), req(0), sock(0), pending(false), ext(0) {}
+
+        ~Session() {
+            if (req) {
+                owner->reqConnectionMap.erase(req);
+                delete req;
+            }
+            owner->wsConnectionMap.erase(sock);
+            delete sock;
+        }
+    };
+
+    struct WSConnections {
+        Connection closedConnection;
+        Connection errorConnection;
+    };
+
+    struct ZhttpReqConnections {
+        Connection readyReadConnection;
+        Connection bytesWrittenConnection;
+        Connection errorConnection;
+    };
+
+    SockJsManager *q;
+    QSet<Session *> sessions;
+    QHash<ZhttpRequest *, Session *> sessionsByRequest;
+    QHash<ZWebSocket *, Session *> sessionsBySocket;
+    QHash<QByteArray, Session *> sessionsById;
+    QHash<SockJsSession *, Session *> sessionsByExt;
+    QHash<Timer *, Session *> sessionsByTimer;
+    QList<Session *> pendingSessions;
+    QByteArray iframeHtml;
+    QByteArray iframeHtmlEtag;
+    QSet<ZhttpRequest *> discardedRequests;
+    map<ZhttpRequest *, ZhttpReqConnections> reqConnectionMap;
+    map<ZWebSocket *, WSConnections> wsConnectionMap;
+
+    Private(SockJsManager *_q, const QString &sockJsUrl) : q(_q) {
+        iframeHtml = QString(iframeHtmlTemplate).arg(sockJsUrl).toUtf8();
+        iframeHtmlEtag =
+            '\"' + QCryptographicHash::hash(iframeHtml, QCryptographicHash::Md5).toHex() + '\"';
+    }
+
+    ~Private() {
+        qDeleteAll(discardedRequests);
+
+        while (!pendingSessions.isEmpty())
+            removeSession(pendingSessions.takeFirst());
+
+        assert(sessions.isEmpty());
+    }
+
+    void removeSession(Session *s) {
+        // Can't remove unless unlinked
+        assert(!s->ext);
+
+        // Note: this method assumes the session has already been removed
+        // from pendingSessions if needed
+        if (s->req)
+            sessionsByRequest.remove(s->req);
+        if (s->sock)
+            sessionsBySocket.remove(s->sock);
+        if (!s->sid.isEmpty())
+            sessionsById.remove(s->sid);
+        if (s->ext)
+            sessionsByExt.remove(s->ext);
+        if (s->timer)
+            sessionsByTimer.remove(s->timer.get());
+        sessions.remove(s);
+        delete s;
+    }
+
+    void unlink(SockJsSession *ext) {
+        Session *s = sessionsByExt.value(ext);
+        assert(s);
+
+        sessionsByExt.remove(s->ext);
+        s->ext = 0;
+
+        if (s->closeValue.isValid()) {
+            // If there's a close value, hang around for a little bit
+            s->timer = std::make_unique<Timer>();
+            s->timerConnection = s->timer->timeout.connect(
+                boost::bind(&Private::timer_timeout, this, s->timer.get()));
+            s->timer->setSingleShot(true);
+            sessionsByTimer.insert(s->timer.get(), s);
+            s->timer->start(5000);
+        } else
+            removeSession(s);
+    }
+
+    void setLinger(SockJsSession *ext, const Variant &closeValue) {
+        Session *s = sessionsByExt.value(ext);
+        assert(s);
+
+        s->closeValue = closeValue;
+    }
+
+    void startHandleRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath,
+                            const DomainMap::Entry &route) {
+        Session *s = new Session(this);
+        s->req = req;
+
+        Url uri = req->requestUri();
+
+        QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
+        s->path = encPath.mid(basePathStart);
+
+        QUrlQuery query(uri);
+
+        QList<QByteArray> parts = s->path.split('/');
+        if (!parts.isEmpty() && parts.last().startsWith("jsonp")) {
+            if (query.hasQueryItem("callback")) {
+                s->jsonpCallback = query.queryItemValue("callback").toUtf8();
+                query.removeAllQueryItems("callback");
+            } else if (query.hasQueryItem("c")) {
+                s->jsonpCallback = query.queryItemValue("c").toUtf8();
+                query.removeAllQueryItems("c");
+            }
+        }
+
+        s->asUri = uri;
+        s->asUri.setScheme((s->asUri.scheme() == "https") ? "wss" : "ws");
+        if (!asPath.isEmpty())
+            s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
+        else
+            s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart)), Url::StrictMode);
+
+        s->route = route;
+
+        reqConnectionMap[req] = {
+            req->readyRead.connect(boost::bind(&Private::req_readyRead, this, req)),
+            req->bytesWritten.connect(
+                boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, req)),
+            req->error.connect(boost::bind(&Private::req_error, this, req))};
+
+        sessions += s;
+        sessionsByRequest.insert(s->req, s);
+
+        processRequestInput(s);
+    }
+
+    void startHandleSocket(ZWebSocket *sock, int basePathStart, const QByteArray &asPath,
+                           const DomainMap::Entry &route) {
+        Session *s = new Session(this);
+        s->sock = sock;
+
+        QByteArray encPath = sock->requestUri().path(Url::FullyEncoded).toUtf8();
+        s->path = encPath.mid(basePathStart);
+        s->asUri = sock->requestUri();
+        if (!asPath.isEmpty())
+            s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
+        else
+            s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart) + "/websocket"),
+                             Url::StrictMode);
+        s->route = route;
+
+        wsConnectionMap[sock] = {
+            sock->closed.connect(boost::bind(&Private::sock_closed, this, sock)),
+            sock->error.connect(boost::bind(&Private::sock_error, this, sock))};
+
+        sessions += s;
+        sessionsBySocket.insert(s->sock, s);
+
+        handleSocket(s);
+    }
+
+    void applyHeaders(const HttpHeaders &in, HttpHeaders *out) {
+        *out += HttpHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+
+        QByteArray origin;
+        if (in.contains("Origin"))
+            origin = in.get("Origin").asQByteArray();
+        else
+            origin = "*";
+        *out += HttpHeader("Access-Control-Allow-Origin", origin);
+        *out += HttpHeader("Access-Control-Allow-Credentials", "true");
+    }
+
+    void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body) {
+        HttpHeaders outHeaders = headers;
+        applyHeaders(req->requestHeaders(), &outHeaders);
+
+        req->beginResponse(code, reason, outHeaders);
+        req->writeBody(body);
+        req->endBody();
+    }
+
+    void respondEmpty(ZhttpRequest *req) {
+        HttpHeaders headers;
+        headers +=
+            HttpHeader("Content-Type", "text/plain"); // Workaround FF issue. See sockjs spec.
+        respond(req, 204, "No Content", headers, QByteArray());
+    }
+
+    void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(),
+                   const QByteArray &jsonpCallback = QByteArray()) {
+        HttpHeaders headers;
+        if (!jsonpCallback.isEmpty())
+            headers += HttpHeader("Content-Type", "application/javascript");
+        else
+            headers += HttpHeader("Content-Type", "text/plain");
+
+        QByteArray body;
+        if (data.isValid()) {
+            QJsonDocument doc;
+            if (typeId(data) == VariantType::Map)
+                doc = QJsonDocument(QJsonObject::fromVariantMap(data.toMap()));
+            else // List
+                doc = QJsonDocument(QJsonArray::fromVariantList(data.toList()));
+
+            body = doc.toJson(QJsonDocument::Compact);
+        }
+        if (!prefix.isEmpty())
+            body.prepend(prefix);
+
+        if (!jsonpCallback.isEmpty()) {
+            QByteArray encBody = serializeJsonString(QString::fromUtf8(body));
+            body = "/**/" + jsonpCallback + '(' + encBody + ");\n";
+        } else if (!body.isEmpty())
+            body += "\n"; // Newline is required
+
+        respond(req, 200, "OK", headers, body);
+    }
+
+    void respondOk(ZhttpRequest *req, const QString &str,
+                   const QByteArray &jsonpCallback = QByteArray()) {
+        HttpHeaders headers;
+        if (!jsonpCallback.isEmpty())
+            headers += HttpHeader("Content-Type", "application/javascript");
+        else
+            headers += HttpHeader("Content-Type", "text/plain");
+
+        QByteArray body;
+        if (!jsonpCallback.isEmpty()) {
+            QByteArray encBody = serializeJsonString(str);
+            body = "/**/" + jsonpCallback + '(' + encBody + ");\n";
+        } else
+            body = str.toUtf8();
+
+        respond(req, 200, "OK", headers, body);
+    }
+
+    void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message,
+                      bool discard = false) {
+        // If discarded, manager takes ownership of req to handle sending
+        if (discard) {
+            discardedRequests += req;
+
+            reqConnectionMap[req] = {
+                req->readyRead.connect(boost::bind(&Private::req_readyRead, this, req)),
+                req->bytesWritten.connect(
+                    boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, req)),
+                req->error.connect(boost::bind(&Private::req_error, this, req))};
+        }
+
+        HttpHeaders headers;
+        headers += HttpHeader("Content-Type", "text/plain");
+        respond(req, code, reason, headers, message.toUtf8() + '\n');
+    }
+
+    void respondError(ZWebSocket *sock, int code, const QByteArray &reason,
+                      const QString &message) {
+        HttpHeaders headers;
+        headers += HttpHeader("Content-Type", "text/plain");
+        sock->respondError(code, reason, headers, message.toUtf8() + '\n');
+    }
+
+    void processRequestInput(Session *s) {
+        s->reqBody += s->req->readBody(MAX_REQUEST_BODY - s->reqBody.size() + 1);
+        if (s->reqBody.size() > MAX_REQUEST_BODY) {
+            respondError(s->req, 400, "Bad Request", "Request too large.");
+            return;
+        }
+
+        if (s->req->isInputFinished())
+            handleRequest(s);
+    }
+
+    void handleRequest(Session *s) {
+        QString method = s->req->requestMethod();
+        log_debug("sockjs request: path=[%s], asUri=[%s]", s->path.data(),
+                  s->asUri.toEncoded().data());
+
+        if (method == "OPTIONS") {
+            respondEmpty(s->req);
+        } else if (method == "GET" && s->path == "/info") {
+            uint32_t x = QRandomGenerator::global()->generate();
+
+            VariantMap out;
+            out["websocket"] = true;
+            out["origins"] = VariantList() << QString("*:*");
+            out["cookie_needed"] = false;
+            out["entropy"] = x;
+            respondOk(s->req, out);
+        } else if (method == "GET" && s->path.startsWith("/iframe") && s->path.endsWith(".html")) {
+            HttpHeaders headers;
+            headers += HttpHeader("ETag", iframeHtmlEtag);
+
+            QByteArray ifNoneMatch = s->req->requestHeaders().get("If-None-Match").asQByteArray();
+            if (ifNoneMatch == iframeHtmlEtag) {
+                respond(s->req, 304, "Not Modified", headers, QByteArray());
+            } else {
+                headers += HttpHeader("Content-Type", "text/html; charset=UTF-8");
+                headers += HttpHeader("Cache-Control", "public, max-age=31536000");
+                respond(s->req, 200, "OK", headers, iframeHtml);
+            }
+        } else {
+            QList<QByteArray> parts = s->path.mid(1).split('/');
+            if (parts.count() == 3) {
+                QByteArray sid = parts[1];
+                QByteArray lastPart = parts[2];
+
+                Session *existing = sessionsById.value(sid);
+                if (existing) {
+                    if (existing->ext) {
+                        // Give to external session
+                        ZhttpRequest *req = s->req;
+                        QByteArray body = s->reqBody.toByteArray();
+                        QByteArray jsonpCallback = s->jsonpCallback;
+                        reqConnectionMap.erase(req);
+                        s->req = 0;
+                        removeSession(s);
+
+                        existing->ext->handleRequest(req, jsonpCallback, lastPart, body);
+                    } else {
+                        if (existing->closeValue.isValid()) {
+                            respondOk(s->req, existing->closeValue, "c", s->jsonpCallback);
+                        } else {
+                            VariantList out;
+                            out += 2010;
+                            out += QString("Another connection still open");
+                            respondOk(s->req, out, "c", s->jsonpCallback);
+                        }
+                    }
+                    return;
+                }
+
+                if ((method == "POST" && lastPart == "xhr") ||
+                    ((method == "GET" || method == "POST") && lastPart == "jsonp")) {
+                    if (lastPart == "jsonp" && s->jsonpCallback.isEmpty()) {
+                        respondError(s->req, 400, "Bad Request", "Bad Request");
+                        return;
+                    }
+
+                    s->sid = sid;
+                    s->lastPart = lastPart;
+                    sessionsById.insert(s->sid, s);
+                    s->pending = true;
+                    pendingSessions += s;
+                    q->sessionReady();
+                    return;
+                }
+            }
+
+            respondError(s->req, 404, "Not Found", "Not Found");
+        }
+    }
+
+    void handleSocket(Session *s) {
+        if (s->path == "/websocket") {
+            s->pending = true;
+            pendingSessions += s;
+            q->sessionReady();
+            return;
+        } else {
+            QList<QByteArray> parts = s->path.mid(1).split('/');
+            if (parts.count() == 3) {
+                QByteArray sid = parts[1];
+                QByteArray lastPart = parts[2];
+
+                s->sid = sid;
+                s->lastPart = lastPart;
+                s->pending = true;
+                pendingSessions += s;
+                q->sessionReady();
+                return;
+            }
+
+            respondError(s->sock, 404, "Not Found", "Not Found");
+        }
+    }
+
+    SockJsSession *takeNext() {
+        Session *s = 0;
+
+        while (!s) {
+            if (pendingSessions.isEmpty())
+                return 0;
+
+            s = pendingSessions.takeFirst();
+            s->pending = false;
+            if (!s->req && !s->sock) {
+                // This means the object was a zombie. Clean up and take next
+                removeSession(s);
+                s = 0;
+                continue;
+            }
+        }
+
+        s->ext = new SockJsSession;
+
+        if (s->req) {
+            assert(!s->sid.isEmpty());
+            assert(!s->lastPart.isEmpty());
+
+            s->ext->setupServer(q, s->req, s->jsonpCallback, s->asUri, s->sid, s->lastPart,
+                                s->reqBody.toByteArray(), s->route);
+
+            reqConnectionMap.erase(s->req);
+            sessionsByRequest.remove(s->req);
+            s->req = 0;
+        } else // S->sock
+        {
+            if (!s->sid.isEmpty()) {
+                assert(!s->lastPart.isEmpty());
+                s->ext->setupServer(q, s->sock, s->asUri, s->sid, s->lastPart, s->route);
+            } else
+                s->ext->setupServer(q, s->sock, s->asUri, s->route);
+
+            wsConnectionMap.erase(s->sock);
+            sessionsBySocket.remove(s->sock);
+            s->sock = 0;
+        }
+
+        sessionsByExt.insert(s->ext, s);
+        s->ext->startServer();
+        return s->ext;
+    }
 
 private:
-	void req_readyRead(ZhttpRequest *req)
-	{
-		// For a request to have been discardable, we must have read the
-		// entire input already and handed to the session
-		assert(!discardedRequests.contains(req));
+    void req_readyRead(ZhttpRequest *req) {
+        // For a request to have been discardable, we must have read the
+        // entire input already and handed to the session
+        assert(!discardedRequests.contains(req));
 
-		Session *s = sessionsByRequest.value(req);
-		assert(s);
+        Session *s = sessionsByRequest.value(req);
+        assert(s);
 
-		processRequestInput(s);
-	}
+        processRequestInput(s);
+    }
 
-	void req_bytesWritten(int count, ZhttpRequest *req)
-	{
-		Q_UNUSED(count);
+    void req_bytesWritten(int count, ZhttpRequest *req) {
+        Q_UNUSED(count);
 
-		if(discardedRequests.contains(req))
-		{
-			if(req->isFinished())
-			{
-				discardedRequests.remove(req);
-				reqConnectionMap.erase(req);
-				delete req;
-			}
+        if (discardedRequests.contains(req)) {
+            if (req->isFinished()) {
+                discardedRequests.remove(req);
+                reqConnectionMap.erase(req);
+                delete req;
+            }
 
-			return;
-		}
+            return;
+        }
 
-		Session *s = sessionsByRequest.value(req);
-		assert(s);
+        Session *s = sessionsByRequest.value(req);
+        assert(s);
 
-		if(req->isFinished())
-		{
-			assert(!s->pending);
-			removeSession(s);
-		}
-	}
+        if (req->isFinished()) {
+            assert(!s->pending);
+            removeSession(s);
+        }
+    }
 
-	void req_error(ZhttpRequest *req)
-	{
-		if(discardedRequests.contains(req))
-		{
-			discardedRequests.remove(req);
-			reqConnectionMap.erase(req);
-			delete req;
-			return;
-		}
+    void req_error(ZhttpRequest *req) {
+        if (discardedRequests.contains(req)) {
+            discardedRequests.remove(req);
+            reqConnectionMap.erase(req);
+            delete req;
+            return;
+        }
 
-		Session *s = sessionsByRequest.value(req);
-		assert(s);
+        Session *s = sessionsByRequest.value(req);
+        assert(s);
 
-		if(s->pending)
-			s->req = 0;
-		else
-			removeSession(s);
-	}
+        if (s->pending)
+            s->req = 0;
+        else
+            removeSession(s);
+    }
 
-	void sock_closed(ZWebSocket *sock)
-	{
-		Session *s = sessionsBySocket.value(sock);
-		assert(s);
+    void sock_closed(ZWebSocket *sock) {
+        Session *s = sessionsBySocket.value(sock);
+        assert(s);
 
-		if(s->pending)
-			s->sock = 0;
-		else
-			removeSession(s);
-	}
+        if (s->pending)
+            s->sock = 0;
+        else
+            removeSession(s);
+    }
 
-	void sock_error(ZWebSocket *sock)
-	{
-		Session *s = sessionsBySocket.value(sock);
-		assert(s);
+    void sock_error(ZWebSocket *sock) {
+        Session *s = sessionsBySocket.value(sock);
+        assert(s);
 
-		if(s->pending)
-			s->sock = 0;
-		else
-			removeSession(s);
-	}
+        if (s->pending)
+            s->sock = 0;
+        else
+            removeSession(s);
+    }
 
 private:
-	void timer_timeout(Timer *timer)
-	{
-		Session *s = sessionsByTimer.value(timer);
-		assert(s);
+    void timer_timeout(Timer *timer) {
+        Session *s = sessionsByTimer.value(timer);
+        assert(s);
 
-		assert(!s->pending);
-		removeSession(s);
-	}
+        assert(!s->pending);
+        removeSession(s);
+    }
 };
 
-SockJsManager::SockJsManager(const QString &sockJsUrl)
-{
-	d = new Private(this, sockJsUrl);
+SockJsManager::SockJsManager(const QString &sockJsUrl) { d = new Private(this, sockJsUrl); }
+
+SockJsManager::~SockJsManager() { delete d; }
+
+void SockJsManager::giveRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath,
+                                const DomainMap::Entry &route) {
+    d->startHandleRequest(req, basePathStart, asPath, route);
 }
 
-SockJsManager::~SockJsManager()
-{
-	delete d;
+void SockJsManager::giveSocket(ZWebSocket *sock, int basePathStart, const QByteArray &asPath,
+                               const DomainMap::Entry &route) {
+    d->startHandleSocket(sock, basePathStart, asPath, route);
 }
 
-void SockJsManager::giveRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath, const DomainMap::Entry &route)
-{
-	d->startHandleRequest(req, basePathStart, asPath, route);
+SockJsSession *SockJsManager::takeNext() { return d->takeNext(); }
+
+void SockJsManager::unlink(SockJsSession *sess) { d->unlink(sess); }
+
+void SockJsManager::setLinger(SockJsSession *ext, const Variant &closeValue) {
+    d->setLinger(ext, closeValue);
 }
 
-void SockJsManager::giveSocket(ZWebSocket *sock, int basePathStart, const QByteArray &asPath, const DomainMap::Entry &route)
-{
-	d->startHandleSocket(sock, basePathStart, asPath, route);
+void SockJsManager::respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix,
+                              const QByteArray &jsonpCallback) {
+    d->respondOk(req, data, prefix, jsonpCallback);
 }
 
-SockJsSession *SockJsManager::takeNext()
-{
-	return d->takeNext();
+void SockJsManager::respondOk(ZhttpRequest *req, const QString &str,
+                              const QByteArray &jsonpCallback) {
+    d->respondOk(req, str, jsonpCallback);
 }
 
-void SockJsManager::unlink(SockJsSession *sess)
-{
-	d->unlink(sess);
+void SockJsManager::respondError(ZhttpRequest *req, int code, const QByteArray &reason,
+                                 const QString &message, bool discard) {
+    d->respondError(req, code, reason, message, discard);
 }
 
-void SockJsManager::setLinger(SockJsSession *ext, const Variant &closeValue)
-{
-	d->setLinger(ext, closeValue);
-}
-
-void SockJsManager::respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix, const QByteArray &jsonpCallback)
-{
-	d->respondOk(req, data, prefix, jsonpCallback);
-}
-
-void SockJsManager::respondOk(ZhttpRequest *req, const QString &str, const QByteArray &jsonpCallback)
-{
-	d->respondOk(req, str, jsonpCallback);
-}
-
-void SockJsManager::respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message, bool discard)
-{
-	d->respondError(req, code, reason, message, discard);
-}
-
-void SockJsManager::respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	d->respond(req, code, reason, headers, body);
+void SockJsManager::respond(ZhttpRequest *req, int code, const QByteArray &reason,
+                            const HttpHeaders &headers, const QByteArray &body) {
+    d->respond(req, code, reason, headers, body);
 }

--- a/src/proxy/sockjsmanager.h
+++ b/src/proxy/sockjsmanager.h
@@ -24,9 +24,8 @@
 #ifndef SOCKJSMANAGER_H
 #define SOCKJSMANAGER_H
 
-#include "variant.h"
 #include "domainmap.h"
-#include <boost/signals2.hpp>
+#include "variant.h"
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
@@ -37,32 +36,38 @@ class ZhttpRequest;
 class ZWebSocket;
 class SockJsSession;
 
-/// Manages SockJS sessions and routes clients using WebSocket, XHR, or JSONP comms
-class SockJsManager
-{
+/// Manages SockJS sessions and routes clients using WebSocket, XHR, or JSONP
+/// comms
+class SockJsManager {
 public:
-	SockJsManager(const QString &sockJsUrl);
-	~SockJsManager();
+    SockJsManager(const QString &sockJsUrl);
+    ~SockJsManager();
 
-	void giveRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath = QByteArray(), const DomainMap::Entry &route = DomainMap::Entry());
-	void giveSocket(ZWebSocket *sock, int basePathStart, const QByteArray &asPath = QByteArray(), const DomainMap::Entry &route = DomainMap::Entry());
+    void giveRequest(ZhttpRequest *req, int basePathStart, const QByteArray &asPath = QByteArray(),
+                     const DomainMap::Entry &route = DomainMap::Entry());
+    void giveSocket(ZWebSocket *sock, int basePathStart, const QByteArray &asPath = QByteArray(),
+                    const DomainMap::Entry &route = DomainMap::Entry());
 
-	SockJsSession *takeNext();
+    SockJsSession *takeNext();
 
-	Signal sessionReady;
+    Signal sessionReady;
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 
-	friend class SockJsSession;
-	void unlink(SockJsSession *sess);
-	void setLinger(SockJsSession *sess, const Variant &closeValue);
-	void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray());
-	void respondOk(ZhttpRequest *req, const QString &str, const QByteArray &jsonpCallback = QByteArray());
-	void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message, bool discard = false);
-	void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
+    friend class SockJsSession;
+    void unlink(SockJsSession *sess);
+    void setLinger(SockJsSession *sess, const Variant &closeValue);
+    void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(),
+                   const QByteArray &jsonpCallback = QByteArray());
+    void respondOk(ZhttpRequest *req, const QString &str,
+                   const QByteArray &jsonpCallback = QByteArray());
+    void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message,
+                      bool discard = false);
+    void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body);
 };
 
 #endif

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -23,21 +23,21 @@
 
 #include "sockjssession.h"
 
-#include <assert.h>
-#include <QUrlQuery>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include "qtcompat.h"
-#include "variant.h"
-#include "log.h"
 #include "bufferlist.h"
-#include "packet/httprequestdata.h"
-#include "timer.h"
 #include "defercall.h"
+#include "log.h"
+#include "packet/httprequestdata.h"
+#include "qtcompat.h"
+#include "sockjsmanager.h"
+#include "timer.h"
+#include "variant.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
-#include "sockjsmanager.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrlQuery>
+#include <assert.h>
 
 using std::map;
 
@@ -45,1321 +45,1112 @@ using std::map;
 #define KEEPALIVE_TIMEOUT 25
 #define UNCONNECTED_TIMEOUT 5
 
-class SockJsSession::Private
-{
+class SockJsSession::Private {
 public:
-	enum Mode
-	{
-		Http,
-		WebSocketFramed,
-		WebSocketPassthrough
-	};
-
-	class RequestItem
-	{
-	public:
-		enum Type
-		{
-			Background,
-			Connect,
-			Accept,
-			Reject,
-			Send, // Data from client
-			Receive, // Data to client
-			ReceiveClose // Close to client
-		};
-
-		ZhttpRequest *req;
-		QByteArray jsonpCallback;
-		Type type;
-		bool responded;
-
-		QList<Frame> sendFrames;
-		int sendBytes;
-		int receiveFrames;
-		int receiveBytes;
-
-		RequestItem(ZhttpRequest *_req, const QByteArray &_jsonpCallback, Type _type, bool _responded = false) :
-			req(_req),
-			jsonpCallback(_jsonpCallback),
-			type(_type),
-			responded(_responded),
-			sendBytes(0),
-			receiveFrames(0),
-			receiveBytes(0)
-		{
-		}
-
-		~RequestItem()
-		{
-			delete req;
-		}
-	};
-
-	class WriteItem
-	{
-	public:
-		enum Type
-		{
-			Transport,
-			User
-		};
-
-		Type type;
-		int size;
-
-		WriteItem(Type _type, int _size = 0) :
-			type(_type),
-			size(_size)
-		{
-		}
-	};
-
-	struct WSConnections {
-		Connection readyReadConnection;
-		Connection framesWrittenConnection;
-		Connection writeBytesChangedConnection;
-		Connection closedConnection;
-		Connection peerClosedConnection;
-		Connection sockErrorConnection;
-	};
-
-	struct ReqConnections {
-		Connection bytesWrittenConnection;
-		Connection errorConnection;
-	};
-
-	SockJsSession *q;
-	SockJsManager *manager;
-	Mode mode;
-	QByteArray sid;
-	DomainMap::Entry route;
-	HttpRequestData requestData;
-	QHostAddress peerAddress;
-	State state;
-	bool errored;
-	ErrorCondition errorCondition;
-	ZhttpRequest *initialReq;
-	QByteArray initialJsonpCallback;
-	QByteArray initialLastPart;
-	QByteArray initialBody;
-	ZhttpRequest *req;
-	ZWebSocket *sock;
-	bool passThrough;
-	QList<Frame> inWrappedFrames;
-	QList<Frame> inFrames;
-	QList<Frame> outFrames;
-	int inBytes;
-	int pendingWrittenFrames;
-	int pendingWrittenBytes;
-	QList<WriteItem> pendingWrites;
-	QHash<ZhttpRequest*, RequestItem*> requests;
-	std::unique_ptr<Timer> keepAliveTimer;
-	int closeCode;
-	QString closeReason;
-	bool closeSent;
-	bool peerClosed;
-	int peerCloseCode;
-	QString peerCloseReason;
-	bool updating;
-	map<ZhttpRequest*, ReqConnections> reqConnectionMap;
-	WSConnections wsConnection;
-	Connection keepAliveTimerConnection;
-	DeferCall deferCall;
-
-	Private(SockJsSession *_q) :
-		q(_q),
-		manager(0),
-		mode((Mode)-1),
-		state(WebSocket::Idle),
-		errored(false),
-		errorCondition(WebSocket::ErrorGeneric),
-		initialReq(0),
-		req(0),
-		sock(0),
-		inBytes(0),
-		pendingWrittenFrames(0),
-		pendingWrittenBytes(0),
-		closeCode(-1),
-		closeSent(false),
-		peerClosed(false),
-		peerCloseCode(-1),
-		updating(false)
-	{
-		keepAliveTimer = std::make_unique<Timer>();
-		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
-	}
-
-	~Private()
-	{
-		cleanup();
-	}
-
-	void removeRequestItem(RequestItem *ri)
-	{
-		reqConnectionMap.erase(ri->req);
-		requests.remove(ri->req);
-		delete ri;
-	}
-
-	RequestItem *findFirstSendRequest()
-	{
-		QHashIterator<ZhttpRequest*, RequestItem*> it(requests);
-		while(it.hasNext())
-		{
-			it.next();
-
-			RequestItem *ri = it.value();
-			if(ri->type == RequestItem::Send)
-				return ri;
-		}
-
-		return 0;
-	}
-
-	void cleanup()
-	{
-		keepAliveTimer->stop();
-
-		if(req)
-		{
-			RequestItem *ri = requests.value(req);
-			assert(ri);
-
-			// Detach req from RequestItem
-			reqConnectionMap.erase(ri->req);
-			requests.remove(ri->req);
-			ri->req = 0;
-			delete ri;
-
-			// Discard=true to let manager take over
-			manager->respondError(req, 410, "Gone", "Session terminated", true);
-
-			req = 0;
-		}
-
-		QHashIterator<ZhttpRequest*, RequestItem*> it(requests);
-		while(it.hasNext())
-		{
-			it.next();
-			delete it.value();
-		}
-		requests.clear();
-
-		wsConnection = WSConnections();
-		delete sock;
-		sock = 0;
-
-		if(manager)
-		{
-			manager->unlink(q);
-			manager = 0;
-		}
-	}
-
-	void setup()
-	{
-		if(mode == Http)
-		{
-			req = initialReq;
-			initialReq = 0;
-			QByteArray jsonpCallback = initialJsonpCallback;
-			initialJsonpCallback.clear();
-
-			// Don't need these things
-			initialLastPart.clear();
-			initialBody.clear();
-
-			requests.insert(req, new RequestItem(req, jsonpCallback, RequestItem::Connect));
-
-			reqConnectionMap[req] = {
-				req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, req)),
-				req->error.connect(boost::bind(&Private::req_error, this, req))
-			};
-		}
-		else
-		{
-			wsConnection = WSConnections{
-				sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this)),
-				sock->framesWritten.connect(boost::bind(&Private::sock_framesWritten, this, boost::placeholders::_1, boost::placeholders::_2)),
-				sock->writeBytesChanged.connect(boost::bind(&Private::sock_writeBytesChanged, this)),
-				sock->closed.connect(boost::bind(&Private::sock_closed, this)),
-				sock->peerClosed.connect(boost::bind(&Private::sock_peerClosed, this)),
-				sock->error.connect(boost::bind(&Private::sock_error, this))
-			};
-		}
-	}
-
-	void startServer()
-	{
-		state = Connecting;
-	}
-
-	void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(), const QByteArray &jsonpCallback = QByteArray())
-	{
-		manager->respondOk(req, data, prefix, jsonpCallback);
-	}
-
-	void respondOk(ZhttpRequest *req, const QString &str, const QByteArray &jsonpCallback = QByteArray())
-	{
-		manager->respondOk(req, str, jsonpCallback);
-	}
-
-	void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QString &message)
-	{
-		manager->respondError(req, code, reason, message);
-	}
-
-	void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		manager->respond(req, code, reason, headers, body);
-	}
-
-	void handleRequest(ZhttpRequest *_req, const QByteArray &jsonpCallback, const QByteArray &lastPart, const QByteArray &body)
-	{
-		reqConnectionMap[_req] = {
-			_req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, _req)),
-			_req->error.connect(boost::bind(&Private::req_error, this, _req))
-		};
-
-		if(lastPart == "xhr" || lastPart == "jsonp")
-		{
-			if(req)
-			{
-				VariantList out;
-				out += 2010;
-				out += QString("Another connection still open");
-
-				requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-				respondOk(_req, out, "c", jsonpCallback);
-				return;
-			}
-
-			if(peerClosed)
-			{
-				VariantList out;
-				out += 3000;
-				out += QString("Client already closed connection");
-
-				requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-				respondOk(_req, out, "c", jsonpCallback);
-				return;
-			}
-
-			req = _req;
-			requests.insert(req, new RequestItem(req, jsonpCallback, RequestItem::Receive));
-			keepAliveTimer->start(KEEPALIVE_TIMEOUT * 1000);
-
-			tryWrite();
-		}
-		else if(lastPart == "xhr_send" || lastPart == "jsonp_send")
-		{
-			// Only allow one outstanding send request at a time
-			if(findFirstSendRequest())
-			{
-				requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-				respondError(_req, 400, "Bad Request", "Already sending");
-				return;
-			}
-
-			QByteArray param;
-
-			if(_req->requestMethod() == "POST")
-			{
-				if(lastPart == "xhr_send")
-				{
-					// Assume json
-					param = body;
-				}
-				else // jsonp_send
-				{
-					// Assume form encoded
-					foreach(const QByteArray &kv, body.split('&'))
-					{
-						int at = kv.indexOf('=');
-						if(at == -1)
-							continue;
-
-						if(Url::fromPercentEncoding(kv.mid(0, at)) == "d")
-						{
-							param = Url::fromPercentEncoding(kv.mid(at + 1)).toUtf8();
-							break;
-						}
-					}
-				}
-			}
-			else // GET
-			{
-				QUrlQuery query(_req->requestUri());
-				param = query.queryItemValue("d").toUtf8();
-			}
-
-			QJsonParseError error;
-			QJsonDocument doc = QJsonDocument::fromJson(param, &error);
-			if(error.error != QJsonParseError::NoError || !doc.isArray())
-			{
-				requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-				respondError(_req, 400, "Bad Request", "Payload expected");
-				return;
-			}
-
-			VariantList messages = doc.array().toVariantList();
-
-			QList<Frame> frames;
-			int bytes = 0;
-			for(const Variant &vmessage : messages)
-			{
-				if(typeId(vmessage) != VariantType::String)
-				{
-					requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-					respondError(_req, 400, "Bad Request", "Payload expected");
-					return;
-				}
-
-				QByteArray data = vmessage.toString().toUtf8();
-				if(data.size() > BUFFER_SIZE)
-				{
-					requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-					respondError(_req, 400, "Bad Request", "Message too large");
-					return;
-				}
-
-				frames += Frame(Frame::Text, data, false);
-				bytes += data.size();
-			}
-
-			if(frames.isEmpty())
-			{
-				requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-				respondOk(_req, QString("ok"), jsonpCallback);
-				return;
-			}
-
-			RequestItem *ri = new RequestItem(_req, jsonpCallback, RequestItem::Send);
-			requests.insert(_req, ri);
-			ri->sendFrames = frames;
-			ri->sendBytes = bytes;
-
-			tryRead();
-		}
-		else
-		{
-			requests.insert(_req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
-			respondError(_req, 404, "Not Found", "Not Found");
-		}
-	}
-
-	void accept(const QByteArray &reason, const HttpHeaders &headers)
-	{
-		if(errored)
-			return;
-
-		if(mode == Http)
-		{
-			assert(req);
-			RequestItem *ri = requests.value(req);
-			assert(ri && !ri->responded);
-
-			// Note: reason/headers don't have meaning with sockjs http
-
-			ri->type = RequestItem::Accept;
-			ri->responded = true;
-			respondOk(req, Variant(), "o", ri->jsonpCallback);
-		}
-		else
-		{
-			assert(sock);
-
-			sock->respondSuccess(reason, headers);
-
-			state = Connected;
-
-			if(mode == WebSocketFramed)
-			{
-				Frame f(Frame::Text, "o", false);
-				pendingWrites += WriteItem(WriteItem::Transport);
-				sock->writeFrame(f);
-
-				keepAliveTimer->start(KEEPALIVE_TIMEOUT * 1000);
-			}
-		}
-	}
-
-	void reject(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		if(errored)
-			return;
-
-		if(mode == Http)
-		{
-			assert(req);
-			RequestItem *ri = requests.value(req);
-			assert(ri && !ri->responded);
-
-			ri->type = RequestItem::Reject;
-			ri->responded = true;
-			respond(req, code, reason, headers, body);
-		}
-		else
-		{
-			assert(sock);
-
-			sock->respondError(code, reason, headers, body);
-		}
-	}
-
-	void writeFrame(const Frame &frame)
-	{
-		assert(state != Closing);
-
-		if(mode == WebSocketPassthrough)
-		{
-			sock->writeFrame(frame);
-		}
-		else
-		{
-			if(frame.type != Frame::Text && frame.type != Frame::Binary)
-			{
-				++pendingWrittenFrames;
-				pendingWrittenBytes += frame.data.size();
-				update();
-				return;
-			}
-
-			if(mode == Http)
-			{
-				int outSize = 0;
-				foreach(const Frame &f, outFrames)
-					outSize += f.data.size();
-
-				if(outSize + frame.data.size() > BUFFER_SIZE)
-				{
-					errored = true;
-					errorCondition = ErrorGeneric;
-					update();
-					return;
-				}
-
-				outFrames += frame;
-
-				tryWrite();
-			}
-			else // WebSocketFramed
-			{
-				VariantList messages;
-				messages += QString::fromUtf8(frame.data);
-
-				QByteArray arrayJson = QJsonDocument(QJsonArray::fromVariantList(messages)).toJson(QJsonDocument::Compact);
-				Frame f(Frame::Text, "a" + arrayJson, false);
-
-				pendingWrites += WriteItem(WriteItem::User, frame.data.size());
-				sock->writeFrame(f);
-			}
-		}
-	}
-
-	Frame readFrame()
-	{
-		if(mode == Http || mode == WebSocketFramed)
-		{
-			Frame f = inFrames.takeFirst();
-			inBytes -= f.data.size();
-			update();
-			return f;
-		}
-		else
-		{
-			return sock->readFrame();
-		}
-	}
-
-	void close(int code, const QString &reason)
-	{
-		assert(state != Closing);
-
-		state = Closing;
-		closeCode = code;
-		closeReason = reason;
-
-		if(mode == Http)
-		{
-			if(peerClosed)
-			{
-				state = Idle;
-				applyLinger();
-				cleanup();
-				deferCall.defer([=] { doClosed(); });
-			}
-			else
-				tryWrite();
-		}
-		else
-		{
-			assert(sock);
-
-			sock->close(closeCode, closeReason);
-		}
-	}
-
-	void tryWrite()
-	{
-		if(!req || closeSent)
-			return;
-
-		RequestItem *ri = requests.value(req);
-		assert(ri);
-
-		if(ri->responded)
-			return;
-
-		VariantList messages;
-
-		int frames = 0;
-		int bytes = 0;
-		while(!outFrames.isEmpty())
-		{
-			// Find end
-			int end = 0;
-			for(; end < outFrames.count(); ++end)
-			{
-				if(!outFrames[end].more)
-					break;
-			}
-			if(end >= outFrames.count())
-				break;
-
-			Frame first = outFrames[0];
-
-			BufferList bufs;
-			for(int n = 0; n <= end; ++n)
-			{
-				Frame f = outFrames.takeFirst();
-				++frames;
-				bytes += f.data.size();
-				bufs += f.data;
-			}
-
-			assert(first.type == Frame::Text || first.type == Frame::Binary);
-
-			QByteArray data = bufs.toByteArray();
-
-			pendingWrites += WriteItem(WriteItem::User, data.size());
-			messages += QString::fromUtf8(data);
-		}
-
-		if(bytes > 0)
-		{
-			std::weak_ptr<Private> self = q->d;
-			q->writeBytesChanged();
-			if(self.expired())
-				return;
-		}
-
-		ri->receiveFrames = frames;
-		ri->receiveBytes = bytes;
-
-		if(!messages.isEmpty())
-		{
-			ri->responded = true;
-			respondOk(req, messages, "a", ri->jsonpCallback);
-			keepAliveTimer->stop();
-		}
-		else if(state == Closing)
-		{
-			closeSent = true;
-			Variant closeValue = applyLinger();
-
-			ri->type = RequestItem::ReceiveClose;
-			ri->responded = true;
-			respondOk(req, closeValue, "c", ri->jsonpCallback);
-		}
-	}
-
-	bool tryRead()
-	{
-		std::weak_ptr<Private> self = q->d;
-
-		if(mode == Http)
-		{
-			QList<RequestItem*> sendRequests;
-			QHashIterator<ZhttpRequest*, RequestItem*> it(requests);
-			while(it.hasNext())
-			{
-				it.next();
-				RequestItem *ri = it.value();
-
-				if(ri->type == RequestItem::Send && !ri->responded)
-					sendRequests += ri;
-			}
-
-			bool emitReadyRead = false;
-
-			foreach(RequestItem *ri, sendRequests)
-			{
-				assert(!ri->sendFrames.isEmpty());
-
-				if(inBytes + ri->sendFrames.first().data.size() > BUFFER_SIZE)
-					break;
-
-				Frame f = ri->sendFrames.takeFirst();
-				ri->sendBytes -= f.data.size();
-
-				if(ri->sendFrames.isEmpty())
-				{
-					assert(ri->sendBytes == 0);
-
-					ri->responded = true;
-					respondOk(ri->req, QString("ok"), ri->jsonpCallback);
-				}
-
-				inFrames += f;
-				inBytes += f.data.size();
-
-				emitReadyRead = true;
-			}
-
-			if(emitReadyRead)
-			{
-				q->readyRead();
-				if(self.expired())
-					return false;
-			}
-		}
-		else if(mode == WebSocketFramed)
-		{
-			bool error = false;
-			bool emitReadyRead = false;
-
-			while(inBytes < BUFFER_SIZE)
-			{
-				int end = 0;
-				for(; end < inWrappedFrames.count(); ++end)
-				{
-					if(!inWrappedFrames[end].more)
-						break;
-				}
-				if(end >= inWrappedFrames.count())
-				{
-					if(sock->framesAvailable() == 0)
-						break;
-
-					Frame f = sock->readFrame();
-
-					// Allow a larger temporary read size due to wrapping
-					if(f.data.size() > BUFFER_SIZE * 2)
-					{
-						error = true;
-						break;
-					}
-
-					inWrappedFrames += f;
-					continue;
-				}
-
-				int size = 0;
-				for(int n = 0; n <= end; ++n)
-					size += inWrappedFrames[n].data.size();
-
-				// Allow a larger temporary read size due to wrapping
-				if(size > BUFFER_SIZE * 2)
-				{
-					error = true;
-					break;
-				}
-
-				Frame first = inWrappedFrames[0];
-
-				BufferList bufs;
-				for(int n = 0; n <= end; ++n)
-				{
-					Frame f = inWrappedFrames.takeFirst();
-					bufs += f.data;
-				}
-
-				if(first.type != Frame::Text && first.type != Frame::Binary)
-					continue;
-
-				QByteArray data = bufs.toByteArray();
-
-				QJsonParseError e;
-				QJsonDocument doc = QJsonDocument::fromJson(data, &e);
-				if(e.error != QJsonParseError::NoError || !doc.isArray())
-				{
-					error = true;
-					break;
-				}
-
-				VariantList messages = doc.array().toVariantList();
-
-				QList<Frame> frames;
-				int bytes = 0;
-				for(const Variant &vmessage : messages)
-				{
-					if(typeId(vmessage) != VariantType::String)
-					{
-						error = true;
-						break;
-					}
-
-					data = vmessage.toString().toUtf8();
-					if(data.size() > BUFFER_SIZE)
-					{
-						error = true;
-						break;
-					}
-
-					frames += Frame(Frame::Text, data, false);
-					bytes += data.size();
-				}
-
-				if(error)
-					break;
-
-				// note: inBytes may exceed BUFFER_SIZE at this point, but
-				// It shouldn't be by more than double
-
-				inFrames += frames;
-				inBytes += bytes;
-				emitReadyRead = true;
-			}
-
-			if(error)
-			{
-				state = Idle;
-				cleanup();
-				q->error();
-
-				// Stop signals
-				return false;
-			}
-
-			if(emitReadyRead)
-			{
-				q->readyRead();
-				if(self.expired())
-					return false;
-			}
-		}
-
-		return true;
-	}
-
-	void update()
-	{
-		if(!updating)
-		{
-			updating = true;
-			deferCall.defer([=] { doUpdate(); });
-		}
-	}
-
-	void handleWritten(int count, int contentBytes)
-	{
-		if(mode == Http || mode == WebSocketFramed)
-		{
-			int newCount = 0;
-			int newContentBytes = 0;
-			for(int n = 0; n < count; ++n)
-			{
-				WriteItem i = pendingWrites.takeFirst();
-				if(i.type == WriteItem::User)
-				{
-					++newCount;
-					newContentBytes += i.size;
-				}
-			}
-
-			count = newCount;
-			contentBytes = newContentBytes;
-
-			count += pendingWrittenFrames;
-			contentBytes += pendingWrittenBytes;
-			pendingWrittenFrames = 0;
-			pendingWrittenBytes = 0;
-		}
-
-		q->framesWritten(count, contentBytes);
-	}
-
-	Variant applyLinger()
-	{
-		VariantList closeValue;
-
-		if(closeCode != -1)
-			closeValue += closeCode;
-		else
-			closeValue += 0;
-
-		if(closeCode != -1 && !closeReason.isEmpty())
-			closeValue += closeReason;
-		else
-			closeValue += QString("Connection closed");
-
-		manager->setLinger(q, closeValue);
-		return closeValue;
-	}
-
-	void req_bytesWritten(int count, ZhttpRequest *_req)
-	{
-		Q_UNUSED(count);
-
-		RequestItem *ri = requests.value(_req);
-		assert(ri);
-
-		if(!_req->isFinished())
-			return;
-
-		if(ri->type == RequestItem::Accept)
-		{
-			assert(_req == req);
-			state = Connected;
-			req = 0;
-			removeRequestItem(ri);
-
-			keepAliveTimer->start(UNCONNECTED_TIMEOUT * 1000);
-		}
-		else
-		{
-			if(_req == req)
-			{
-				req = 0;
-
-				if(ri->type == RequestItem::Reject)
-				{
-					state = Idle;
-					removeRequestItem(ri);
-					cleanup();
-					q->closed();
-					return;
-				}
-				else if(ri->type == RequestItem::Receive)
-				{
-					int count = ri->receiveFrames;
-					int contentBytes = ri->receiveBytes;
-					removeRequestItem(ri);
-					keepAliveTimer->start(UNCONNECTED_TIMEOUT * 1000);
-					handleWritten(count, contentBytes);
-					return;
-				}
-				else if(ri->type == RequestItem::ReceiveClose)
-				{
-					state = Idle;
-					removeRequestItem(ri);
-					cleanup();
-					q->closed();
-					return;
-				}
-			}
-
-			removeRequestItem(ri);
-		}
-	}
-
-	void req_error(ZhttpRequest *_req)
-	{
-		RequestItem *ri = requests.value(_req);
-		assert(ri);
-
-		if(ri->type == RequestItem::Connect ||
-			ri->type == RequestItem::Accept ||
-			ri->type == RequestItem::Reject ||
-			ri->type == RequestItem::Receive ||
-			ri->type == RequestItem::ReceiveClose)
-		{
-			assert(_req == req);
-
-			// Disconnect while long-polling means close, not error
-			bool close = false;
-			if(ri->type == RequestItem::Receive && !ri->responded)
-				close = (_req->errorCondition() == ZhttpRequest::ErrorDisconnected);
-
-			req = 0;
-			removeRequestItem(ri);
-
-			if(close && !peerClosed)
-			{
-				peerClosed = true;
-				q->peerClosed();
-				return;
-			}
-
-			state = Idle;
-			cleanup();
-
-			if(close)
-				q->closed();
-			else
-				q->error();
-		}
-		else
-		{
-			removeRequestItem(ri);
-		}
-	}
-
-	void sock_readyRead()
-	{
-		if(mode == WebSocketFramed)
-		{
-			tryRead();
-		}
-		else // WebSocketPassthrough
-		{
-			q->readyRead();
-		}
-	}
-
-	void sock_framesWritten(int count, int contentBytes)
-	{
-		handleWritten(count, contentBytes);
-	}
-
-	void sock_writeBytesChanged()
-	{
-		q->writeBytesChanged();
-	}
-
-	void sock_peerClosed()
-	{
-		peerCloseCode = sock->peerCloseCode();
-		peerCloseReason = sock->peerCloseReason();
-		q->peerClosed();
-	}
-
-	void sock_closed()
-	{
-		peerCloseCode = sock->peerCloseCode();
-		peerCloseReason = sock->peerCloseReason();
-		state = Idle;
-		cleanup();
-		q->closed();
-	}
-
-	void sock_error()
-	{
-		state = Idle;
-		errorCondition = sock->errorCondition();
-		cleanup();
-		q->error();
-	}
-
-	void doUpdate()
-	{
-		updating = false;
-
-		if(errored)
-		{
-			state = Idle;
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(mode == Http || mode == WebSocketFramed)
-		{
-			if(!tryRead())
-				return;
-
-			if(pendingWrittenFrames > 0)
-			{
-				int count = pendingWrittenFrames;
-				int contentBytes = pendingWrittenBytes;
-				pendingWrittenFrames = 0;
-				pendingWrittenBytes = 0;
-
-				q->framesWritten(count, contentBytes);
-			}
-		}
-	}
-
-	void doClosed()
-	{
-		q->closed();
-	}
-
-	void keepAliveTimer_timeout()
-	{
-		assert(mode != WebSocketPassthrough);
-
-		if(mode == Http)
-		{
-			if(req)
-			{
-				RequestItem *ri = requests.value(req);
-				assert(ri && !ri->responded);
-
-				ri->responded = true;
-				respondOk(req, Variant(), "h", ri->jsonpCallback);
-			}
-			else
-			{
-				// Timeout while unconnected
-				state = Idle;
-				cleanup();
-				q->error();
-			}
-		}
-		else
-		{
-			assert(sock);
-
-			Frame f(Frame::Text, "h", false);
-			pendingWrites += WriteItem(WriteItem::Transport);
-			sock->writeFrame(f);
-		}
-	}
+    enum Mode { Http, WebSocketFramed, WebSocketPassthrough };
+
+    class RequestItem {
+    public:
+        enum Type {
+            Background,
+            Connect,
+            Accept,
+            Reject,
+            Send,        // Data from client
+            Receive,     // Data to client
+            ReceiveClose // Close to client
+        };
+
+        ZhttpRequest *req;
+        QByteArray jsonpCallback;
+        Type type;
+        bool responded;
+
+        QList<Frame> sendFrames;
+        int sendBytes;
+        int receiveFrames;
+        int receiveBytes;
+
+        RequestItem(ZhttpRequest *_req, const QByteArray &_jsonpCallback, Type _type,
+                    bool _responded = false)
+            : req(_req),
+              jsonpCallback(_jsonpCallback),
+              type(_type),
+              responded(_responded),
+              sendBytes(0),
+              receiveFrames(0),
+              receiveBytes(0) {}
+
+        ~RequestItem() { delete req; }
+    };
+
+    class WriteItem {
+    public:
+        enum Type { Transport, User };
+
+        Type type;
+        int size;
+
+        WriteItem(Type _type, int _size = 0) : type(_type), size(_size) {}
+    };
+
+    struct WSConnections {
+        Connection readyReadConnection;
+        Connection framesWrittenConnection;
+        Connection writeBytesChangedConnection;
+        Connection closedConnection;
+        Connection peerClosedConnection;
+        Connection sockErrorConnection;
+    };
+
+    struct ReqConnections {
+        Connection bytesWrittenConnection;
+        Connection errorConnection;
+    };
+
+    SockJsSession *q;
+    SockJsManager *manager;
+    Mode mode;
+    QByteArray sid;
+    DomainMap::Entry route;
+    HttpRequestData requestData;
+    QHostAddress peerAddress;
+    State state;
+    bool errored;
+    ErrorCondition errorCondition;
+    ZhttpRequest *initialReq;
+    QByteArray initialJsonpCallback;
+    QByteArray initialLastPart;
+    QByteArray initialBody;
+    ZhttpRequest *req;
+    ZWebSocket *sock;
+    bool passThrough;
+    QList<Frame> inWrappedFrames;
+    QList<Frame> inFrames;
+    QList<Frame> outFrames;
+    int inBytes;
+    int pendingWrittenFrames;
+    int pendingWrittenBytes;
+    QList<WriteItem> pendingWrites;
+    QHash<ZhttpRequest *, RequestItem *> requests;
+    std::unique_ptr<Timer> keepAliveTimer;
+    int closeCode;
+    QString closeReason;
+    bool closeSent;
+    bool peerClosed;
+    int peerCloseCode;
+    QString peerCloseReason;
+    bool updating;
+    map<ZhttpRequest *, ReqConnections> reqConnectionMap;
+    WSConnections wsConnection;
+    Connection keepAliveTimerConnection;
+    DeferCall deferCall;
+
+    Private(SockJsSession *_q)
+        : q(_q),
+          manager(0),
+          mode((Mode)-1),
+          state(WebSocket::Idle),
+          errored(false),
+          errorCondition(WebSocket::ErrorGeneric),
+          initialReq(0),
+          req(0),
+          sock(0),
+          inBytes(0),
+          pendingWrittenFrames(0),
+          pendingWrittenBytes(0),
+          closeCode(-1),
+          closeSent(false),
+          peerClosed(false),
+          peerCloseCode(-1),
+          updating(false) {
+        keepAliveTimer = std::make_unique<Timer>();
+        keepAliveTimerConnection =
+            keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
+    }
+
+    ~Private() { cleanup(); }
+
+    void removeRequestItem(RequestItem *ri) {
+        reqConnectionMap.erase(ri->req);
+        requests.remove(ri->req);
+        delete ri;
+    }
+
+    RequestItem *findFirstSendRequest() {
+        QHashIterator<ZhttpRequest *, RequestItem *> it(requests);
+        while (it.hasNext()) {
+            it.next();
+
+            RequestItem *ri = it.value();
+            if (ri->type == RequestItem::Send)
+                return ri;
+        }
+
+        return 0;
+    }
+
+    void cleanup() {
+        keepAliveTimer->stop();
+
+        if (req) {
+            RequestItem *ri = requests.value(req);
+            assert(ri);
+
+            // Detach req from RequestItem
+            reqConnectionMap.erase(ri->req);
+            requests.remove(ri->req);
+            ri->req = 0;
+            delete ri;
+
+            // Discard=true to let manager take over
+            manager->respondError(req, 410, "Gone", "Session terminated", true);
+
+            req = 0;
+        }
+
+        QHashIterator<ZhttpRequest *, RequestItem *> it(requests);
+        while (it.hasNext()) {
+            it.next();
+            delete it.value();
+        }
+        requests.clear();
+
+        wsConnection = WSConnections();
+        delete sock;
+        sock = 0;
+
+        if (manager) {
+            manager->unlink(q);
+            manager = 0;
+        }
+    }
+
+    void setup() {
+        if (mode == Http) {
+            req = initialReq;
+            initialReq = 0;
+            QByteArray jsonpCallback = initialJsonpCallback;
+            initialJsonpCallback.clear();
+
+            // Don't need these things
+            initialLastPart.clear();
+            initialBody.clear();
+
+            requests.insert(req, new RequestItem(req, jsonpCallback, RequestItem::Connect));
+
+            reqConnectionMap[req] = {
+                req->bytesWritten.connect(
+                    boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, req)),
+                req->error.connect(boost::bind(&Private::req_error, this, req))};
+        } else {
+            wsConnection = WSConnections{
+                sock->readyRead.connect(boost::bind(&Private::sock_readyRead, this)),
+                sock->framesWritten.connect(boost::bind(&Private::sock_framesWritten, this,
+                                                        boost::placeholders::_1,
+                                                        boost::placeholders::_2)),
+                sock->writeBytesChanged.connect(
+                    boost::bind(&Private::sock_writeBytesChanged, this)),
+                sock->closed.connect(boost::bind(&Private::sock_closed, this)),
+                sock->peerClosed.connect(boost::bind(&Private::sock_peerClosed, this)),
+                sock->error.connect(boost::bind(&Private::sock_error, this))};
+        }
+    }
+
+    void startServer() { state = Connecting; }
+
+    void respondOk(ZhttpRequest *req, const Variant &data, const QByteArray &prefix = QByteArray(),
+                   const QByteArray &jsonpCallback = QByteArray()) {
+        manager->respondOk(req, data, prefix, jsonpCallback);
+    }
+
+    void respondOk(ZhttpRequest *req, const QString &str,
+                   const QByteArray &jsonpCallback = QByteArray()) {
+        manager->respondOk(req, str, jsonpCallback);
+    }
+
+    void respondError(ZhttpRequest *req, int code, const QByteArray &reason,
+                      const QString &message) {
+        manager->respondError(req, code, reason, message);
+    }
+
+    void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body) {
+        manager->respond(req, code, reason, headers, body);
+    }
+
+    void handleRequest(ZhttpRequest *_req, const QByteArray &jsonpCallback,
+                       const QByteArray &lastPart, const QByteArray &body) {
+        reqConnectionMap[_req] = {
+            _req->bytesWritten.connect(
+                boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1, _req)),
+            _req->error.connect(boost::bind(&Private::req_error, this, _req))};
+
+        if (lastPart == "xhr" || lastPart == "jsonp") {
+            if (req) {
+                VariantList out;
+                out += 2010;
+                out += QString("Another connection still open");
+
+                requests.insert(
+                    _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                respondOk(_req, out, "c", jsonpCallback);
+                return;
+            }
+
+            if (peerClosed) {
+                VariantList out;
+                out += 3000;
+                out += QString("Client already closed connection");
+
+                requests.insert(
+                    _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                respondOk(_req, out, "c", jsonpCallback);
+                return;
+            }
+
+            req = _req;
+            requests.insert(req, new RequestItem(req, jsonpCallback, RequestItem::Receive));
+            keepAliveTimer->start(KEEPALIVE_TIMEOUT * 1000);
+
+            tryWrite();
+        } else if (lastPart == "xhr_send" || lastPart == "jsonp_send") {
+            // Only allow one outstanding send request at a time
+            if (findFirstSendRequest()) {
+                requests.insert(
+                    _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                respondError(_req, 400, "Bad Request", "Already sending");
+                return;
+            }
+
+            QByteArray param;
+
+            if (_req->requestMethod() == "POST") {
+                if (lastPart == "xhr_send") {
+                    // Assume json
+                    param = body;
+                } else // jsonp_send
+                {
+                    // Assume form encoded
+                    foreach (const QByteArray &kv, body.split('&')) {
+                        int at = kv.indexOf('=');
+                        if (at == -1)
+                            continue;
+
+                        if (Url::fromPercentEncoding(kv.mid(0, at)) == "d") {
+                            param = Url::fromPercentEncoding(kv.mid(at + 1)).toUtf8();
+                            break;
+                        }
+                    }
+                }
+            } else // GET
+            {
+                QUrlQuery query(_req->requestUri());
+                param = query.queryItemValue("d").toUtf8();
+            }
+
+            QJsonParseError error;
+            QJsonDocument doc = QJsonDocument::fromJson(param, &error);
+            if (error.error != QJsonParseError::NoError || !doc.isArray()) {
+                requests.insert(
+                    _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                respondError(_req, 400, "Bad Request", "Payload expected");
+                return;
+            }
+
+            VariantList messages = doc.array().toVariantList();
+
+            QList<Frame> frames;
+            int bytes = 0;
+            for (const Variant &vmessage : messages) {
+                if (typeId(vmessage) != VariantType::String) {
+                    requests.insert(
+                        _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                    respondError(_req, 400, "Bad Request", "Payload expected");
+                    return;
+                }
+
+                QByteArray data = vmessage.toString().toUtf8();
+                if (data.size() > BUFFER_SIZE) {
+                    requests.insert(
+                        _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                    respondError(_req, 400, "Bad Request", "Message too large");
+                    return;
+                }
+
+                frames += Frame(Frame::Text, data, false);
+                bytes += data.size();
+            }
+
+            if (frames.isEmpty()) {
+                requests.insert(
+                    _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+                respondOk(_req, QString("ok"), jsonpCallback);
+                return;
+            }
+
+            RequestItem *ri = new RequestItem(_req, jsonpCallback, RequestItem::Send);
+            requests.insert(_req, ri);
+            ri->sendFrames = frames;
+            ri->sendBytes = bytes;
+
+            tryRead();
+        } else {
+            requests.insert(_req,
+                            new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
+            respondError(_req, 404, "Not Found", "Not Found");
+        }
+    }
+
+    void accept(const QByteArray &reason, const HttpHeaders &headers) {
+        if (errored)
+            return;
+
+        if (mode == Http) {
+            assert(req);
+            RequestItem *ri = requests.value(req);
+            assert(ri && !ri->responded);
+
+            // Note: reason/headers don't have meaning with sockjs http
+
+            ri->type = RequestItem::Accept;
+            ri->responded = true;
+            respondOk(req, Variant(), "o", ri->jsonpCallback);
+        } else {
+            assert(sock);
+
+            sock->respondSuccess(reason, headers);
+
+            state = Connected;
+
+            if (mode == WebSocketFramed) {
+                Frame f(Frame::Text, "o", false);
+                pendingWrites += WriteItem(WriteItem::Transport);
+                sock->writeFrame(f);
+
+                keepAliveTimer->start(KEEPALIVE_TIMEOUT * 1000);
+            }
+        }
+    }
+
+    void reject(int code, const QByteArray &reason, const HttpHeaders &headers,
+                const QByteArray &body) {
+        if (errored)
+            return;
+
+        if (mode == Http) {
+            assert(req);
+            RequestItem *ri = requests.value(req);
+            assert(ri && !ri->responded);
+
+            ri->type = RequestItem::Reject;
+            ri->responded = true;
+            respond(req, code, reason, headers, body);
+        } else {
+            assert(sock);
+
+            sock->respondError(code, reason, headers, body);
+        }
+    }
+
+    void writeFrame(const Frame &frame) {
+        assert(state != Closing);
+
+        if (mode == WebSocketPassthrough) {
+            sock->writeFrame(frame);
+        } else {
+            if (frame.type != Frame::Text && frame.type != Frame::Binary) {
+                ++pendingWrittenFrames;
+                pendingWrittenBytes += frame.data.size();
+                update();
+                return;
+            }
+
+            if (mode == Http) {
+                int outSize = 0;
+                foreach (const Frame &f, outFrames)
+                    outSize += f.data.size();
+
+                if (outSize + frame.data.size() > BUFFER_SIZE) {
+                    errored = true;
+                    errorCondition = ErrorGeneric;
+                    update();
+                    return;
+                }
+
+                outFrames += frame;
+
+                tryWrite();
+            } else // WebSocketFramed
+            {
+                VariantList messages;
+                messages += QString::fromUtf8(frame.data);
+
+                QByteArray arrayJson = QJsonDocument(QJsonArray::fromVariantList(messages))
+                                           .toJson(QJsonDocument::Compact);
+                Frame f(Frame::Text, "a" + arrayJson, false);
+
+                pendingWrites += WriteItem(WriteItem::User, frame.data.size());
+                sock->writeFrame(f);
+            }
+        }
+    }
+
+    Frame readFrame() {
+        if (mode == Http || mode == WebSocketFramed) {
+            Frame f = inFrames.takeFirst();
+            inBytes -= f.data.size();
+            update();
+            return f;
+        } else {
+            return sock->readFrame();
+        }
+    }
+
+    void close(int code, const QString &reason) {
+        assert(state != Closing);
+
+        state = Closing;
+        closeCode = code;
+        closeReason = reason;
+
+        if (mode == Http) {
+            if (peerClosed) {
+                state = Idle;
+                applyLinger();
+                cleanup();
+                deferCall.defer([=] { doClosed(); });
+            } else
+                tryWrite();
+        } else {
+            assert(sock);
+
+            sock->close(closeCode, closeReason);
+        }
+    }
+
+    void tryWrite() {
+        if (!req || closeSent)
+            return;
+
+        RequestItem *ri = requests.value(req);
+        assert(ri);
+
+        if (ri->responded)
+            return;
+
+        VariantList messages;
+
+        int frames = 0;
+        int bytes = 0;
+        while (!outFrames.isEmpty()) {
+            // Find end
+            int end = 0;
+            for (; end < outFrames.count(); ++end) {
+                if (!outFrames[end].more)
+                    break;
+            }
+            if (end >= outFrames.count())
+                break;
+
+            Frame first = outFrames[0];
+
+            BufferList bufs;
+            for (int n = 0; n <= end; ++n) {
+                Frame f = outFrames.takeFirst();
+                ++frames;
+                bytes += f.data.size();
+                bufs += f.data;
+            }
+
+            assert(first.type == Frame::Text || first.type == Frame::Binary);
+
+            QByteArray data = bufs.toByteArray();
+
+            pendingWrites += WriteItem(WriteItem::User, data.size());
+            messages += QString::fromUtf8(data);
+        }
+
+        if (bytes > 0) {
+            std::weak_ptr<Private> self = q->d;
+            q->writeBytesChanged();
+            if (self.expired())
+                return;
+        }
+
+        ri->receiveFrames = frames;
+        ri->receiveBytes = bytes;
+
+        if (!messages.isEmpty()) {
+            ri->responded = true;
+            respondOk(req, messages, "a", ri->jsonpCallback);
+            keepAliveTimer->stop();
+        } else if (state == Closing) {
+            closeSent = true;
+            Variant closeValue = applyLinger();
+
+            ri->type = RequestItem::ReceiveClose;
+            ri->responded = true;
+            respondOk(req, closeValue, "c", ri->jsonpCallback);
+        }
+    }
+
+    bool tryRead() {
+        std::weak_ptr<Private> self = q->d;
+
+        if (mode == Http) {
+            QList<RequestItem *> sendRequests;
+            QHashIterator<ZhttpRequest *, RequestItem *> it(requests);
+            while (it.hasNext()) {
+                it.next();
+                RequestItem *ri = it.value();
+
+                if (ri->type == RequestItem::Send && !ri->responded)
+                    sendRequests += ri;
+            }
+
+            bool emitReadyRead = false;
+
+            foreach (RequestItem *ri, sendRequests) {
+                assert(!ri->sendFrames.isEmpty());
+
+                if (inBytes + ri->sendFrames.first().data.size() > BUFFER_SIZE)
+                    break;
+
+                Frame f = ri->sendFrames.takeFirst();
+                ri->sendBytes -= f.data.size();
+
+                if (ri->sendFrames.isEmpty()) {
+                    assert(ri->sendBytes == 0);
+
+                    ri->responded = true;
+                    respondOk(ri->req, QString("ok"), ri->jsonpCallback);
+                }
+
+                inFrames += f;
+                inBytes += f.data.size();
+
+                emitReadyRead = true;
+            }
+
+            if (emitReadyRead) {
+                q->readyRead();
+                if (self.expired())
+                    return false;
+            }
+        } else if (mode == WebSocketFramed) {
+            bool error = false;
+            bool emitReadyRead = false;
+
+            while (inBytes < BUFFER_SIZE) {
+                int end = 0;
+                for (; end < inWrappedFrames.count(); ++end) {
+                    if (!inWrappedFrames[end].more)
+                        break;
+                }
+                if (end >= inWrappedFrames.count()) {
+                    if (sock->framesAvailable() == 0)
+                        break;
+
+                    Frame f = sock->readFrame();
+
+                    // Allow a larger temporary read size due to wrapping
+                    if (f.data.size() > BUFFER_SIZE * 2) {
+                        error = true;
+                        break;
+                    }
+
+                    inWrappedFrames += f;
+                    continue;
+                }
+
+                int size = 0;
+                for (int n = 0; n <= end; ++n)
+                    size += inWrappedFrames[n].data.size();
+
+                // Allow a larger temporary read size due to wrapping
+                if (size > BUFFER_SIZE * 2) {
+                    error = true;
+                    break;
+                }
+
+                Frame first = inWrappedFrames[0];
+
+                BufferList bufs;
+                for (int n = 0; n <= end; ++n) {
+                    Frame f = inWrappedFrames.takeFirst();
+                    bufs += f.data;
+                }
+
+                if (first.type != Frame::Text && first.type != Frame::Binary)
+                    continue;
+
+                QByteArray data = bufs.toByteArray();
+
+                QJsonParseError e;
+                QJsonDocument doc = QJsonDocument::fromJson(data, &e);
+                if (e.error != QJsonParseError::NoError || !doc.isArray()) {
+                    error = true;
+                    break;
+                }
+
+                VariantList messages = doc.array().toVariantList();
+
+                QList<Frame> frames;
+                int bytes = 0;
+                for (const Variant &vmessage : messages) {
+                    if (typeId(vmessage) != VariantType::String) {
+                        error = true;
+                        break;
+                    }
+
+                    data = vmessage.toString().toUtf8();
+                    if (data.size() > BUFFER_SIZE) {
+                        error = true;
+                        break;
+                    }
+
+                    frames += Frame(Frame::Text, data, false);
+                    bytes += data.size();
+                }
+
+                if (error)
+                    break;
+
+                // note: inBytes may exceed BUFFER_SIZE at this point, but
+                // It shouldn't be by more than double
+
+                inFrames += frames;
+                inBytes += bytes;
+                emitReadyRead = true;
+            }
+
+            if (error) {
+                state = Idle;
+                cleanup();
+                q->error();
+
+                // Stop signals
+                return false;
+            }
+
+            if (emitReadyRead) {
+                q->readyRead();
+                if (self.expired())
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    void update() {
+        if (!updating) {
+            updating = true;
+            deferCall.defer([=] { doUpdate(); });
+        }
+    }
+
+    void handleWritten(int count, int contentBytes) {
+        if (mode == Http || mode == WebSocketFramed) {
+            int newCount = 0;
+            int newContentBytes = 0;
+            for (int n = 0; n < count; ++n) {
+                WriteItem i = pendingWrites.takeFirst();
+                if (i.type == WriteItem::User) {
+                    ++newCount;
+                    newContentBytes += i.size;
+                }
+            }
+
+            count = newCount;
+            contentBytes = newContentBytes;
+
+            count += pendingWrittenFrames;
+            contentBytes += pendingWrittenBytes;
+            pendingWrittenFrames = 0;
+            pendingWrittenBytes = 0;
+        }
+
+        q->framesWritten(count, contentBytes);
+    }
+
+    Variant applyLinger() {
+        VariantList closeValue;
+
+        if (closeCode != -1)
+            closeValue += closeCode;
+        else
+            closeValue += 0;
+
+        if (closeCode != -1 && !closeReason.isEmpty())
+            closeValue += closeReason;
+        else
+            closeValue += QString("Connection closed");
+
+        manager->setLinger(q, closeValue);
+        return closeValue;
+    }
+
+    void req_bytesWritten(int count, ZhttpRequest *_req) {
+        Q_UNUSED(count);
+
+        RequestItem *ri = requests.value(_req);
+        assert(ri);
+
+        if (!_req->isFinished())
+            return;
+
+        if (ri->type == RequestItem::Accept) {
+            assert(_req == req);
+            state = Connected;
+            req = 0;
+            removeRequestItem(ri);
+
+            keepAliveTimer->start(UNCONNECTED_TIMEOUT * 1000);
+        } else {
+            if (_req == req) {
+                req = 0;
+
+                if (ri->type == RequestItem::Reject) {
+                    state = Idle;
+                    removeRequestItem(ri);
+                    cleanup();
+                    q->closed();
+                    return;
+                } else if (ri->type == RequestItem::Receive) {
+                    int count = ri->receiveFrames;
+                    int contentBytes = ri->receiveBytes;
+                    removeRequestItem(ri);
+                    keepAliveTimer->start(UNCONNECTED_TIMEOUT * 1000);
+                    handleWritten(count, contentBytes);
+                    return;
+                } else if (ri->type == RequestItem::ReceiveClose) {
+                    state = Idle;
+                    removeRequestItem(ri);
+                    cleanup();
+                    q->closed();
+                    return;
+                }
+            }
+
+            removeRequestItem(ri);
+        }
+    }
+
+    void req_error(ZhttpRequest *_req) {
+        RequestItem *ri = requests.value(_req);
+        assert(ri);
+
+        if (ri->type == RequestItem::Connect || ri->type == RequestItem::Accept ||
+            ri->type == RequestItem::Reject || ri->type == RequestItem::Receive ||
+            ri->type == RequestItem::ReceiveClose) {
+            assert(_req == req);
+
+            // Disconnect while long-polling means close, not error
+            bool close = false;
+            if (ri->type == RequestItem::Receive && !ri->responded)
+                close = (_req->errorCondition() == ZhttpRequest::ErrorDisconnected);
+
+            req = 0;
+            removeRequestItem(ri);
+
+            if (close && !peerClosed) {
+                peerClosed = true;
+                q->peerClosed();
+                return;
+            }
+
+            state = Idle;
+            cleanup();
+
+            if (close)
+                q->closed();
+            else
+                q->error();
+        } else {
+            removeRequestItem(ri);
+        }
+    }
+
+    void sock_readyRead() {
+        if (mode == WebSocketFramed) {
+            tryRead();
+        } else // WebSocketPassthrough
+        {
+            q->readyRead();
+        }
+    }
+
+    void sock_framesWritten(int count, int contentBytes) { handleWritten(count, contentBytes); }
+
+    void sock_writeBytesChanged() { q->writeBytesChanged(); }
+
+    void sock_peerClosed() {
+        peerCloseCode = sock->peerCloseCode();
+        peerCloseReason = sock->peerCloseReason();
+        q->peerClosed();
+    }
+
+    void sock_closed() {
+        peerCloseCode = sock->peerCloseCode();
+        peerCloseReason = sock->peerCloseReason();
+        state = Idle;
+        cleanup();
+        q->closed();
+    }
+
+    void sock_error() {
+        state = Idle;
+        errorCondition = sock->errorCondition();
+        cleanup();
+        q->error();
+    }
+
+    void doUpdate() {
+        updating = false;
+
+        if (errored) {
+            state = Idle;
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (mode == Http || mode == WebSocketFramed) {
+            if (!tryRead())
+                return;
+
+            if (pendingWrittenFrames > 0) {
+                int count = pendingWrittenFrames;
+                int contentBytes = pendingWrittenBytes;
+                pendingWrittenFrames = 0;
+                pendingWrittenBytes = 0;
+
+                q->framesWritten(count, contentBytes);
+            }
+        }
+    }
+
+    void doClosed() { q->closed(); }
+
+    void keepAliveTimer_timeout() {
+        assert(mode != WebSocketPassthrough);
+
+        if (mode == Http) {
+            if (req) {
+                RequestItem *ri = requests.value(req);
+                assert(ri && !ri->responded);
+
+                ri->responded = true;
+                respondOk(req, Variant(), "h", ri->jsonpCallback);
+            } else {
+                // Timeout while unconnected
+                state = Idle;
+                cleanup();
+                q->error();
+            }
+        } else {
+            assert(sock);
+
+            Frame f(Frame::Text, "h", false);
+            pendingWrites += WriteItem(WriteItem::Transport);
+            sock->writeFrame(f);
+        }
+    }
 };
 
-SockJsSession::SockJsSession()
-{
-	d = std::make_shared<Private>(this);
-}
+SockJsSession::SockJsSession() { d = std::make_shared<Private>(this); }
 
 SockJsSession::~SockJsSession() = default;
 
-QByteArray SockJsSession::sid() const
-{
-	return d->sid;
+QByteArray SockJsSession::sid() const { return d->sid; }
+
+DomainMap::Entry SockJsSession::route() const { return d->route; }
+
+QHostAddress SockJsSession::peerAddress() const { return d->peerAddress; }
+
+void SockJsSession::setConnectHost(const QString &host) {
+    Q_UNUSED(host);
+
+    // This class is server only
+    assert(0);
 }
 
-DomainMap::Entry SockJsSession::route() const
-{
-	return d->route;
+void SockJsSession::setConnectPort(int port) {
+    Q_UNUSED(port);
+
+    // This class is server only
+    assert(0);
 }
 
-QHostAddress SockJsSession::peerAddress() const
-{
-	return d->peerAddress;
+void SockJsSession::setIgnorePolicies(bool on) {
+    Q_UNUSED(on);
+
+    // This class is server only
+    assert(0);
 }
 
-void SockJsSession::setConnectHost(const QString &host)
-{
-	Q_UNUSED(host);
+void SockJsSession::setTrustConnectHost(bool on) {
+    Q_UNUSED(on);
 
-	// This class is server only
-	assert(0);
+    // This class is server only
+    assert(0);
 }
 
-void SockJsSession::setConnectPort(int port)
-{
-	Q_UNUSED(port);
+void SockJsSession::setIgnoreTlsErrors(bool on) {
+    Q_UNUSED(on);
 
-	// This class is server only
-	assert(0);
+    // This class is server only
+    assert(0);
 }
 
-void SockJsSession::setIgnorePolicies(bool on)
-{
-	Q_UNUSED(on);
+void SockJsSession::setClientCert(const QString &cert, const QString &key) {
+    Q_UNUSED(cert);
+    Q_UNUSED(key);
 
-	// This class is server only
-	assert(0);
+    // This class is server only
+    assert(0);
 }
 
-void SockJsSession::setTrustConnectHost(bool on)
-{
-	Q_UNUSED(on);
+void SockJsSession::start(const Url &uri, const HttpHeaders &headers) {
+    Q_UNUSED(uri);
+    Q_UNUSED(headers);
 
-	// This class is server only
-	assert(0);
+    // This class is server only
+    assert(0);
 }
 
-void SockJsSession::setIgnoreTlsErrors(bool on)
-{
-	Q_UNUSED(on);
-
-	// This class is server only
-	assert(0);
+void SockJsSession::respondSuccess(const QByteArray &reason, const HttpHeaders &headers) {
+    d->accept(reason, headers);
 }
 
-void SockJsSession::setClientCert(const QString &cert, const QString &key)
-{
-	Q_UNUSED(cert);
-	Q_UNUSED(key);
-
-	// This class is server only
-	assert(0);
+void SockJsSession::respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                                 const QByteArray &body) {
+    d->reject(code, reason, headers, body);
 }
 
-void SockJsSession::start(const Url &uri, const HttpHeaders &headers)
-{
-	Q_UNUSED(uri);
-	Q_UNUSED(headers);
+WebSocket::State SockJsSession::state() const { return d->state; }
 
-	// This class is server only
-	assert(0);
+Url SockJsSession::requestUri() const { return d->requestData.uri; }
+
+HttpHeaders SockJsSession::requestHeaders() const { return d->requestData.headers; }
+
+int SockJsSession::responseCode() const {
+    // This class is server only
+    assert(0);
+    return -1;
 }
 
-void SockJsSession::respondSuccess(const QByteArray &reason, const HttpHeaders &headers)
-{
-	d->accept(reason, headers);
+QByteArray SockJsSession::responseReason() const {
+    // This class is server only
+    assert(0);
+    return QByteArray();
 }
 
-void SockJsSession::respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	d->reject(code, reason, headers, body);
+HttpHeaders SockJsSession::responseHeaders() const {
+    // This class is server only
+    assert(0);
+    return HttpHeaders();
 }
 
-WebSocket::State SockJsSession::state() const
-{
-	return d->state;
+QByteArray SockJsSession::responseBody() const {
+    // This class is server only
+    assert(0);
+    return QByteArray();
 }
 
-Url SockJsSession::requestUri() const
-{
-	return d->requestData.uri;
+int SockJsSession::framesAvailable() const {
+    if (d->mode == Private::Http || d->mode == Private::WebSocketFramed) {
+        return d->inFrames.count();
+    } else {
+        return d->sock->framesAvailable();
+    }
 }
 
-HttpHeaders SockJsSession::requestHeaders() const
-{
-	return d->requestData.headers;
+int SockJsSession::writeBytesAvailable() const {
+    if (d->mode == Private::WebSocketFramed || d->mode == Private::WebSocketPassthrough) {
+        return d->sock->writeBytesAvailable();
+    } else {
+        int outSize = 0;
+        foreach (const Frame &f, d->outFrames)
+            outSize += f.data.size();
+
+        if (outSize < BUFFER_SIZE)
+            return BUFFER_SIZE - outSize;
+        else
+            return 0;
+    }
 }
 
-int SockJsSession::responseCode() const
-{
-	// This class is server only
-	assert(0);
-	return -1;
+int SockJsSession::peerCloseCode() const { return d->peerCloseCode; }
+
+QString SockJsSession::peerCloseReason() const { return d->peerCloseReason; }
+
+WebSocket::ErrorCondition SockJsSession::errorCondition() const { return d->errorCondition; }
+
+void SockJsSession::writeFrame(const Frame &frame) { d->writeFrame(frame); }
+
+WebSocket::Frame SockJsSession::readFrame() { return d->readFrame(); }
+
+void SockJsSession::close(int code, const QString &reason) { d->close(code, reason); }
+
+void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req,
+                                const QByteArray &jsonpCallback, const Url &asUri,
+                                const QByteArray &sid, const QByteArray &lastPart,
+                                const QByteArray &body, const DomainMap::Entry &route) {
+    d->manager = manager;
+    d->mode = Private::Http;
+    d->sid = sid;
+    d->requestData.uri = asUri;
+    d->requestData.headers = req->requestHeaders();
+
+    // We're not forwarding the request content so ignore this
+    d->requestData.headers.removeAll("Content-Length");
+
+    d->peerAddress = req->peerAddress();
+    d->route = route;
+    d->initialReq = req;
+    d->initialJsonpCallback = jsonpCallback;
+    d->initialLastPart = lastPart;
+    d->initialBody = body;
+
+    d->setup();
 }
 
-QByteArray SockJsSession::responseReason() const
-{
-	// This class is server only
-	assert(0);
-	return QByteArray();
+void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+                                const DomainMap::Entry &route) {
+    d->manager = manager;
+    d->mode = Private::WebSocketPassthrough;
+    d->requestData.uri = asUri;
+    d->requestData.headers = sock->requestHeaders();
+    d->peerAddress = sock->peerAddress();
+    d->route = route;
+    d->sock = sock;
+
+    d->setup();
 }
 
-HttpHeaders SockJsSession::responseHeaders() const
-{
-	// This class is server only
-	assert(0);
-	return HttpHeaders();
+void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+                                const QByteArray &sid, const QByteArray &lastPart,
+                                const DomainMap::Entry &route) {
+    Q_UNUSED(lastPart);
+
+    d->manager = manager;
+    d->mode = Private::WebSocketFramed;
+    d->sid = sid;
+    d->requestData.uri = asUri;
+    d->requestData.headers = sock->requestHeaders();
+    d->peerAddress = sock->peerAddress();
+    d->route = route;
+    d->sock = sock;
+
+    d->setup();
 }
 
-QByteArray SockJsSession::responseBody() const
-{
-	// This class is server only
-	assert(0);
-	return QByteArray();
-}
+void SockJsSession::startServer() { d->startServer(); }
 
-int SockJsSession::framesAvailable() const
-{
-	if(d->mode == Private::Http || d->mode == Private::WebSocketFramed)
-	{
-		return d->inFrames.count();
-	}
-	else
-	{
-		return d->sock->framesAvailable();
-	}
-}
-
-int SockJsSession::writeBytesAvailable() const
-{
-	if(d->mode == Private::WebSocketFramed || d->mode == Private::WebSocketPassthrough)
-	{
-		return d->sock->writeBytesAvailable();
-	}
-	else
-	{
-		int outSize = 0;
-		foreach(const Frame &f, d->outFrames)
-			outSize += f.data.size();
-
-		if(outSize < BUFFER_SIZE)
-			return BUFFER_SIZE - outSize;
-		else
-			return 0;
-	}
-}
-
-int SockJsSession::peerCloseCode() const
-{
-	return d->peerCloseCode;
-}
-
-QString SockJsSession::peerCloseReason() const
-{
-	return d->peerCloseReason;
-}
-
-WebSocket::ErrorCondition SockJsSession::errorCondition() const
-{
-	return d->errorCondition;
-}
-
-void SockJsSession::writeFrame(const Frame &frame)
-{
-	d->writeFrame(frame);
-}
-
-WebSocket::Frame SockJsSession::readFrame()
-{
-	return d->readFrame();
-}
-
-void SockJsSession::close(int code, const QString &reason)
-{
-	d->close(code, reason);
-}
-
-void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route)
-{
-	d->manager = manager;
-	d->mode = Private::Http;
-	d->sid = sid;
-	d->requestData.uri = asUri;
-	d->requestData.headers = req->requestHeaders();
-
-	// We're not forwarding the request content so ignore this
-	d->requestData.headers.removeAll("Content-Length");
-
-	d->peerAddress = req->peerAddress();
-	d->route = route;
-	d->initialReq = req;
-	d->initialJsonpCallback = jsonpCallback;
-	d->initialLastPart = lastPart;
-	d->initialBody = body;
-
-	d->setup();
-}
-
-void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const DomainMap::Entry &route)
-{
-	d->manager = manager;
-	d->mode = Private::WebSocketPassthrough;
-	d->requestData.uri = asUri;
-	d->requestData.headers = sock->requestHeaders();
-	d->peerAddress = sock->peerAddress();
-	d->route = route;
-	d->sock = sock;
-
-	d->setup();
-}
-
-void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route)
-{
-	Q_UNUSED(lastPart);
-
-	d->manager = manager;
-	d->mode = Private::WebSocketFramed;
-	d->sid = sid;
-	d->requestData.uri = asUri;
-	d->requestData.headers = sock->requestHeaders();
-	d->peerAddress = sock->peerAddress();
-	d->route = route;
-	d->sock = sock;
-
-	d->setup();
-}
-
-void SockJsSession::startServer()
-{
-	d->startServer();
-}
-
-void SockJsSession::handleRequest(ZhttpRequest *req, const QByteArray &jsonpCallback, const QByteArray &lastPart, const QByteArray &body)
-{
-	d->handleRequest(req, jsonpCallback, lastPart, body);
+void SockJsSession::handleRequest(ZhttpRequest *req, const QByteArray &jsonpCallback,
+                                  const QByteArray &lastPart, const QByteArray &body) {
+    d->handleRequest(req, jsonpCallback, lastPart, body);
 }

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -24,11 +24,11 @@
 #ifndef SOCKJSSESSION_H
 #define SOCKJSSESSION_H
 
-#include "url.h"
-#include <QHostAddress>
-#include "httpheaders.h"
-#include "websocket.h"
 #include "domainmap.h"
+#include "httpheaders.h"
+#include "url.h"
+#include "websocket.h"
+#include <QHostAddress>
 #include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
@@ -37,62 +37,69 @@ class ZhttpRequest;
 class ZWebSocket;
 class SockJsManager;
 
-/// SockJS session for incoming client connections that converts XHR-polling, JSONP, and native WebSocket
-/// into unified WebSocket-style messaging with session state management, keepalive handling, and request queueing
-class SockJsSession : public WebSocket
-{
+/// SockJS session for incoming client connections that converts XHR-polling,
+/// JSONP, and native WebSocket into unified WebSocket-style messaging with
+/// session state management, keepalive handling, and request queueing
+class SockJsSession : public WebSocket {
 public:
-	~SockJsSession();
+    ~SockJsSession();
 
-	QByteArray sid() const;
-	DomainMap::Entry route() const;
+    QByteArray sid() const;
+    DomainMap::Entry route() const;
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QHostAddress peerAddress() const;
+    virtual QHostAddress peerAddress() const;
 
-	virtual void setConnectHost(const QString &host);
-	virtual void setConnectPort(int port);
-	virtual void setIgnorePolicies(bool on);
-	virtual void setTrustConnectHost(bool on);
-	virtual void setIgnoreTlsErrors(bool on);
-	virtual void setClientCert(const QString &cert, const QString &key);
+    virtual void setConnectHost(const QString &host);
+    virtual void setConnectPort(int port);
+    virtual void setIgnorePolicies(bool on);
+    virtual void setTrustConnectHost(bool on);
+    virtual void setIgnoreTlsErrors(bool on);
+    virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const Url &uri, const HttpHeaders &headers);
 
-	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
-	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
+    virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
+    virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                              const QByteArray &body);
 
-	virtual State state() const;
-	virtual Url requestUri() const;
-	virtual HttpHeaders requestHeaders() const;
-	virtual int responseCode() const;
-	virtual QByteArray responseReason() const;
-	virtual HttpHeaders responseHeaders() const;
-	virtual QByteArray responseBody() const;
-	virtual int framesAvailable() const;
-	virtual int writeBytesAvailable() const;
-	virtual int peerCloseCode() const;
-	virtual QString peerCloseReason() const;
-	virtual ErrorCondition errorCondition() const;
+    virtual State state() const;
+    virtual Url requestUri() const;
+    virtual HttpHeaders requestHeaders() const;
+    virtual int responseCode() const;
+    virtual QByteArray responseReason() const;
+    virtual HttpHeaders responseHeaders() const;
+    virtual QByteArray responseBody() const;
+    virtual int framesAvailable() const;
+    virtual int writeBytesAvailable() const;
+    virtual int peerCloseCode() const;
+    virtual QString peerCloseReason() const;
+    virtual ErrorCondition errorCondition() const;
 
-	virtual void writeFrame(const Frame &frame);
-	virtual Frame readFrame();
-	virtual void close(int code = -1, const QString &reason = QString());
+    virtual void writeFrame(const Frame &frame);
+    virtual Frame readFrame();
+    virtual void close(int code = -1, const QString &reason = QString());
 
 private:
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 
-	friend class SockJsManager;
-	SockJsSession();
-	void setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const QByteArray &body, const DomainMap::Entry &route);
-	void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const DomainMap::Entry &route);
-	void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri, const QByteArray &sid, const QByteArray &lastPart, const DomainMap::Entry &route);
+    friend class SockJsManager;
+    SockJsSession();
+    void setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback,
+                     const Url &asUri, const QByteArray &sid, const QByteArray &lastPart,
+                     const QByteArray &body, const DomainMap::Entry &route);
+    void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+                     const DomainMap::Entry &route);
+    void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+                     const QByteArray &sid, const QByteArray &lastPart,
+                     const DomainMap::Entry &route);
 
-	void startServer();
-	void handleRequest(ZhttpRequest *req, const QByteArray &jsonpCallback, const QByteArray &lastPart, const QByteArray &body);
+    void startServer();
+    void handleRequest(ZhttpRequest *req, const QByteArray &jsonpCallback,
+                       const QByteArray &lastPart, const QByteArray &body);
 };
 
 #endif

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -23,296 +23,203 @@
 
 #include "testhttprequest.h"
 
-#include <assert.h>
-#include <QSet>
-#include <QUrlQuery>
-#include "log.h"
-#include "defercall.h"
 #include "bufferlist.h"
+#include "defercall.h"
+#include "log.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "statusreasons.h"
+#include <QSet>
+#include <QUrlQuery>
+#include <assert.h>
 
 #define MAX_REQUEST_SIZE 100000
 
-class TestHttpRequest::Private
-{
+class TestHttpRequest::Private {
 public:
-	enum State
-	{
-		Idle,
-		ReceivingRequest,
-		Responding,
-		Responded
-	};
+    enum State { Idle, ReceivingRequest, Responding, Responded };
 
-	TestHttpRequest *q;
-	State state;
-	HttpRequestData request;
-	HttpResponseData response;
-	BufferList requestBody;
-	bool requestBodyFinished;
-	BufferList responseBody;
-	ErrorCondition errorCondition;
-	DeferCall deferCall;
+    TestHttpRequest *q;
+    State state;
+    HttpRequestData request;
+    HttpResponseData response;
+    BufferList requestBody;
+    bool requestBodyFinished;
+    BufferList responseBody;
+    ErrorCondition errorCondition;
+    DeferCall deferCall;
 
-	Private(TestHttpRequest *_q) :
-		q(_q),
-		state(Idle),
-		requestBodyFinished(false),
-		errorCondition(ErrorGeneric)
-	{
-	}
+    Private(TestHttpRequest *_q)
+        : q(_q), state(Idle), requestBodyFinished(false), errorCondition(ErrorGeneric) {}
 
-	void doBytesWritten(int cnt){
-		q->bytesWritten(cnt);
-	}
+    void doBytesWritten(int cnt) { q->bytesWritten(cnt); }
 
-	void processRequest()
-	{
-		if(!requestBodyFinished)
-		{
-			response.code = 400;
-			response.reason = StatusReasons::getReason(response.code);
-			response.headers += HttpHeader("Content-Type", "text/plain");
-			responseBody += QByteArray("request too large\n");
+    void processRequest() {
+        if (!requestBodyFinished) {
+            response.code = 400;
+            response.reason = StatusReasons::getReason(response.code);
+            response.headers += HttpHeader("Content-Type", "text/plain");
+            responseBody += QByteArray("request too large\n");
 
-			state = Responded;
-			q->readyRead();
-			return;
-		}
+            state = Responded;
+            q->readyRead();
+            return;
+        }
 
-		log_debug("processing test request: %s", qPrintable(request.uri.path()));
+        log_debug("processing test request: %s", qPrintable(request.uri.path()));
 
-		QString path = request.uri.path();
-		if(path.length() >= 2 && path.endsWith('/'))
-			path.truncate(path.length() - 1);
+        QString path = request.uri.path();
+        if (path.length() >= 2 && path.endsWith('/'))
+            path.truncate(path.length() - 1);
 
-		QSet<QString> channels;
+        QSet<QString> channels;
 
-		QUrlQuery query(request.uri);
-		QList<QPair<QString, QString> > queryItems = query.queryItems();
-		for(int n = 0; n < queryItems.count(); ++n)
-		{
-			if(queryItems[n].first == "channel")
-				channels += queryItems[n].second;
-		}
+        QUrlQuery query(request.uri);
+        QList<QPair<QString, QString>> queryItems = query.queryItems();
+        for (int n = 0; n < queryItems.count(); ++n) {
+            if (queryItems[n].first == "channel")
+                channels += queryItems[n].second;
+        }
 
-		if(channels.isEmpty())
-			channels += "test";
+        if (channels.isEmpty())
+            channels += "test";
 
-		if(path == "/")
-		{
-			response.code = 200;
-			response.reason = StatusReasons::getReason(response.code);
-			response.headers += HttpHeader("Content-Type", "text/plain");
-			responseBody += QByteArray("Hello from the Pushpin test handler!\n");
-		}
-		else if(path == "/response")
-		{
-			response.code = 200;
-			response.reason = StatusReasons::getReason(response.code);
-			response.headers += HttpHeader("Content-Type", "text/plain");
-			response.headers += HttpHeader("Grip-Hold", "response");
-			response.headers += HttpHeader("Grip-Channel", QStringList(channels.values()).join(", ").toUtf8());
-			responseBody += QByteArray("nothing for now\n");
-		}
-		else if(path == "/stream")
-		{
-			response.code = 200;
-			response.reason = StatusReasons::getReason(response.code);
-			response.headers += HttpHeader("Content-Type", "text/plain");
-			response.headers += HttpHeader("Grip-Hold", "stream");
-			response.headers += HttpHeader("Grip-Channel", QStringList(channels.values()).join(", ").toUtf8());
-			responseBody += QByteArray("[stream opened]\n");
-		}
-		else
-		{
-			response.code = 404;
-			response.reason = StatusReasons::getReason(response.code);
-			response.headers += HttpHeader("Content-Type", "text/plain");
-			responseBody += QByteArray("no such test resource\n");
-		}
+        if (path == "/") {
+            response.code = 200;
+            response.reason = StatusReasons::getReason(response.code);
+            response.headers += HttpHeader("Content-Type", "text/plain");
+            responseBody += QByteArray("Hello from the Pushpin test handler!\n");
+        } else if (path == "/response") {
+            response.code = 200;
+            response.reason = StatusReasons::getReason(response.code);
+            response.headers += HttpHeader("Content-Type", "text/plain");
+            response.headers += HttpHeader("Grip-Hold", "response");
+            response.headers +=
+                HttpHeader("Grip-Channel", QStringList(channels.values()).join(", ").toUtf8());
+            responseBody += QByteArray("nothing for now\n");
+        } else if (path == "/stream") {
+            response.code = 200;
+            response.reason = StatusReasons::getReason(response.code);
+            response.headers += HttpHeader("Content-Type", "text/plain");
+            response.headers += HttpHeader("Grip-Hold", "stream");
+            response.headers +=
+                HttpHeader("Grip-Channel", QStringList(channels.values()).join(", ").toUtf8());
+            responseBody += QByteArray("[stream opened]\n");
+        } else {
+            response.code = 404;
+            response.reason = StatusReasons::getReason(response.code);
+            response.headers += HttpHeader("Content-Type", "text/plain");
+            responseBody += QByteArray("no such test resource\n");
+        }
 
-		state = Responded;
-		q->readyRead();
-	}
+        state = Responded;
+        q->readyRead();
+    }
 };
 
-TestHttpRequest::TestHttpRequest()
-{
-	d = new Private(this);
+TestHttpRequest::TestHttpRequest() { d = new Private(this); }
+
+TestHttpRequest::~TestHttpRequest() { delete d; }
+
+QHostAddress TestHttpRequest::peerAddress() const {
+    // This class is client only
+    return QHostAddress();
 }
 
-TestHttpRequest::~TestHttpRequest()
-{
-	delete d;
+void TestHttpRequest::setConnectHost(const QString &host) { Q_UNUSED(host); }
+
+void TestHttpRequest::setConnectPort(int port) { Q_UNUSED(port); }
+
+void TestHttpRequest::setIgnorePolicies(bool on) { Q_UNUSED(on); }
+
+void TestHttpRequest::setTrustConnectHost(bool on) { Q_UNUSED(on); }
+
+void TestHttpRequest::setIgnoreTlsErrors(bool on) { Q_UNUSED(on); }
+
+void TestHttpRequest::setTimeout(int msecs) { Q_UNUSED(msecs); }
+
+void TestHttpRequest::setClientCert(const QString &cert, const QString &key) {
+    Q_UNUSED(cert);
+    Q_UNUSED(key);
 }
 
-QHostAddress TestHttpRequest::peerAddress() const
-{
-	// This class is client only
-	return QHostAddress();
+void TestHttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers) {
+    assert(d->state == Private::Idle);
+
+    d->state = Private::ReceivingRequest;
+
+    d->request.method = method;
+    d->request.uri = uri;
+    d->request.headers = headers;
 }
 
-void TestHttpRequest::setConnectHost(const QString &host)
-{
-	Q_UNUSED(host);
+void TestHttpRequest::beginResponse(int code, const QByteArray &reason,
+                                    const HttpHeaders &headers) {
+    Q_UNUSED(code);
+    Q_UNUSED(reason);
+    Q_UNUSED(headers);
+
+    // This class is client only
+    assert(0);
 }
 
-void TestHttpRequest::setConnectPort(int port)
-{
-	Q_UNUSED(port);
+void TestHttpRequest::writeBody(const QByteArray &body) {
+    if (d->state == Private::ReceivingRequest) {
+        if (d->requestBody.size() + body.size() > MAX_REQUEST_SIZE) {
+            d->state = Private::Responding;
+            d->deferCall.defer([=] { d->processRequest(); });
+            return;
+        }
+
+        QByteArray buf = body.mid(0, MAX_REQUEST_SIZE - d->requestBody.size());
+
+        if (!buf.isEmpty()) {
+            d->requestBody += buf;
+
+            int written = buf.size();
+            d->deferCall.defer([=] { d->doBytesWritten(written); });
+        }
+    }
 }
 
-void TestHttpRequest::setIgnorePolicies(bool on)
-{
-	Q_UNUSED(on);
+void TestHttpRequest::endBody() {
+    if (d->state == Private::ReceivingRequest) {
+        d->requestBodyFinished = true;
+
+        d->state = Private::Responding;
+        d->deferCall.defer([=] { d->processRequest(); });
+    }
 }
 
-void TestHttpRequest::setTrustConnectHost(bool on)
-{
-	Q_UNUSED(on);
+int TestHttpRequest::bytesAvailable() const { return d->responseBody.size(); }
+
+int TestHttpRequest::writeBytesAvailable() const {
+    return (MAX_REQUEST_SIZE - d->requestBody.size() + 1);
 }
 
-void TestHttpRequest::setIgnoreTlsErrors(bool on)
-{
-	Q_UNUSED(on);
+bool TestHttpRequest::isFinished() const { return (d->state == Private::Responded); }
+
+bool TestHttpRequest::isInputFinished() const { return (d->state == Private::Responded); }
+
+bool TestHttpRequest::isOutputFinished() const { return d->requestBodyFinished; }
+
+bool TestHttpRequest::isErrored() const {
+    // This class can't fail
+    return false;
 }
 
-void TestHttpRequest::setTimeout(int msecs)
-{
-	Q_UNUSED(msecs);
-}
+HttpRequest::ErrorCondition TestHttpRequest::errorCondition() const { return d->errorCondition; }
 
-void TestHttpRequest::setClientCert(const QString &cert, const QString &key)
-{
-	Q_UNUSED(cert);
-	Q_UNUSED(key);
-}
+QString TestHttpRequest::requestMethod() const { return d->request.method; }
 
-void TestHttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers)
-{
-	assert(d->state == Private::Idle);
+Url TestHttpRequest::requestUri() const { return d->request.uri; }
 
-	d->state = Private::ReceivingRequest;
+HttpHeaders TestHttpRequest::requestHeaders() const { return d->request.headers; }
 
-	d->request.method = method;
-	d->request.uri = uri;
-	d->request.headers = headers;
-}
+int TestHttpRequest::responseCode() const { return d->response.code; }
 
-void TestHttpRequest::beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers)
-{
-	Q_UNUSED(code);
-	Q_UNUSED(reason);
-	Q_UNUSED(headers);
+QByteArray TestHttpRequest::responseReason() const { return d->response.reason; }
 
-	// This class is client only
-	assert(0);
-}
+HttpHeaders TestHttpRequest::responseHeaders() const { return d->response.headers; }
 
-void TestHttpRequest::writeBody(const QByteArray &body)
-{
-	if(d->state == Private::ReceivingRequest)
-	{
-		if(d->requestBody.size() + body.size() > MAX_REQUEST_SIZE)
-		{
-			d->state = Private::Responding;
-			d->deferCall.defer([=] { d->processRequest(); });
-			return;
-		}
-
-		QByteArray buf = body.mid(0, MAX_REQUEST_SIZE - d->requestBody.size());
-
-		if(!buf.isEmpty())
-		{
-			d->requestBody += buf;
-
-			int written = buf.size();
-			d->deferCall.defer([=] { d->doBytesWritten(written); });
-		}
-	}
-}
-
-void TestHttpRequest::endBody()
-{
-	if(d->state == Private::ReceivingRequest)
-	{
-		d->requestBodyFinished = true;
-
-		d->state = Private::Responding;
-		d->deferCall.defer([=] { d->processRequest(); });
-	}
-}
-
-int TestHttpRequest::bytesAvailable() const
-{
-	return d->responseBody.size();
-}
-
-int TestHttpRequest::writeBytesAvailable() const
-{
-	return (MAX_REQUEST_SIZE - d->requestBody.size() + 1);
-}
-
-bool TestHttpRequest::isFinished() const
-{
-	return (d->state == Private::Responded);
-}
-
-bool TestHttpRequest::isInputFinished() const
-{
-	return (d->state == Private::Responded);
-}
-
-bool TestHttpRequest::isOutputFinished() const
-{
-	return d->requestBodyFinished;
-}
-
-bool TestHttpRequest::isErrored() const
-{
-	// This class can't fail
-	return false;
-}
-
-HttpRequest::ErrorCondition TestHttpRequest::errorCondition() const
-{
-	return d->errorCondition;
-}
-
-QString TestHttpRequest::requestMethod() const
-{
-	return d->request.method;
-}
-
-Url TestHttpRequest::requestUri() const
-{
-	return d->request.uri;
-}
-
-HttpHeaders TestHttpRequest::requestHeaders() const
-{
-	return d->request.headers;
-}
-
-int TestHttpRequest::responseCode() const
-{
-	return d->response.code;
-}
-
-QByteArray TestHttpRequest::responseReason() const
-{
-	return d->response.reason;
-}
-
-HttpHeaders TestHttpRequest::responseHeaders() const
-{
-	return d->response.headers;
-}
-
-QByteArray TestHttpRequest::readBody(int size)
-{
-	return d->responseBody.take(size);
-}
+QByteArray TestHttpRequest::readBody(int size) { return d->responseBody.take(size); }

--- a/src/proxy/testhttprequest.h
+++ b/src/proxy/testhttprequest.h
@@ -27,56 +27,55 @@
 #include "url.h"
 
 /// HTTP request instance for testing that simulates HTTP behavior
-class TestHttpRequest : public HttpRequest
-{
+class TestHttpRequest : public HttpRequest {
 public:
-	// Pair of sender + request id
-	typedef QPair<QByteArray, QByteArray> Rid;
+    // Pair of sender + request id
+    typedef QPair<QByteArray, QByteArray> Rid;
 
-	TestHttpRequest();
-	~TestHttpRequest();
+    TestHttpRequest();
+    ~TestHttpRequest();
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QHostAddress peerAddress() const;
+    virtual QHostAddress peerAddress() const;
 
-	virtual void setConnectHost(const QString &host);
-	virtual void setConnectPort(int port);
-	virtual void setIgnorePolicies(bool on);
-	virtual void setTrustConnectHost(bool on);
-	virtual void setIgnoreTlsErrors(bool on);
-	virtual void setTimeout(int msecs);
-	virtual void setClientCert(const QString &cert, const QString &key);
+    virtual void setConnectHost(const QString &host);
+    virtual void setConnectPort(int port);
+    virtual void setIgnorePolicies(bool on);
+    virtual void setTrustConnectHost(bool on);
+    virtual void setIgnoreTlsErrors(bool on);
+    virtual void setTimeout(int msecs);
+    virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
-	virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
+    virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
+    virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
 
-	virtual void writeBody(const QByteArray &body);
+    virtual void writeBody(const QByteArray &body);
 
-	virtual void endBody();
+    virtual void endBody();
 
-	virtual int bytesAvailable() const;
-	virtual int writeBytesAvailable() const;
-	virtual bool isFinished() const;
-	virtual bool isInputFinished() const;
-	virtual bool isOutputFinished() const;
-	virtual bool isErrored() const;
-	virtual ErrorCondition errorCondition() const;
+    virtual int bytesAvailable() const;
+    virtual int writeBytesAvailable() const;
+    virtual bool isFinished() const;
+    virtual bool isInputFinished() const;
+    virtual bool isOutputFinished() const;
+    virtual bool isErrored() const;
+    virtual ErrorCondition errorCondition() const;
 
-	virtual QString requestMethod() const;
-	virtual Url requestUri() const;
-	virtual HttpHeaders requestHeaders() const;
+    virtual QString requestMethod() const;
+    virtual Url requestUri() const;
+    virtual HttpHeaders requestHeaders() const;
 
-	virtual int responseCode() const;
-	virtual QByteArray responseReason() const;
-	virtual HttpHeaders responseHeaders() const;
+    virtual int responseCode() const;
+    virtual QByteArray responseReason() const;
+    virtual HttpHeaders responseHeaders() const;
 
-	virtual QByteArray readBody(int size = -1);
+    virtual QByteArray readBody(int size = -1);
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -23,314 +23,223 @@
 
 #include "testwebsocket.h"
 
-#include <assert.h>
-#include <QUrlQuery>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include "defercall.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "statusreasons.h"
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrlQuery>
+#include <assert.h>
 
 #define BUFFER_SIZE 200000
 
-class TestWebSocket::Private
-{
+class TestWebSocket::Private {
 public:
-	enum State
-	{
-		Idle,
-		Connecting,
-		Connected,
-		Closing
-	};
+    enum State { Idle, Connecting, Connected, Closing };
 
-	TestWebSocket *q;
-	State state;
-	HttpRequestData request;
-	HttpResponseData response;
-	bool gripEnabled;
-	QList<Frame> inFrames;
-	int peerCloseCode;
-	QString peerCloseReason;
-	ErrorCondition errorCondition;
-	DeferCall deferCall;
+    TestWebSocket *q;
+    State state;
+    HttpRequestData request;
+    HttpResponseData response;
+    bool gripEnabled;
+    QList<Frame> inFrames;
+    int peerCloseCode;
+    QString peerCloseReason;
+    ErrorCondition errorCondition;
+    DeferCall deferCall;
 
-	Private(TestWebSocket *_q) :
-		q(_q),
-		state(Idle),
-		gripEnabled(false),
-		peerCloseCode(-1),
-		errorCondition(ErrorGeneric)
-	{
-	}
+    Private(TestWebSocket *_q)
+        : q(_q), state(Idle), gripEnabled(false), peerCloseCode(-1), errorCondition(ErrorGeneric) {}
 
-	void handleConnect()
-	{
-		QString path = request.uri.path();
-		if(path.length() >= 2 && path.endsWith('/'))
-			path.truncate(path.length() - 1);
+    void handleConnect() {
+        QString path = request.uri.path();
+        if (path.length() >= 2 && path.endsWith('/'))
+            path.truncate(path.length() - 1);
 
-		QSet<QString> channels;
+        QSet<QString> channels;
 
-		QUrlQuery query(request.uri);
-		QList<QPair<QString, QString> > queryItems = query.queryItems();
-		for(int n = 0; n < queryItems.count(); ++n)
-		{
-			if(queryItems[n].first == "channel")
-				channels += queryItems[n].second;
-		}
+        QUrlQuery query(request.uri);
+        QList<QPair<QString, QString>> queryItems = query.queryItems();
+        for (int n = 0; n < queryItems.count(); ++n) {
+            if (queryItems[n].first == "channel")
+                channels += queryItems[n].second;
+        }
 
-		if(channels.isEmpty())
-			channels += "test";
+        if (channels.isEmpty())
+            channels += "test";
 
-		if(path == "/ws")
-		{
-			state = Connected;
-			response.code = 101;
-			response.reason = StatusReasons::getReason(response.code);
+        if (path == "/ws") {
+            state = Connected;
+            response.code = 101;
+            response.reason = StatusReasons::getReason(response.code);
 
-			gripEnabled = false;
-			foreach(const HttpHeaderParameters &ext, request.headers.getAllAsParameters("Sec-WebSocket-Extensions"))
-			{
-				if(!ext.isEmpty() && ext[0].first == "grip")
-				{
-					gripEnabled = true;
-					break;
-				}
-			}
+            gripEnabled = false;
+            foreach (const HttpHeaderParameters &ext,
+                     request.headers.getAllAsParameters("Sec-WebSocket-Extensions")) {
+                if (!ext.isEmpty() && ext[0].first == "grip") {
+                    gripEnabled = true;
+                    break;
+                }
+            }
 
-			if(gripEnabled)
-			{
-				response.headers += HttpHeader("Sec-WebSocket-Extensions", "grip");
+            if (gripEnabled) {
+                response.headers += HttpHeader("Sec-WebSocket-Extensions", "grip");
 
-				foreach(const QString &channel, channels)
-				{
-					QJsonObject obj;
-					obj["type"] = QString("subscribe");
-					obj["channel"] = channel;
-					inFrames += Frame(Frame::Text, QByteArray("c:") + QJsonDocument(obj).toJson(), false);
-				}
-			}
+                foreach (const QString &channel, channels) {
+                    QJsonObject obj;
+                    obj["type"] = QString("subscribe");
+                    obj["channel"] = channel;
+                    inFrames +=
+                        Frame(Frame::Text, QByteArray("c:") + QJsonDocument(obj).toJson(), false);
+                }
+            }
 
-			q->connected();
+            q->connected();
 
-			if(gripEnabled && !channels.isEmpty())
-				deferCall.defer([=] { doReadyRead(); });
-		}
-		else
-		{
-			response.code = 404;
-			response.reason = StatusReasons::getReason(response.code);
-			response.headers += HttpHeader("Content-Type", "text/plain");
-			response.body += QByteArray("no such test resource\n");
+            if (gripEnabled && !channels.isEmpty())
+                deferCall.defer([=] { doReadyRead(); });
+        } else {
+            response.code = 404;
+            response.reason = StatusReasons::getReason(response.code);
+            response.headers += HttpHeader("Content-Type", "text/plain");
+            response.body += QByteArray("no such test resource\n");
 
-			errorCondition = ErrorRejected;
-			q->error();
-		}
-	}
+            errorCondition = ErrorRejected;
+            q->error();
+        }
+    }
 
-	void doReadyRead()
-	{
-		q->readyRead();
-	}
+    void doReadyRead() { q->readyRead(); }
 
-	void doFramesWritten(int count, int bytes)
-	{
-		q->framesWritten(count, bytes);
-	}
+    void doFramesWritten(int count, int bytes) { q->framesWritten(count, bytes); }
 
-	void doWriteBytesChanged()
-	{
-		q->writeBytesChanged();
-	}
+    void doWriteBytesChanged() { q->writeBytesChanged(); }
 
-	void handleClose()
-	{
-		state = Idle;
-		q->closed();
-	}
+    void handleClose() {
+        state = Idle;
+        q->closed();
+    }
 };
 
-TestWebSocket::TestWebSocket()
-{
-	d = new Private(this);
+TestWebSocket::TestWebSocket() { d = new Private(this); }
+
+TestWebSocket::~TestWebSocket() { delete d; }
+
+QHostAddress TestWebSocket::peerAddress() const {
+    // This class is client only
+    return QHostAddress();
 }
 
-TestWebSocket::~TestWebSocket()
-{
-	delete d;
+void TestWebSocket::setConnectHost(const QString &host) { Q_UNUSED(host); }
+
+void TestWebSocket::setConnectPort(int port) { Q_UNUSED(port); }
+
+void TestWebSocket::setIgnorePolicies(bool on) { Q_UNUSED(on); }
+
+void TestWebSocket::setTrustConnectHost(bool on) { Q_UNUSED(on); }
+
+void TestWebSocket::setIgnoreTlsErrors(bool on) { Q_UNUSED(on); }
+
+void TestWebSocket::setClientCert(const QString &cert, const QString &key) {
+    Q_UNUSED(cert);
+    Q_UNUSED(key);
 }
 
-QHostAddress TestWebSocket::peerAddress() const
-{
-	// This class is client only
-	return QHostAddress();
+void TestWebSocket::start(const Url &uri, const HttpHeaders &headers) {
+    d->request.uri = uri;
+    d->request.headers = headers;
+
+    d->state = Private::Connecting;
+
+    d->deferCall.defer([=] { d->handleConnect(); });
 }
 
-void TestWebSocket::setConnectHost(const QString &host)
-{
-	Q_UNUSED(host);
+void TestWebSocket::respondSuccess(const QByteArray &reason, const HttpHeaders &headers) {
+    Q_UNUSED(reason);
+    Q_UNUSED(headers);
+
+    // This class is client only
+    assert(0);
 }
 
-void TestWebSocket::setConnectPort(int port)
-{
-	Q_UNUSED(port);
+void TestWebSocket::respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                                 const QByteArray &body) {
+    Q_UNUSED(code);
+    Q_UNUSED(reason);
+    Q_UNUSED(headers);
+    Q_UNUSED(body);
+
+    // This class is client only
+    assert(0);
 }
 
-void TestWebSocket::setIgnorePolicies(bool on)
-{
-	Q_UNUSED(on);
+WebSocket::State TestWebSocket::state() const {
+    if (d->state == Private::Idle)
+        return Idle;
+    else if (d->state == Private::Connecting)
+        return Connecting;
+    else if (d->state == Private::Connected)
+        return Connected;
+    else // Private::Closing
+        return Closing;
 }
 
-void TestWebSocket::setTrustConnectHost(bool on)
-{
-	Q_UNUSED(on);
+Url TestWebSocket::requestUri() const { return d->request.uri; }
+
+HttpHeaders TestWebSocket::requestHeaders() const { return d->request.headers; }
+
+int TestWebSocket::responseCode() const { return d->response.code; }
+
+QByteArray TestWebSocket::responseReason() const { return d->response.reason; }
+
+HttpHeaders TestWebSocket::responseHeaders() const { return d->response.headers; }
+
+QByteArray TestWebSocket::responseBody() const { return d->response.body; }
+
+int TestWebSocket::framesAvailable() const { return d->inFrames.count(); }
+
+int TestWebSocket::writeBytesAvailable() const {
+    int inSize = 0;
+    foreach (const Frame &f, d->inFrames)
+        inSize += f.data.size();
+
+    if (inSize < BUFFER_SIZE)
+        return BUFFER_SIZE - inSize;
+    else
+        return 0;
 }
 
-void TestWebSocket::setIgnoreTlsErrors(bool on)
-{
-	Q_UNUSED(on);
+int TestWebSocket::peerCloseCode() const { return d->peerCloseCode; }
+
+QString TestWebSocket::peerCloseReason() const { return d->peerCloseReason; }
+
+WebSocket::ErrorCondition TestWebSocket::errorCondition() const { return d->errorCondition; }
+
+void TestWebSocket::writeFrame(const Frame &frame) {
+    Frame tmp = frame;
+
+    if (d->gripEnabled && (frame.type == Frame::Text || frame.type == Frame::Binary)) {
+        tmp.data = "m:" + tmp.data;
+    }
+
+    d->inFrames += tmp;
+
+    int contentBytesWritten = tmp.data.size();
+    d->deferCall.defer([=] { d->doFramesWritten(1, contentBytesWritten); });
+    d->deferCall.defer([=] { d->doReadyRead(); });
 }
 
-void TestWebSocket::setClientCert(const QString &cert, const QString &key)
-{
-	Q_UNUSED(cert);
-	Q_UNUSED(key);
+WebSocket::Frame TestWebSocket::readFrame() {
+    d->deferCall.defer([=] { d->doWriteBytesChanged(); });
+
+    return d->inFrames.takeFirst();
 }
 
-void TestWebSocket::start(const Url &uri, const HttpHeaders &headers)
-{
-	d->request.uri = uri;
-	d->request.headers = headers;
+void TestWebSocket::close(int code, const QString &reason) {
+    d->state = Private::Closing;
+    d->peerCloseCode = code;
+    d->peerCloseReason = reason;
 
-	d->state = Private::Connecting;
-
-	d->deferCall.defer([=] { d->handleConnect(); });
-}
-
-void TestWebSocket::respondSuccess(const QByteArray &reason, const HttpHeaders &headers)
-{
-	Q_UNUSED(reason);
-	Q_UNUSED(headers);
-
-	// This class is client only
-	assert(0);
-}
-
-void TestWebSocket::respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	Q_UNUSED(code);
-	Q_UNUSED(reason);
-	Q_UNUSED(headers);
-	Q_UNUSED(body);
-
-	// This class is client only
-	assert(0);
-}
-
-WebSocket::State TestWebSocket::state() const
-{
-	if(d->state == Private::Idle)
-		return Idle;
-	else if(d->state == Private::Connecting)
-		return Connecting;
-	else if(d->state == Private::Connected)
-		return Connected;
-	else // Private::Closing
-		return Closing;
-}
-
-Url TestWebSocket::requestUri() const
-{
-	return d->request.uri;
-}
-
-HttpHeaders TestWebSocket::requestHeaders() const
-{
-	return d->request.headers;
-}
-
-int TestWebSocket::responseCode() const
-{
-	return d->response.code;
-}
-
-QByteArray TestWebSocket::responseReason() const
-{
-	return d->response.reason;
-}
-
-HttpHeaders TestWebSocket::responseHeaders() const
-{
-	return d->response.headers;
-}
-
-QByteArray TestWebSocket::responseBody() const
-{
-	return d->response.body;
-}
-
-int TestWebSocket::framesAvailable() const
-{
-	return d->inFrames.count();
-}
-
-int TestWebSocket::writeBytesAvailable() const
-{
-	int inSize = 0;
-	foreach(const Frame &f, d->inFrames)
-		inSize += f.data.size();
-
-	if(inSize < BUFFER_SIZE)
-		return BUFFER_SIZE - inSize;
-	else
-		return 0;
-}
-
-int TestWebSocket::peerCloseCode() const
-{
-	return d->peerCloseCode;
-}
-
-QString TestWebSocket::peerCloseReason() const
-{
-	return d->peerCloseReason;
-}
-
-WebSocket::ErrorCondition TestWebSocket::errorCondition() const
-{
-	return d->errorCondition;
-}
-
-void TestWebSocket::writeFrame(const Frame &frame)
-{
-	Frame tmp = frame;
-
-	if(d->gripEnabled && (frame.type == Frame::Text || frame.type == Frame::Binary))
-	{
-		tmp.data = "m:" + tmp.data;
-	}
-
-	d->inFrames += tmp;
-
-	int contentBytesWritten = tmp.data.size();
-	d->deferCall.defer([=] { d->doFramesWritten(1, contentBytesWritten); });
-	d->deferCall.defer([=] { d->doReadyRead(); });
-}
-
-WebSocket::Frame TestWebSocket::readFrame()
-{
-	d->deferCall.defer([=] { d->doWriteBytesChanged(); });
-
-	return d->inFrames.takeFirst();
-}
-
-void TestWebSocket::close(int code, const QString &reason)
-{
-	d->state = Private::Closing;
-	d->peerCloseCode = code;
-	d->peerCloseReason = reason;
-
-	d->deferCall.defer([=] { d->handleClose(); });
+    d->deferCall.defer([=] { d->handleClose(); });
 }

--- a/src/proxy/testwebsocket.h
+++ b/src/proxy/testwebsocket.h
@@ -24,55 +24,55 @@
 #ifndef TESTWEBSOCKET_H
 #define TESTWEBSOCKET_H
 
-#include "websocket.h"
 #include "url.h"
+#include "websocket.h"
 
 class ZhttpManager;
 
 /// WebSocket instance for testing that simulates WebSocket behavior
-class TestWebSocket : public WebSocket
-{
+class TestWebSocket : public WebSocket {
 public:
-	TestWebSocket();
-	~TestWebSocket();
+    TestWebSocket();
+    ~TestWebSocket();
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QHostAddress peerAddress() const;
+    virtual QHostAddress peerAddress() const;
 
-	virtual void setConnectHost(const QString &host);
-	virtual void setConnectPort(int port);
-	virtual void setIgnorePolicies(bool on);
-	virtual void setTrustConnectHost(bool on);
-	virtual void setIgnoreTlsErrors(bool on);
-	virtual void setClientCert(const QString &cert, const QString &key);
+    virtual void setConnectHost(const QString &host);
+    virtual void setConnectPort(int port);
+    virtual void setIgnorePolicies(bool on);
+    virtual void setTrustConnectHost(bool on);
+    virtual void setIgnoreTlsErrors(bool on);
+    virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const Url &uri, const HttpHeaders &headers);
 
-	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
-	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
+    virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
+    virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                              const QByteArray &body);
 
-	virtual State state() const;
-	virtual Url requestUri() const;
-	virtual HttpHeaders requestHeaders() const;
-	virtual int responseCode() const;
-	virtual QByteArray responseReason() const;
-	virtual HttpHeaders responseHeaders() const;
-	virtual QByteArray responseBody() const;
-	virtual int framesAvailable() const;
-	virtual int writeBytesAvailable() const;
-	virtual int peerCloseCode() const;
-	virtual QString peerCloseReason() const;
-	virtual ErrorCondition errorCondition() const;
+    virtual State state() const;
+    virtual Url requestUri() const;
+    virtual HttpHeaders requestHeaders() const;
+    virtual int responseCode() const;
+    virtual QByteArray responseReason() const;
+    virtual HttpHeaders responseHeaders() const;
+    virtual QByteArray responseBody() const;
+    virtual int framesAvailable() const;
+    virtual int writeBytesAvailable() const;
+    virtual int peerCloseCode() const;
+    virtual QString peerCloseReason() const;
+    virtual ErrorCondition errorCondition() const;
 
-	virtual void writeFrame(const Frame &frame);
-	virtual Frame readFrame();
-	virtual void close(int code = -1, const QString &reason = QString());
+    virtual void writeFrame(const Frame &frame);
+    virtual Frame readFrame();
+    virtual void close(int code = -1, const QString &reason = QString());
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -23,17 +23,17 @@
 
 #include "websocketoverhttp.h"
 
-#include <assert.h>
-#include <QRandomGenerator>
-#include "log.h"
 #include "bufferlist.h"
+#include "defercall.h"
+#include "log.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
-#include "zhttprequest.h"
-#include "zhttpmanager.h"
-#include "uuidutil.h"
 #include "timer.h"
-#include "defercall.h"
+#include "uuidutil.h"
+#include "zhttpmanager.h"
+#include "zhttprequest.h"
+#include <QRandomGenerator>
+#include <assert.h>
 
 #define BUFFER_SIZE 200000
 #define FRAME_SIZE_MAX 16384
@@ -43,1312 +43,1094 @@
 #define RETRY_MAX 5
 #define RETRY_RAND_MAX 1000
 
-class WebSocketOverHttp::DisconnectManager
-{
+class WebSocketOverHttp::DisconnectManager {
 public:
-	~DisconnectManager()
-	{
-		while(!wsConnectionMap.empty())
-		{
-			auto it = wsConnectionMap.begin();
-			WebSocketOverHttp *sock = it->first;
-			wsConnectionMap.erase(it);
-			deleteSocket(sock);
-		}
-	}
+    ~DisconnectManager() {
+        while (!wsConnectionMap.empty()) {
+            auto it = wsConnectionMap.begin();
+            WebSocketOverHttp *sock = it->first;
+            wsConnectionMap.erase(it);
+            deleteSocket(sock);
+        }
+    }
 
-	void addSocket(WebSocketOverHttp *sock)
-	{
-		wsConnectionMap[sock] = { 
-			sock->disconnected.connect(boost::bind(&DisconnectManager::sock_disconnected, this, sock)),
-			sock->closed.connect(boost::bind(&DisconnectManager::sock_closed, this, sock)),
-			sock->error.connect(boost::bind(&DisconnectManager::sock_error, this, sock))
-		};
+    void addSocket(WebSocketOverHttp *sock) {
+        wsConnectionMap[sock] = {
+            sock->disconnected.connect(
+                boost::bind(&DisconnectManager::sock_disconnected, this, sock)),
+            sock->closed.connect(boost::bind(&DisconnectManager::sock_closed, this, sock)),
+            sock->error.connect(boost::bind(&DisconnectManager::sock_error, this, sock))};
 
-		sock->sendDisconnect();
-	}
+        sock->sendDisconnect();
+    }
 
-	int count() const
-	{
-		return wsConnectionMap.size();
-	}
+    int count() const { return wsConnectionMap.size(); }
 
-	bool contains(WebSocketOverHttp *sock)
-	{
-		auto it = wsConnectionMap.find(sock);
-		return (it != wsConnectionMap.end());
-	}
+    bool contains(WebSocketOverHttp *sock) {
+        auto it = wsConnectionMap.find(sock);
+        return (it != wsConnectionMap.end());
+    }
 
 private:
-	struct WSConnections {
-		Connection disconnectedConnection;
-		Connection closedConnection;
-		Connection errorConnection;
-	};
+    struct WSConnections {
+        Connection disconnectedConnection;
+        Connection closedConnection;
+        Connection errorConnection;
+    };
 
-	map<WebSocketOverHttp *, WSConnections> wsConnectionMap;
+    map<WebSocketOverHttp *, WSConnections> wsConnectionMap;
 
-	void deleteSocket(WebSocketOverHttp *sock);
+    void deleteSocket(WebSocketOverHttp *sock);
 
-	void cleanupSocket(WebSocketOverHttp *sock)
-	{
-		wsConnectionMap.erase(sock);
-		deleteSocket(sock);
-	}
+    void cleanupSocket(WebSocketOverHttp *sock) {
+        wsConnectionMap.erase(sock);
+        deleteSocket(sock);
+    }
 
-	void sock_disconnected(WebSocketOverHttp *sock)
-	{
-		cleanupSocket(sock);
-	}
+    void sock_disconnected(WebSocketOverHttp *sock) { cleanupSocket(sock); }
 
-	void sock_closed(WebSocketOverHttp *sock)
-	{
-		cleanupSocket(sock);
-	}
+    void sock_closed(WebSocketOverHttp *sock) { cleanupSocket(sock); }
 
-	void sock_error(WebSocketOverHttp *sock)
-	{
-		cleanupSocket(sock);
-	}
+    void sock_error(WebSocketOverHttp *sock) { cleanupSocket(sock); }
 };
 
 thread_local WebSocketOverHttp::DisconnectManager *WebSocketOverHttp::g_disconnectManager = 0;
 thread_local int WebSocketOverHttp::g_maxManagedDisconnects = -1;
 
-static QList<WebSocketOverHttp::Event> decodeEvents(const QByteArray &in, bool *ok = 0)
-{
-	QList<WebSocketOverHttp::Event> out;
-	if(ok)
-		*ok = false;
+static QList<WebSocketOverHttp::Event> decodeEvents(const QByteArray &in, bool *ok = 0) {
+    QList<WebSocketOverHttp::Event> out;
+    if (ok)
+        *ok = false;
 
-	int start = 0;
-	while(start < in.size())
-	{
-		int at = in.indexOf("\r\n", start);
-		if(at == -1)
-			return QList<WebSocketOverHttp::Event>();
+    int start = 0;
+    while (start < in.size()) {
+        int at = in.indexOf("\r\n", start);
+        if (at == -1)
+            return QList<WebSocketOverHttp::Event>();
 
-		QByteArray typeLine = in.mid(start, at - start);
-		start = at + 2;
+        QByteArray typeLine = in.mid(start, at - start);
+        start = at + 2;
 
-		WebSocketOverHttp::Event e;
-		at = typeLine.indexOf(' ');
-		if(at != -1)
-		{
-			e.type = typeLine.mid(0, at);
+        WebSocketOverHttp::Event e;
+        at = typeLine.indexOf(' ');
+        if (at != -1) {
+            e.type = typeLine.mid(0, at);
 
-			bool check;
-			int clen = typeLine.mid(at + 1).toInt(&check, 16);
-			if(!check)
-				return QList<WebSocketOverHttp::Event>();
+            bool check;
+            int clen = typeLine.mid(at + 1).toInt(&check, 16);
+            if (!check)
+                return QList<WebSocketOverHttp::Event>();
 
-			e.content = in.mid(start, clen);
-			start += clen + 2;
-		}
-		else
-		{
-			e.type = typeLine;
-		}
+            e.content = in.mid(start, clen);
+            start += clen + 2;
+        } else {
+            e.type = typeLine;
+        }
 
-		out += e;
-	}
+        out += e;
+    }
 
-	if(ok)
-		*ok = true;
-	return out;
+    if (ok)
+        *ok = true;
+    return out;
 }
 
-static QByteArray encodeEvents(const QList<WebSocketOverHttp::Event> &events)
-{
-	QByteArray out;
+static QByteArray encodeEvents(const QList<WebSocketOverHttp::Event> &events) {
+    QByteArray out;
 
-	foreach(const WebSocketOverHttp::Event &e, events)
-	{
-		if(!e.content.isNull())
-		{
-			out += e.type + ' ' + QByteArray::number(e.content.size(), 16) + "\r\n" + e.content + "\r\n";
-		}
-		else
-		{
-			out += e.type + "\r\n";
-		}
-	}
+    foreach (const WebSocketOverHttp::Event &e, events) {
+        if (!e.content.isNull()) {
+            out += e.type + ' ' + QByteArray::number(e.content.size(), 16) + "\r\n" + e.content +
+                   "\r\n";
+        } else {
+            out += e.type + "\r\n";
+        }
+    }
 
-	return out;
+    return out;
 }
 
-class WebSocketOverHttp::Private
-{
+class WebSocketOverHttp::Private {
 public:
-	struct ReqConnections {
-		Connection readyReadConnection;
-		Connection bytesWrittenConnection;
-		Connection errorConnection;
-	};
+    struct ReqConnections {
+        Connection readyReadConnection;
+        Connection bytesWrittenConnection;
+        Connection errorConnection;
+    };
 
-	WebSocketOverHttp *q;
-	ZhttpManager *zhttpManager;
-	QString connectHost;
-	int connectPort;
-	bool ignorePolicies;
-	bool trustConnectHost;
-	bool ignoreTlsErrors;
-	QString clientCert;
-	QString clientKey;
-	State state;
-	QByteArray cid;
-	HttpRequestData requestData;
-	HttpResponseData responseData;
-	ErrorCondition errorCondition;
-	ErrorCondition pendingErrorCondition;
-	int keepAliveInterval;
-	HttpHeaders meta;
-	bool updating;
-	std::unique_ptr<ZhttpRequest> req;
-	QByteArray reqBody;
-	int reqPendingBytes;
-	int reqFrames;
-	int reqContentSize;
-	bool reqMaxed;
-	bool reqClose;
-	int reqCloseContentSize;
-	BufferList inBuf;
-	QList<Frame> inFrames;
-	QList<Frame> outFrames;
-	int outContentSize;
-	int outFramesReplay;
-	int outContentReplay;
-	int closeCode;
-	QString closeReason;
-	bool closeSent;
-	bool peerClosing;
-	int peerCloseCode;
-	QString peerCloseReason;
-	bool disconnecting;
-	bool disconnectSent;
-	bool updateQueued;
-	std::unique_ptr<Timer> keepAliveTimer;
-	std::unique_ptr<Timer> retryTimer;
-	int retries;
-	int maxEvents;
-	ReqConnections reqConnections;
-	Connection keepAliveTimerConnection;
-	Connection retryTimerConnection;
-	DeferCall deferCall;
+    WebSocketOverHttp *q;
+    ZhttpManager *zhttpManager;
+    QString connectHost;
+    int connectPort;
+    bool ignorePolicies;
+    bool trustConnectHost;
+    bool ignoreTlsErrors;
+    QString clientCert;
+    QString clientKey;
+    State state;
+    QByteArray cid;
+    HttpRequestData requestData;
+    HttpResponseData responseData;
+    ErrorCondition errorCondition;
+    ErrorCondition pendingErrorCondition;
+    int keepAliveInterval;
+    HttpHeaders meta;
+    bool updating;
+    std::unique_ptr<ZhttpRequest> req;
+    QByteArray reqBody;
+    int reqPendingBytes;
+    int reqFrames;
+    int reqContentSize;
+    bool reqMaxed;
+    bool reqClose;
+    int reqCloseContentSize;
+    BufferList inBuf;
+    QList<Frame> inFrames;
+    QList<Frame> outFrames;
+    int outContentSize;
+    int outFramesReplay;
+    int outContentReplay;
+    int closeCode;
+    QString closeReason;
+    bool closeSent;
+    bool peerClosing;
+    int peerCloseCode;
+    QString peerCloseReason;
+    bool disconnecting;
+    bool disconnectSent;
+    bool updateQueued;
+    std::unique_ptr<Timer> keepAliveTimer;
+    std::unique_ptr<Timer> retryTimer;
+    int retries;
+    int maxEvents;
+    ReqConnections reqConnections;
+    Connection keepAliveTimerConnection;
+    Connection retryTimerConnection;
+    DeferCall deferCall;
 
-	Private(WebSocketOverHttp *_q) :
-		q(_q),
-		connectPort(-1),
-		ignorePolicies(false),
-		trustConnectHost(false),
-		ignoreTlsErrors(false),
-		state(WebSocket::Idle),
-		errorCondition(ErrorGeneric),
-		pendingErrorCondition((ErrorCondition)-1),
-		keepAliveInterval(-1),
-		updating(false),
-		reqPendingBytes(0),
-		reqFrames(0),
-		reqContentSize(0),
-		reqMaxed(false),
-		reqClose(false),
-		reqCloseContentSize(0),
-		outContentSize(0),
-		outFramesReplay(0),
-		outContentReplay(0),
-		closeCode(-1),
-		closeSent(false),
-		peerClosing(false),
-		peerCloseCode(-1),
-		disconnecting(false),
-		disconnectSent(false),
-		updateQueued(false),
-		retries(0),
-		maxEvents(0)
-	{
-		if(!g_disconnectManager)
-			g_disconnectManager = new DisconnectManager;
+    Private(WebSocketOverHttp *_q)
+        : q(_q),
+          connectPort(-1),
+          ignorePolicies(false),
+          trustConnectHost(false),
+          ignoreTlsErrors(false),
+          state(WebSocket::Idle),
+          errorCondition(ErrorGeneric),
+          pendingErrorCondition((ErrorCondition)-1),
+          keepAliveInterval(-1),
+          updating(false),
+          reqPendingBytes(0),
+          reqFrames(0),
+          reqContentSize(0),
+          reqMaxed(false),
+          reqClose(false),
+          reqCloseContentSize(0),
+          outContentSize(0),
+          outFramesReplay(0),
+          outContentReplay(0),
+          closeCode(-1),
+          closeSent(false),
+          peerClosing(false),
+          peerCloseCode(-1),
+          disconnecting(false),
+          disconnectSent(false),
+          updateQueued(false),
+          retries(0),
+          maxEvents(0) {
+        if (!g_disconnectManager)
+            g_disconnectManager = new DisconnectManager;
 
-		keepAliveTimer = std::make_unique<Timer>();
-		keepAliveTimerConnection = keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
-		keepAliveTimer->setSingleShot(true);
+        keepAliveTimer = std::make_unique<Timer>();
+        keepAliveTimerConnection =
+            keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
+        keepAliveTimer->setSingleShot(true);
 
-		retryTimer = std::make_unique<Timer>();
-		retryTimerConnection = retryTimer->timeout.connect(boost::bind(&Private::retryTimer_timeout, this));
-		retryTimer->setSingleShot(true);
-	}
+        retryTimer = std::make_unique<Timer>();
+        retryTimerConnection =
+            retryTimer->timeout.connect(boost::bind(&Private::retryTimer_timeout, this));
+        retryTimer->setSingleShot(true);
+    }
 
-	void cleanup()
-	{
-		keepAliveTimer->stop();
-		retryTimer->stop();
+    void cleanup() {
+        keepAliveTimer->stop();
+        retryTimer->stop();
 
-		updating = false;
-		disconnecting = false;
-		updateQueued = false;
+        updating = false;
+        disconnecting = false;
+        updateQueued = false;
 
-		reqConnections = ReqConnections();
-		req.reset();
+        reqConnections = ReqConnections();
+        req.reset();
 
-		state = Idle;
-	}
+        state = Idle;
+    }
 
-	void sanitizeRequestHeaders()
-	{
-		// Don't forward certain headers
-		requestData.headers.removeAll("Upgrade");
-		requestData.headers.removeAll("Accept");
-		requestData.headers.removeAll("Connection-Id");
-		requestData.headers.removeAll("Content-Length");
+    void sanitizeRequestHeaders() {
+        // Don't forward certain headers
+        requestData.headers.removeAll("Upgrade");
+        requestData.headers.removeAll("Accept");
+        requestData.headers.removeAll("Connection-Id");
+        requestData.headers.removeAll("Content-Length");
 
-		// Don't forward headers starting with Meta-*
-		for(int n = 0; n < requestData.headers.count(); ++n)
-		{
-			const HttpHeader &h = requestData.headers[n];
-			if(qstrnicmp(h.first.data(), "Meta-", 5) == 0)
-			{
-				requestData.headers.removeAt(n);
-				--n; // Adjust position
-			}
-		}
-	}
+        // Don't forward headers starting with Meta-*
+        for (int n = 0; n < requestData.headers.count(); ++n) {
+            const HttpHeader &h = requestData.headers[n];
+            if (qstrnicmp(h.first.data(), "Meta-", 5) == 0) {
+                requestData.headers.removeAt(n);
+                --n; // Adjust position
+            }
+        }
+    }
 
-	void start()
-	{
-		state = Connecting;
+    void start() {
+        state = Connecting;
 
-		if(cid.isEmpty())
-			cid = UuidUtil::createUuid();
+        if (cid.isEmpty())
+            cid = UuidUtil::createUuid();
 
-		if(requestData.uri.scheme() == "wss")
-			requestData.uri.setScheme("https");
-		else
-			requestData.uri.setScheme("http");
+        if (requestData.uri.scheme() == "wss")
+            requestData.uri.setScheme("https");
+        else
+            requestData.uri.setScheme("http");
 
-		update();
-	}
+        update();
+    }
 
-	void writeFrame(const Frame &frame)
-	{
-		assert(state == Connected);
+    void writeFrame(const Frame &frame) {
+        assert(state == Connected);
 
-		outFrames += frame;
-		outContentSize += frame.data.size();
+        outFrames += frame;
+        outContentSize += frame.data.size();
 
-		if(needUpdate())
-			update();
-	}
+        if (needUpdate())
+            update();
+    }
 
-	Frame readFrame()
-	{
-		return inFrames.takeFirst();
-	}
+    Frame readFrame() { return inFrames.takeFirst(); }
 
-	void close(int code, const QString &reason)
-	{
-		assert(state != Closing);
+    void close(int code, const QString &reason) {
+        assert(state != Closing);
 
-		state = Closing;
-		closeCode = code;
-		closeReason = reason;
+        state = Closing;
+        closeCode = code;
+        closeReason = reason;
 
-		update();
-	}
+        update();
+    }
 
-	int writeBytesAvailable() const
-	{
-		if(outContentSize < BUFFER_SIZE)
-			return BUFFER_SIZE - outContentSize;
-		else
-			return 0;
-	}
+    int writeBytesAvailable() const {
+        if (outContentSize < BUFFER_SIZE)
+            return BUFFER_SIZE - outContentSize;
+        else
+            return 0;
+    }
 
-	void sendDisconnect()
-	{
-		disconnecting = true;
+    void sendDisconnect() {
+        disconnecting = true;
 
-		update();
-	}
+        update();
+    }
 
-	void refresh()
-	{
-		// Only allow refresh requests if connected
-		if(state == Connected && !disconnecting)
-		{
-			if(!updating)
-				update();
-			else
-				updateQueued = true;
-		}
-	}
+    void refresh() {
+        // Only allow refresh requests if connected
+        if (state == Connected && !disconnecting) {
+            if (!updating)
+                update();
+            else
+                updateQueued = true;
+        }
+    }
 
 private:
-	bool canReceive() const
-	{
-		int avail = 0;
-		foreach(const Frame &f, inFrames)
-		{
-			avail += f.data.size();
-			if(avail >= BUFFER_SIZE)
-				return false;
-		}
-
-		return true;
-	}
-
-	void appendInMessage(Frame::Type type, const QByteArray &message)
-	{
-		// Split into frames to avoid credits issue
-		QList<Frame> frames;
-
-		for(int n = 0; frames.isEmpty() || n < message.size(); n += FRAME_SIZE_MAX)
-		{
-			Frame::Type ftype;
-			if(n == 0)
-				ftype = type;
-			else
-				ftype = Frame::Continuation;
-
-			QByteArray data = message.mid(n, FRAME_SIZE_MAX);
-			bool more = (n + FRAME_SIZE_MAX < message.size());
-
-			frames += Frame(ftype, data, more);
-		}
-
-		foreach(const Frame &f, frames)
-			inFrames += f;
-	}
-
-	bool canSendCompleteMessage() const
-	{
-		foreach(const Frame &f, outFrames)
-		{
-			if(!f.more)
-				return true;
-		}
-
-		return false;
-	}
-
-	bool needUpdate() const
-	{
-		// Always send this right away
-		if(disconnecting && !disconnectSent)
-			return true;
-
-		if(updateQueued)
-			return true;
-
-		bool cscm = canSendCompleteMessage();
-
-		if(!cscm && writeBytesAvailable() == 0)
-		{
-			// Write buffer maxed with incomplete message. This is
-			// unrecoverable. Update to throw error right away.
-			return true;
-		}
-
-		// If we can't fit a response then don't update yet
-		if(!canReceive())
-			return false;
-
-		bool newData = outFrames.count() > outFramesReplay || outContentSize > outContentReplay;
-
-		// Have message to send or close?
-		if((cscm && newData) || (outFrames.isEmpty() && state == Closing && !closeSent))
-			return true;
-
-		return false;
-	}
-
-	void queueError(ErrorCondition e)
-	{
-		if((int)pendingErrorCondition == -1)
-		{
-			pendingErrorCondition = e;
-			deferCall.defer([=] { doError(); });
-		}
-	}
-
-	void update()
-	{
-		// Only one request allowed at a time
-		if(updating)
-			return;
-
-		updateQueued = false;
-
-		updating = true;
-
-		keepAliveTimer->stop();
-
-		// If we can't send yet but also have no room for writes, then fail
-		if(!canSendCompleteMessage() && writeBytesAvailable() == 0)
-		{
-			updating = false;
-			queueError(ErrorGeneric);
-			return;
-		}
-
-		reqFrames = 0;
-		reqContentSize = 0;
-		reqMaxed = false;
-		reqClose = false;
-		reqCloseContentSize = 0;
-
-		QList<Event> events;
-
-		if(state == Connecting)
-		{
-			events += Event("OPEN");
-		}
-		else if(disconnecting && !disconnectSent)
-		{
-			events += Event("DISCONNECT");
-			disconnectSent = true;
-		}
-		else
-		{
-			bool ok = false;
-			events += framesToEvents(outFrames, BUFFER_SIZE, maxEvents, &ok, &reqFrames, &reqContentSize);
-			if(!ok)
-			{
-				updating = false;
-				queueError(ErrorGeneric);
-				return;
-			}
-
-			// Set this if we couldn't fit everything
-			reqMaxed = reqFrames < outFrames.count();
-
-			if(state == Closing && (maxEvents <= 0 || events.count() < maxEvents))
-			{
-				if(reqFrames < outFrames.count())
-					log_debug("woh: skipping partial message at close");
-
-				if(closeCode != -1)
-				{
-					QByteArray rawReason = closeReason.toUtf8();
-
-					QByteArray buf(2 + rawReason.size(), 0);
-					buf[0] = (closeCode >> 8) & 0xff;
-					buf[1] = closeCode & 0xff;
-					memcpy(buf.data() + 2, rawReason.data(), rawReason.size());
-					events += Event("CLOSE", buf);
-
-					reqCloseContentSize = buf.size();
-				}
-				else
-					events += Event("CLOSE");
-
-				reqClose = true;
-			}
-		}
-
-		reqBody = encodeEvents(events);
-
-		doRequest();
-	}
-
-	void doRequest()
-	{
-		assert(!req);
-
-		q->aboutToSendRequest();
-
-		req = std::unique_ptr<ZhttpRequest>(zhttpManager->createRequest());
-		reqConnections = {
-			req->readyRead.connect(boost::bind(&Private::req_readyRead, this)),
-			req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this, boost::placeholders::_1)),
-			req->error.connect(boost::bind(&Private::req_error, this))
-		};
-
-		if(!connectHost.isEmpty())
-			req->setConnectHost(connectHost);
-		if(connectPort != -1)
-			req->setConnectPort(connectPort);
-		req->setIgnorePolicies(ignorePolicies);
-		req->setTrustConnectHost(trustConnectHost);
-		req->setIgnoreTlsErrors(ignoreTlsErrors);
-		if(!clientCert.isEmpty())
-			req->setClientCert(clientCert, clientKey);
-		req->setSendBodyAfterAcknowledgement(true);
-
-		HttpHeaders headers = requestData.headers;
-
-		headers += HttpHeader("Accept", "application/websocket-events");
-		headers += HttpHeader("Connection-Id", cid);
-		headers += HttpHeader("Content-Type", "application/websocket-events");
-		headers += HttpHeader("Content-Length", QByteArray::number(reqBody.size()));
-
-		if(outContentReplay > 0)
-			headers += HttpHeader("Content-Bytes-Replayed", QByteArray::number(outContentReplay));
-
-		foreach(const HttpHeader &h, meta)
-			headers += HttpHeader("Meta-" + h.first, h.second);
-
-		reqPendingBytes = reqBody.size();
-
-		req->start("POST", requestData.uri, headers);
-		req->writeBody(reqBody);
-		req->endBody();
-	}
-
-	void req_readyRead()
-	{
-		if(inBuf.size() + req->bytesAvailable() > RESPONSE_BODY_MAX)
-		{
-			cleanup();
-			q->error();
-			return;
-		}
-
-		inBuf += req->readBody();
-
-		if(!req->isFinished())
-		{
-			// If request isn't finished yet, keep waiting
-			return;
-		}
-
-		reqBody.clear();
-		retries = 0;
-
-		int responseCode = req->responseCode();
-		QByteArray responseReason = req->responseReason();
-		HttpHeaders responseHeaders = req->responseHeaders();
-		QByteArray responseBody = inBuf.take();
-
-		reqConnections = ReqConnections();
-		req.reset();
-
-		if(state == Connecting)
-		{
-			// Save the initial response
-			responseData.code = responseCode;
-			responseData.reason = responseReason;
-			responseData.headers = responseHeaders;
-		}
-
-		QByteArray contentType = responseHeaders.get("Content-Type").asQByteArray();
-
-		if(responseCode != 200 || contentType != "application/websocket-events")
-		{
-			if(state == Connecting)
-			{
-				errorCondition = ErrorRejected;
-				responseData.body = responseBody.mid(0, REJECT_BODY_MAX);
-			}
-			else
-				errorCondition = ErrorGeneric;
-
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(responseHeaders.contains("Keep-Alive-Interval"))
-		{
-			bool ok;
-			int x = responseHeaders.get("Keep-Alive-Interval").asQByteArray().toInt(&ok);
-			if(ok && x > 0)
-			{
-				if(x < 20)
-					x = 20;
-
-				keepAliveInterval = x;
-			}
-			else
-				keepAliveInterval = -1;
-		}
-
-		int reqContentSizeWithClose = reqContentSize + reqCloseContentSize;
-
-		// By default, accept all
-		int contentBytesAccepted = reqContentSizeWithClose;
-
-		if(responseHeaders.contains("Content-Bytes-Accepted"))
-		{
-			bool ok;
-			int x = responseHeaders.get("Content-Bytes-Accepted").asQByteArray().toInt(&ok);
-			if(ok && x >= 0)
-				contentBytesAccepted = x;
-
-			// Can't accept more than was offered
-			if(contentBytesAccepted > reqContentSizeWithClose)
-			{
-				cleanup();
-				q->error();
-				return;
-			}
-		}
-
-		int nonCloseContentBytesAccepted = qMin(contentBytesAccepted, reqContentSize);
-
-		int outFramesCountOrig = outFrames.count();
-		int contentRemoved = removeContentFromFrames(&outFrames, nonCloseContentBytesAccepted);
-		int framesRemoved = outFramesCountOrig - outFrames.count();
-
-		// Guaranteed to succeed, since reqContentSize represents the initial
-		// data in outFrames and we guard against too large of an input
-		assert(contentRemoved == nonCloseContentBytesAccepted);
-
-		outContentSize -= contentRemoved;
-
-		// If we couldn't fit all pending data in the request, then require
-		// progress to be made
-		if(reqMaxed && framesRemoved == 0 && contentRemoved == 0)
-		{
-			updating = false;
-			queueError(ErrorGeneric);
-			return;
-		}
-
-		// FramesRemoved could exceed reqFrames if any zero-sized frames are
-		// appended to outFrames before acceptance, causing them to be
-		// removed even though they weren't in the request
-		outFramesReplay = qMax(reqFrames - framesRemoved, 0);
-
-		outContentReplay = reqContentSize - contentRemoved;
-
-		if(reqClose)
-		{
-			if(nonCloseContentBytesAccepted < reqContentSize)
-			{
-				// If server didn't accept all content before close, then don't close yet
-				reqClose = false;
-			}
-			else
-			{
-				// Server accepted all content before close. In that case, we
-				// require the server to also accept the close. Partial
-				// acceptance is meant for waiting for more data and from
-				// this point there won't be any more data.
-				if(contentBytesAccepted < reqContentSizeWithClose)
-				{
-					cleanup();
-					q->error();
-					return;
-				}
-			}
-		}
-
-		// After close, remove any partial message left
-		if(reqClose)
-		{
-			outFrames.clear();
-			outContentSize = 0;
-			outFramesReplay = 0;
-			outContentReplay = 0;
-		}
-
-		foreach(const HttpHeader &h, responseHeaders)
-		{
-			if(h.first.size() >= 10 && qstrnicmp(h.first.data(), "Set-Meta-", 9) == 0)
-			{
-				QByteArray name = h.first.mid(9).asQByteArray();
-				if(meta.contains(name))
-					meta.removeAll(name);
-				if(!h.second.isEmpty())
-					meta += HttpHeader(name, h.second);
-			}
-		}
-
-		bool ok;
-		QList<Event> events = decodeEvents(responseBody, &ok);
-		if(!ok)
-		{
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(state == Connecting)
-		{
-			// Server must respond with events or enable keep alive
-			if(events.isEmpty() && keepAliveInterval == -1)
-			{
-				cleanup();
-				q->error();
-				return;
-			}
-
-			// First event must be OPEN
-			if(!events.isEmpty() && events.first().type != "OPEN")
-			{
-				cleanup();
-				q->error();
-				return;
-			}
-
-			// Correct the status code/reason
-			responseData.code = 101;
-			responseData.reason = "Switching Protocols";
-
-			// Strip private headers from the initial response
-			responseData.headers.removeAll("Content-Length");
-			responseData.headers.removeAll("Content-Type");
-			responseData.headers.removeAll("Keep-Alive-Interval");
-			for(int n = 0; n < responseData.headers.count(); ++n)
-			{
-				const HttpHeader &h = responseData.headers[n];
-				if(h.first.size() >= 10 && qstrnicmp(h.first.data(), "Set-Meta-", 9) == 0)
-				{
-					responseData.headers.removeAt(n);
-					--n; // Adjust position
-				}
-			}
-		}
-
-		if(disconnectSent)
-		{
-			cleanup();
-			q->disconnected();
-			return;
-		}
-
-		std::weak_ptr<Private> self = q->d;
-
-		bool emitConnected = false;
-		bool emitReadyRead = false;
-		bool closed = false;
-		bool disconnected = false;
-
-		foreach(const Event &e, events)
-		{
-			if(e.type == "OPEN")
-			{
-				if(state != Connecting)
-				{
-					disconnected = true;
-					break;
-				}
-
-				state = Connected;
-				emitConnected = true;
-			}
-			else if(e.type == "TEXT")
-			{
-				appendInMessage(Frame::Text, e.content);
-				emitReadyRead = true;
-			}
-			else if(e.type == "BINARY")
-			{
-				appendInMessage(Frame::Binary, e.content);
-				emitReadyRead = true;
-			}
-			else if(e.type == "PING")
-			{
-				appendInMessage(Frame::Ping, e.content);
-				emitReadyRead = true;
-			}
-			else if(e.type == "PONG")
-			{
-				appendInMessage(Frame::Pong, e.content);
-				emitReadyRead = true;
-			}
-			else if(e.type == "CLOSE")
-			{
-				peerClosing = true;
-				if(e.content.size() >= 2)
-				{
-					int hi = (unsigned char)e.content[0];
-					int lo = (unsigned char)e.content[1];
-					peerCloseCode = (hi << 8) + lo;
-					peerCloseReason = QString::fromUtf8(e.content.mid(2));
-				}
-
-				closed = true;
-				break;
-			}
-			else if(e.type == "DISCONNECT")
-			{
-				disconnected = true;
-				break;
-			}
-		}
-
-		if(emitConnected)
-		{
-			q->connected();
-			if(self.expired())
-				return;
-		}
-
-		if(emitReadyRead)
-		{
-			q->readyRead();
-			if(self.expired())
-				return;
-		}
-
-		if(framesRemoved > 0 || contentRemoved > 0)
-		{
-			q->framesWritten(framesRemoved, contentRemoved);
-			if(self.expired())
-				return;
-		}
-
-		if(contentRemoved > 0)
-		{
-			q->writeBytesChanged();
-			if(self.expired())
-				return;
-		}
-
-		if(reqClose)
-			closeSent = true;
-
-		if(closed)
-		{
-			if(closeSent)
-			{
-				cleanup();
-				q->closed();
-				return;
-			}
-			else
-			{
-				q->peerClosed();
-			}
-		}
-		else if(closeSent && keepAliveInterval == -1)
-		{
-			// If there are no keep alives, then the server has only one
-			// chance to respond to a close. If it doesn't, then
-			// consider the connection uncleanly disconnected.
-			disconnected = true;
-		}
-
-		if(disconnected)
-		{
-			cleanup();
-			q->error();
-			return;
-		}
-
-		if(reqClose && peerClosing)
-		{
-			cleanup();
-			q->closed();
-			return;
-		}
-
-		updating = false;
-
-		if(needUpdate())
-			update();
-		else if(keepAliveInterval != -1)
-			keepAliveTimer->start(keepAliveInterval * 1000);
-	}
-
-	void req_bytesWritten(int count)
-	{
-		reqPendingBytes -= count;
-		assert(reqPendingBytes >= 0);
-	}
-
-	void req_error()
-	{
-		bool retry = false;
-
-		ZhttpRequest::ErrorCondition reqError = req->errorCondition();
-
-		switch(reqError)
-		{
-			case ZhttpRequest::ErrorConnect:
-			case ZhttpRequest::ErrorConnectTimeout:
-			case ZhttpRequest::ErrorTls:
-				// These errors mean the server wasn't reached at all
-				retry = true;
-				break;
-			case ZhttpRequest::ErrorGeneric:
-			case ZhttpRequest::ErrorTimeout:
-				// These errors mean the server may have been reached, so
-				// only retry if the request body wasn't completely sent
-				if(reqPendingBytes > 0)
-					retry = true;
-				break;
-			default:
-				// All other errors are hard fails that shouldn't be retried
-				break;
-		}
-
-		reqConnections = ReqConnections();
-		req.reset();
-
-		if(retry && retries < RETRY_MAX && state != Connecting)
-		{
-			keepAliveTimer->stop();
-
-			int delay = RETRY_TIMEOUT;
-			for(int n = 0; n < retries; ++n)
-				delay *= 2;
-			delay += (int)(QRandomGenerator::global()->generate() % RETRY_RAND_MAX);
-
-			log_debug("woh: trying again in %dms", delay);
-
-			++retries;
-
-			// This should still be flagged, for protection while retrying
-			assert(updating);
-
-			retryTimer->start(delay);
-			return;
-		}
-
-		if(reqError == ZhttpRequest::ErrorConnect)
-			errorCondition = WebSocket::ErrorConnect;
-		else if(reqError == ZhttpRequest::ErrorConnectTimeout)
-			errorCondition = WebSocket::ErrorConnectTimeout;
-		else if(reqError == ZhttpRequest::ErrorTls)
-			errorCondition = WebSocket::ErrorTls;
-
-		cleanup();
-		q->error();
-	}
-
-	void keepAliveTimer_timeout()
-	{
-		update();
-	}
-
-	void retryTimer_timeout()
-	{
-		doRequest();
-	}
-
-	void doError()
-	{
-		cleanup();
-		errorCondition = pendingErrorCondition;
-		pendingErrorCondition = (ErrorCondition)-1;
-		q->error();
-	}
+    bool canReceive() const {
+        int avail = 0;
+        foreach (const Frame &f, inFrames) {
+            avail += f.data.size();
+            if (avail >= BUFFER_SIZE)
+                return false;
+        }
+
+        return true;
+    }
+
+    void appendInMessage(Frame::Type type, const QByteArray &message) {
+        // Split into frames to avoid credits issue
+        QList<Frame> frames;
+
+        for (int n = 0; frames.isEmpty() || n < message.size(); n += FRAME_SIZE_MAX) {
+            Frame::Type ftype;
+            if (n == 0)
+                ftype = type;
+            else
+                ftype = Frame::Continuation;
+
+            QByteArray data = message.mid(n, FRAME_SIZE_MAX);
+            bool more = (n + FRAME_SIZE_MAX < message.size());
+
+            frames += Frame(ftype, data, more);
+        }
+
+        foreach (const Frame &f, frames)
+            inFrames += f;
+    }
+
+    bool canSendCompleteMessage() const {
+        foreach (const Frame &f, outFrames) {
+            if (!f.more)
+                return true;
+        }
+
+        return false;
+    }
+
+    bool needUpdate() const {
+        // Always send this right away
+        if (disconnecting && !disconnectSent)
+            return true;
+
+        if (updateQueued)
+            return true;
+
+        bool cscm = canSendCompleteMessage();
+
+        if (!cscm && writeBytesAvailable() == 0) {
+            // Write buffer maxed with incomplete message. This is
+            // unrecoverable. Update to throw error right away.
+            return true;
+        }
+
+        // If we can't fit a response then don't update yet
+        if (!canReceive())
+            return false;
+
+        bool newData = outFrames.count() > outFramesReplay || outContentSize > outContentReplay;
+
+        // Have message to send or close?
+        if ((cscm && newData) || (outFrames.isEmpty() && state == Closing && !closeSent))
+            return true;
+
+        return false;
+    }
+
+    void queueError(ErrorCondition e) {
+        if ((int)pendingErrorCondition == -1) {
+            pendingErrorCondition = e;
+            deferCall.defer([=] { doError(); });
+        }
+    }
+
+    void update() {
+        // Only one request allowed at a time
+        if (updating)
+            return;
+
+        updateQueued = false;
+
+        updating = true;
+
+        keepAliveTimer->stop();
+
+        // If we can't send yet but also have no room for writes, then fail
+        if (!canSendCompleteMessage() && writeBytesAvailable() == 0) {
+            updating = false;
+            queueError(ErrorGeneric);
+            return;
+        }
+
+        reqFrames = 0;
+        reqContentSize = 0;
+        reqMaxed = false;
+        reqClose = false;
+        reqCloseContentSize = 0;
+
+        QList<Event> events;
+
+        if (state == Connecting) {
+            events += Event("OPEN");
+        } else if (disconnecting && !disconnectSent) {
+            events += Event("DISCONNECT");
+            disconnectSent = true;
+        } else {
+            bool ok = false;
+            events +=
+                framesToEvents(outFrames, BUFFER_SIZE, maxEvents, &ok, &reqFrames, &reqContentSize);
+            if (!ok) {
+                updating = false;
+                queueError(ErrorGeneric);
+                return;
+            }
+
+            // Set this if we couldn't fit everything
+            reqMaxed = reqFrames < outFrames.count();
+
+            if (state == Closing && (maxEvents <= 0 || events.count() < maxEvents)) {
+                if (reqFrames < outFrames.count())
+                    log_debug("woh: skipping partial message at close");
+
+                if (closeCode != -1) {
+                    QByteArray rawReason = closeReason.toUtf8();
+
+                    QByteArray buf(2 + rawReason.size(), 0);
+                    buf[0] = (closeCode >> 8) & 0xff;
+                    buf[1] = closeCode & 0xff;
+                    memcpy(buf.data() + 2, rawReason.data(), rawReason.size());
+                    events += Event("CLOSE", buf);
+
+                    reqCloseContentSize = buf.size();
+                } else
+                    events += Event("CLOSE");
+
+                reqClose = true;
+            }
+        }
+
+        reqBody = encodeEvents(events);
+
+        doRequest();
+    }
+
+    void doRequest() {
+        assert(!req);
+
+        q->aboutToSendRequest();
+
+        req = std::unique_ptr<ZhttpRequest>(zhttpManager->createRequest());
+        reqConnections = {req->readyRead.connect(boost::bind(&Private::req_readyRead, this)),
+                          req->bytesWritten.connect(boost::bind(&Private::req_bytesWritten, this,
+                                                                boost::placeholders::_1)),
+                          req->error.connect(boost::bind(&Private::req_error, this))};
+
+        if (!connectHost.isEmpty())
+            req->setConnectHost(connectHost);
+        if (connectPort != -1)
+            req->setConnectPort(connectPort);
+        req->setIgnorePolicies(ignorePolicies);
+        req->setTrustConnectHost(trustConnectHost);
+        req->setIgnoreTlsErrors(ignoreTlsErrors);
+        if (!clientCert.isEmpty())
+            req->setClientCert(clientCert, clientKey);
+        req->setSendBodyAfterAcknowledgement(true);
+
+        HttpHeaders headers = requestData.headers;
+
+        headers += HttpHeader("Accept", "application/websocket-events");
+        headers += HttpHeader("Connection-Id", cid);
+        headers += HttpHeader("Content-Type", "application/websocket-events");
+        headers += HttpHeader("Content-Length", QByteArray::number(reqBody.size()));
+
+        if (outContentReplay > 0)
+            headers += HttpHeader("Content-Bytes-Replayed", QByteArray::number(outContentReplay));
+
+        foreach (const HttpHeader &h, meta)
+            headers += HttpHeader("Meta-" + h.first, h.second);
+
+        reqPendingBytes = reqBody.size();
+
+        req->start("POST", requestData.uri, headers);
+        req->writeBody(reqBody);
+        req->endBody();
+    }
+
+    void req_readyRead() {
+        if (inBuf.size() + req->bytesAvailable() > RESPONSE_BODY_MAX) {
+            cleanup();
+            q->error();
+            return;
+        }
+
+        inBuf += req->readBody();
+
+        if (!req->isFinished()) {
+            // If request isn't finished yet, keep waiting
+            return;
+        }
+
+        reqBody.clear();
+        retries = 0;
+
+        int responseCode = req->responseCode();
+        QByteArray responseReason = req->responseReason();
+        HttpHeaders responseHeaders = req->responseHeaders();
+        QByteArray responseBody = inBuf.take();
+
+        reqConnections = ReqConnections();
+        req.reset();
+
+        if (state == Connecting) {
+            // Save the initial response
+            responseData.code = responseCode;
+            responseData.reason = responseReason;
+            responseData.headers = responseHeaders;
+        }
+
+        QByteArray contentType = responseHeaders.get("Content-Type").asQByteArray();
+
+        if (responseCode != 200 || contentType != "application/websocket-events") {
+            if (state == Connecting) {
+                errorCondition = ErrorRejected;
+                responseData.body = responseBody.mid(0, REJECT_BODY_MAX);
+            } else
+                errorCondition = ErrorGeneric;
+
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (responseHeaders.contains("Keep-Alive-Interval")) {
+            bool ok;
+            int x = responseHeaders.get("Keep-Alive-Interval").asQByteArray().toInt(&ok);
+            if (ok && x > 0) {
+                if (x < 20)
+                    x = 20;
+
+                keepAliveInterval = x;
+            } else
+                keepAliveInterval = -1;
+        }
+
+        int reqContentSizeWithClose = reqContentSize + reqCloseContentSize;
+
+        // By default, accept all
+        int contentBytesAccepted = reqContentSizeWithClose;
+
+        if (responseHeaders.contains("Content-Bytes-Accepted")) {
+            bool ok;
+            int x = responseHeaders.get("Content-Bytes-Accepted").asQByteArray().toInt(&ok);
+            if (ok && x >= 0)
+                contentBytesAccepted = x;
+
+            // Can't accept more than was offered
+            if (contentBytesAccepted > reqContentSizeWithClose) {
+                cleanup();
+                q->error();
+                return;
+            }
+        }
+
+        int nonCloseContentBytesAccepted = qMin(contentBytesAccepted, reqContentSize);
+
+        int outFramesCountOrig = outFrames.count();
+        int contentRemoved = removeContentFromFrames(&outFrames, nonCloseContentBytesAccepted);
+        int framesRemoved = outFramesCountOrig - outFrames.count();
+
+        // Guaranteed to succeed, since reqContentSize represents the initial
+        // data in outFrames and we guard against too large of an input
+        assert(contentRemoved == nonCloseContentBytesAccepted);
+
+        outContentSize -= contentRemoved;
+
+        // If we couldn't fit all pending data in the request, then require
+        // progress to be made
+        if (reqMaxed && framesRemoved == 0 && contentRemoved == 0) {
+            updating = false;
+            queueError(ErrorGeneric);
+            return;
+        }
+
+        // FramesRemoved could exceed reqFrames if any zero-sized frames are
+        // appended to outFrames before acceptance, causing them to be
+        // removed even though they weren't in the request
+        outFramesReplay = qMax(reqFrames - framesRemoved, 0);
+
+        outContentReplay = reqContentSize - contentRemoved;
+
+        if (reqClose) {
+            if (nonCloseContentBytesAccepted < reqContentSize) {
+                // If server didn't accept all content before close, then don't close
+                // yet
+                reqClose = false;
+            } else {
+                // Server accepted all content before close. In that case, we
+                // require the server to also accept the close. Partial
+                // acceptance is meant for waiting for more data and from
+                // this point there won't be any more data.
+                if (contentBytesAccepted < reqContentSizeWithClose) {
+                    cleanup();
+                    q->error();
+                    return;
+                }
+            }
+        }
+
+        // After close, remove any partial message left
+        if (reqClose) {
+            outFrames.clear();
+            outContentSize = 0;
+            outFramesReplay = 0;
+            outContentReplay = 0;
+        }
+
+        foreach (const HttpHeader &h, responseHeaders) {
+            if (h.first.size() >= 10 && qstrnicmp(h.first.data(), "Set-Meta-", 9) == 0) {
+                QByteArray name = h.first.mid(9).asQByteArray();
+                if (meta.contains(name))
+                    meta.removeAll(name);
+                if (!h.second.isEmpty())
+                    meta += HttpHeader(name, h.second);
+            }
+        }
+
+        bool ok;
+        QList<Event> events = decodeEvents(responseBody, &ok);
+        if (!ok) {
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (state == Connecting) {
+            // Server must respond with events or enable keep alive
+            if (events.isEmpty() && keepAliveInterval == -1) {
+                cleanup();
+                q->error();
+                return;
+            }
+
+            // First event must be OPEN
+            if (!events.isEmpty() && events.first().type != "OPEN") {
+                cleanup();
+                q->error();
+                return;
+            }
+
+            // Correct the status code/reason
+            responseData.code = 101;
+            responseData.reason = "Switching Protocols";
+
+            // Strip private headers from the initial response
+            responseData.headers.removeAll("Content-Length");
+            responseData.headers.removeAll("Content-Type");
+            responseData.headers.removeAll("Keep-Alive-Interval");
+            for (int n = 0; n < responseData.headers.count(); ++n) {
+                const HttpHeader &h = responseData.headers[n];
+                if (h.first.size() >= 10 && qstrnicmp(h.first.data(), "Set-Meta-", 9) == 0) {
+                    responseData.headers.removeAt(n);
+                    --n; // Adjust position
+                }
+            }
+        }
+
+        if (disconnectSent) {
+            cleanup();
+            q->disconnected();
+            return;
+        }
+
+        std::weak_ptr<Private> self = q->d;
+
+        bool emitConnected = false;
+        bool emitReadyRead = false;
+        bool closed = false;
+        bool disconnected = false;
+
+        foreach (const Event &e, events) {
+            if (e.type == "OPEN") {
+                if (state != Connecting) {
+                    disconnected = true;
+                    break;
+                }
+
+                state = Connected;
+                emitConnected = true;
+            } else if (e.type == "TEXT") {
+                appendInMessage(Frame::Text, e.content);
+                emitReadyRead = true;
+            } else if (e.type == "BINARY") {
+                appendInMessage(Frame::Binary, e.content);
+                emitReadyRead = true;
+            } else if (e.type == "PING") {
+                appendInMessage(Frame::Ping, e.content);
+                emitReadyRead = true;
+            } else if (e.type == "PONG") {
+                appendInMessage(Frame::Pong, e.content);
+                emitReadyRead = true;
+            } else if (e.type == "CLOSE") {
+                peerClosing = true;
+                if (e.content.size() >= 2) {
+                    int hi = (unsigned char)e.content[0];
+                    int lo = (unsigned char)e.content[1];
+                    peerCloseCode = (hi << 8) + lo;
+                    peerCloseReason = QString::fromUtf8(e.content.mid(2));
+                }
+
+                closed = true;
+                break;
+            } else if (e.type == "DISCONNECT") {
+                disconnected = true;
+                break;
+            }
+        }
+
+        if (emitConnected) {
+            q->connected();
+            if (self.expired())
+                return;
+        }
+
+        if (emitReadyRead) {
+            q->readyRead();
+            if (self.expired())
+                return;
+        }
+
+        if (framesRemoved > 0 || contentRemoved > 0) {
+            q->framesWritten(framesRemoved, contentRemoved);
+            if (self.expired())
+                return;
+        }
+
+        if (contentRemoved > 0) {
+            q->writeBytesChanged();
+            if (self.expired())
+                return;
+        }
+
+        if (reqClose)
+            closeSent = true;
+
+        if (closed) {
+            if (closeSent) {
+                cleanup();
+                q->closed();
+                return;
+            } else {
+                q->peerClosed();
+            }
+        } else if (closeSent && keepAliveInterval == -1) {
+            // If there are no keep alives, then the server has only one
+            // chance to respond to a close. If it doesn't, then
+            // consider the connection uncleanly disconnected.
+            disconnected = true;
+        }
+
+        if (disconnected) {
+            cleanup();
+            q->error();
+            return;
+        }
+
+        if (reqClose && peerClosing) {
+            cleanup();
+            q->closed();
+            return;
+        }
+
+        updating = false;
+
+        if (needUpdate())
+            update();
+        else if (keepAliveInterval != -1)
+            keepAliveTimer->start(keepAliveInterval * 1000);
+    }
+
+    void req_bytesWritten(int count) {
+        reqPendingBytes -= count;
+        assert(reqPendingBytes >= 0);
+    }
+
+    void req_error() {
+        bool retry = false;
+
+        ZhttpRequest::ErrorCondition reqError = req->errorCondition();
+
+        switch (reqError) {
+        case ZhttpRequest::ErrorConnect:
+        case ZhttpRequest::ErrorConnectTimeout:
+        case ZhttpRequest::ErrorTls:
+            // These errors mean the server wasn't reached at all
+            retry = true;
+            break;
+        case ZhttpRequest::ErrorGeneric:
+        case ZhttpRequest::ErrorTimeout:
+            // These errors mean the server may have been reached, so
+            // only retry if the request body wasn't completely sent
+            if (reqPendingBytes > 0)
+                retry = true;
+            break;
+        default:
+            // All other errors are hard fails that shouldn't be retried
+            break;
+        }
+
+        reqConnections = ReqConnections();
+        req.reset();
+
+        if (retry && retries < RETRY_MAX && state != Connecting) {
+            keepAliveTimer->stop();
+
+            int delay = RETRY_TIMEOUT;
+            for (int n = 0; n < retries; ++n)
+                delay *= 2;
+            delay += (int)(QRandomGenerator::global()->generate() % RETRY_RAND_MAX);
+
+            log_debug("woh: trying again in %dms", delay);
+
+            ++retries;
+
+            // This should still be flagged, for protection while retrying
+            assert(updating);
+
+            retryTimer->start(delay);
+            return;
+        }
+
+        if (reqError == ZhttpRequest::ErrorConnect)
+            errorCondition = WebSocket::ErrorConnect;
+        else if (reqError == ZhttpRequest::ErrorConnectTimeout)
+            errorCondition = WebSocket::ErrorConnectTimeout;
+        else if (reqError == ZhttpRequest::ErrorTls)
+            errorCondition = WebSocket::ErrorTls;
+
+        cleanup();
+        q->error();
+    }
+
+    void keepAliveTimer_timeout() { update(); }
+
+    void retryTimer_timeout() { doRequest(); }
+
+    void doError() {
+        cleanup();
+        errorCondition = pendingErrorCondition;
+        pendingErrorCondition = (ErrorCondition)-1;
+        q->error();
+    }
 };
 
-void WebSocketOverHttp::DisconnectManager::deleteSocket(WebSocketOverHttp *sock)
-{
-	// Ensure state is Idle to prevent the destructor from re-adding it to the manager
-	sock->d->cleanup();
+void WebSocketOverHttp::DisconnectManager::deleteSocket(WebSocketOverHttp *sock) {
+    // Ensure state is Idle to prevent the destructor from re-adding it to the
+    // manager
+    sock->d->cleanup();
 
-	delete sock;
+    delete sock;
 }
 
-WebSocketOverHttp::WebSocketOverHttp(ZhttpManager *zhttpManager)
-{
-	d = std::make_shared<Private>(this);
-	d->zhttpManager = zhttpManager;
+WebSocketOverHttp::WebSocketOverHttp(ZhttpManager *zhttpManager) {
+    d = std::make_shared<Private>(this);
+    d->zhttpManager = zhttpManager;
 }
 
 WebSocketOverHttp::WebSocketOverHttp() = default;
 
-WebSocketOverHttp::~WebSocketOverHttp()
-{
-	if(d->state != Idle && !g_disconnectManager->contains(this) && (g_maxManagedDisconnects < 0 || g_disconnectManager->count() < g_maxManagedDisconnects))
-	{
-		// If we get destructed while active, clean up in the background
-		WebSocketOverHttp *sock = new WebSocketOverHttp;
-		sock->d = d;
-		d->q = sock;
-		d.reset();
-		g_disconnectManager->addSocket(sock);
-	}
+WebSocketOverHttp::~WebSocketOverHttp() {
+    if (d->state != Idle && !g_disconnectManager->contains(this) &&
+        (g_maxManagedDisconnects < 0 || g_disconnectManager->count() < g_maxManagedDisconnects)) {
+        // If we get destructed while active, clean up in the background
+        WebSocketOverHttp *sock = new WebSocketOverHttp;
+        sock->d = d;
+        d->q = sock;
+        d.reset();
+        g_disconnectManager->addSocket(sock);
+    }
 }
 
-void WebSocketOverHttp::setConnectionId(const QByteArray &id)
-{
-	d->cid = id;
+void WebSocketOverHttp::setConnectionId(const QByteArray &id) { d->cid = id; }
+
+void WebSocketOverHttp::setMaxEventsPerRequest(int max) { d->maxEvents = max; }
+
+void WebSocketOverHttp::refresh() { d->refresh(); }
+
+void WebSocketOverHttp::setMaxManagedDisconnects(int max) { g_maxManagedDisconnects = max; }
+
+void WebSocketOverHttp::clearDisconnectManager() {
+    delete g_disconnectManager;
+    g_disconnectManager = 0;
 }
 
-void WebSocketOverHttp::setMaxEventsPerRequest(int max)
-{
-	d->maxEvents = max;
+void WebSocketOverHttp::sendDisconnect() { d->sendDisconnect(); }
+
+QHostAddress WebSocketOverHttp::peerAddress() const {
+    // This class is client only
+    return QHostAddress();
 }
 
-void WebSocketOverHttp::refresh()
-{
-	d->refresh();
+void WebSocketOverHttp::setConnectHost(const QString &host) { d->connectHost = host; }
+
+void WebSocketOverHttp::setConnectPort(int port) { d->connectPort = port; }
+
+void WebSocketOverHttp::setIgnorePolicies(bool on) { d->ignorePolicies = on; }
+
+void WebSocketOverHttp::setTrustConnectHost(bool on) { d->trustConnectHost = on; }
+
+void WebSocketOverHttp::setIgnoreTlsErrors(bool on) { d->ignoreTlsErrors = on; }
+
+void WebSocketOverHttp::setClientCert(const QString &cert, const QString &key) {
+    d->clientCert = cert;
+    d->clientKey = key;
 }
 
-void WebSocketOverHttp::setMaxManagedDisconnects(int max)
-{
-	g_maxManagedDisconnects = max;
+void WebSocketOverHttp::start(const Url &uri, const HttpHeaders &headers) {
+    assert(d->state == Idle);
+
+    d->requestData.uri = uri;
+    d->requestData.headers = headers;
+
+    d->sanitizeRequestHeaders();
+
+    d->start();
 }
 
-void WebSocketOverHttp::clearDisconnectManager()
-{
-	delete g_disconnectManager;
-	g_disconnectManager = 0;
+void WebSocketOverHttp::respondSuccess(const QByteArray &reason, const HttpHeaders &headers) {
+    Q_UNUSED(reason);
+    Q_UNUSED(headers);
+
+    // This class is client only
+    assert(0);
 }
 
-void WebSocketOverHttp::sendDisconnect()
-{
-	d->sendDisconnect();
+void WebSocketOverHttp::respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                                     const QByteArray &body) {
+    Q_UNUSED(code);
+    Q_UNUSED(reason);
+    Q_UNUSED(headers);
+    Q_UNUSED(body);
+
+    // This class is client only
+    assert(0);
 }
 
-QHostAddress WebSocketOverHttp::peerAddress() const
-{
-	// This class is client only
-	return QHostAddress();
+WebSocket::State WebSocketOverHttp::state() const { return d->state; }
+
+Url WebSocketOverHttp::requestUri() const { return d->requestData.uri; }
+
+HttpHeaders WebSocketOverHttp::requestHeaders() const { return d->requestData.headers; }
+
+int WebSocketOverHttp::responseCode() const { return d->responseData.code; }
+
+QByteArray WebSocketOverHttp::responseReason() const { return d->responseData.reason; }
+
+HttpHeaders WebSocketOverHttp::responseHeaders() const { return d->responseData.headers; }
+
+QByteArray WebSocketOverHttp::responseBody() const { return d->responseData.body; }
+
+int WebSocketOverHttp::framesAvailable() const { return d->inFrames.count(); }
+
+int WebSocketOverHttp::writeBytesAvailable() const { return d->writeBytesAvailable(); }
+
+int WebSocketOverHttp::peerCloseCode() const { return d->peerCloseCode; }
+
+QString WebSocketOverHttp::peerCloseReason() const { return d->peerCloseReason; }
+
+WebSocket::ErrorCondition WebSocketOverHttp::errorCondition() const { return d->errorCondition; }
+
+void WebSocketOverHttp::writeFrame(const Frame &frame) { d->writeFrame(frame); }
+
+WebSocket::Frame WebSocketOverHttp::readFrame() { return d->readFrame(); }
+
+void WebSocketOverHttp::close(int code, const QString &reason) { d->close(code, reason); }
+
+void WebSocketOverHttp::setHeaders(const HttpHeaders &headers) {
+    d->requestData.headers = headers;
+
+    d->sanitizeRequestHeaders();
 }
 
-void WebSocketOverHttp::setConnectHost(const QString &host)
-{
-	d->connectHost = host;
+QList<WebSocketOverHttp::Event> WebSocketOverHttp::framesToEvents(const QList<Frame> &frames,
+                                                                  int eventsMax, int contentMax,
+                                                                  bool *ok, int *framesRepresented,
+                                                                  int *contentRepresented) {
+    QList<WebSocketOverHttp::Event> out;
+    int pos = 0;
+    int contentSize = 0;
+
+    while (pos < frames.count() && (eventsMax <= 0 || out.count() < eventsMax) &&
+           (contentMax <= 0 || contentSize < contentMax)) {
+        // Make sure the next message is fully readable
+        int takeCount = -1;
+        for (int n = pos; n < frames.count(); ++n) {
+            if (!frames[n].more) {
+                takeCount = n - pos + 1;
+                break;
+            }
+        }
+        if (takeCount < 1)
+            break;
+
+        Frame::Type ftype = Frame::Text;
+        BufferList content;
+
+        for (int n = 0; n < takeCount; ++n) {
+            Frame f = frames[pos + n];
+
+            if ((n == 0 && f.type == Frame::Continuation) ||
+                (n > 0 && f.type != Frame::Continuation)) {
+                *ok = false;
+                return QList<WebSocketOverHttp::Event>();
+            }
+
+            if (n == 0) {
+                assert(f.type != Frame::Continuation);
+                ftype = f.type;
+            }
+
+            content += f.data;
+
+            assert(n + 1 < takeCount || !f.more);
+        }
+
+        QByteArray data = content.toByteArray();
+
+        // For compactness, we only include content on ping/pong if non-empty
+        if (ftype == Frame::Text)
+            out += Event("TEXT", data);
+        else if (ftype == Frame::Binary)
+            out += Event("BINARY", data);
+        else if (ftype == Frame::Ping)
+            out += Event("PING", !data.isEmpty() ? data : QByteArray());
+        else if (ftype == Frame::Pong)
+            out += Event("PONG", !data.isEmpty() ? data : QByteArray());
+
+        pos += takeCount;
+        contentSize += content.size();
+    }
+
+    *ok = true;
+    *framesRepresented = pos;
+    *contentRepresented = contentSize;
+
+    return out;
 }
 
-void WebSocketOverHttp::setConnectPort(int port)
-{
-	d->connectPort = port;
-}
+int WebSocketOverHttp::removeContentFromFrames(QList<WebSocket::Frame> *frames, int count) {
+    int left = count;
 
-void WebSocketOverHttp::setIgnorePolicies(bool on)
-{
-	d->ignorePolicies = on;
-}
+    while (!frames->isEmpty()) {
+        WebSocket::Frame &f = frames->first();
 
-void WebSocketOverHttp::setTrustConnectHost(bool on)
-{
-	d->trustConnectHost = on;
-}
+        // Not allowed
+        if (f.type == WebSocket::Frame::Continuation)
+            break;
 
-void WebSocketOverHttp::setIgnoreTlsErrors(bool on)
-{
-	d->ignoreTlsErrors = on;
-}
+        int size = qMin(left, f.data.size());
+        left -= size;
 
-void WebSocketOverHttp::setClientCert(const QString &cert, const QString &key)
-{
-	d->clientCert = cert;
-	d->clientKey = key;
-}
+        if (size < f.data.size()) {
+            assert(left == 0);
 
-void WebSocketOverHttp::start(const Url &uri, const HttpHeaders &headers)
-{
-	assert(d->state == Idle);
+            if (size > 0)
+                f.data = f.data.mid(size);
 
-	d->requestData.uri = uri;
-	d->requestData.headers = headers;
+            break;
+        }
 
-	d->sanitizeRequestHeaders();
+        WebSocket::Frame::Type ftype = f.type;
+        bool more = f.more;
 
-	d->start();
-}
+        // Only remove frame of a multipart message if we can carry over
+        // the type
+        if (more && frames->count() < 2)
+            break;
 
-void WebSocketOverHttp::respondSuccess(const QByteArray &reason, const HttpHeaders &headers)
-{
-	Q_UNUSED(reason);
-	Q_UNUSED(headers);
+        frames->removeFirst();
 
-	// This class is client only
-	assert(0);
-}
+        // If removed frame was part of a multipart message, carry over
+        // the type
+        if (more) {
+            assert(!frames->isEmpty());
+            frames->first().type = ftype;
+        }
+    }
 
-void WebSocketOverHttp::respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-{
-	Q_UNUSED(code);
-	Q_UNUSED(reason);
-	Q_UNUSED(headers);
-	Q_UNUSED(body);
-
-	// This class is client only
-	assert(0);
-}
-
-WebSocket::State WebSocketOverHttp::state() const
-{
-	return d->state;
-}
-
-Url WebSocketOverHttp::requestUri() const
-{
-	return d->requestData.uri;
-}
-
-HttpHeaders WebSocketOverHttp::requestHeaders() const
-{
-	return d->requestData.headers;
-}
-
-int WebSocketOverHttp::responseCode() const
-{
-	return d->responseData.code;
-}
-
-QByteArray WebSocketOverHttp::responseReason() const
-{
-	return d->responseData.reason;
-}
-
-HttpHeaders WebSocketOverHttp::responseHeaders() const
-{
-	return d->responseData.headers;
-}
-
-QByteArray WebSocketOverHttp::responseBody() const
-{
-	return d->responseData.body;
-}
-
-int WebSocketOverHttp::framesAvailable() const
-{
-	return d->inFrames.count();
-}
-
-int WebSocketOverHttp::writeBytesAvailable() const
-{
-	return d->writeBytesAvailable();
-}
-
-int WebSocketOverHttp::peerCloseCode() const
-{
-	return d->peerCloseCode;
-}
-
-QString WebSocketOverHttp::peerCloseReason() const
-{
-	return d->peerCloseReason;
-}
-
-WebSocket::ErrorCondition WebSocketOverHttp::errorCondition() const
-{
-	return d->errorCondition;
-}
-
-void WebSocketOverHttp::writeFrame(const Frame &frame)
-{
-	d->writeFrame(frame);
-}
-
-WebSocket::Frame WebSocketOverHttp::readFrame()
-{
-	return d->readFrame();
-}
-
-void WebSocketOverHttp::close(int code, const QString &reason)
-{
-	d->close(code, reason);
-}
-
-void WebSocketOverHttp::setHeaders(const HttpHeaders &headers)
-{
-	d->requestData.headers = headers;
-
-	d->sanitizeRequestHeaders();
-}
-
-QList<WebSocketOverHttp::Event> WebSocketOverHttp::framesToEvents(const QList<Frame> &frames, int eventsMax, int contentMax, bool *ok, int *framesRepresented, int *contentRepresented)
-{
-	QList<WebSocketOverHttp::Event> out;
-	int pos = 0;
-	int contentSize = 0;
-
-	while(pos < frames.count() && (eventsMax <= 0 || out.count() < eventsMax) && (contentMax <= 0 || contentSize < contentMax))
-	{
-		// Make sure the next message is fully readable
-		int takeCount = -1;
-		for(int n = pos; n < frames.count(); ++n)
-		{
-			if(!frames[n].more)
-			{
-				takeCount = n - pos + 1;
-				break;
-			}
-		}
-		if(takeCount < 1)
-			break;
-
-		Frame::Type ftype = Frame::Text;
-		BufferList content;
-
-		for(int n = 0; n < takeCount; ++n)
-		{
-			Frame f = frames[pos + n];
-
-			if((n == 0 && f.type == Frame::Continuation) || (n > 0 && f.type != Frame::Continuation))
-			{
-				*ok = false;
-				return QList<WebSocketOverHttp::Event>();
-			}
-
-			if(n == 0)
-			{
-				assert(f.type != Frame::Continuation);
-				ftype = f.type;
-			}
-
-			content += f.data;
-
-			assert(n + 1 < takeCount || !f.more);
-		}
-
-		QByteArray data = content.toByteArray();
-
-		// For compactness, we only include content on ping/pong if non-empty
-		if(ftype == Frame::Text)
-			out += Event("TEXT", data);
-		else if(ftype == Frame::Binary)
-			out += Event("BINARY", data);
-		else if(ftype == Frame::Ping)
-			out += Event("PING", !data.isEmpty() ? data : QByteArray());
-		else if(ftype == Frame::Pong)
-			out += Event("PONG", !data.isEmpty() ? data : QByteArray());
-
-		pos += takeCount;
-		contentSize += content.size();
-	}
-
-	*ok = true;
-	*framesRepresented = pos;
-	*contentRepresented = contentSize;
-
-	return out;
-}
-
-int WebSocketOverHttp::removeContentFromFrames(QList<WebSocket::Frame> *frames, int count)
-{
-	int left = count;
-
-	while(!frames->isEmpty())
-	{
-		WebSocket::Frame &f = frames->first();
-
-		// Not allowed
-		if(f.type == WebSocket::Frame::Continuation)
-			break;
-
-		int size = qMin(left, f.data.size());
-		left -= size;
-
-		if(size < f.data.size())
-		{
-			assert(left == 0);
-
-			if(size > 0)
-				f.data = f.data.mid(size);
-
-			break;
-		}
-
-		WebSocket::Frame::Type ftype = f.type;
-		bool more = f.more;
-
-		// Only remove frame of a multipart message if we can carry over
-		// the type
-		if(more && frames->count() < 2)
-			break;
-
-		frames->removeFirst();
-
-		// If removed frame was part of a multipart message, carry over
-		// the type
-		if(more)
-		{
-			assert(!frames->isEmpty());
-			frames->first().type = ftype;
-		}
-	}
-
-	return (count - left);
+    return (count - left);
 }

--- a/src/proxy/websocketoverhttp.h
+++ b/src/proxy/websocketoverhttp.h
@@ -24,8 +24,8 @@
 #ifndef WEBSOCKETOVERHTTP_H
 #define WEBSOCKETOVERHTTP_H
 
-#include "websocket.h"
 #include "url.h"
+#include "websocket.h"
 #include <boost/signals2.hpp>
 #include <map>
 
@@ -35,105 +35,103 @@ using Connection = boost::signals2::scoped_connection;
 
 class ZhttpManager;
 
-/// Implements WebSocket protocol over HTTP long-polling for outgoing backend connections
-class WebSocketOverHttp : public WebSocket
-{
+/// Implements WebSocket protocol over HTTP long-polling for outgoing backend
+/// connections
+class WebSocketOverHttp : public WebSocket {
 public:
-	class Event
-	{
-	public:
-		QByteArray type;
-		QByteArray content;
+    class Event {
+    public:
+        QByteArray type;
+        QByteArray content;
 
-		Event() = default;
+        Event() = default;
 
-		Event(const QByteArray &_type, const QByteArray &_content = QByteArray()) :
-			type(_type),
-			content(_content)
-		{
-		}
-	};
+        Event(const QByteArray &_type, const QByteArray &_content = QByteArray())
+            : type(_type), content(_content) {}
+    };
 
-	WebSocketOverHttp(ZhttpManager *zhttpManager);
-	~WebSocketOverHttp();
+    WebSocketOverHttp(ZhttpManager *zhttpManager);
+    ~WebSocketOverHttp();
 
-	void setConnectionId(const QByteArray &id);
-	void setMaxEventsPerRequest(int max);
-	void refresh();
+    void setConnectionId(const QByteArray &id);
+    void setMaxEventsPerRequest(int max);
+    void refresh();
 
-	// Disconnection management is thread local
-	static void setMaxManagedDisconnects(int max);
-	static void clearDisconnectManager();
+    // Disconnection management is thread local
+    static void setMaxManagedDisconnects(int max);
+    static void clearDisconnectManager();
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QHostAddress peerAddress() const;
+    virtual QHostAddress peerAddress() const;
 
-	virtual void setConnectHost(const QString &host);
-	virtual void setConnectPort(int port);
-	virtual void setIgnorePolicies(bool on);
-	virtual void setTrustConnectHost(bool on);
-	virtual void setIgnoreTlsErrors(bool on);
-	virtual void setClientCert(const QString &cert, const QString &key);
+    virtual void setConnectHost(const QString &host);
+    virtual void setConnectPort(int port);
+    virtual void setIgnorePolicies(bool on);
+    virtual void setTrustConnectHost(bool on);
+    virtual void setIgnoreTlsErrors(bool on);
+    virtual void setClientCert(const QString &cert, const QString &key);
 
-	virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const Url &uri, const HttpHeaders &headers);
 
-	virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
-	virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body);
+    virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
+    virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
+                              const QByteArray &body);
 
-	virtual State state() const;
-	virtual Url requestUri() const;
-	virtual HttpHeaders requestHeaders() const;
-	virtual int responseCode() const;
-	virtual QByteArray responseReason() const;
-	virtual HttpHeaders responseHeaders() const;
-	virtual QByteArray responseBody() const;
-	virtual int framesAvailable() const;
-	virtual int writeBytesAvailable() const;
-	virtual int peerCloseCode() const;
-	virtual QString peerCloseReason() const;
-	virtual ErrorCondition errorCondition() const;
+    virtual State state() const;
+    virtual Url requestUri() const;
+    virtual HttpHeaders requestHeaders() const;
+    virtual int responseCode() const;
+    virtual QByteArray responseReason() const;
+    virtual HttpHeaders responseHeaders() const;
+    virtual QByteArray responseBody() const;
+    virtual int framesAvailable() const;
+    virtual int writeBytesAvailable() const;
+    virtual int peerCloseCode() const;
+    virtual QString peerCloseReason() const;
+    virtual ErrorCondition errorCondition() const;
 
-	virtual void writeFrame(const Frame &frame);
-	virtual Frame readFrame();
-	virtual void close(int code = -1, const QString &reason = QString());
+    virtual void writeFrame(const Frame &frame);
+    virtual Frame readFrame();
+    virtual void close(int code = -1, const QString &reason = QString());
 
-	void setHeaders(const HttpHeaders &headers);
+    void setHeaders(const HttpHeaders &headers);
 
-	Signal aboutToSendRequest;
-	Signal disconnected;
+    Signal aboutToSendRequest;
+    Signal disconnected;
 
-	// Creates events from `frames`. The returned events are guaranteed to
-	// represent 0 or more full messages from `frames`, where the first
-	// represented frame is a non-continuation frame. This matches the
-	// expectations of `removeContentFromFrames()`, in order to enable
-	// removing the frames afterwards.
-	static QList<Event> framesToEvents(const QList<Frame> &frames, int eventsMax, int contentMax, bool *ok, int *framesRepresented, int *contentRepresented);
+    // Creates events from `frames`. The returned events are guaranteed to
+    // represent 0 or more full messages from `frames`, where the first
+    // represented frame is a non-continuation frame. This matches the
+    // expectations of `removeContentFromFrames()`, in order to enable
+    // removing the frames afterwards.
+    static QList<Event> framesToEvents(const QList<Frame> &frames, int eventsMax, int contentMax,
+                                       bool *ok, int *framesRepresented, int *contentRepresented);
 
-	// Remove `count` content bytes from the beginning of `frames`, removing
-	// frames (including 0-sized frames) when their content is entirely removed.
-	// when a frame is removed from a multipart message, the original type is
-	// carried over into the next frame, which means the first frame can't be a
-	// continuation.
-	// returns the actual number of content bytes removed, which may be less than
-	// `count` if there are not enough content bytes available, or if a frame in
-	// a multipart message needs to be removed and there is no frame after it to
-	// retain the type.
-	static int removeContentFromFrames(QList<WebSocket::Frame> *frames, int count);
+    // Remove `count` content bytes from the beginning of `frames`, removing
+    // frames (including 0-sized frames) when their content is entirely removed.
+    // when a frame is removed from a multipart message, the original type is
+    // carried over into the next frame, which means the first frame can't be a
+    // continuation.
+    // returns the actual number of content bytes removed, which may be less than
+    // `count` if there are not enough content bytes available, or if a frame in
+    // a multipart message needs to be removed and there is no frame after it to
+    // retain the type.
+    static int removeContentFromFrames(QList<WebSocket::Frame> *frames, int count);
 
 private:
-	class DisconnectManager;
-	friend class DisconnectManager;
+    class DisconnectManager;
+    friend class DisconnectManager;
 
-	WebSocketOverHttp();
-	void sendDisconnect();
+    WebSocketOverHttp();
+    void sendDisconnect();
 
-	class Private;
-	friend class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::shared_ptr<Private> d;
 
-	static thread_local DisconnectManager *g_disconnectManager;
-	static thread_local int g_maxManagedDisconnects;
+    static thread_local DisconnectManager *g_disconnectManager;
+    static thread_local int g_maxManagedDisconnects;
 };
 
 #endif

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -20,387 +20,352 @@
  * $FANOUT_END_LICENSE$
  */
 
-#include <unordered_map>
+#include "websocketoverhttp.h"
+#include "log.h"
+#include "test.h"
+#include "zhttpmanager.h"
 #include <QDir>
 #include <boost/signals2.hpp>
-#include "test.h"
-#include "log.h"
-#include "zhttpmanager.h"
-#include "websocketoverhttp.h"
+#include <unordered_map>
 
 namespace {
 
-class WohServer
-{
+class WohServer {
 public:
-	std::unique_ptr<ZhttpManager> zhttpIn;
-	std::unordered_map<ZhttpRequest*, std::unique_ptr<ZhttpRequest>> reqs;
+    std::unique_ptr<ZhttpManager> zhttpIn;
+    std::unordered_map<ZhttpRequest *, std::unique_ptr<ZhttpRequest>> reqs;
 
-	WohServer(const QDir &workDir)
-	{
-		zhttpIn = std::make_unique<ZhttpManager>();
-		zhttpIn->setInstanceId("woh-test-server");
-		zhttpIn->setBind(true);
-		zhttpIn->setServerInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in")));
-		zhttpIn->setServerInStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in-stream")));
-		zhttpIn->setServerOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-out")));
-		zhttpIn->requestReady.connect(boost::bind(&WohServer::zhttpIn_requestReady, this));
-	}
+    WohServer(const QDir &workDir) {
+        zhttpIn = std::make_unique<ZhttpManager>();
+        zhttpIn->setInstanceId("woh-test-server");
+        zhttpIn->setBind(true);
+        zhttpIn->setServerInSpecs(QStringList()
+                                  << QString("ipc://%1").arg(workDir.filePath("woh-test-in")));
+        zhttpIn->setServerInStreamSpecs(
+            QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in-stream")));
+        zhttpIn->setServerOutSpecs(QStringList()
+                                   << QString("ipc://%1").arg(workDir.filePath("woh-test-out")));
+        zhttpIn->requestReady.connect(boost::bind(&WohServer::zhttpIn_requestReady, this));
+    }
 
-	void zhttpIn_requestReady()
-	{
-		ZhttpRequest *req = zhttpIn->takeNextRequest();
-		if(!req)
-			return;
+    void zhttpIn_requestReady() {
+        ZhttpRequest *req = zhttpIn->takeNextRequest();
+        if (!req)
+            return;
 
-		req->readyRead.connect(boost::bind(&WohServer::req_readyRead, this, req));
-		req->bytesWritten.connect(boost::bind(&WohServer::req_bytesWritten, this, req, boost::placeholders::_1));
+        req->readyRead.connect(boost::bind(&WohServer::req_readyRead, this, req));
+        req->bytesWritten.connect(
+            boost::bind(&WohServer::req_bytesWritten, this, req, boost::placeholders::_1));
 
-		reqs.emplace(std::make_pair(req, std::unique_ptr<ZhttpRequest>(req)));
+        reqs.emplace(std::make_pair(req, std::unique_ptr<ZhttpRequest>(req)));
 
-		req_readyRead(req);
-	}
+        req_readyRead(req);
+    }
 
-	void req_readyRead(ZhttpRequest *req)
-	{
-		if(!req->isInputFinished())
-			return;
+    void req_readyRead(ZhttpRequest *req) {
+        if (!req->isInputFinished())
+            return;
 
-		handle(req);
-	}
+        handle(req);
+    }
 
-	void req_bytesWritten(ZhttpRequest *req, int written)
-	{
-		Q_UNUSED(written);
+    void req_bytesWritten(ZhttpRequest *req, int written) {
+        Q_UNUSED(written);
 
-		if(!req->isFinished())
-			return;
+        if (!req->isFinished())
+            return;
 
-		reqs.erase(req);
-	}
+        reqs.erase(req);
+    }
 
-	void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		req->beginResponse(code, reason, headers);
-		req->writeBody(body);
-		req->endBody();
-	}
+    void respond(ZhttpRequest *req, int code, const QByteArray &reason, const HttpHeaders &headers,
+                 const QByteArray &body) {
+        req->beginResponse(code, reason, headers);
+        req->writeBody(body);
+        req->endBody();
+    }
 
-	void respondOk(ZhttpRequest *req, const QByteArray &body, int accepted = -1)
-	{
-		HttpHeaders headers;
-		headers += HttpHeader("Content-Type", "application/websocket-events");
-		if(accepted >= 0)
-			headers += HttpHeader("Content-Bytes-Accepted", QByteArray::number(accepted));
+    void respondOk(ZhttpRequest *req, const QByteArray &body, int accepted = -1) {
+        HttpHeaders headers;
+        headers += HttpHeader("Content-Type", "application/websocket-events");
+        if (accepted >= 0)
+            headers += HttpHeader("Content-Bytes-Accepted", QByteArray::number(accepted));
 
-		respond(req, 200, "OK", headers, body);
-	}
+        respond(req, 200, "OK", headers, body);
+    }
 
-	void respondError(ZhttpRequest *req, int code, const QByteArray &reason, const QByteArray &body)
-	{
-		respond(req, code, reason, HttpHeaders(), body);
-	}
+    void respondError(ZhttpRequest *req, int code, const QByteArray &reason,
+                      const QByteArray &body) {
+        respond(req, code, reason, HttpHeaders(), body);
+    }
 
-	void handle(ZhttpRequest *req)
-	{
-		if(req->requestMethod() != "POST")
-		{
-			respondError(req, 400, "Bad Request", "Method must be POST\n");
-			return;
-		}
+    void handle(ZhttpRequest *req) {
+        if (req->requestMethod() != "POST") {
+            respondError(req, 400, "Bad Request", "Method must be POST\n");
+            return;
+        }
 
-		Url uri = req->requestUri();
-		HttpHeaders headers = req->requestHeaders();
-		QByteArray body = req->readBody();
+        Url uri = req->requestUri();
+        HttpHeaders headers = req->requestHeaders();
+        QByteArray body = req->readBody();
 
-		if(headers.get("Content-Type") != "application/websocket-events")
-		{
-			respondError(req, 400, "Bad Request", "Content-Type must be application/websocket-events\n");
-			return;
-		}
+        if (headers.get("Content-Type") != "application/websocket-events") {
+            respondError(req, 400, "Bad Request",
+                         "Content-Type must be application/websocket-events\n");
+            return;
+        }
 
-		if(headers.get("Accept") != "application/websocket-events")
-		{
-			respondError(req, 400, "Bad Request", "Accept must be application/websocket-events\n");
-			return;
-		}
+        if (headers.get("Accept") != "application/websocket-events") {
+            respondError(req, 400, "Bad Request", "Accept must be application/websocket-events\n");
+            return;
+        }
 
-		if(uri.path() == "/ws")
-		{
-			if(body == "OPEN\r\n")
-				respondOk(req, "OPEN\r\n");
-			else if(body == "TEXT 5\r\nhello\r\n")
-				respondOk(req, "TEXT 5\r\nworld\r\n");
-			else if(body == "TEXT b\r\n[foo][hello\r\n")
-				respondOk(req, "", 5);
-			else if(body == "TEXT 6\r\n[hello\r\nTEXT 7\r\n world]\r\n")
-			{
-				if(headers.get("Content-Bytes-Replayed") != "6")
-				{
-					respondError(req, 400, "Bad Request", "Expected replayed=5\n");
-					return;
-				}
+        if (uri.path() == "/ws") {
+            if (body == "OPEN\r\n")
+                respondOk(req, "OPEN\r\n");
+            else if (body == "TEXT 5\r\nhello\r\n")
+                respondOk(req, "TEXT 5\r\nworld\r\n");
+            else if (body == "TEXT b\r\n[foo][hello\r\n")
+                respondOk(req, "", 5);
+            else if (body == "TEXT 6\r\n[hello\r\nTEXT 7\r\n world]\r\n") {
+                if (headers.get("Content-Bytes-Replayed") != "6") {
+                    respondError(req, 400, "Bad Request", "Expected replayed=5\n");
+                    return;
+                }
 
-				respondOk(req, "TEXT 4\r\n[ok]\r\n");
-			}
-			else if(body == "CLOSE\r\n")
-				respondOk(req, "CLOSE\r\n");
-			else
-				respondOk(req, "");
-		}
-		else
-		{
-			respondError(req, 404, "Not Found", "Not Found\n");
-		}
-	}
+                respondOk(req, "TEXT 4\r\n[ok]\r\n");
+            } else if (body == "CLOSE\r\n")
+                respondOk(req, "CLOSE\r\n");
+            else
+                respondOk(req, "");
+        } else {
+            respondError(req, 404, "Not Found", "Not Found\n");
+        }
+    }
 };
 
-class TestState
-{
+class TestState {
 public:
-	std::unique_ptr<WohServer> wohServer;
-	std::unique_ptr<ZhttpManager> zhttpOut;
+    std::unique_ptr<WohServer> wohServer;
+    std::unique_ptr<ZhttpManager> zhttpOut;
 
-	TestState(std::function<void (int)> loop_wait)
-	{
-		log_setOutputLevel(LOG_LEVEL_WARNING);
+    TestState(std::function<void(int)> loop_wait) {
+        log_setOutputLevel(LOG_LEVEL_WARNING);
 
-		QDir outDir(qgetenv("OUT_DIR"));
-		QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
+        QDir outDir(qgetenv("OUT_DIR"));
+        QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 
-		wohServer = std::make_unique<WohServer>(workDir);
+        wohServer = std::make_unique<WohServer>(workDir);
 
-		zhttpOut = std::make_unique<ZhttpManager>();
+        zhttpOut = std::make_unique<ZhttpManager>();
 
-		bool connected = false;
-		zhttpOut->probeAcked.connect([&] {
-			connected = true;
-		});
+        bool connected = false;
+        zhttpOut->probeAcked.connect([&] { connected = true; });
 
-		zhttpOut->setInstanceId("woh-test-client");
-		zhttpOut->setProbe(true);
-		zhttpOut->setClientOutSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in")));
-		zhttpOut->setClientOutStreamSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in-stream")));
-		zhttpOut->setClientInSpecs(QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-out")));
+        zhttpOut->setInstanceId("woh-test-client");
+        zhttpOut->setProbe(true);
+        zhttpOut->setClientOutSpecs(QStringList()
+                                    << QString("ipc://%1").arg(workDir.filePath("woh-test-in")));
+        zhttpOut->setClientOutStreamSpecs(
+            QStringList() << QString("ipc://%1").arg(workDir.filePath("woh-test-in-stream")));
+        zhttpOut->setClientInSpecs(QStringList()
+                                   << QString("ipc://%1").arg(workDir.filePath("woh-test-out")));
 
-		while(!connected)
-			loop_wait(10);
-	}
+        while (!connected)
+            loop_wait(10);
+    }
 
-	~TestState()
-	{
-		WebSocketOverHttp::clearDisconnectManager();
+    ~TestState() {
+        WebSocketOverHttp::clearDisconnectManager();
 
-		zhttpOut.reset();
-		wohServer.reset();
-	}
+        zhttpOut.reset();
+        wohServer.reset();
+    }
 };
 
+} // namespace
+
+static void convertFrames() {
+    QList<WebSocket::Frame> frames;
+    frames += WebSocket::Frame(WebSocket::Frame::Text, "hello", true);
+    frames += WebSocket::Frame(WebSocket::Frame::Continuation, " world", false);
+
+    bool ok = false;
+    int framesRepresented = 0;
+    int contentRepresented = 0;
+    QList<WebSocketOverHttp::Event> events = WebSocketOverHttp::framesToEvents(
+        frames, -1, -1, &ok, &framesRepresented, &contentRepresented);
+    TEST_ASSERT(ok);
+    TEST_ASSERT_EQ(events.count(), 1);
+    TEST_ASSERT_EQ(events[0].type, "TEXT");
+    TEST_ASSERT_EQ(events[0].content, "hello world");
+
+    int removed = WebSocketOverHttp::removeContentFromFrames(&frames, contentRepresented);
+    TEST_ASSERT_EQ(removed, contentRepresented);
+    TEST_ASSERT(frames.isEmpty());
 }
 
-static void convertFrames()
-{
-	QList<WebSocket::Frame> frames;
-	frames += WebSocket::Frame(WebSocket::Frame::Text, "hello", true);
-	frames += WebSocket::Frame(WebSocket::Frame::Continuation, " world", false);
+static void removePartial() {
+    QList<WebSocket::Frame> frames;
+    frames += WebSocket::Frame(WebSocket::Frame::Text, "hello", true);
+    frames += WebSocket::Frame(WebSocket::Frame::Continuation, " world", false);
+    frames += WebSocket::Frame(WebSocket::Frame::Text, "", false);
+    frames += WebSocket::Frame(WebSocket::Frame::Text, "foo", false);
 
-	bool ok = false;
-	int framesRepresented = 0;
-	int contentRepresented = 0;
-	QList<WebSocketOverHttp::Event> events = WebSocketOverHttp::framesToEvents(frames, -1, -1, &ok, &framesRepresented, &contentRepresented);
-	TEST_ASSERT(ok);
-	TEST_ASSERT_EQ(events.count(), 1);
-	TEST_ASSERT_EQ(events[0].type, "TEXT");
-	TEST_ASSERT_EQ(events[0].content, "hello world");
+    int removed = WebSocketOverHttp::removeContentFromFrames(&frames, 3);
+    TEST_ASSERT_EQ(removed, 3);
+    TEST_ASSERT_EQ(frames.count(), 4);
+    TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
+    TEST_ASSERT_EQ(frames[0].data, "lo");
 
-	int removed = WebSocketOverHttp::removeContentFromFrames(&frames, contentRepresented);
-	TEST_ASSERT_EQ(removed, contentRepresented);
-	TEST_ASSERT(frames.isEmpty());
+    removed = WebSocketOverHttp::removeContentFromFrames(&frames, 2);
+    TEST_ASSERT_EQ(removed, 2);
+    TEST_ASSERT_EQ(frames.count(), 3);
+    TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
+    TEST_ASSERT_EQ(frames[0].data, " world");
+
+    removed = WebSocketOverHttp::removeContentFromFrames(&frames, 6);
+    TEST_ASSERT_EQ(removed, 6);
+    TEST_ASSERT_EQ(frames.count(), 1);
+    TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
+    TEST_ASSERT_EQ(frames[0].data, "foo");
+
+    removed = WebSocketOverHttp::removeContentFromFrames(&frames, 10);
+    TEST_ASSERT_EQ(removed, 3);
+    TEST_ASSERT(frames.isEmpty());
 }
 
-static void removePartial()
-{
-	QList<WebSocket::Frame> frames;
-	frames += WebSocket::Frame(WebSocket::Frame::Text, "hello", true);
-	frames += WebSocket::Frame(WebSocket::Frame::Continuation, " world", false);
-	frames += WebSocket::Frame(WebSocket::Frame::Text, "", false);
-	frames += WebSocket::Frame(WebSocket::Frame::Text, "foo", false);
+static void io(std::function<void(int)> loop_wait) {
+    TestState state(loop_wait);
 
-	int removed = WebSocketOverHttp::removeContentFromFrames(&frames, 3);
-	TEST_ASSERT_EQ(removed, 3);
-	TEST_ASSERT_EQ(frames.count(), 4);
-	TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
-	TEST_ASSERT_EQ(frames[0].data, "lo");
+    WebSocketOverHttp client(state.zhttpOut.get());
 
-	removed = WebSocketOverHttp::removeContentFromFrames(&frames, 2);
-	TEST_ASSERT_EQ(removed, 2);
-	TEST_ASSERT_EQ(frames.count(), 3);
-	TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
-	TEST_ASSERT_EQ(frames[0].data, " world");
+    bool clientConnected = false;
+    client.connected.connect([&] { clientConnected = true; });
 
-	removed = WebSocketOverHttp::removeContentFromFrames(&frames, 6);
-	TEST_ASSERT_EQ(removed, 6);
-	TEST_ASSERT_EQ(frames.count(), 1);
-	TEST_ASSERT_EQ(frames[0].type, WebSocket::Frame::Text);
-	TEST_ASSERT_EQ(frames[0].data, "foo");
+    bool clientReadyRead = false;
+    client.readyRead.connect([&] { clientReadyRead = true; });
 
-	removed = WebSocketOverHttp::removeContentFromFrames(&frames, 10);
-	TEST_ASSERT_EQ(removed, 3);
-	TEST_ASSERT(frames.isEmpty());
+    int clientFramesWritten = 0;
+    int clientContentWritten = 0;
+    client.framesWritten.connect([&](int count, int contentBytes) {
+        clientFramesWritten += count;
+        clientContentWritten += contentBytes;
+    });
+
+    bool clientClosed = false;
+    client.closed.connect([&] { clientClosed = true; });
+
+    bool clientError = false;
+    client.error.connect([&] { clientError = true; });
+
+    client.start(Url("ws://localhost/ws"), HttpHeaders());
+
+    while (!clientConnected && !clientError)
+        loop_wait(10);
+
+    TEST_ASSERT(!clientError);
+    TEST_ASSERT(clientConnected);
+
+    client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, "hello", false));
+
+    while (!clientReadyRead && !clientError)
+        loop_wait(10);
+
+    TEST_ASSERT(!clientError);
+    TEST_ASSERT(clientReadyRead);
+    TEST_ASSERT_EQ(clientFramesWritten, 1);
+    TEST_ASSERT_EQ(clientContentWritten, 5);
+
+    WebSocket::Frame f = client.readFrame();
+    TEST_ASSERT_EQ(f.type, WebSocket::Frame::Text);
+    TEST_ASSERT_EQ(f.data, "world");
+    TEST_ASSERT(!f.more);
+
+    client.close();
+
+    while (!clientClosed && !clientError)
+        loop_wait(10);
+
+    TEST_ASSERT(!clientError);
+    TEST_ASSERT(clientClosed);
 }
 
-static void io(std::function<void (int)> loop_wait)
-{
-	TestState state(loop_wait);
+static void replay(std::function<void(int)> loop_wait) {
+    TestState state(loop_wait);
 
-	WebSocketOverHttp client(state.zhttpOut.get());
+    WebSocketOverHttp client(state.zhttpOut.get());
 
-	bool clientConnected = false;
-	client.connected.connect([&] {
-		clientConnected = true;
-	});
+    bool clientConnected = false;
+    client.connected.connect([&] { clientConnected = true; });
 
-	bool clientReadyRead = false;
-	client.readyRead.connect([&] {
-		clientReadyRead = true;
-	});
+    bool clientReadyRead = false;
+    client.readyRead.connect([&] { clientReadyRead = true; });
 
-	int clientFramesWritten = 0;
-	int clientContentWritten = 0;
-	client.framesWritten.connect([&](int count, int contentBytes) {
-		clientFramesWritten += count;
-		clientContentWritten += contentBytes;
-	});
+    int clientFramesWritten = 0;
+    int clientContentWritten = 0;
+    client.framesWritten.connect([&](int count, int contentBytes) {
+        clientFramesWritten += count;
+        clientContentWritten += contentBytes;
+    });
 
-	bool clientClosed = false;
-	client.closed.connect([&] {
-		clientClosed = true;
-	});
+    bool clientWriteBytesChanged = false;
+    client.writeBytesChanged.connect([&] { clientWriteBytesChanged = true; });
 
-	bool clientError = false;
-	client.error.connect([&] {
-		clientError = true;
-	});
+    bool clientClosed = false;
+    client.closed.connect([&] { clientClosed = true; });
 
-	client.start(Url("ws://localhost/ws"), HttpHeaders());
+    bool clientError = false;
+    client.error.connect([&] { clientError = true; });
 
-	while(!clientConnected && !clientError)
-		loop_wait(10);
+    client.start(Url("ws://localhost/ws"), HttpHeaders());
 
-	TEST_ASSERT(!clientError);
-	TEST_ASSERT(clientConnected);
+    while (!clientConnected && !clientError)
+        loop_wait(10);
 
-	client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, "hello", false));
+    TEST_ASSERT(!clientError);
+    TEST_ASSERT(clientConnected);
 
-	while(!clientReadyRead && !clientError)
-		loop_wait(10);
+    int maxAvail = client.writeBytesAvailable();
+    client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, "[foo][hello", false));
+    TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail - 11);
 
-	TEST_ASSERT(!clientError);
-	TEST_ASSERT(clientReadyRead);
-	TEST_ASSERT_EQ(clientFramesWritten, 1);
-	TEST_ASSERT_EQ(clientContentWritten, 5);
+    while (!clientWriteBytesChanged && !clientError)
+        loop_wait(10);
 
-	WebSocket::Frame f = client.readFrame();
-	TEST_ASSERT_EQ(f.type, WebSocket::Frame::Text);
-	TEST_ASSERT_EQ(f.data, "world");
-	TEST_ASSERT(!f.more);
+    TEST_ASSERT(!clientError);
+    TEST_ASSERT(clientWriteBytesChanged);
+    TEST_ASSERT_EQ(clientFramesWritten, 0);
+    TEST_ASSERT_EQ(clientContentWritten, 5);
+    TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail - 6);
 
-	client.close();
+    client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, " world]", false));
 
-	while(!clientClosed && !clientError)
-		loop_wait(10);
+    while (!clientReadyRead && !clientError)
+        loop_wait(10);
 
-	TEST_ASSERT(!clientError);
-	TEST_ASSERT(clientClosed);
+    WebSocket::Frame f = client.readFrame();
+    TEST_ASSERT_EQ(f.type, WebSocket::Frame::Text);
+    TEST_ASSERT_EQ(f.data, "[ok]");
+    TEST_ASSERT(!f.more);
+    TEST_ASSERT_EQ(clientFramesWritten, 2);
+    TEST_ASSERT_EQ(clientContentWritten, 18);
+    TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail);
+
+    client.close();
+
+    while (!clientClosed && !clientError)
+        loop_wait(10);
+
+    TEST_ASSERT(!clientError);
+    TEST_ASSERT(clientClosed);
 }
 
-static void replay(std::function<void (int)> loop_wait)
-{
-	TestState state(loop_wait);
+extern "C" int websocketoverhttp_test(ffi::TestException *out_ex) {
+    TEST_CATCH(convertFrames());
+    TEST_CATCH(removePartial());
+    TEST_CATCH(test_with_event_loop(io));
+    TEST_CATCH(test_with_event_loop(replay));
 
-	WebSocketOverHttp client(state.zhttpOut.get());
-
-	bool clientConnected = false;
-	client.connected.connect([&] {
-		clientConnected = true;
-	});
-
-	bool clientReadyRead = false;
-	client.readyRead.connect([&] {
-		clientReadyRead = true;
-	});
-
-	int clientFramesWritten = 0;
-	int clientContentWritten = 0;
-	client.framesWritten.connect([&](int count, int contentBytes) {
-		clientFramesWritten += count;
-		clientContentWritten += contentBytes;
-	});
-
-	bool clientWriteBytesChanged = false;
-	client.writeBytesChanged.connect([&] {
-		clientWriteBytesChanged = true;
-	});
-
-	bool clientClosed = false;
-	client.closed.connect([&] {
-		clientClosed = true;
-	});
-
-	bool clientError = false;
-	client.error.connect([&] {
-		clientError = true;
-	});
-
-	client.start(Url("ws://localhost/ws"), HttpHeaders());
-
-	while(!clientConnected && !clientError)
-		loop_wait(10);
-
-	TEST_ASSERT(!clientError);
-	TEST_ASSERT(clientConnected);
-
-	int maxAvail = client.writeBytesAvailable();
-	client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, "[foo][hello", false));
-	TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail - 11);
-
-	while(!clientWriteBytesChanged && !clientError)
-		loop_wait(10);
-
-	TEST_ASSERT(!clientError);
-	TEST_ASSERT(clientWriteBytesChanged);
-	TEST_ASSERT_EQ(clientFramesWritten, 0);
-	TEST_ASSERT_EQ(clientContentWritten, 5);
-	TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail - 6);
-
-	client.writeFrame(WebSocket::Frame(WebSocket::Frame::Text, " world]", false));
-
-	while(!clientReadyRead && !clientError)
-		loop_wait(10);
-
-	WebSocket::Frame f = client.readFrame();
-	TEST_ASSERT_EQ(f.type, WebSocket::Frame::Text);
-	TEST_ASSERT_EQ(f.data, "[ok]");
-	TEST_ASSERT(!f.more);
-	TEST_ASSERT_EQ(clientFramesWritten, 2);
-	TEST_ASSERT_EQ(clientContentWritten, 18);
-	TEST_ASSERT_EQ(client.writeBytesAvailable(), maxAvail);
-
-	client.close();
-
-	while(!clientClosed && !clientError)
-		loop_wait(10);
-
-	TEST_ASSERT(!clientError);
-	TEST_ASSERT(clientClosed);
-}
-
-extern "C" int websocketoverhttp_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(convertFrames());
-	TEST_CATCH(removePartial());
-	TEST_CATCH(test_with_event_loop(io));
-	TEST_CATCH(test_with_event_loop(replay));
-
-	return 0;
+    return 0;
 }

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -23,19 +23,19 @@
 
 #include "wscontrolmanager.h"
 
-#include <assert.h>
-#include <QDateTime>
-#include <boost/signals2.hpp>
-#include "zmqsocket.h"
-#include "zmqvalve.h"
-#include "zmqreqmessage.h"
 #include "log.h"
+#include "logutil.h"
 #include "timer.h"
 #include "tnetstring.h"
 #include "variant.h"
-#include "zutil.h"
-#include "logutil.h"
 #include "wscontrolsession.h"
+#include "zmqreqmessage.h"
+#include "zmqsocket.h"
+#include "zmqvalve.h"
+#include "zutil.h"
+#include <QDateTime>
+#include <assert.h>
+#include <boost/signals2.hpp>
 
 #define DEFAULT_HWM 101000
 
@@ -50,435 +50,378 @@
 
 using Connection = boost::signals2::scoped_connection;
 
-class WsControlManager::Private
-{
+class WsControlManager::Private {
 public:
-	class KeepAliveRegistration
-	{
-	public:
-		WsControlSession *s;
-		int64_t lastRefresh;
-		int refreshBucket;
-	};
+    class KeepAliveRegistration {
+    public:
+        WsControlSession *s;
+        int64_t lastRefresh;
+        int refreshBucket;
+    };
 
-	WsControlManager *q;
-	QByteArray identity;
-	int ipcFileMode;
-	QStringList initSpecs;
-	QStringList streamSpecs;
-	std::unique_ptr<ZmqSocket> initSock;
-	std::unique_ptr<ZmqSocket> streamSock;
-	std::unique_ptr<ZmqValve> streamValve;
-	QHash<QByteArray, WsControlSession*> sessionsByCid;
-	std::unique_ptr<Timer> refreshTimer;
-	QHash<WsControlSession*, KeepAliveRegistration*> keepAliveRegistrations;
-	QMap<QPair<int64_t, KeepAliveRegistration*>, KeepAliveRegistration*> sessionsByLastRefresh;
-	QSet<KeepAliveRegistration*> sessionRefreshBuckets[SESSION_REFRESH_BUCKETS];
-	int currentSessionRefreshBucket;
-	Connection streamValveConnection;
-	Connection refreshTimerConnection;
+    WsControlManager *q;
+    QByteArray identity;
+    int ipcFileMode;
+    QStringList initSpecs;
+    QStringList streamSpecs;
+    std::unique_ptr<ZmqSocket> initSock;
+    std::unique_ptr<ZmqSocket> streamSock;
+    std::unique_ptr<ZmqValve> streamValve;
+    QHash<QByteArray, WsControlSession *> sessionsByCid;
+    std::unique_ptr<Timer> refreshTimer;
+    QHash<WsControlSession *, KeepAliveRegistration *> keepAliveRegistrations;
+    QMap<QPair<int64_t, KeepAliveRegistration *>, KeepAliveRegistration *> sessionsByLastRefresh;
+    QSet<KeepAliveRegistration *> sessionRefreshBuckets[SESSION_REFRESH_BUCKETS];
+    int currentSessionRefreshBucket;
+    Connection streamValveConnection;
+    Connection refreshTimerConnection;
 
-	Private(WsControlManager *_q) :
-		q(_q),
-		ipcFileMode(-1),
-		currentSessionRefreshBucket(0)
-	{
-		refreshTimer = std::make_unique<Timer>();
-		refreshTimerConnection = refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
-	}
+    Private(WsControlManager *_q) : q(_q), ipcFileMode(-1), currentSessionRefreshBucket(0) {
+        refreshTimer = std::make_unique<Timer>();
+        refreshTimerConnection =
+            refreshTimer->timeout.connect(boost::bind(&Private::refresh_timeout, this));
+    }
 
-	~Private()
-	{
-		assert(sessionsByCid.isEmpty());
-		assert(keepAliveRegistrations.isEmpty());
-	}
+    ~Private() {
+        assert(sessionsByCid.isEmpty());
+        assert(keepAliveRegistrations.isEmpty());
+    }
 
-	bool setupInit()
-	{
-		initSock.reset();
+    bool setupInit() {
+        initSock.reset();
 
-		initSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
+        initSock = std::make_unique<ZmqSocket>(ZmqSocket::Push);
 
-		initSock->setHwm(DEFAULT_HWM);
-		initSock->setShutdownWaitTime(0);
+        initSock->setHwm(DEFAULT_HWM);
+        initSock->setShutdownWaitTime(0);
 
-		foreach(const QString &spec, initSpecs)
-		{
-			QString errorMessage;
-			if(!ZUtil::setupSocket(initSock.get(), spec, true, ipcFileMode, &errorMessage))
-			{
-				log_error("%s", qPrintable(errorMessage));
-				return false;
-			}
-		}
+        foreach (const QString &spec, initSpecs) {
+            QString errorMessage;
+            if (!ZUtil::setupSocket(initSock.get(), spec, true, ipcFileMode, &errorMessage)) {
+                log_error("%s", qPrintable(errorMessage));
+                return false;
+            }
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	bool setupStream()
-	{
-		streamValve.reset();
-		streamSock.reset();
+    bool setupStream() {
+        streamValve.reset();
+        streamSock.reset();
 
-		streamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
+        streamSock = std::make_unique<ZmqSocket>(ZmqSocket::Router);
 
-		streamSock->setIdentity(identity);
-		streamSock->setHwm(DEFAULT_HWM);
-		streamSock->setShutdownWaitTime(0);
+        streamSock->setIdentity(identity);
+        streamSock->setHwm(DEFAULT_HWM);
+        streamSock->setShutdownWaitTime(0);
 
-		foreach(const QString &spec, streamSpecs)
-		{
-			QString errorMessage;
-			if(!ZUtil::setupSocket(streamSock.get(), spec, true, ipcFileMode, &errorMessage))
-			{
-				log_error("%s", qPrintable(errorMessage));
-				return false;
-			}
-		}
+        foreach (const QString &spec, streamSpecs) {
+            QString errorMessage;
+            if (!ZUtil::setupSocket(streamSock.get(), spec, true, ipcFileMode, &errorMessage)) {
+                log_error("%s", qPrintable(errorMessage));
+                return false;
+            }
+        }
 
-		streamValve = std::make_unique<ZmqValve>(streamSock.get());
-		streamValveConnection = streamValve->readyRead.connect(boost::bind(&Private::stream_readyRead, this, boost::placeholders::_1));
+        streamValve = std::make_unique<ZmqValve>(streamSock.get());
+        streamValveConnection = streamValve->readyRead.connect(
+            boost::bind(&Private::stream_readyRead, this, boost::placeholders::_1));
 
-		streamValve->open();
+        streamValve->open();
 
-		return true;
-	}
+        return true;
+    }
 
-	int smallestSessionRefreshBucket()
-	{
-		int best = -1;
-		int bestSize = 0;
+    int smallestSessionRefreshBucket() {
+        int best = -1;
+        int bestSize = 0;
 
-		for(int n = 0; n < SESSION_REFRESH_BUCKETS; ++n)
-		{
-			if(best == -1 || sessionRefreshBuckets[n].count() < bestSize)
-			{
-				best = n;
-				bestSize = sessionRefreshBuckets[n].count();
-			}
-		}
+        for (int n = 0; n < SESSION_REFRESH_BUCKETS; ++n) {
+            if (best == -1 || sessionRefreshBuckets[n].count() < bestSize) {
+                best = n;
+                bestSize = sessionRefreshBuckets[n].count();
+            }
+        }
 
-		return best;
-	}
+        return best;
+    }
 
-	void writeInit(const WsControlPacket &packet)
-	{
-		assert(streamSock);
+    void writeInit(const WsControlPacket &packet) {
+        assert(streamSock);
 
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = TnetString::fromVariant(vpacket);
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = TnetString::fromVariant(vpacket);
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariant(LOG_LEVEL_DEBUG, vpacket, "wscontrol: OUT");
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariant(LOG_LEVEL_DEBUG, vpacket, "wscontrol: OUT");
 
-		initSock->write(QList<QByteArray>() << buf);
-	}
+        initSock->write(QList<QByteArray>() << buf);
+    }
 
-	void writeStream(const WsControlPacket &packet, const QByteArray &instanceAddress)
-	{
-		assert(streamSock);
+    void writeStream(const WsControlPacket &packet, const QByteArray &instanceAddress) {
+        assert(streamSock);
 
-		Variant vpacket = packet.toVariant();
-		QByteArray buf = TnetString::fromVariant(vpacket);
+        Variant vpacket = packet.toVariant();
+        QByteArray buf = TnetString::fromVariant(vpacket);
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariant(LOG_LEVEL_DEBUG, vpacket, "wscontrol: OUT to=%s", instanceAddress.data());
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariant(LOG_LEVEL_DEBUG, vpacket, "wscontrol: OUT to=%s",
+                                instanceAddress.data());
 
-		QList<QByteArray> msg;
-		msg += instanceAddress;
-		msg += QByteArray();
-		msg += buf;
-		streamSock->write(msg);
-	}
+        QList<QByteArray> msg;
+        msg += instanceAddress;
+        msg += QByteArray();
+        msg += buf;
+        streamSock->write(msg);
+    }
 
-	void writeInit(const WsControlPacket::Item &item)
-	{
-		WsControlPacket out;
-		out.from = identity;
-		out.items += item;
-		writeInit(out);
-	}
+    void writeInit(const WsControlPacket::Item &item) {
+        WsControlPacket out;
+        out.from = identity;
+        out.items += item;
+        writeInit(out);
+    }
 
-	void writeStream(const WsControlPacket::Item &item, const QByteArray &instanceAddress)
-	{
-		WsControlPacket out;
-		out.from = identity;
-		out.items += item;
-		writeStream(out, instanceAddress);
-	}
+    void writeStream(const WsControlPacket::Item &item, const QByteArray &instanceAddress) {
+        WsControlPacket out;
+        out.from = identity;
+        out.items += item;
+        writeStream(out, instanceAddress);
+    }
 
-	void registerKeepAlive(WsControlSession *s)
-	{
-		if(keepAliveRegistrations.contains(s))
-			return;
+    void registerKeepAlive(WsControlSession *s) {
+        if (keepAliveRegistrations.contains(s))
+            return;
 
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
 
-		KeepAliveRegistration *r = new KeepAliveRegistration;
-		r->s = s;
-		keepAliveRegistrations.insert(s, r);
+        KeepAliveRegistration *r = new KeepAliveRegistration;
+        r->s = s;
+        keepAliveRegistrations.insert(s, r);
 
-		r->lastRefresh = now;
-		sessionsByLastRefresh.insert(QPair<int64_t, KeepAliveRegistration*>(r->lastRefresh, r), r);
+        r->lastRefresh = now;
+        sessionsByLastRefresh.insert(QPair<int64_t, KeepAliveRegistration *>(r->lastRefresh, r), r);
 
-		r->refreshBucket = smallestSessionRefreshBucket();
-		sessionRefreshBuckets[r->refreshBucket] += r;
+        r->refreshBucket = smallestSessionRefreshBucket();
+        sessionRefreshBuckets[r->refreshBucket] += r;
 
-		setupKeepAlive();
-	}
+        setupKeepAlive();
+    }
 
-	void unregisterKeepAlive(WsControlSession *s)
-	{
-		KeepAliveRegistration *r = keepAliveRegistrations.value(s);
-		if(!r)
-			return;
+    void unregisterKeepAlive(WsControlSession *s) {
+        KeepAliveRegistration *r = keepAliveRegistrations.value(s);
+        if (!r)
+            return;
 
-		sessionRefreshBuckets[r->refreshBucket].remove(r);
-		sessionsByLastRefresh.remove(QPair<int64_t, KeepAliveRegistration*>(r->lastRefresh, r));
-		keepAliveRegistrations.remove(s);
-		delete r;
+        sessionRefreshBuckets[r->refreshBucket].remove(r);
+        sessionsByLastRefresh.remove(QPair<int64_t, KeepAliveRegistration *>(r->lastRefresh, r));
+        keepAliveRegistrations.remove(s);
+        delete r;
 
-		setupKeepAlive();
-	}
+        setupKeepAlive();
+    }
 
-	void setupKeepAlive()
-	{
-		if(!keepAliveRegistrations.isEmpty())
-		{
-			if(!refreshTimer->isActive())
-				refreshTimer->start(REFRESH_INTERVAL);
-		}
-		else
-			refreshTimer->stop();
-	}
+    void setupKeepAlive() {
+        if (!keepAliveRegistrations.isEmpty()) {
+            if (!refreshTimer->isActive())
+                refreshTimer->start(REFRESH_INTERVAL);
+        } else
+            refreshTimer->stop();
+    }
 
 private:
-	void stream_readyRead(const CowByteArrayList &message)
-	{
-		ZmqReqMessage req(message);
+    void stream_readyRead(const CowByteArrayList &message) {
+        ZmqReqMessage req(message);
 
-		if(req.content().count() != 1)
-		{
-			log_warning("wscontrol: received message with parts != 1, skipping");
-			return;
-		}
+        if (req.content().count() != 1) {
+            log_warning("wscontrol: received message with parts != 1, skipping");
+            return;
+        }
 
-		Variant data = TnetString::toVariant(req.content()[0]);
-		if(data.isNull())
-		{
-			log_warning("wscontrol: received message with invalid format (tnetstring parse failed), skipping");
-			return;
-		}
+        Variant data = TnetString::toVariant(req.content()[0]);
+        if (data.isNull()) {
+            log_warning("wscontrol: received message with invalid format (tnetstring "
+                        "parse failed), skipping");
+            return;
+        }
 
-		if(log_outputLevel() >= LOG_LEVEL_DEBUG)
-			LogUtil::logVariant(LOG_LEVEL_DEBUG, data, "wscontrol: IN");
+        if (log_outputLevel() >= LOG_LEVEL_DEBUG)
+            LogUtil::logVariant(LOG_LEVEL_DEBUG, data, "wscontrol: IN");
 
-		WsControlPacket p;
-		if(!p.fromVariant(data))
-		{
-			log_warning("wscontrol: received message with invalid format (parse failed), skipping");
-			return;
-		}
+        WsControlPacket p;
+        if (!p.fromVariant(data)) {
+            log_warning("wscontrol: received message with invalid format (parse "
+                        "failed), skipping");
+            return;
+        }
 
-		if(p.from.isEmpty())
-		{
-			log_warning("wscontrol: received message with invalid from value, skipping");
-			return;
-		}
+        if (p.from.isEmpty()) {
+            log_warning("wscontrol: received message with invalid from value, skipping");
+            return;
+        }
 
-		std::weak_ptr<Private> self = q->d;
+        std::weak_ptr<Private> self = q->d;
 
-		foreach(const WsControlPacket::Item &i, p.items)
-		{
-			WsControlSession *s = sessionsByCid.value(i.cid);
-			if(!s)
-			{
-				log_debug("wscontrol: received item for unknown connection id, canceling");
+        foreach (const WsControlPacket::Item &i, p.items) {
+            WsControlSession *s = sessionsByCid.value(i.cid);
+            if (!s) {
+                log_debug("wscontrol: received item for unknown connection id, canceling");
 
-				// If this was not an error item, send cancel
-				if(i.type != WsControlPacket::Item::Cancel)
-				{
-					WsControlPacket::Item out;
-					out.cid = i.cid;
-					out.type = WsControlPacket::Item::Cancel;
-					writeStream(out, p.from);
-				}
+                // If this was not an error item, send cancel
+                if (i.type != WsControlPacket::Item::Cancel) {
+                    WsControlPacket::Item out;
+                    out.cid = i.cid;
+                    out.type = WsControlPacket::Item::Cancel;
+                    writeStream(out, p.from);
+                }
 
-				continue;
-			}
+                continue;
+            }
 
-			s->handle(p.from, i);
+            s->handle(p.from, i);
 
-			if(self.expired())
-				return;
-		}
-	}
+            if (self.expired())
+                return;
+        }
+    }
 
-	void refresh_timeout()
-	{
-		int64_t now = QDateTime::currentMSecsSinceEpoch();
+    void refresh_timeout() {
+        int64_t now = QDateTime::currentMSecsSinceEpoch();
 
-		QHash<QByteArray, WsControlPacket> packets;
+        QHash<QByteArray, WsControlPacket> packets;
 
-		// Process the current bucket
-		const QSet<KeepAliveRegistration*> &bucket = sessionRefreshBuckets[currentSessionRefreshBucket];
-		foreach(KeepAliveRegistration *r, bucket)
-		{
-			// Move to the end
-			QPair<int64_t, KeepAliveRegistration*> k(r->lastRefresh, r);
-			sessionsByLastRefresh.remove(k);
-			r->lastRefresh = now;
-			sessionsByLastRefresh.insert(QPair<int64_t, KeepAliveRegistration*>(r->lastRefresh, r), r);
+        // Process the current bucket
+        const QSet<KeepAliveRegistration *> &bucket =
+            sessionRefreshBuckets[currentSessionRefreshBucket];
+        foreach (KeepAliveRegistration *r, bucket) {
+            // Move to the end
+            QPair<int64_t, KeepAliveRegistration *> k(r->lastRefresh, r);
+            sessionsByLastRefresh.remove(k);
+            r->lastRefresh = now;
+            sessionsByLastRefresh.insert(QPair<int64_t, KeepAliveRegistration *>(r->lastRefresh, r),
+                                         r);
 
-			QByteArray peer = r->s->peer();
-			if(peer.isEmpty())
-				continue;
+            QByteArray peer = r->s->peer();
+            if (peer.isEmpty())
+                continue;
 
-			if(!packets.contains(peer))
-			{
-				WsControlPacket packet;
-				packet.from = identity;
-				packets.insert(peer, packet);
-			}
+            if (!packets.contains(peer)) {
+                WsControlPacket packet;
+                packet.from = identity;
+                packets.insert(peer, packet);
+            }
 
-			WsControlPacket &packet = packets[peer];
+            WsControlPacket &packet = packets[peer];
 
-			WsControlPacket::Item i;
-			i.cid = r->s->cid();
-			i.type = WsControlPacket::Item::KeepAlive;
-			i.ttl = SESSION_EXPIRE / 1000;
-			packet.items += i;
+            WsControlPacket::Item i;
+            i.cid = r->s->cid();
+            i.type = WsControlPacket::Item::KeepAlive;
+            i.ttl = SESSION_EXPIRE / 1000;
+            packet.items += i;
 
-			// If we're at max, send out now
-			if(packet.items.count() >= PACKET_ITEMS_MAX)
-			{
-				writeStream(packet, peer);
-				packet.items.clear();
-			}
-		}
+            // If we're at max, send out now
+            if (packet.items.count() >= PACKET_ITEMS_MAX) {
+                writeStream(packet, peer);
+                packet.items.clear();
+            }
+        }
 
-		// Process any others
-		int64_t threshold = now - SESSION_MUST_PROCESS;
-		while(!sessionsByLastRefresh.isEmpty())
-		{
-			QMap<QPair<int64_t, KeepAliveRegistration*>, KeepAliveRegistration*>::iterator it = sessionsByLastRefresh.begin();
-			KeepAliveRegistration *r = it.value();
+        // Process any others
+        int64_t threshold = now - SESSION_MUST_PROCESS;
+        while (!sessionsByLastRefresh.isEmpty()) {
+            QMap<QPair<int64_t, KeepAliveRegistration *>, KeepAliveRegistration *>::iterator it =
+                sessionsByLastRefresh.begin();
+            KeepAliveRegistration *r = it.value();
 
-			if(r->lastRefresh > threshold)
-				break;
+            if (r->lastRefresh > threshold)
+                break;
 
-			// Move to the end
-			sessionsByLastRefresh.erase(it);
-			r->lastRefresh = now;
-			sessionsByLastRefresh.insert(QPair<int64_t, KeepAliveRegistration*>(r->lastRefresh, r), r);
+            // Move to the end
+            sessionsByLastRefresh.erase(it);
+            r->lastRefresh = now;
+            sessionsByLastRefresh.insert(QPair<int64_t, KeepAliveRegistration *>(r->lastRefresh, r),
+                                         r);
 
-			QByteArray peer = r->s->peer();
-			if(peer.isEmpty())
-				continue;
+            QByteArray peer = r->s->peer();
+            if (peer.isEmpty())
+                continue;
 
-			if(!packets.contains(peer))
-			{
-				WsControlPacket packet;
-				packet.from = identity;
-				packets.insert(peer, packet);
-			}
+            if (!packets.contains(peer)) {
+                WsControlPacket packet;
+                packet.from = identity;
+                packets.insert(peer, packet);
+            }
 
-			WsControlPacket &packet = packets[peer];
+            WsControlPacket &packet = packets[peer];
 
-			WsControlPacket::Item i;
-			i.cid = r->s->cid();
-			i.type = WsControlPacket::Item::KeepAlive;
-			i.ttl = SESSION_EXPIRE / 1000;
-			packet.items += i;
+            WsControlPacket::Item i;
+            i.cid = r->s->cid();
+            i.type = WsControlPacket::Item::KeepAlive;
+            i.ttl = SESSION_EXPIRE / 1000;
+            packet.items += i;
 
-			// If we're at max, send out now
-			if(packet.items.count() >= PACKET_ITEMS_MAX)
-			{
-				writeStream(packet, peer);
-				packet.items.clear();
-			}
-		}
+            // If we're at max, send out now
+            if (packet.items.count() >= PACKET_ITEMS_MAX) {
+                writeStream(packet, peer);
+                packet.items.clear();
+            }
+        }
 
-		// Send the rest
-		QHashIterator<QByteArray, WsControlPacket> it(packets);
-		while(it.hasNext())
-		{
-			it.next();
-			const QByteArray &peer = it.key();
-			const WsControlPacket &packet = it.value();
+        // Send the rest
+        QHashIterator<QByteArray, WsControlPacket> it(packets);
+        while (it.hasNext()) {
+            it.next();
+            const QByteArray &peer = it.key();
+            const WsControlPacket &packet = it.value();
 
-			if(!packet.items.isEmpty())
-				writeStream(packet, peer);
-		}
+            if (!packet.items.isEmpty())
+                writeStream(packet, peer);
+        }
 
-		++currentSessionRefreshBucket;
-		if(currentSessionRefreshBucket >= SESSION_REFRESH_BUCKETS)
-			currentSessionRefreshBucket = 0;
-	}
+        ++currentSessionRefreshBucket;
+        if (currentSessionRefreshBucket >= SESSION_REFRESH_BUCKETS)
+            currentSessionRefreshBucket = 0;
+    }
 };
 
-WsControlManager::WsControlManager() 
-{
-	d = std::make_shared<Private>(this);
-}
+WsControlManager::WsControlManager() { d = std::make_shared<Private>(this); }
 
 WsControlManager::~WsControlManager() = default;
 
-void WsControlManager::setIdentity(const QByteArray &id)
-{
-	d->identity = id;
+void WsControlManager::setIdentity(const QByteArray &id) { d->identity = id; }
+
+void WsControlManager::setIpcFileMode(int mode) { d->ipcFileMode = mode; }
+
+bool WsControlManager::setInitSpecs(const QStringList &specs) {
+    d->initSpecs = specs;
+    return d->setupInit();
 }
 
-void WsControlManager::setIpcFileMode(int mode)
-{
-	d->ipcFileMode = mode;
+bool WsControlManager::setStreamSpecs(const QStringList &specs) {
+    d->streamSpecs = specs;
+    return d->setupStream();
 }
 
-bool WsControlManager::setInitSpecs(const QStringList &specs)
-{
-	d->initSpecs = specs;
-	return d->setupInit();
+WsControlSession *WsControlManager::createSession(const QByteArray &cid) {
+    WsControlSession *s = new WsControlSession;
+    s->setup(this, cid);
+    return s;
 }
 
-bool WsControlManager::setStreamSpecs(const QStringList &specs)
-{
-	d->streamSpecs = specs;
-	return d->setupStream();
+void WsControlManager::link(WsControlSession *s, const QByteArray &cid) {
+    d->sessionsByCid.insert(cid, s);
 }
 
-WsControlSession *WsControlManager::createSession(const QByteArray &cid)
-{
-	WsControlSession *s = new WsControlSession;
-	s->setup(this, cid);
-	return s;
+void WsControlManager::unlink(const QByteArray &cid) { d->sessionsByCid.remove(cid); }
+
+void WsControlManager::writeInit(const WsControlPacket::Item &item) { d->writeInit(item); }
+
+void WsControlManager::writeStream(const WsControlPacket::Item &item,
+                                   const QByteArray &instanceAddress) {
+    d->writeStream(item, instanceAddress);
 }
 
-void WsControlManager::link(WsControlSession *s, const QByteArray &cid)
-{
-	d->sessionsByCid.insert(cid, s);
-}
+void WsControlManager::registerKeepAlive(WsControlSession *s) { d->registerKeepAlive(s); }
 
-void WsControlManager::unlink(const QByteArray &cid)
-{
-	d->sessionsByCid.remove(cid);
-}
-
-void WsControlManager::writeInit(const WsControlPacket::Item &item)
-{
-	d->writeInit(item);
-}
-
-void WsControlManager::writeStream(const WsControlPacket::Item &item, const QByteArray &instanceAddress)
-{
-	d->writeStream(item, instanceAddress);
-}
-
-void WsControlManager::registerKeepAlive(WsControlSession *s)
-{
-	d->registerKeepAlive(s);
-}
-
-void WsControlManager::unregisterKeepAlive(WsControlSession *s)
-{
-	d->unregisterKeepAlive(s);
-}
+void WsControlManager::unregisterKeepAlive(WsControlSession *s) { d->unregisterKeepAlive(s); }

--- a/src/proxy/wscontrolmanager.h
+++ b/src/proxy/wscontrolmanager.h
@@ -24,38 +24,37 @@
 #ifndef WSCONTROLMANAGER_H
 #define WSCONTROLMANAGER_H
 
-#include <memory>
 #include "packet/wscontrolpacket.h"
+#include <memory>
 
 class WsControlSession;
 
-/// Creates and tracks WebSocket control sessions and manages the shared ZMQ init and stream channel
-/// sockets used for handler communication
-class WsControlManager
-{
+/// Creates and tracks WebSocket control sessions and manages the shared ZMQ
+/// init and stream channel sockets used for handler communication
+class WsControlManager {
 public:
-	WsControlManager();
-	~WsControlManager();
+    WsControlManager();
+    ~WsControlManager();
 
-	void setIdentity(const QByteArray &id);
-	void setIpcFileMode(int mode);
+    void setIdentity(const QByteArray &id);
+    void setIpcFileMode(int mode);
 
-	bool setInitSpecs(const QStringList &specs);
-	bool setStreamSpecs(const QStringList &specs);
+    bool setInitSpecs(const QStringList &specs);
+    bool setStreamSpecs(const QStringList &specs);
 
-	WsControlSession *createSession(const QByteArray &cid);
+    WsControlSession *createSession(const QByteArray &cid);
 
 private:
-	class Private;
-	std::shared_ptr<Private> d;
+    class Private;
+    std::shared_ptr<Private> d;
 
-	friend class WsControlSession;
-	void link(WsControlSession *s, const QByteArray &cid);
-	void unlink(const QByteArray &cid);
-	void writeInit(const WsControlPacket::Item &item);
-	void writeStream(const WsControlPacket::Item &item, const QByteArray &instanceAddress);
-	void registerKeepAlive(WsControlSession *s);
-	void unregisterKeepAlive(WsControlSession *s);
+    friend class WsControlSession;
+    void link(WsControlSession *s, const QByteArray &cid);
+    void unlink(const QByteArray &cid);
+    void writeInit(const WsControlPacket::Item &item);
+    void writeStream(const WsControlPacket::Item &item, const QByteArray &instanceAddress);
+    void registerKeepAlive(WsControlSession *s);
+    void unregisterKeepAlive(WsControlSession *s);
 };
 
 #endif

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -23,353 +23,286 @@
 
 #include "wscontrolsession.h"
 
-#include <assert.h>
-#include <QDateTime>
-#include "url.h"
-#include <boost/signals2.hpp>
 #include "timer.h"
+#include "url.h"
 #include "wscontrolmanager.h"
+#include <QDateTime>
+#include <assert.h>
+#include <boost/signals2.hpp>
 
 #define SESSION_TTL 60
 #define REQUEST_TIMEOUT 8000
 
 using Connection = boost::signals2::scoped_connection;
 
-class WsControlSession::Private
-{
+class WsControlSession::Private {
 public:
-	WsControlSession *q;
-	WsControlManager *manager;
-	int nextReqId;
-	QList<WsControlPacket::Item> pendingItems;
-	QHash<int, int64_t> pendingRequests;
-	QList<QByteArray> pendingSendEventWrites;
-	std::unique_ptr<Timer> requestTimer;
-	QByteArray peer;
-	QByteArray cid;
-	bool debug;
-	QByteArray route;
-	bool separateStats;
-	QByteArray channelPrefix;
-	int logLevel;
-	Url uri;
-	bool targetTrusted;
-	Connection requestTimerConnection;
+    WsControlSession *q;
+    WsControlManager *manager;
+    int nextReqId;
+    QList<WsControlPacket::Item> pendingItems;
+    QHash<int, int64_t> pendingRequests;
+    QList<QByteArray> pendingSendEventWrites;
+    std::unique_ptr<Timer> requestTimer;
+    QByteArray peer;
+    QByteArray cid;
+    bool debug;
+    QByteArray route;
+    bool separateStats;
+    QByteArray channelPrefix;
+    int logLevel;
+    Url uri;
+    bool targetTrusted;
+    Connection requestTimerConnection;
 
-	Private(WsControlSession *_q) :
-		q(_q),
-		manager(0),
-		nextReqId(0),
-		debug(false),
-		separateStats(false),
-		logLevel(-1),
-		targetTrusted(false)
-	{
-		requestTimer = std::make_unique<Timer>();
-		requestTimerConnection = requestTimer->timeout.connect(boost::bind(&Private::requestTimer_timeout, this));
-		requestTimer->setSingleShot(true);
-	}
+    Private(WsControlSession *_q)
+        : q(_q),
+          manager(0),
+          nextReqId(0),
+          debug(false),
+          separateStats(false),
+          logLevel(-1),
+          targetTrusted(false) {
+        requestTimer = std::make_unique<Timer>();
+        requestTimerConnection =
+            requestTimer->timeout.connect(boost::bind(&Private::requestTimer_timeout, this));
+        requestTimer->setSingleShot(true);
+    }
 
-	~Private()
-	{
-		cleanup();
-	}
+    ~Private() { cleanup(); }
 
-	void cleanup()
-	{
-		if(manager)
-		{
-			manager->unregisterKeepAlive(q);
+    void cleanup() {
+        if (manager) {
+            manager->unregisterKeepAlive(q);
 
-			WsControlPacket::Item i;
-			i.type = WsControlPacket::Item::Gone;
-			write(i);
+            WsControlPacket::Item i;
+            i.type = WsControlPacket::Item::Gone;
+            write(i);
 
-			manager->unlink(cid);
-			manager = 0;
-		}
-	}
+            manager->unlink(cid);
+            manager = 0;
+        }
+    }
 
-	void start()
-	{
-		manager->registerKeepAlive(q);
+    void start() {
+        manager->registerKeepAlive(q);
 
-		int reqId = nextReqId++;
+        int reqId = nextReqId++;
 
-		WsControlPacket::Item i;
-		i.type = WsControlPacket::Item::Here;
-		i.requestId = QByteArray::number(reqId);
-		i.debug = debug;
-		i.route = route;
-		i.separateStats = separateStats;
-		i.channelPrefix = channelPrefix;
-		i.logLevel = logLevel;
-		i.uri = uri;
-		i.trusted = targetTrusted;
-		i.ttl = SESSION_TTL;
-		write(i, true);
-	}
+        WsControlPacket::Item i;
+        i.type = WsControlPacket::Item::Here;
+        i.requestId = QByteArray::number(reqId);
+        i.debug = debug;
+        i.route = route;
+        i.separateStats = separateStats;
+        i.channelPrefix = channelPrefix;
+        i.logLevel = logLevel;
+        i.uri = uri;
+        i.trusted = targetTrusted;
+        i.ttl = SESSION_TTL;
+        write(i, true);
+    }
 
-	void setupRequestTimer()
-	{
-		if(!pendingRequests.isEmpty())
-		{
-			// Find next expiring request
-			int64_t lowestTime = -1;
-			QHashIterator<int, int64_t> it(pendingRequests);
-			while(it.hasNext())
-			{
-				it.next();
-				int64_t time = it.value();
+    void setupRequestTimer() {
+        if (!pendingRequests.isEmpty()) {
+            // Find next expiring request
+            int64_t lowestTime = -1;
+            QHashIterator<int, int64_t> it(pendingRequests);
+            while (it.hasNext()) {
+                it.next();
+                int64_t time = it.value();
 
-				if(lowestTime == -1 || time < lowestTime)
-					lowestTime = time;
-			}
+                if (lowestTime == -1 || time < lowestTime)
+                    lowestTime = time;
+            }
 
-			int until = int(lowestTime - QDateTime::currentMSecsSinceEpoch());
+            int until = int(lowestTime - QDateTime::currentMSecsSinceEpoch());
 
-			requestTimer->start(qMax(until, 0));
-		}
-		else
-		{
-			requestTimer->stop();
-		}
-	}
+            requestTimer->start(qMax(until, 0));
+        } else {
+            requestTimer->stop();
+        }
+    }
 
-	void sendGripMessage(const QByteArray &message)
-	{
-		int reqId = nextReqId++;
+    void sendGripMessage(const QByteArray &message) {
+        int reqId = nextReqId++;
 
-		WsControlPacket::Item i;
-		i.type = WsControlPacket::Item::Grip;
-		i.requestId = QByteArray::number(reqId);
-		i.message = message;
+        WsControlPacket::Item i;
+        i.type = WsControlPacket::Item::Grip;
+        i.requestId = QByteArray::number(reqId);
+        i.message = message;
 
-		pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
-		setupRequestTimer();
+        pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
+        setupRequestTimer();
 
-		write(i);
-	}
+        write(i);
+    }
 
-	void sendNeedKeepAlive()
-	{
-		WsControlPacket::Item i;
-		i.type = WsControlPacket::Item::NeedKeepAlive;
-		write(i);
-	}
+    void sendNeedKeepAlive() {
+        WsControlPacket::Item i;
+        i.type = WsControlPacket::Item::NeedKeepAlive;
+        write(i);
+    }
 
-	void sendSubscribe(const QByteArray &channel)
-	{
-		int reqId = nextReqId++;
+    void sendSubscribe(const QByteArray &channel) {
+        int reqId = nextReqId++;
 
-		WsControlPacket::Item i;
-		i.type = WsControlPacket::Item::Subscribe;
-		i.requestId = QByteArray::number(reqId);
-		i.channel = channel;
+        WsControlPacket::Item i;
+        i.type = WsControlPacket::Item::Subscribe;
+        i.requestId = QByteArray::number(reqId);
+        i.channel = channel;
 
-		pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
-		setupRequestTimer();
+        pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
+        setupRequestTimer();
 
-		write(i);
-	}
+        write(i);
+    }
 
-	void write(const WsControlPacket::Item &item, bool init = false)
-	{
-		if(init)
-		{
-			WsControlPacket::Item out = item;
-			out.cid = cid;
+    void write(const WsControlPacket::Item &item, bool init = false) {
+        if (init) {
+            WsControlPacket::Item out = item;
+            out.cid = cid;
 
-			manager->writeInit(out);
-		}
-		else
-		{
-			if(!peer.isEmpty())
-			{
-				WsControlPacket::Item out = item;
-				out.cid = cid;
+            manager->writeInit(out);
+        } else {
+            if (!peer.isEmpty()) {
+                WsControlPacket::Item out = item;
+                out.cid = cid;
 
-				manager->writeStream(out, peer);
-			}
-			else
-				pendingItems += item;
-		}
-	}
+                manager->writeStream(out, peer);
+            } else
+                pendingItems += item;
+        }
+    }
 
-	void flushPending()
-	{
-		while(!pendingItems.isEmpty())
-		{
-			WsControlPacket::Item out = pendingItems.takeFirst();
-			out.cid = cid;
+    void flushPending() {
+        while (!pendingItems.isEmpty()) {
+            WsControlPacket::Item out = pendingItems.takeFirst();
+            out.cid = cid;
 
-			manager->writeStream(out, peer);
-		}
-	}
+            manager->writeStream(out, peer);
+        }
+    }
 
-	void handle(const QByteArray &from, const WsControlPacket::Item &item)
-	{
-		peer = from;
+    void handle(const QByteArray &from, const WsControlPacket::Item &item) {
+        peer = from;
 
-		flushPending();
+        flushPending();
 
-		if(item.type != WsControlPacket::Item::Ack && !item.requestId.isEmpty())
-		{
-			// Ack non-sends immediately
-			if(item.type != WsControlPacket::Item::Send)
-			{
-				WsControlPacket::Item i;
-				i.type = WsControlPacket::Item::Ack;
-				i.requestId = item.requestId;
-				write(i);
-			}
-		}
+        if (item.type != WsControlPacket::Item::Ack && !item.requestId.isEmpty()) {
+            // Ack non-sends immediately
+            if (item.type != WsControlPacket::Item::Send) {
+                WsControlPacket::Item i;
+                i.type = WsControlPacket::Item::Ack;
+                i.requestId = item.requestId;
+                write(i);
+            }
+        }
 
-		if(item.type == WsControlPacket::Item::Send)
-		{
-			WebSocket::Frame::Type type;
-			if(item.contentType == "binary")
-				type = WebSocket::Frame::Binary;
-			else if(item.contentType == "ping")
-				type = WebSocket::Frame::Ping;
-			else if(item.contentType == "pong")
-				type = WebSocket::Frame::Pong;
-			else
-				type = WebSocket::Frame::Text;
+        if (item.type == WsControlPacket::Item::Send) {
+            WebSocket::Frame::Type type;
+            if (item.contentType == "binary")
+                type = WebSocket::Frame::Binary;
+            else if (item.contentType == "ping")
+                type = WebSocket::Frame::Ping;
+            else if (item.contentType == "pong")
+                type = WebSocket::Frame::Pong;
+            else
+                type = WebSocket::Frame::Text;
 
-			// For sends, don't ack until written
+            // For sends, don't ack until written
 
-			if(!item.requestId.isEmpty())
-				pendingSendEventWrites += item.requestId;
-			else
-				pendingSendEventWrites += QByteArray(); // Placeholder
+            if (!item.requestId.isEmpty())
+                pendingSendEventWrites += item.requestId;
+            else
+                pendingSendEventWrites += QByteArray(); // Placeholder
 
-			q->sendEventReceived(type, item.message, item.queue);
-		}
-		else if(item.type == WsControlPacket::Item::KeepAliveSetup)
-		{
-			if(item.timeout > 0)
-			{
-				WsControl::KeepAliveMode mode;
-				if(item.keepAliveMode == "interval")
-					mode = WsControl::Interval;
-				else // Idle
-					mode = WsControl::Idle;
-				q->keepAliveSetupEventReceived(mode, item.timeout);
-			}
-			else
-				q->keepAliveSetupEventReceived(WsControl::NoKeepAlive, -1);
-		}
-		else if(item.type == WsControlPacket::Item::Refresh)
-		{
-			q->refreshEventReceived();
-		}
-		else if(item.type == WsControlPacket::Item::Close)
-		{
-			q->closeEventReceived(item.code, item.reason);
-		}
-		else if(item.type == WsControlPacket::Item::Detach)
-		{
-			q->detachEventReceived();
-		}
-		else if(item.type == WsControlPacket::Item::Cancel)
-		{
-			q->cancelEventReceived();
-		}
-		else if(item.type == WsControlPacket::Item::Ack)
-		{
-			int reqId = item.requestId.toInt();
-			if(pendingRequests.contains(reqId))
-			{
-				pendingRequests.remove(reqId);
-				setupRequestTimer();
-			}
-		}
-	}
+            q->sendEventReceived(type, item.message, item.queue);
+        } else if (item.type == WsControlPacket::Item::KeepAliveSetup) {
+            if (item.timeout > 0) {
+                WsControl::KeepAliveMode mode;
+                if (item.keepAliveMode == "interval")
+                    mode = WsControl::Interval;
+                else // Idle
+                    mode = WsControl::Idle;
+                q->keepAliveSetupEventReceived(mode, item.timeout);
+            } else
+                q->keepAliveSetupEventReceived(WsControl::NoKeepAlive, -1);
+        } else if (item.type == WsControlPacket::Item::Refresh) {
+            q->refreshEventReceived();
+        } else if (item.type == WsControlPacket::Item::Close) {
+            q->closeEventReceived(item.code, item.reason);
+        } else if (item.type == WsControlPacket::Item::Detach) {
+            q->detachEventReceived();
+        } else if (item.type == WsControlPacket::Item::Cancel) {
+            q->cancelEventReceived();
+        } else if (item.type == WsControlPacket::Item::Ack) {
+            int reqId = item.requestId.toInt();
+            if (pendingRequests.contains(reqId)) {
+                pendingRequests.remove(reqId);
+                setupRequestTimer();
+            }
+        }
+    }
 
-	void sendEventWritten()
-	{
-		assert(!pendingSendEventWrites.isEmpty());
+    void sendEventWritten() {
+        assert(!pendingSendEventWrites.isEmpty());
 
-		QByteArray requestId = pendingSendEventWrites.takeFirst();
-		if(!requestId.isNull())
-		{
-			WsControlPacket::Item i;
-			i.type = WsControlPacket::Item::Ack;
-			i.requestId = requestId;
-			write(i);
-		}
-	}
+        QByteArray requestId = pendingSendEventWrites.takeFirst();
+        if (!requestId.isNull()) {
+            WsControlPacket::Item i;
+            i.type = WsControlPacket::Item::Ack;
+            i.requestId = requestId;
+            write(i);
+        }
+    }
 
-	void requestTimer_timeout()
-	{
-		// On error, destroy any other pending requests
-		pendingRequests.clear();
-		setupRequestTimer();
+    void requestTimer_timeout() {
+        // On error, destroy any other pending requests
+        pendingRequests.clear();
+        setupRequestTimer();
 
-		q->error();
-	}
+        q->error();
+    }
 };
 
-WsControlSession::WsControlSession()
-{
-	d = std::make_unique<Private>(this);
-}
+WsControlSession::WsControlSession() { d = std::make_unique<Private>(this); }
 
 WsControlSession::~WsControlSession() = default;
 
-QByteArray WsControlSession::peer() const
-{
-	return d->peer;
+QByteArray WsControlSession::peer() const { return d->peer; }
+
+QByteArray WsControlSession::cid() const { return d->cid; }
+
+void WsControlSession::start(bool debug, const QByteArray &routeId, bool separateStats,
+                             const QByteArray &channelPrefix, int logLevel, const Url &uri,
+                             bool targetTrusted) {
+    d->debug = debug;
+    d->route = routeId;
+    d->separateStats = separateStats;
+    d->channelPrefix = channelPrefix;
+    d->logLevel = logLevel;
+    d->uri = uri;
+    d->targetTrusted = targetTrusted;
+    d->start();
 }
 
-QByteArray WsControlSession::cid() const
-{
-	return d->cid;
+void WsControlSession::sendGripMessage(const QByteArray &message) { d->sendGripMessage(message); }
+
+void WsControlSession::sendNeedKeepAlive() { d->sendNeedKeepAlive(); }
+
+void WsControlSession::sendSubscribe(const QByteArray &channel) { d->sendSubscribe(channel); }
+
+void WsControlSession::setup(WsControlManager *manager, const QByteArray &cid) {
+    d->manager = manager;
+    d->cid = cid;
+    d->manager->link(this, d->cid);
 }
 
-void WsControlSession::start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const Url &uri, bool targetTrusted)
-{
-	d->debug = debug;
-	d->route = routeId;
-	d->separateStats = separateStats;
-	d->channelPrefix = channelPrefix;
-	d->logLevel = logLevel;
-	d->uri = uri;
-	d->targetTrusted = targetTrusted;
-	d->start();
-}
+void WsControlSession::sendEventWritten() { d->sendEventWritten(); }
 
-void WsControlSession::sendGripMessage(const QByteArray &message)
-{
-	d->sendGripMessage(message);
-}
+void WsControlSession::handle(const QByteArray &from, const WsControlPacket::Item &item) {
+    assert(d->manager);
 
-void WsControlSession::sendNeedKeepAlive()
-{
-	d->sendNeedKeepAlive();
-}
-
-void WsControlSession::sendSubscribe(const QByteArray &channel)
-{
-	d->sendSubscribe(channel);
-}
-
-void WsControlSession::setup(WsControlManager *manager, const QByteArray &cid)
-{
-	d->manager = manager;
-	d->cid = cid;
-	d->manager->link(this, d->cid);
-}
-
-void WsControlSession::sendEventWritten()
-{
-	d->sendEventWritten();
-}
-
-void WsControlSession::handle(const QByteArray &from, const WsControlPacket::Item &item)
-{
-	assert(d->manager);
-
-	d->handle(from, item);
+    d->handle(from, item);
 }

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -24,52 +24,54 @@
 #ifndef WSCONTROLSESSION_H
 #define WSCONTROLSESSION_H
 
-#include <QByteArray>
-#include <boost/signals2.hpp>
-#include "websocket.h"
-#include "wscontrol.h"
 #include "packet/wscontrolpacket.h"
 #include "url.h"
+#include "websocket.h"
+#include "wscontrol.h"
+#include <QByteArray>
+#include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
 
 class WsControlManager;
 
-/// Handles communication with the handler for controlling an active WebSocket connection including
-/// sending GRIP control messages, managing channel subscriptions, and coordinating keepalives
-class WsControlSession
-{
+/// Handles communication with the handler for controlling an active WebSocket
+/// connection including sending GRIP control messages, managing channel
+/// subscriptions, and coordinating keepalives
+class WsControlSession {
 public:
-	~WsControlSession();
+    ~WsControlSession();
 
-	QByteArray peer() const;
-	QByteArray cid() const;
+    QByteArray peer() const;
+    QByteArray cid() const;
 
-	void start(bool debug, const QByteArray &routeId, bool separateStats, const QByteArray &channelPrefix, int logLevel, const Url &uri, bool targetTrusted);
-	void sendGripMessage(const QByteArray &message);
-	void sendNeedKeepAlive();
-	void sendSubscribe(const QByteArray &channel);
+    void start(bool debug, const QByteArray &routeId, bool separateStats,
+               const QByteArray &channelPrefix, int logLevel, const Url &uri, bool targetTrusted);
+    void sendGripMessage(const QByteArray &message);
+    void sendNeedKeepAlive();
+    void sendSubscribe(const QByteArray &channel);
 
-	// Tell session that a received sendEvent has been written
-	void sendEventWritten();
+    // Tell session that a received sendEvent has been written
+    void sendEventWritten();
 
-	boost::signals2::signal<void(WebSocket::Frame::Type, const QByteArray&, bool)> sendEventReceived;
-	boost::signals2::signal<void(WsControl::KeepAliveMode, int)> keepAliveSetupEventReceived;
-	Signal refreshEventReceived;
-	boost::signals2::signal<void(int, const QByteArray&)> closeEventReceived; // Use -1 for no code
-	Signal detachEventReceived;
-	Signal cancelEventReceived;
-	Signal error;
+    boost::signals2::signal<void(WebSocket::Frame::Type, const QByteArray &, bool)>
+        sendEventReceived;
+    boost::signals2::signal<void(WsControl::KeepAliveMode, int)> keepAliveSetupEventReceived;
+    Signal refreshEventReceived;
+    boost::signals2::signal<void(int, const QByteArray &)> closeEventReceived; // Use -1 for no code
+    Signal detachEventReceived;
+    Signal cancelEventReceived;
+    Signal error;
 
 private:
-	class Private;
-	friend class Private;
-	std::unique_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::unique_ptr<Private> d;
 
-	friend class WsControlManager;
-	WsControlSession();
-	void setup(WsControlManager *manager, const QByteArray &cid);
-	void handle(const QByteArray &from, const WsControlPacket::Item &item);
+    friend class WsControlManager;
+    WsControlSession();
+    void setup(WsControlManager *manager, const QByteArray &cid);
+    void handle(const QByteArray &from, const WsControlPacket::Item &item);
 };
 
 #endif

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -23,1237 +23,1085 @@
 
 #include "wsproxysession.h"
 
-#include <assert.h>
-#include <QDateTime>
-#include "url.h"
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QHostAddress>
-#include <QRandomGenerator>
-#include "packet/httprequestdata.h"
-#include "log.h"
-#include "timer.h"
+#include "connectionmanager.h"
 #include "defercall.h"
+#include "inspectdata.h"
 #include "jwt.h"
-#include "zhttpmanager.h"
-#include "zwebsocket.h"
+#include "log.h"
+#include "packet/httprequestdata.h"
+#include "proxyutil.h"
+#include "statsmanager.h"
+#include "testwebsocket.h"
+#include "timer.h"
+#include "url.h"
 #include "websocketoverhttp.h"
-#include "zroutes.h"
 #include "wscontrol.h"
 #include "wscontrolmanager.h"
 #include "wscontrolsession.h"
 #include "xffrule.h"
-#include "proxyutil.h"
-#include "statsmanager.h"
-#include "inspectdata.h"
-#include "connectionmanager.h"
-#include "testwebsocket.h"
+#include "zhttpmanager.h"
+#include "zroutes.h"
+#include "zwebsocket.h"
+#include <QDateTime>
+#include <QHostAddress>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRandomGenerator>
+#include <assert.h>
 
 #define ACTIVITY_TIMEOUT 60000
 #define KEEPALIVE_RAND_MAX 1000
 
-class HttpExtension
-{
+class HttpExtension {
 public:
-	bool isNull() const { return name.isEmpty(); }
+    bool isNull() const { return name.isEmpty(); }
 
-	QByteArray name;
-	QHash<QByteArray, QByteArray> params;
+    QByteArray name;
+    QHash<QByteArray, QByteArray> params;
 };
 
-static int findNext(const QByteArray &in, const char *charList, int start = 0)
-{
-	int len = qstrlen(charList);
-	for(int n = start; n < in.size(); ++n)
-	{
-		char c = in[n];
-		for(int i = 0; i < len; ++i)
-		{
-			if(c == charList[i])
-				return n;
-		}
-	}
+static int findNext(const QByteArray &in, const char *charList, int start = 0) {
+    int len = qstrlen(charList);
+    for (int n = start; n < in.size(); ++n) {
+        char c = in[n];
+        for (int i = 0; i < len; ++i) {
+            if (c == charList[i])
+                return n;
+        }
+    }
 
-	return -1;
+    return -1;
 }
 
-static QHash<QByteArray, QByteArray> parseParams(const QByteArray &in, bool *ok = 0)
-{
-	QHash<QByteArray, QByteArray> out;
+static QHash<QByteArray, QByteArray> parseParams(const QByteArray &in, bool *ok = 0) {
+    QHash<QByteArray, QByteArray> out;
 
-	int start = 0;
-	while(start < in.size())
-	{
-		QByteArray var;
-		QByteArray val;
+    int start = 0;
+    while (start < in.size()) {
+        QByteArray var;
+        QByteArray val;
 
-		int at = findNext(in, "=;", start);
-		if(at != -1)
-		{
-			var = in.mid(start, at - start).trimmed();
-			if(in[at] == '=')
-			{
-				if(at + 1 >= in.size())
-				{
-					if(ok)
-						*ok = false;
-					return QHash<QByteArray, QByteArray>();
-				}
+        int at = findNext(in, "=;", start);
+        if (at != -1) {
+            var = in.mid(start, at - start).trimmed();
+            if (in[at] == '=') {
+                if (at + 1 >= in.size()) {
+                    if (ok)
+                        *ok = false;
+                    return QHash<QByteArray, QByteArray>();
+                }
 
-				++at;
+                ++at;
 
-				if(in[at] == '\"')
-				{
-					++at;
+                if (in[at] == '\"') {
+                    ++at;
 
-					bool complete = false;
-					for(int n = at; n < in.size(); ++n)
-					{
-						if(in[n] == '\\')
-						{
-							if(n + 1 >= in.size())
-							{
-								if(ok)
-									*ok = false;
-								return QHash<QByteArray, QByteArray>();
-							}
+                    bool complete = false;
+                    for (int n = at; n < in.size(); ++n) {
+                        if (in[n] == '\\') {
+                            if (n + 1 >= in.size()) {
+                                if (ok)
+                                    *ok = false;
+                                return QHash<QByteArray, QByteArray>();
+                            }
 
-							++n;
-							val += in[n];
-						}
-						else if(in[n] == '\"')
-						{
-							complete = true;
-							at = n + 1;
-							break;
-						}
-						else
-							val += in[n];
-					}
+                            ++n;
+                            val += in[n];
+                        } else if (in[n] == '\"') {
+                            complete = true;
+                            at = n + 1;
+                            break;
+                        } else
+                            val += in[n];
+                    }
 
-					if(!complete)
-					{
-						if(ok)
-							*ok = false;
-						return QHash<QByteArray, QByteArray>();
-					}
+                    if (!complete) {
+                        if (ok)
+                            *ok = false;
+                        return QHash<QByteArray, QByteArray>();
+                    }
 
-					at = in.indexOf(';', at);
-					if(at != -1)
-						start = at + 1;
-					else
-						start = in.size();
-				}
-				else
-				{
-					int vstart = at;
-					at = in.indexOf(';', vstart);
-					if(at != -1)
-					{
-						val = in.mid(vstart, at - vstart).trimmed();
-						start = at + 1;
-					}
-					else
-					{
-						val = in.mid(vstart).trimmed();
-						start = in.size();
-					}
-				}
-			}
-			else
-				start = at + 1;
-		}
-		else
-		{
-			var = in.mid(start).trimmed();
-			start = in.size();
-		}
+                    at = in.indexOf(';', at);
+                    if (at != -1)
+                        start = at + 1;
+                    else
+                        start = in.size();
+                } else {
+                    int vstart = at;
+                    at = in.indexOf(';', vstart);
+                    if (at != -1) {
+                        val = in.mid(vstart, at - vstart).trimmed();
+                        start = at + 1;
+                    } else {
+                        val = in.mid(vstart).trimmed();
+                        start = in.size();
+                    }
+                }
+            } else
+                start = at + 1;
+        } else {
+            var = in.mid(start).trimmed();
+            start = in.size();
+        }
 
-		out[var] = val;
-	}
+        out[var] = val;
+    }
 
-	if(ok)
-		*ok = true;
+    if (ok)
+        *ok = true;
 
-	return out;
+    return out;
 }
 
-static QByteArray getExtensionRaw(const QList<QByteArray> &extStrings, const QByteArray &name)
-{
-	foreach(const QByteArray &ext, extStrings)
-	{
-		int at = ext.indexOf(';');
-		if(at != -1)
-		{
-			if(ext.mid(0, at).trimmed() == name)
-				return ext;
-		}
-		else
-		{
-			if(ext == name)
-				return ext;
-		}
-	}
+static QByteArray getExtensionRaw(const QList<QByteArray> &extStrings, const QByteArray &name) {
+    foreach (const QByteArray &ext, extStrings) {
+        int at = ext.indexOf(';');
+        if (at != -1) {
+            if (ext.mid(0, at).trimmed() == name)
+                return ext;
+        } else {
+            if (ext == name)
+                return ext;
+        }
+    }
 
-	return QByteArray();
+    return QByteArray();
 }
 
-static HttpExtension getExtension(const QList<QByteArray> &extStrings, const QByteArray &name)
-{
-	QByteArray ext = getExtensionRaw(extStrings, name);
-	if(ext.isNull())
-		return HttpExtension();
+static HttpExtension getExtension(const QList<QByteArray> &extStrings, const QByteArray &name) {
+    QByteArray ext = getExtensionRaw(extStrings, name);
+    if (ext.isNull())
+        return HttpExtension();
 
-	HttpExtension e;
-	e.name = name;
+    HttpExtension e;
+    e.name = name;
 
-	int at = ext.indexOf(';');
-	if(at != -1)
-	{
-		bool ok;
-		e.params = parseParams(ext.mid(at + 1), &ok);
-		if(!ok)
-			return HttpExtension();
-	}
+    int at = ext.indexOf(';');
+    if (at != -1) {
+        bool ok;
+        e.params = parseParams(ext.mid(at + 1), &ok);
+        if (!ok)
+            return HttpExtension();
+    }
 
-	return e;
+    return e;
 }
 
-class WsProxySession::Private
-{
+class WsProxySession::Private {
 public:
-	enum State
-	{
-		Idle,
-		Connecting,
-		Connected,
-		Closing
-	};
-
-	typedef QPair<WebSocket::Frame, bool> QueuedFrame;
-
-	struct WSConnections {
-		Connection connectedConnection;
-		Connection readyReadConnection;
-		Connection writeBytesChangedConnection;
-		Connection peerClosedConnection;
-		Connection closedConnection;
-		Connection errorConnection;
-	};
-
-	struct InWSConnections {
-		Connection readyReadConnection;
-		Connection framesWrittenConnection;
-		Connection writeBytesChangedConnection;
-		Connection peerClosedConnection;
-		Connection closedConnection;
-		Connection errorConnection;
-	};
-
-	struct WSProxyConnections {
-		Connection sendEventReceivedConnection;
-		Connection keepAliveSetupEventReceivedConnection;
-		Connection refreshEventReceivedConnection;
-		Connection closeEventReceivedConnection;
-		Connection detachEventReceivedConnection;
-		Connection cancelEventReceivedConnection;
-		Connection errorConnection;
-	};
-
-	WsProxySession *q;
-	State state;
-	ZRoutes *zroutes;
-	ZhttpManager *zhttpManager;
-	ConnectionManager *connectionManager;
-	StatsManager *statsManager;
-	WsControlManager *wsControlManager;
-	WsControlSession *wsControl;
-	DomainMap::Entry route;
-	bool debug;
-	QByteArray defaultSigIss;
-	Jwt::EncodingKey defaultSigKey;
-	Jwt::DecodingKey defaultUpstreamKey;
-	bool passToUpstream;
-	bool acceptXForwardedProtocol;
-	bool useXForwardedProto;
-	bool useXForwardedProtocol;
-	XffRule xffRule;
-	XffRule xffTrustedRule;
-	QList<QByteArray> origHeadersNeedMark;
-	bool acceptPushpinRoute;
-	QByteArray cdnLoop;
-	HttpRequestData requestData;
-	bool trustedClient;
-	QHostAddress logicalClientAddress;
-	QByteArray sigIss;
-	Jwt::EncodingKey sigKey;
-	std::unique_ptr<WebSocket> inSock;
-	std::unique_ptr<WebSocket> outSock;
-	QList<bool> inPendingFrames; // True means we should ack a send event
-	int outReadInProgress; // Frame type or -1
-	QByteArray pathBeg;
-	QByteArray channelPrefix;
-	QList<DomainMap::Target> targets;
-	DomainMap::Target target;
-	QHostAddress clientAddress;
-	bool acceptGripMessages;
-	QByteArray messagePrefix;
-	bool detached;
-	QDateTime activityTime;
-	QByteArray publicCid;
-	std::unique_ptr<Timer> keepAliveTimer;
-	WsControl::KeepAliveMode keepAliveMode;
-	int keepAliveTimeout;
-	QList<QueuedFrame> queuedInFrames; // Frames to deliver after out read finishes
-	LogUtil::Config logConfig;
-	Callback<std::tuple<WsProxySession *>> finishedByPassthroughCallback;
-	Connection keepAliveConnection;
-	Connection aboutToSendRequestConnection;
-	map<WsControlSession*, WSProxyConnections> wsProxyConnectionMap;
-	WSConnections outWSConnection;
-	InWSConnections inWSConnection;
-
-	Private(WsProxySession *_q, ZRoutes *_zroutes, ConnectionManager *_connectionManager, const LogUtil::Config &_logConfig, StatsManager *_statsManager, WsControlManager *_wsControlManager) :
-		q(_q),
-		state(Idle),
-		zroutes(_zroutes),
-		zhttpManager(0),
-		connectionManager(_connectionManager),
-		statsManager(_statsManager),
-		wsControlManager(_wsControlManager),
-		wsControl(0),
-		debug(false),
-		passToUpstream(false),
-		acceptXForwardedProtocol(false),
-		useXForwardedProto(false),
-		useXForwardedProtocol(false),
-		acceptPushpinRoute(false),
-		trustedClient(false),
-		outReadInProgress(-1),
-		acceptGripMessages(false),
-		detached(false),
-		keepAliveMode(WsControl::NoKeepAlive),
-		keepAliveTimeout(0),
-		logConfig(_logConfig)
-	{
-	}
-
-	~Private()
-	{
-		cleanup();
-	}
-
-	void cleanup()
-	{
-		cleanupKeepAliveTimer();
-
-		cleanupInSock();
-		cleanupOutSock();
-		
-		wsProxyConnectionMap.erase(wsControl);
-		delete wsControl;
-		wsControl = 0;
-
-		if(zhttpManager)
-		{
-			zroutes->removeRef(zhttpManager);
-			zhttpManager = 0;
-		}
-	}
-
-	void cleanupInSock()
-	{
-		if(inSock)
-		{
-			connectionManager->removeConnection(inSock.get());
-			inWSConnection = InWSConnections();
-			inSock.reset();
-		}
-	}
-
-	void cleanupOutSock()
-	{
-		if(outSock)
-		{
-			// Ensure the socket has an updated Grip-Sig to use during its
-			// destruction process
-			updateGripSig();
-
-			outWSConnection = WSConnections();
-			outSock.reset();
-		}
-	}
-
-	void cleanupKeepAliveTimer()
-	{
-		keepAliveTimer.reset();
-	}
-
-	void start(WebSocket *sock, const QByteArray &_publicCid, const DomainMap::Entry &entry)
-	{
-		assert(!inSock);
-
-		state = Connecting;
-
-		publicCid = _publicCid;
-
-		if(statsManager)
-			activityTime = QDateTime::currentDateTimeUtc();
-
-		inSock = std::unique_ptr<WebSocket>(sock);
-		inWSConnection = InWSConnections{
-			inSock->readyRead.connect(boost::bind(&Private::in_readyRead, this)),
-			inSock->framesWritten.connect(boost::bind(&Private::in_framesWritten, this, boost::placeholders::_1, boost::placeholders::_2)),
-			inSock->writeBytesChanged.connect(boost::bind(&Private::in_writeBytesChanged, this)),
-			inSock->peerClosed.connect(boost::bind(&Private::in_peerClosed, this)),
-			inSock->closed.connect(boost::bind(&Private::in_closed, this)),
-			inSock->error.connect(boost::bind(&Private::in_error, this))
-		};
-
-		requestData.uri = inSock->requestUri();
-		requestData.headers = inSock->requestHeaders();
-
-		trustedClient = ProxyUtil::checkTrustedClient("wsproxysession", q, requestData, defaultUpstreamKey);
-
-		logicalClientAddress = ProxyUtil::getLogicalAddress(requestData.headers, trustedClient ? xffTrustedRule : xffRule, inSock->peerAddress());
-
-		QString host = requestData.uri.host();
-
-		route = entry;
-
-		log_debug("wsproxysession: %p %s has %d routes", q, qPrintable(host), route.targets.count());
-
-		if(route.isNull())
-		{
-			reject(false, 502, "Bad Gateway", QString("No route for host: %1").arg(host));
-			return;
-		}
-
-		incCounter(Stats::ClientHeaderBytesReceived, ZhttpManager::estimateRequestHeaderBytes("GET", requestData.uri, requestData.headers));
-
-		if(!route.asHost.isEmpty())
-			ProxyUtil::applyHost(&requestData.uri, route.asHost);
-
-		QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
-
-		if(route.pathRemove > 0)
-			path = path.mid(route.pathRemove);
-
-		if(!route.pathPrepend.isEmpty())
-			path = route.pathPrepend + path;
-
-		requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
-
-		sigIss = defaultSigIss;
-		sigKey = defaultSigKey;
-
-		if(!route.sigIss.isEmpty())
-			sigIss = route.sigIss;
-
-		if(!route.sigKey.isNull())
-			sigKey = route.sigKey;
-
-		pathBeg = route.pathBeg;
-		channelPrefix = route.prefix;
-		targets = route.targets;
-
-		foreach(const HttpHeader &h, route.headers)
-		{
-			requestData.headers.removeAll(h.first);
-			if(!h.second.isEmpty())
-				requestData.headers += HttpHeader(h.first, h.second);
-		}
-
-		clientAddress = inSock->peerAddress();
-
-		ProxyUtil::manipulateRequestHeaders("wsproxysession", q, &requestData, trustedClient, route, sigIss, sigKey, acceptXForwardedProtocol, useXForwardedProto, useXForwardedProtocol, xffTrustedRule, xffRule, origHeadersNeedMark, acceptPushpinRoute, cdnLoop, clientAddress, InspectData(), route.grip, false);
-
-		// Don't proxy extensions, as we may not know how to handle them
-		requestData.headers.removeAll("Sec-WebSocket-Extensions");
-
-		if(route.grip)
-		{
-			// Send grip extension
-			requestData.headers += HttpHeader("Sec-WebSocket-Extensions", "grip");
-		}
-
-		if(trustedClient || !route.grip)
-			passToUpstream = true;
-
-		tryNextTarget();
-	}
-
-	void writeInFrame(const WebSocket::Frame &frame, bool fromSendEvent = false)
-	{
-		inPendingFrames += fromSendEvent;
-
-		inSock->writeFrame(frame);
-
-		incCounter(Stats::ClientContentBytesSent, frame.data.size());
-		if(!frame.more)
-			incCounter(Stats::ClientMessagesSent);
-	}
-
-	void tryNextTarget()
-	{
-		if(targets.isEmpty())
-		{
-			QString msg = "Error while proxying to origin.";
-
-			QStringList targetStrs;
-			foreach(const DomainMap::Target &t, route.targets)
-				targetStrs += ProxyUtil::targetToString(t);
-			QString dmsg = QString("Unable to connect to any targets. Tried: %1").arg(targetStrs.join(", "));
-
-			reject(true, 502, "Bad Gateway", msg, dmsg);
-			return;
-		}
-
-		target = targets.takeFirst();
-
-		Url uri = requestData.uri;
-		if(target.ssl)
-			uri.setScheme("wss");
-		else
-			uri.setScheme("ws");
-
-		if(!target.host.isEmpty())
-			ProxyUtil::applyHost(&uri, target.host);
-
-		if(zhttpManager)
-		{
-			zroutes->removeRef(zhttpManager);
-			zhttpManager = 0;
-		}
-
-		if(target.type == DomainMap::Target::Test)
-		{
-			// For test route, auto-adjust path
-			if(!pathBeg.isEmpty())
-			{
-				int pathRemove = pathBeg.length();
-				if(pathBeg.endsWith('/'))
-					--pathRemove;
-
-				if(pathRemove > 0)
-					uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
-			}
-
-			outSock = std::make_unique<TestWebSocket>();
-		}
-		else
-		{
-			if(target.type == DomainMap::Target::Custom)
-			{
-				zhttpManager = zroutes->managerForRoute(target.zhttpRoute);
-				log_debug("wsproxysession: %p forwarding to %s", q, qPrintable(target.zhttpRoute.baseSpec));
-			}
-			else // Default
-			{
-				zhttpManager = zroutes->defaultManager();
-				log_debug("wsproxysession: %p forwarding to %s:%d", q, qPrintable(target.connectHost), target.connectPort);
-			}
-
-			zroutes->addRef(zhttpManager);
-
-			if(target.overHttp)
-			{
-				std::unique_ptr<WebSocketOverHttp> woh = std::make_unique<WebSocketOverHttp>(zhttpManager);
-
-				woh->setConnectionId(publicCid);
-
-				if(target.oneEvent)
-					woh->setMaxEventsPerRequest(1);
-
-				aboutToSendRequestConnection = woh->aboutToSendRequest.connect(boost::bind(&Private::out_aboutToSendRequest, this));
-				outSock = std::move(woh);
-			}
-			else
-			{
-				// Websockets don't work with zhttp req mode
-				if(zhttpManager->clientUsesReq())
-				{
-					reject(false, 502, "Bad Gateway", "Error while proxying to origin.", "WebSockets cannot be used with zhttpreq target");
-					return;
-				}
-
-				outSock = std::unique_ptr<WebSocket>(zhttpManager->createSocket());
-			}
-		}
-		outWSConnection = {
-			outSock->connected.connect(boost::bind(&Private::out_connected, this)),
-			outSock->readyRead.connect(boost::bind(&Private::out_readyRead, this)),
-			outSock->writeBytesChanged.connect(boost::bind(&Private::out_writeBytesChanged, this)),
-			outSock->peerClosed.connect(boost::bind(&Private::out_peerClosed, this)),
-			outSock->closed.connect(boost::bind(&Private::out_closed, this)),
-			outSock->error.connect(boost::bind(&Private::out_error, this))
-		};
-
-		if(target.trusted)
-			outSock->setIgnorePolicies(true);
-
-		if(target.trustConnectHost)
-			outSock->setTrustConnectHost(true);
-
-		if(target.insecure)
-			outSock->setIgnoreTlsErrors(true);
-
-		if(target.type == DomainMap::Target::Default)
-		{
-			outSock->setConnectHost(target.connectHost);
-			outSock->setConnectPort(target.connectPort);
-		}
-
-		if(!target.clientCert.isEmpty())
-			outSock->setClientCert(target.clientCert, target.clientKey);
-
-		ProxyUtil::applyHostHeader(&requestData.headers, uri);
-
-		incCounter(Stats::ServerHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes("GET", uri, requestData.headers));
-
-		outSock->start(uri, requestData.headers);
-	}
-
-	void reject(bool proxied, int code, const QByteArray &reason, const HttpHeaders &headers, const QByteArray &body)
-	{
-		assert(state == Connecting);
-
-		state = Closing;
-		inSock->respondError(code, reason, headers, body);
-
-		incCounter(Stats::ClientHeaderBytesSent, ZhttpManager::estimateResponseHeaderBytes(code, reason, headers));
-
-		logConnection(proxied, code, body.size());
-	}
-
-	void reject(bool proxied, int code, const QString &reason, const QString &errorMessage, const QString &debugErrorMessage)
-	{
-		QString msg = debug ? debugErrorMessage : errorMessage;
-
-		reject(proxied, code, reason.toUtf8(), HttpHeaders(), (msg + '\n').toUtf8());
-	}
-
-	void reject(bool proxied, int code, const QString &reason, const QString &errorMessage)
-	{
-		reject(proxied, code, reason, errorMessage, errorMessage);
-	}
-
-	void tryReadIn()
-	{
-		while(inSock->framesAvailable() > 0 && ((outSock && outSock->writeBytesAvailable() > 0) || detached))
-		{
-			WebSocket::Frame f = inSock->readFrame();
-
-			tryLogActivity();
-
-			incCounter(Stats::ClientContentBytesReceived, f.data.size());
-			if(!f.more)
-				incCounter(Stats::ClientMessagesReceived);
-
-			if(detached)
-				continue;
-
-			outSock->writeFrame(f);
-
-			incCounter(Stats::ServerContentBytesSent, f.data.size());
-			if(!f.more)
-				incCounter(Stats::ServerMessagesSent);
-		}
-	}
-
-	void tryReadOut()
-	{
-		while(outSock->framesAvailable() > 0 && ((inSock && inSock->writeBytesAvailable() > 0) || detached))
-		{
-			WebSocket::Frame f = outSock->readFrame();
-
-			tryLogActivity();
-
-			incCounter(Stats::ServerContentBytesReceived, f.data.size());
-			if(!f.more)
-				incCounter(Stats::ServerMessagesReceived);
-
-			if(detached && outReadInProgress == -1)
-				continue;
-
-			if(f.type == WebSocket::Frame::Text || f.type == WebSocket::Frame::Binary || f.type == WebSocket::Frame::Continuation)
-			{
-				// We are skipping the rest of this message
-				if(f.type == WebSocket::Frame::Continuation && outReadInProgress == -1)
-					continue;
-
-				if(f.type != WebSocket::Frame::Continuation)
-					outReadInProgress = (int)f.type;
-
-				if(wsControl && acceptGripMessages)
-				{
-					if(f.type == WebSocket::Frame::Text && f.data.startsWith("c:"))
-					{
-						// Grip messages must only be one frame
-						if(!f.more)
-							wsControl->sendGripMessage(f.data.mid(2)); // Process
-						else
-							outReadInProgress = -1; // Ignore rest of message
-					}
-					else if(f.type != WebSocket::Frame::Continuation)
-					{
-						if(f.data.startsWith(messagePrefix))
-						{
-							f.data = f.data.mid(messagePrefix.size());
-							writeInFrame(f);
-
-							adjustKeepAlive();
-						}
-						else
-						{
-							log_debug("wsproxysession: dropping unprefixed message");
-						}
-					}
-					else if(f.type == WebSocket::Frame::Continuation)
-					{
-						assert(outReadInProgress != -1);
-
-						writeInFrame(f);
-
-						adjustKeepAlive();
-					}
-				}
-				else
-				{
-					writeInFrame(f);
-
-					adjustKeepAlive();
-				}
-
-				if(!f.more)
-					outReadInProgress = -1;
-			}
-			else
-			{
-				// Always relay non-content frames
-				writeInFrame(f);
-
-				adjustKeepAlive();
-			}
-
-			if(outReadInProgress == -1 && !queuedInFrames.isEmpty())
-			{
-				foreach(const QueuedFrame &i, queuedInFrames)
-					writeInFrame(i.first, i.second);
-			}
-		}
-	}
-
-	void tryFinish()
-	{
-		if(!inSock && !outSock)
-		{
-			cleanup();
-			finishedByPassthroughCallback.call({q});
-		}
-	}
-
-	void tryLogActivity()
-	{
-		if(statsManager && !activityTime.isNull())
-		{
-			QDateTime now = QDateTime::currentDateTimeUtc();
-			if(now >= activityTime.addMSecs(ACTIVITY_TIMEOUT))
-			{
-				statsManager->addActivity(route.id);
-
-				activityTime = activityTime.addMSecs((activityTime.msecsTo(now) / ACTIVITY_TIMEOUT) * ACTIVITY_TIMEOUT);
-			}
-		}
-	}
-
-	void logConnection(bool proxied, int responseCode, int responseBodySize)
-	{
-		LogUtil::RequestData rd;
-
-		// Only log route id if explicitly set
-		if(route.separateStats)
-			rd.routeId = route.id;
-
-		if(responseCode != -1)
-		{
-			rd.status = LogUtil::Response;
-			rd.responseData.code = responseCode;
-			rd.responseBodySize = responseBodySize;
-		}
-		else
-		{
-			rd.status = LogUtil::Error;
-		}
-
-		rd.requestData.method = "GET";
-		rd.requestData.uri = inSock->requestUri();
-		rd.requestData.headers = inSock->requestHeaders();
-
-		if(proxied)
-		{
-			rd.targetStr = ProxyUtil::targetToString(target);
-			rd.targetOverHttp = target.overHttp;
-		}
-
-		rd.fromAddress = logicalClientAddress;
-
-		LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
-	}
-
-	void setupKeepAlive()
-	{
-		if(keepAliveTimeout >= 0)
-		{
-			int timeout = keepAliveTimeout * 1000;
-			timeout = qMax(timeout - (int)(QRandomGenerator::global()->generate() % KEEPALIVE_RAND_MAX), 0);
-			keepAliveTimer->start(timeout);
-		}
-	}
-
-	void adjustKeepAlive()
-	{
-		// If idle mode, restart the timer. Else leave alone
-		if(keepAliveTimer && keepAliveMode == WsControl::Idle)
-			setupKeepAlive();
-	}
-
-	void updateGripSig()
-	{
-		WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp*>(outSock.get());
-		if(!woh)
-			return;
-
-		ProxyUtil::applyGripSig("wsproxysession", q, &requestData.headers, sigIss, sigKey);
-
-		woh->setHeaders(requestData.headers);
-	}
-
-	void incCounter(Stats::Counter c, int count = 1)
-	{
-		if(statsManager)
-			statsManager->incCounter(route.statsRoute(), c, count);
-	}
-
-	void in_readyRead()
-	{
-		if((outSock && outSock->state() == WebSocket::Connected) || detached)
-			tryReadIn();
-	}
-
-	void in_framesWritten(int count, int contentBytes)
-	{
-		Q_UNUSED(contentBytes);
-
-		for(int n = 0; n < count; ++n)
-		{
-			bool fromSendEvent = inPendingFrames.takeFirst();
-			if(fromSendEvent)
-				wsControl->sendEventWritten();
-		}
-	}
-
-	void in_writeBytesChanged()
-	{
-		if(!detached && outSock)
-			tryReadOut();
-	}
-
-	void in_peerClosed()
-	{
-		if(detached)
-		{
-			inSock->close();
-		}
-		else
-		{
-			if(outSock)
-			{
-				if(outSock->state() == WebSocket::Connecting)
-				{
-					cleanupOutSock();
-					inSock->close();
-				}
-				else if(outSock->state() == WebSocket::Connected)
-				{
-					outSock->close(inSock->peerCloseCode(), inSock->peerCloseReason());
-				}
-			}
-		}
-	}
-
-	void in_closed()
-	{
-		int code = inSock->peerCloseCode();
-		QString reason = inSock->peerCloseReason();
-		cleanupInSock();
-
-		if(!detached && outSock && outSock->state() != WebSocket::Closing)
-			outSock->close(code, reason);
-
-		tryFinish();
-	}
-
-	void in_error()
-	{
-		cleanupInSock();
-
-		if(!detached)
-			cleanupOutSock();
-
-		tryFinish();
-	}
-
-	void out_connected()
-	{
-		log_debug("wsproxysession: %p connected", q);
-
-		state = Connected;
-
-		HttpHeaders headers = outSock->responseHeaders();
-
-		incCounter(Stats::ServerHeaderBytesReceived, ZhttpManager::estimateResponseHeaderBytes(101, outSock->responseReason(), headers));
-
-		// Don't proxy extensions, as we may not know how to handle them
-		QList<QByteArray> wsExtensions = headers.takeAll("Sec-WebSocket-Extensions").asQByteArrayList();
-
-		HttpExtension grip = getExtension(wsExtensions, "grip");
-		if(!grip.isNull() || !target.subscriptions.isEmpty())
-		{
-			if(!grip.isNull())
-			{
-				if(!passToUpstream)
-				{
-					if(grip.params.contains("message-prefix"))
-						messagePrefix = grip.params.value("message-prefix");
-					else
-						messagePrefix = "m:";
-
-					acceptGripMessages = true;
-					log_debug("wsproxysession: %p grip enabled, message-prefix=[%s]", q, messagePrefix.data());
-				}
-				else
-				{
-					// Tell upstream to do the grip stuff
-					headers += HttpHeader("Sec-WebSocket-Extensions", getExtensionRaw(wsExtensions, "grip"));
-				}
-			}
-
-			if(wsControlManager)
-			{
-				wsControl = wsControlManager->createSession(publicCid);
-				wsProxyConnectionMap[wsControl] = {
-					wsControl->sendEventReceived.connect(boost::bind(&Private::wsControl_sendEventReceived, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3)),
-					wsControl->keepAliveSetupEventReceived.connect(boost::bind(&Private::wsControl_keepAliveSetupEventReceived, this, boost::placeholders::_1, boost::placeholders::_2)),
-					wsControl->refreshEventReceived.connect(boost::bind(&Private::wsControl_refreshEventReceived, this)),
-					wsControl->closeEventReceived.connect(boost::bind(&Private::wsControl_closeEventReceived, this, boost::placeholders::_1, boost::placeholders::_2)),
-					wsControl->detachEventReceived.connect(boost::bind(&Private::wsControl_detachEventReceived, this)),
-					wsControl->cancelEventReceived.connect(boost::bind(&Private::wsControl_cancelEventReceived, this)),
-					wsControl->error.connect(boost::bind(&Private::wsControl_error, this))
-				};
-				wsControl->start(route.debug, route.id, route.separateStats, channelPrefix, route.logLevel, inSock->requestUri(), target.trusted);
-
-				foreach(const QString &subChannel, target.subscriptions)
-				{
-					log_debug("wsproxysession: %p implicit subscription to [%s]", q, qPrintable(subChannel));
-
-					wsControl->sendSubscribe(subChannel.toUtf8());
-				}
-			}
-		}
-
-		inSock->respondSuccess(outSock->responseReason(), headers);
-
-		incCounter(Stats::ClientHeaderBytesSent, ZhttpManager::estimateResponseHeaderBytes(101, outSock->responseReason(), headers));
-
-		logConnection(true, 101, 0);
-
-		// Send any pending frames
-		tryReadIn();
-	}
-
-	void out_readyRead()
-	{
-		tryReadOut();
-	}
-
-	void out_writeBytesChanged()
-	{
-		if(!detached && inSock)
-			tryReadIn();
-	}
-
-	void out_peerClosed()
-	{
-		if(!detached && inSock && inSock->state() != WebSocket::Closing)
-			inSock->close(outSock->peerCloseCode(), outSock->peerCloseReason());
-	}
-
-	void out_closed()
-	{
-		int code = outSock->peerCloseCode();
-		QString reason = outSock->peerCloseReason();
-		cleanupOutSock();
-
-		if(!detached && inSock && inSock->state() != WebSocket::Closing)
-			inSock->close(code, reason);
-
-		tryFinish();
-	}
-
-	void out_error()
-	{
-		WebSocket::ErrorCondition e = outSock->errorCondition();
-		log_debug("wsproxysession: %p target error state=%d, condition=%d", q, (int)state, (int)e);
-
-		if(detached)
-		{
-			cleanupOutSock();
-			tryFinish();
-			return;
-		}
-
-		if(state == Connecting)
-		{
-			bool tryAgain = false;
-
-			switch(e)
-			{
-				case WebSocket::ErrorConnect:
-				case WebSocket::ErrorConnectTimeout:
-				case WebSocket::ErrorTls:
-					tryAgain = true;
-					break;
-				case WebSocket::ErrorRejected:
-					reject(true, outSock->responseCode(), outSock->responseReason(), outSock->responseHeaders(), outSock->responseBody());
-					break;
-				default:
-					reject(true, 502, "Bad Gateway", "Error while proxying to origin.");
-					break;
-			}
-
-			cleanupOutSock();
-
-			if(tryAgain)
-				tryNextTarget();
-		}
-		else
-		{
-			cleanupInSock();
-			cleanupOutSock();
-
-			tryFinish();
-		}
-	}
-
-	void out_aboutToSendRequest()
-	{
-		updateGripSig();
-	}
-
-	void wsControl_sendEventReceived(WebSocket::Frame::Type type, const QByteArray &message, bool queue)
-	{
-		// This method accepts a full message, which must be typed
-		if(type == WebSocket::Frame::Continuation)
-			return;
-
-		// If we have no socket to write to, say the data was written anyway.
-		// this is not quite correct but better than leaving the send event
-		// dangling
-		if(!inSock || inSock->state() != WebSocket::Connected)
-		{
-			wsControl->sendEventWritten();
-			return;
-		}
-
-		// If queue == false, drop if we can't send right now
-		if(!queue && (inSock->writeBytesAvailable() == 0 || outReadInProgress != -1))
-		{
-			// If drop is allowed, drop is success :)
-			wsControl->sendEventWritten();
-			return;
-		}
-
-		WebSocket::Frame f(type, message, false);
-
-		if(outReadInProgress != -1)
-		{
-			queuedInFrames += QueuedFrame(f, true);
-		}
-		else
-		{
-			writeInFrame(f, true);
-		}
-
-		adjustKeepAlive();
-	}
-
-	void wsControl_keepAliveSetupEventReceived(WsControl::KeepAliveMode mode, int timeout)
-	{
-		keepAliveMode = mode;
-
-		if(keepAliveMode != WsControl::NoKeepAlive && timeout > 0)
-		{
-			keepAliveTimeout = timeout;
-
-			if(!keepAliveTimer)
-			{
-				keepAliveTimer = std::make_unique<Timer>();
-
-				// Safe to not track, since timer doesn't outlive this
-				keepAliveTimer->timeout.connect(boost::bind(&Private::keepAliveTimer_timeout, this));
-
-				keepAliveTimer->setSingleShot(true);
-			}
-
-			setupKeepAlive();
-		}
-		else
-		{
-			cleanupKeepAliveTimer();
-		}
-	}
-
-	void wsControl_refreshEventReceived()
-	{
-		WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp*>(outSock.get());
-		if(woh)
-			woh->refresh();
-	}
-
-	void wsControl_closeEventReceived(int code, const QByteArray &reason)
-	{
-		if(!detached && outSock && outSock->state() != WebSocket::Closing)
-			outSock->close();
-
-		if(inSock && inSock->state() != WebSocket::Closing)
-			inSock->close(code, reason);
-	}
-
-	void wsControl_detachEventReceived()
-	{
-		// If already detached, do nothing
-		if(detached)
-			return;
-
-		detached = true;
-
-		if(outSock && outSock->state() != WebSocket::Closing)
-			outSock->close();
-	}
-
-	void wsControl_cancelEventReceived()
-	{
-		cleanupInSock();
-		cleanupOutSock();
-
-		tryFinish();
-	}
-
-	void wsControl_error()
-	{
-		log_debug("wsproxysession: %p wscontrol session error", q);
-		wsControl_cancelEventReceived();
-	}
-
-	void keepAliveTimer_timeout()
-	{
-		wsControl->sendNeedKeepAlive();
-
-		if(keepAliveMode == WsControl::Interval)
-			setupKeepAlive();
-	}
+    enum State { Idle, Connecting, Connected, Closing };
+
+    typedef QPair<WebSocket::Frame, bool> QueuedFrame;
+
+    struct WSConnections {
+        Connection connectedConnection;
+        Connection readyReadConnection;
+        Connection writeBytesChangedConnection;
+        Connection peerClosedConnection;
+        Connection closedConnection;
+        Connection errorConnection;
+    };
+
+    struct InWSConnections {
+        Connection readyReadConnection;
+        Connection framesWrittenConnection;
+        Connection writeBytesChangedConnection;
+        Connection peerClosedConnection;
+        Connection closedConnection;
+        Connection errorConnection;
+    };
+
+    struct WSProxyConnections {
+        Connection sendEventReceivedConnection;
+        Connection keepAliveSetupEventReceivedConnection;
+        Connection refreshEventReceivedConnection;
+        Connection closeEventReceivedConnection;
+        Connection detachEventReceivedConnection;
+        Connection cancelEventReceivedConnection;
+        Connection errorConnection;
+    };
+
+    WsProxySession *q;
+    State state;
+    ZRoutes *zroutes;
+    ZhttpManager *zhttpManager;
+    ConnectionManager *connectionManager;
+    StatsManager *statsManager;
+    WsControlManager *wsControlManager;
+    WsControlSession *wsControl;
+    DomainMap::Entry route;
+    bool debug;
+    QByteArray defaultSigIss;
+    Jwt::EncodingKey defaultSigKey;
+    Jwt::DecodingKey defaultUpstreamKey;
+    bool passToUpstream;
+    bool acceptXForwardedProtocol;
+    bool useXForwardedProto;
+    bool useXForwardedProtocol;
+    XffRule xffRule;
+    XffRule xffTrustedRule;
+    QList<QByteArray> origHeadersNeedMark;
+    bool acceptPushpinRoute;
+    QByteArray cdnLoop;
+    HttpRequestData requestData;
+    bool trustedClient;
+    QHostAddress logicalClientAddress;
+    QByteArray sigIss;
+    Jwt::EncodingKey sigKey;
+    std::unique_ptr<WebSocket> inSock;
+    std::unique_ptr<WebSocket> outSock;
+    QList<bool> inPendingFrames; // True means we should ack a send event
+    int outReadInProgress;       // Frame type or -1
+    QByteArray pathBeg;
+    QByteArray channelPrefix;
+    QList<DomainMap::Target> targets;
+    DomainMap::Target target;
+    QHostAddress clientAddress;
+    bool acceptGripMessages;
+    QByteArray messagePrefix;
+    bool detached;
+    QDateTime activityTime;
+    QByteArray publicCid;
+    std::unique_ptr<Timer> keepAliveTimer;
+    WsControl::KeepAliveMode keepAliveMode;
+    int keepAliveTimeout;
+    QList<QueuedFrame> queuedInFrames; // Frames to deliver after out read finishes
+    LogUtil::Config logConfig;
+    Callback<std::tuple<WsProxySession *>> finishedByPassthroughCallback;
+    Connection keepAliveConnection;
+    Connection aboutToSendRequestConnection;
+    map<WsControlSession *, WSProxyConnections> wsProxyConnectionMap;
+    WSConnections outWSConnection;
+    InWSConnections inWSConnection;
+
+    Private(WsProxySession *_q, ZRoutes *_zroutes, ConnectionManager *_connectionManager,
+            const LogUtil::Config &_logConfig, StatsManager *_statsManager,
+            WsControlManager *_wsControlManager)
+        : q(_q),
+          state(Idle),
+          zroutes(_zroutes),
+          zhttpManager(0),
+          connectionManager(_connectionManager),
+          statsManager(_statsManager),
+          wsControlManager(_wsControlManager),
+          wsControl(0),
+          debug(false),
+          passToUpstream(false),
+          acceptXForwardedProtocol(false),
+          useXForwardedProto(false),
+          useXForwardedProtocol(false),
+          acceptPushpinRoute(false),
+          trustedClient(false),
+          outReadInProgress(-1),
+          acceptGripMessages(false),
+          detached(false),
+          keepAliveMode(WsControl::NoKeepAlive),
+          keepAliveTimeout(0),
+          logConfig(_logConfig) {}
+
+    ~Private() { cleanup(); }
+
+    void cleanup() {
+        cleanupKeepAliveTimer();
+
+        cleanupInSock();
+        cleanupOutSock();
+
+        wsProxyConnectionMap.erase(wsControl);
+        delete wsControl;
+        wsControl = 0;
+
+        if (zhttpManager) {
+            zroutes->removeRef(zhttpManager);
+            zhttpManager = 0;
+        }
+    }
+
+    void cleanupInSock() {
+        if (inSock) {
+            connectionManager->removeConnection(inSock.get());
+            inWSConnection = InWSConnections();
+            inSock.reset();
+        }
+    }
+
+    void cleanupOutSock() {
+        if (outSock) {
+            // Ensure the socket has an updated Grip-Sig to use during its
+            // destruction process
+            updateGripSig();
+
+            outWSConnection = WSConnections();
+            outSock.reset();
+        }
+    }
+
+    void cleanupKeepAliveTimer() { keepAliveTimer.reset(); }
+
+    void start(WebSocket *sock, const QByteArray &_publicCid, const DomainMap::Entry &entry) {
+        assert(!inSock);
+
+        state = Connecting;
+
+        publicCid = _publicCid;
+
+        if (statsManager)
+            activityTime = QDateTime::currentDateTimeUtc();
+
+        inSock = std::unique_ptr<WebSocket>(sock);
+        inWSConnection = InWSConnections{
+            inSock->readyRead.connect(boost::bind(&Private::in_readyRead, this)),
+            inSock->framesWritten.connect(boost::bind(&Private::in_framesWritten, this,
+                                                      boost::placeholders::_1,
+                                                      boost::placeholders::_2)),
+            inSock->writeBytesChanged.connect(boost::bind(&Private::in_writeBytesChanged, this)),
+            inSock->peerClosed.connect(boost::bind(&Private::in_peerClosed, this)),
+            inSock->closed.connect(boost::bind(&Private::in_closed, this)),
+            inSock->error.connect(boost::bind(&Private::in_error, this))};
+
+        requestData.uri = inSock->requestUri();
+        requestData.headers = inSock->requestHeaders();
+
+        trustedClient =
+            ProxyUtil::checkTrustedClient("wsproxysession", q, requestData, defaultUpstreamKey);
+
+        logicalClientAddress = ProxyUtil::getLogicalAddress(
+            requestData.headers, trustedClient ? xffTrustedRule : xffRule, inSock->peerAddress());
+
+        QString host = requestData.uri.host();
+
+        route = entry;
+
+        log_debug("wsproxysession: %p %s has %d routes", q, qPrintable(host),
+                  route.targets.count());
+
+        if (route.isNull()) {
+            reject(false, 502, "Bad Gateway", QString("No route for host: %1").arg(host));
+            return;
+        }
+
+        incCounter(
+            Stats::ClientHeaderBytesReceived,
+            ZhttpManager::estimateRequestHeaderBytes("GET", requestData.uri, requestData.headers));
+
+        if (!route.asHost.isEmpty())
+            ProxyUtil::applyHost(&requestData.uri, route.asHost);
+
+        QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
+
+        if (route.pathRemove > 0)
+            path = path.mid(route.pathRemove);
+
+        if (!route.pathPrepend.isEmpty())
+            path = route.pathPrepend + path;
+
+        requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
+
+        sigIss = defaultSigIss;
+        sigKey = defaultSigKey;
+
+        if (!route.sigIss.isEmpty())
+            sigIss = route.sigIss;
+
+        if (!route.sigKey.isNull())
+            sigKey = route.sigKey;
+
+        pathBeg = route.pathBeg;
+        channelPrefix = route.prefix;
+        targets = route.targets;
+
+        foreach (const HttpHeader &h, route.headers) {
+            requestData.headers.removeAll(h.first);
+            if (!h.second.isEmpty())
+                requestData.headers += HttpHeader(h.first, h.second);
+        }
+
+        clientAddress = inSock->peerAddress();
+
+        ProxyUtil::manipulateRequestHeaders(
+            "wsproxysession", q, &requestData, trustedClient, route, sigIss, sigKey,
+            acceptXForwardedProtocol, useXForwardedProto, useXForwardedProtocol, xffTrustedRule,
+            xffRule, origHeadersNeedMark, acceptPushpinRoute, cdnLoop, clientAddress, InspectData(),
+            route.grip, false);
+
+        // Don't proxy extensions, as we may not know how to handle them
+        requestData.headers.removeAll("Sec-WebSocket-Extensions");
+
+        if (route.grip) {
+            // Send grip extension
+            requestData.headers += HttpHeader("Sec-WebSocket-Extensions", "grip");
+        }
+
+        if (trustedClient || !route.grip)
+            passToUpstream = true;
+
+        tryNextTarget();
+    }
+
+    void writeInFrame(const WebSocket::Frame &frame, bool fromSendEvent = false) {
+        inPendingFrames += fromSendEvent;
+
+        inSock->writeFrame(frame);
+
+        incCounter(Stats::ClientContentBytesSent, frame.data.size());
+        if (!frame.more)
+            incCounter(Stats::ClientMessagesSent);
+    }
+
+    void tryNextTarget() {
+        if (targets.isEmpty()) {
+            QString msg = "Error while proxying to origin.";
+
+            QStringList targetStrs;
+            foreach (const DomainMap::Target &t, route.targets)
+                targetStrs += ProxyUtil::targetToString(t);
+            QString dmsg =
+                QString("Unable to connect to any targets. Tried: %1").arg(targetStrs.join(", "));
+
+            reject(true, 502, "Bad Gateway", msg, dmsg);
+            return;
+        }
+
+        target = targets.takeFirst();
+
+        Url uri = requestData.uri;
+        if (target.ssl)
+            uri.setScheme("wss");
+        else
+            uri.setScheme("ws");
+
+        if (!target.host.isEmpty())
+            ProxyUtil::applyHost(&uri, target.host);
+
+        if (zhttpManager) {
+            zroutes->removeRef(zhttpManager);
+            zhttpManager = 0;
+        }
+
+        if (target.type == DomainMap::Target::Test) {
+            // For test route, auto-adjust path
+            if (!pathBeg.isEmpty()) {
+                int pathRemove = pathBeg.length();
+                if (pathBeg.endsWith('/'))
+                    --pathRemove;
+
+                if (pathRemove > 0)
+                    uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
+            }
+
+            outSock = std::make_unique<TestWebSocket>();
+        } else {
+            if (target.type == DomainMap::Target::Custom) {
+                zhttpManager = zroutes->managerForRoute(target.zhttpRoute);
+                log_debug("wsproxysession: %p forwarding to %s", q,
+                          qPrintable(target.zhttpRoute.baseSpec));
+            } else // Default
+            {
+                zhttpManager = zroutes->defaultManager();
+                log_debug("wsproxysession: %p forwarding to %s:%d", q,
+                          qPrintable(target.connectHost), target.connectPort);
+            }
+
+            zroutes->addRef(zhttpManager);
+
+            if (target.overHttp) {
+                std::unique_ptr<WebSocketOverHttp> woh =
+                    std::make_unique<WebSocketOverHttp>(zhttpManager);
+
+                woh->setConnectionId(publicCid);
+
+                if (target.oneEvent)
+                    woh->setMaxEventsPerRequest(1);
+
+                aboutToSendRequestConnection = woh->aboutToSendRequest.connect(
+                    boost::bind(&Private::out_aboutToSendRequest, this));
+                outSock = std::move(woh);
+            } else {
+                // Websockets don't work with zhttp req mode
+                if (zhttpManager->clientUsesReq()) {
+                    reject(false, 502, "Bad Gateway", "Error while proxying to origin.",
+                           "WebSockets cannot be used with zhttpreq target");
+                    return;
+                }
+
+                outSock = std::unique_ptr<WebSocket>(zhttpManager->createSocket());
+            }
+        }
+        outWSConnection = {
+            outSock->connected.connect(boost::bind(&Private::out_connected, this)),
+            outSock->readyRead.connect(boost::bind(&Private::out_readyRead, this)),
+            outSock->writeBytesChanged.connect(boost::bind(&Private::out_writeBytesChanged, this)),
+            outSock->peerClosed.connect(boost::bind(&Private::out_peerClosed, this)),
+            outSock->closed.connect(boost::bind(&Private::out_closed, this)),
+            outSock->error.connect(boost::bind(&Private::out_error, this))};
+
+        if (target.trusted)
+            outSock->setIgnorePolicies(true);
+
+        if (target.trustConnectHost)
+            outSock->setTrustConnectHost(true);
+
+        if (target.insecure)
+            outSock->setIgnoreTlsErrors(true);
+
+        if (target.type == DomainMap::Target::Default) {
+            outSock->setConnectHost(target.connectHost);
+            outSock->setConnectPort(target.connectPort);
+        }
+
+        if (!target.clientCert.isEmpty())
+            outSock->setClientCert(target.clientCert, target.clientKey);
+
+        ProxyUtil::applyHostHeader(&requestData.headers, uri);
+
+        incCounter(Stats::ServerHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes("GET", uri, requestData.headers));
+
+        outSock->start(uri, requestData.headers);
+    }
+
+    void reject(bool proxied, int code, const QByteArray &reason, const HttpHeaders &headers,
+                const QByteArray &body) {
+        assert(state == Connecting);
+
+        state = Closing;
+        inSock->respondError(code, reason, headers, body);
+
+        incCounter(Stats::ClientHeaderBytesSent,
+                   ZhttpManager::estimateResponseHeaderBytes(code, reason, headers));
+
+        logConnection(proxied, code, body.size());
+    }
+
+    void reject(bool proxied, int code, const QString &reason, const QString &errorMessage,
+                const QString &debugErrorMessage) {
+        QString msg = debug ? debugErrorMessage : errorMessage;
+
+        reject(proxied, code, reason.toUtf8(), HttpHeaders(), (msg + '\n').toUtf8());
+    }
+
+    void reject(bool proxied, int code, const QString &reason, const QString &errorMessage) {
+        reject(proxied, code, reason, errorMessage, errorMessage);
+    }
+
+    void tryReadIn() {
+        while (inSock->framesAvailable() > 0 &&
+               ((outSock && outSock->writeBytesAvailable() > 0) || detached)) {
+            WebSocket::Frame f = inSock->readFrame();
+
+            tryLogActivity();
+
+            incCounter(Stats::ClientContentBytesReceived, f.data.size());
+            if (!f.more)
+                incCounter(Stats::ClientMessagesReceived);
+
+            if (detached)
+                continue;
+
+            outSock->writeFrame(f);
+
+            incCounter(Stats::ServerContentBytesSent, f.data.size());
+            if (!f.more)
+                incCounter(Stats::ServerMessagesSent);
+        }
+    }
+
+    void tryReadOut() {
+        while (outSock->framesAvailable() > 0 &&
+               ((inSock && inSock->writeBytesAvailable() > 0) || detached)) {
+            WebSocket::Frame f = outSock->readFrame();
+
+            tryLogActivity();
+
+            incCounter(Stats::ServerContentBytesReceived, f.data.size());
+            if (!f.more)
+                incCounter(Stats::ServerMessagesReceived);
+
+            if (detached && outReadInProgress == -1)
+                continue;
+
+            if (f.type == WebSocket::Frame::Text || f.type == WebSocket::Frame::Binary ||
+                f.type == WebSocket::Frame::Continuation) {
+                // We are skipping the rest of this message
+                if (f.type == WebSocket::Frame::Continuation && outReadInProgress == -1)
+                    continue;
+
+                if (f.type != WebSocket::Frame::Continuation)
+                    outReadInProgress = (int)f.type;
+
+                if (wsControl && acceptGripMessages) {
+                    if (f.type == WebSocket::Frame::Text && f.data.startsWith("c:")) {
+                        // Grip messages must only be one frame
+                        if (!f.more)
+                            wsControl->sendGripMessage(f.data.mid(2)); // Process
+                        else
+                            outReadInProgress = -1; // Ignore rest of message
+                    } else if (f.type != WebSocket::Frame::Continuation) {
+                        if (f.data.startsWith(messagePrefix)) {
+                            f.data = f.data.mid(messagePrefix.size());
+                            writeInFrame(f);
+
+                            adjustKeepAlive();
+                        } else {
+                            log_debug("wsproxysession: dropping unprefixed message");
+                        }
+                    } else if (f.type == WebSocket::Frame::Continuation) {
+                        assert(outReadInProgress != -1);
+
+                        writeInFrame(f);
+
+                        adjustKeepAlive();
+                    }
+                } else {
+                    writeInFrame(f);
+
+                    adjustKeepAlive();
+                }
+
+                if (!f.more)
+                    outReadInProgress = -1;
+            } else {
+                // Always relay non-content frames
+                writeInFrame(f);
+
+                adjustKeepAlive();
+            }
+
+            if (outReadInProgress == -1 && !queuedInFrames.isEmpty()) {
+                foreach (const QueuedFrame &i, queuedInFrames)
+                    writeInFrame(i.first, i.second);
+            }
+        }
+    }
+
+    void tryFinish() {
+        if (!inSock && !outSock) {
+            cleanup();
+            finishedByPassthroughCallback.call({q});
+        }
+    }
+
+    void tryLogActivity() {
+        if (statsManager && !activityTime.isNull()) {
+            QDateTime now = QDateTime::currentDateTimeUtc();
+            if (now >= activityTime.addMSecs(ACTIVITY_TIMEOUT)) {
+                statsManager->addActivity(route.id);
+
+                activityTime = activityTime.addMSecs(
+                    (activityTime.msecsTo(now) / ACTIVITY_TIMEOUT) * ACTIVITY_TIMEOUT);
+            }
+        }
+    }
+
+    void logConnection(bool proxied, int responseCode, int responseBodySize) {
+        LogUtil::RequestData rd;
+
+        // Only log route id if explicitly set
+        if (route.separateStats)
+            rd.routeId = route.id;
+
+        if (responseCode != -1) {
+            rd.status = LogUtil::Response;
+            rd.responseData.code = responseCode;
+            rd.responseBodySize = responseBodySize;
+        } else {
+            rd.status = LogUtil::Error;
+        }
+
+        rd.requestData.method = "GET";
+        rd.requestData.uri = inSock->requestUri();
+        rd.requestData.headers = inSock->requestHeaders();
+
+        if (proxied) {
+            rd.targetStr = ProxyUtil::targetToString(target);
+            rd.targetOverHttp = target.overHttp;
+        }
+
+        rd.fromAddress = logicalClientAddress;
+
+        LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
+    }
+
+    void setupKeepAlive() {
+        if (keepAliveTimeout >= 0) {
+            int timeout = keepAliveTimeout * 1000;
+            timeout = qMax(
+                timeout - (int)(QRandomGenerator::global()->generate() % KEEPALIVE_RAND_MAX), 0);
+            keepAliveTimer->start(timeout);
+        }
+    }
+
+    void adjustKeepAlive() {
+        // If idle mode, restart the timer. Else leave alone
+        if (keepAliveTimer && keepAliveMode == WsControl::Idle)
+            setupKeepAlive();
+    }
+
+    void updateGripSig() {
+        WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp *>(outSock.get());
+        if (!woh)
+            return;
+
+        ProxyUtil::applyGripSig("wsproxysession", q, &requestData.headers, sigIss, sigKey);
+
+        woh->setHeaders(requestData.headers);
+    }
+
+    void incCounter(Stats::Counter c, int count = 1) {
+        if (statsManager)
+            statsManager->incCounter(route.statsRoute(), c, count);
+    }
+
+    void in_readyRead() {
+        if ((outSock && outSock->state() == WebSocket::Connected) || detached)
+            tryReadIn();
+    }
+
+    void in_framesWritten(int count, int contentBytes) {
+        Q_UNUSED(contentBytes);
+
+        for (int n = 0; n < count; ++n) {
+            bool fromSendEvent = inPendingFrames.takeFirst();
+            if (fromSendEvent)
+                wsControl->sendEventWritten();
+        }
+    }
+
+    void in_writeBytesChanged() {
+        if (!detached && outSock)
+            tryReadOut();
+    }
+
+    void in_peerClosed() {
+        if (detached) {
+            inSock->close();
+        } else {
+            if (outSock) {
+                if (outSock->state() == WebSocket::Connecting) {
+                    cleanupOutSock();
+                    inSock->close();
+                } else if (outSock->state() == WebSocket::Connected) {
+                    outSock->close(inSock->peerCloseCode(), inSock->peerCloseReason());
+                }
+            }
+        }
+    }
+
+    void in_closed() {
+        int code = inSock->peerCloseCode();
+        QString reason = inSock->peerCloseReason();
+        cleanupInSock();
+
+        if (!detached && outSock && outSock->state() != WebSocket::Closing)
+            outSock->close(code, reason);
+
+        tryFinish();
+    }
+
+    void in_error() {
+        cleanupInSock();
+
+        if (!detached)
+            cleanupOutSock();
+
+        tryFinish();
+    }
+
+    void out_connected() {
+        log_debug("wsproxysession: %p connected", q);
+
+        state = Connected;
+
+        HttpHeaders headers = outSock->responseHeaders();
+
+        incCounter(Stats::ServerHeaderBytesReceived, ZhttpManager::estimateResponseHeaderBytes(
+                                                         101, outSock->responseReason(), headers));
+
+        // Don't proxy extensions, as we may not know how to handle them
+        QList<QByteArray> wsExtensions =
+            headers.takeAll("Sec-WebSocket-Extensions").asQByteArrayList();
+
+        HttpExtension grip = getExtension(wsExtensions, "grip");
+        if (!grip.isNull() || !target.subscriptions.isEmpty()) {
+            if (!grip.isNull()) {
+                if (!passToUpstream) {
+                    if (grip.params.contains("message-prefix"))
+                        messagePrefix = grip.params.value("message-prefix");
+                    else
+                        messagePrefix = "m:";
+
+                    acceptGripMessages = true;
+                    log_debug("wsproxysession: %p grip enabled, message-prefix=[%s]", q,
+                              messagePrefix.data());
+                } else {
+                    // Tell upstream to do the grip stuff
+                    headers += HttpHeader("Sec-WebSocket-Extensions",
+                                          getExtensionRaw(wsExtensions, "grip"));
+                }
+            }
+
+            if (wsControlManager) {
+                wsControl = wsControlManager->createSession(publicCid);
+                wsProxyConnectionMap[wsControl] = {
+                    wsControl->sendEventReceived.connect(boost::bind(
+                        &Private::wsControl_sendEventReceived, this, boost::placeholders::_1,
+                        boost::placeholders::_2, boost::placeholders::_3)),
+                    wsControl->keepAliveSetupEventReceived.connect(
+                        boost::bind(&Private::wsControl_keepAliveSetupEventReceived, this,
+                                    boost::placeholders::_1, boost::placeholders::_2)),
+                    wsControl->refreshEventReceived.connect(
+                        boost::bind(&Private::wsControl_refreshEventReceived, this)),
+                    wsControl->closeEventReceived.connect(
+                        boost::bind(&Private::wsControl_closeEventReceived, this,
+                                    boost::placeholders::_1, boost::placeholders::_2)),
+                    wsControl->detachEventReceived.connect(
+                        boost::bind(&Private::wsControl_detachEventReceived, this)),
+                    wsControl->cancelEventReceived.connect(
+                        boost::bind(&Private::wsControl_cancelEventReceived, this)),
+                    wsControl->error.connect(boost::bind(&Private::wsControl_error, this))};
+                wsControl->start(route.debug, route.id, route.separateStats, channelPrefix,
+                                 route.logLevel, inSock->requestUri(), target.trusted);
+
+                foreach (const QString &subChannel, target.subscriptions) {
+                    log_debug("wsproxysession: %p implicit subscription to [%s]", q,
+                              qPrintable(subChannel));
+
+                    wsControl->sendSubscribe(subChannel.toUtf8());
+                }
+            }
+        }
+
+        inSock->respondSuccess(outSock->responseReason(), headers);
+
+        incCounter(Stats::ClientHeaderBytesSent, ZhttpManager::estimateResponseHeaderBytes(
+                                                     101, outSock->responseReason(), headers));
+
+        logConnection(true, 101, 0);
+
+        // Send any pending frames
+        tryReadIn();
+    }
+
+    void out_readyRead() { tryReadOut(); }
+
+    void out_writeBytesChanged() {
+        if (!detached && inSock)
+            tryReadIn();
+    }
+
+    void out_peerClosed() {
+        if (!detached && inSock && inSock->state() != WebSocket::Closing)
+            inSock->close(outSock->peerCloseCode(), outSock->peerCloseReason());
+    }
+
+    void out_closed() {
+        int code = outSock->peerCloseCode();
+        QString reason = outSock->peerCloseReason();
+        cleanupOutSock();
+
+        if (!detached && inSock && inSock->state() != WebSocket::Closing)
+            inSock->close(code, reason);
+
+        tryFinish();
+    }
+
+    void out_error() {
+        WebSocket::ErrorCondition e = outSock->errorCondition();
+        log_debug("wsproxysession: %p target error state=%d, condition=%d", q, (int)state, (int)e);
+
+        if (detached) {
+            cleanupOutSock();
+            tryFinish();
+            return;
+        }
+
+        if (state == Connecting) {
+            bool tryAgain = false;
+
+            switch (e) {
+            case WebSocket::ErrorConnect:
+            case WebSocket::ErrorConnectTimeout:
+            case WebSocket::ErrorTls:
+                tryAgain = true;
+                break;
+            case WebSocket::ErrorRejected:
+                reject(true, outSock->responseCode(), outSock->responseReason(),
+                       outSock->responseHeaders(), outSock->responseBody());
+                break;
+            default:
+                reject(true, 502, "Bad Gateway", "Error while proxying to origin.");
+                break;
+            }
+
+            cleanupOutSock();
+
+            if (tryAgain)
+                tryNextTarget();
+        } else {
+            cleanupInSock();
+            cleanupOutSock();
+
+            tryFinish();
+        }
+    }
+
+    void out_aboutToSendRequest() { updateGripSig(); }
+
+    void wsControl_sendEventReceived(WebSocket::Frame::Type type, const QByteArray &message,
+                                     bool queue) {
+        // This method accepts a full message, which must be typed
+        if (type == WebSocket::Frame::Continuation)
+            return;
+
+        // If we have no socket to write to, say the data was written anyway.
+        // this is not quite correct but better than leaving the send event
+        // dangling
+        if (!inSock || inSock->state() != WebSocket::Connected) {
+            wsControl->sendEventWritten();
+            return;
+        }
+
+        // If queue == false, drop if we can't send right now
+        if (!queue && (inSock->writeBytesAvailable() == 0 || outReadInProgress != -1)) {
+            // If drop is allowed, drop is success :)
+            wsControl->sendEventWritten();
+            return;
+        }
+
+        WebSocket::Frame f(type, message, false);
+
+        if (outReadInProgress != -1) {
+            queuedInFrames += QueuedFrame(f, true);
+        } else {
+            writeInFrame(f, true);
+        }
+
+        adjustKeepAlive();
+    }
+
+    void wsControl_keepAliveSetupEventReceived(WsControl::KeepAliveMode mode, int timeout) {
+        keepAliveMode = mode;
+
+        if (keepAliveMode != WsControl::NoKeepAlive && timeout > 0) {
+            keepAliveTimeout = timeout;
+
+            if (!keepAliveTimer) {
+                keepAliveTimer = std::make_unique<Timer>();
+
+                // Safe to not track, since timer doesn't outlive this
+                keepAliveTimer->timeout.connect(
+                    boost::bind(&Private::keepAliveTimer_timeout, this));
+
+                keepAliveTimer->setSingleShot(true);
+            }
+
+            setupKeepAlive();
+        } else {
+            cleanupKeepAliveTimer();
+        }
+    }
+
+    void wsControl_refreshEventReceived() {
+        WebSocketOverHttp *woh = dynamic_cast<WebSocketOverHttp *>(outSock.get());
+        if (woh)
+            woh->refresh();
+    }
+
+    void wsControl_closeEventReceived(int code, const QByteArray &reason) {
+        if (!detached && outSock && outSock->state() != WebSocket::Closing)
+            outSock->close();
+
+        if (inSock && inSock->state() != WebSocket::Closing)
+            inSock->close(code, reason);
+    }
+
+    void wsControl_detachEventReceived() {
+        // If already detached, do nothing
+        if (detached)
+            return;
+
+        detached = true;
+
+        if (outSock && outSock->state() != WebSocket::Closing)
+            outSock->close();
+    }
+
+    void wsControl_cancelEventReceived() {
+        cleanupInSock();
+        cleanupOutSock();
+
+        tryFinish();
+    }
+
+    void wsControl_error() {
+        log_debug("wsproxysession: %p wscontrol session error", q);
+        wsControl_cancelEventReceived();
+    }
+
+    void keepAliveTimer_timeout() {
+        wsControl->sendNeedKeepAlive();
+
+        if (keepAliveMode == WsControl::Interval)
+            setupKeepAlive();
+    }
 };
 
-WsProxySession::WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager, const LogUtil::Config &logConfig, StatsManager *statsManager, WsControlManager *wsControlManager)
-{
-	d = new Private(this, zroutes, connectionManager, logConfig, statsManager, wsControlManager);
+WsProxySession::WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager,
+                               const LogUtil::Config &logConfig, StatsManager *statsManager,
+                               WsControlManager *wsControlManager) {
+    d = new Private(this, zroutes, connectionManager, logConfig, statsManager, wsControlManager);
 }
 
-WsProxySession::~WsProxySession()
-{
-	delete d;
+WsProxySession::~WsProxySession() { delete d; }
+
+QHostAddress WsProxySession::logicalClientAddress() const { return d->logicalClientAddress; }
+
+QByteArray WsProxySession::statsRoute() const { return d->route.statsRoute(); }
+
+QByteArray WsProxySession::cid() const { return d->publicCid; }
+
+WebSocket *WsProxySession::inSocket() const { return d->inSock.get(); }
+
+WebSocket *WsProxySession::outSocket() const { return d->outSock.get(); }
+
+void WsProxySession::setDebugEnabled(bool enabled) { d->debug = enabled; }
+
+void WsProxySession::setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key) {
+    d->defaultSigIss = iss;
+    d->defaultSigKey = key;
 }
 
-QHostAddress WsProxySession::logicalClientAddress() const
-{
-	return d->logicalClientAddress;
+void WsProxySession::setDefaultUpstreamKey(const Jwt::DecodingKey &key) {
+    d->defaultUpstreamKey = key;
 }
 
-QByteArray WsProxySession::statsRoute() const
-{
-	return d->route.statsRoute();
+void WsProxySession::setAcceptXForwardedProtocol(bool enabled) {
+    d->acceptXForwardedProtocol = enabled;
 }
 
-QByteArray WsProxySession::cid() const
-{
-	return d->publicCid;
+void WsProxySession::setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled) {
+    d->useXForwardedProto = protoEnabled;
+    d->useXForwardedProtocol = protocolEnabled;
 }
 
-WebSocket *WsProxySession::inSocket() const
-{
-	return d->inSock.get();
+void WsProxySession::setXffRules(const XffRule &untrusted, const XffRule &trusted) {
+    d->xffRule = untrusted;
+    d->xffTrustedRule = trusted;
 }
 
-WebSocket *WsProxySession::outSocket() const
-{
-	return d->outSock.get();
+void WsProxySession::setOrigHeadersNeedMark(const QList<QByteArray> &names) {
+    d->origHeadersNeedMark = names;
 }
 
-void WsProxySession::setDebugEnabled(bool enabled)
-{
-	d->debug = enabled;
+void WsProxySession::setAcceptPushpinRoute(bool enabled) { d->acceptPushpinRoute = enabled; }
+
+void WsProxySession::setCdnLoop(const QByteArray &value) { d->cdnLoop = value; }
+
+void WsProxySession::start(WebSocket *sock, const QByteArray &publicCid,
+                           const DomainMap::Entry &route) {
+    d->start(sock, publicCid, route);
 }
 
-void WsProxySession::setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key)
-{
-	d->defaultSigIss = iss;
-	d->defaultSigKey = key;
-}
-
-void WsProxySession::setDefaultUpstreamKey(const Jwt::DecodingKey &key)
-{
-	d->defaultUpstreamKey = key;
-}
-
-void WsProxySession::setAcceptXForwardedProtocol(bool enabled)
-{
-	d->acceptXForwardedProtocol = enabled;
-}
-
-void WsProxySession::setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled)
-{
-	d->useXForwardedProto = protoEnabled;
-	d->useXForwardedProtocol = protocolEnabled;
-}
-
-void WsProxySession::setXffRules(const XffRule &untrusted, const XffRule &trusted)
-{
-	d->xffRule = untrusted;
-	d->xffTrustedRule = trusted;
-}
-
-void WsProxySession::setOrigHeadersNeedMark(const QList<QByteArray> &names)
-{
-	d->origHeadersNeedMark = names;
-}
-
-void WsProxySession::setAcceptPushpinRoute(bool enabled)
-{
-	d->acceptPushpinRoute = enabled;
-}
-
-void WsProxySession::setCdnLoop(const QByteArray &value)
-{
-	d->cdnLoop = value;
-}
-
-void WsProxySession::start(WebSocket *sock, const QByteArray &publicCid, const DomainMap::Entry &route)
-{
-	d->start(sock, publicCid, route);
-}
-
-Callback<std::tuple<WsProxySession *>> & WsProxySession::finishedByPassthroughCallback()
-{
-	return d->finishedByPassthroughCallback;
+Callback<std::tuple<WsProxySession *>> &WsProxySession::finishedByPassthroughCallback() {
+    return d->finishedByPassthroughCallback;
 }

--- a/src/proxy/wsproxysession.h
+++ b/src/proxy/wsproxysession.h
@@ -25,17 +25,17 @@
 #define WSPROXYSESSION_H
 
 #include "callback.h"
-#include "logutil.h"
 #include "domainmap.h"
+#include "logutil.h"
 #include <boost/signals2.hpp>
 
 using std::map;
 using Connection = boost::signals2::scoped_connection;
 
 namespace Jwt {
-	class EncodingKey;
-	class DecodingKey;
-}
+class EncodingKey;
+class DecodingKey;
+} // namespace Jwt
 
 class WebSocket;
 class ZRoutes;
@@ -44,40 +44,42 @@ class StatsManager;
 class ConnectionManager;
 class XffRule;
 
-/// Proxies WebSocket requests to backends with GRIP streaming and request sharing
-class WsProxySession
-{
+/// Proxies WebSocket requests to backends with GRIP streaming and request
+/// sharing
+class WsProxySession {
 public:
-	WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager, const LogUtil::Config &logConfig, StatsManager *stats = 0, WsControlManager *wsControlManager = 0);
-	~WsProxySession();
+    WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager,
+                   const LogUtil::Config &logConfig, StatsManager *stats = 0,
+                   WsControlManager *wsControlManager = 0);
+    ~WsProxySession();
 
-	QHostAddress logicalClientAddress() const;
-	QByteArray statsRoute() const;
-	QByteArray cid() const;
+    QHostAddress logicalClientAddress() const;
+    QByteArray statsRoute() const;
+    QByteArray cid() const;
 
-	WebSocket *inSocket() const;
-	WebSocket *outSocket() const;
+    WebSocket *inSocket() const;
+    WebSocket *outSocket() const;
 
-	void setDebugEnabled(bool enabled);
-	void setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key);
-	void setDefaultUpstreamKey(const Jwt::DecodingKey &key);
-	void setAcceptXForwardedProtocol(bool enabled);
-	void setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled);
-	void setXffRules(const XffRule &untrusted, const XffRule &trusted);
-	void setOrigHeadersNeedMark(const QList<QByteArray> &names);
-	void setAcceptPushpinRoute(bool enabled);
-	void setCdnLoop(const QByteArray &value);
+    void setDebugEnabled(bool enabled);
+    void setDefaultSigKey(const QByteArray &iss, const Jwt::EncodingKey &key);
+    void setDefaultUpstreamKey(const Jwt::DecodingKey &key);
+    void setAcceptXForwardedProtocol(bool enabled);
+    void setUseXForwardedProtocol(bool protoEnabled, bool protocolEnabled);
+    void setXffRules(const XffRule &untrusted, const XffRule &trusted);
+    void setOrigHeadersNeedMark(const QList<QByteArray> &names);
+    void setAcceptPushpinRoute(bool enabled);
+    void setCdnLoop(const QByteArray &value);
 
-	// Takes ownership
-	void start(WebSocket *sock, const QByteArray &publicCid, const DomainMap::Entry &route);
+    // Takes ownership
+    void start(WebSocket *sock, const QByteArray &publicCid, const DomainMap::Entry &route);
 
-	// NOTE: for performance reasons we use callbacks instead of signals/slots
-	Callback<std::tuple<WsProxySession *>> & finishedByPassthroughCallback();
+    // NOTE: for performance reasons we use callbacks instead of signals/slots
+    Callback<std::tuple<WsProxySession *>> &finishedByPassthroughCallback();
 
 private:
-	class Private;
-	friend class Private;
-	Private *d;
+    class Private;
+    friend class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/xffrule.h
+++ b/src/proxy/xffrule.h
@@ -24,17 +24,12 @@
 #define XFFRULE_H
 
 /// Configuration for X-Forwarded-For header manipulation
-class XffRule
-{
+class XffRule {
 public:
-	int truncate;
-	bool append;
+    int truncate;
+    bool append;
 
-	XffRule() :
-		truncate(-1),
-		append(false)
-	{
-	}
+    XffRule() : truncate(-1), append(false) {}
 };
 
 #endif

--- a/src/proxy/zroutes.cpp
+++ b/src/proxy/zroutes.cpp
@@ -23,271 +23,223 @@
 
 #include "zroutes.h"
 
-#include <assert.h>
-#include <QHash>
-#include <QStringList>
-#include <boost/signals2.hpp>
 #include "log.h"
 #include "timer.h"
+#include <QHash>
+#include <QStringList>
+#include <assert.h>
+#include <boost/signals2.hpp>
 
 using Connection = boost::signals2::scoped_connection;
 
-static QStringList baseSpecToSpecs(const QString &baseSpec)
-{
-	int at = baseSpec.indexOf("://");
-	assert(at != -1);
+static QStringList baseSpecToSpecs(const QString &baseSpec) {
+    int at = baseSpec.indexOf("://");
+    assert(at != -1);
 
-	at = baseSpec.indexOf(':', at + 3);
-	if(at != -1) // Probably a host:port spec
-	{
-		QString s = baseSpec.mid(0, at + 1);
-		QString portStr = baseSpec.mid(at + 1);
-		bool ok = false;
-		int port = portStr.toInt(&ok);
-		assert(ok);
+    at = baseSpec.indexOf(':', at + 3);
+    if (at != -1) // Probably a host:port spec
+    {
+        QString s = baseSpec.mid(0, at + 1);
+        QString portStr = baseSpec.mid(at + 1);
+        bool ok = false;
+        int port = portStr.toInt(&ok);
+        assert(ok);
 
-		QStringList out;
-		out += s + QString::number(port);
-		out += s + QString::number(port + 1);
-		out += s + QString::number(port + 2);
-		return out;
-	}
-	else // Probably a path spec
-	{
-		QStringList out;
-		out += baseSpec + "-out";
-		out += baseSpec + "-out-stream";
-		out += baseSpec + "-in";
-		return out;
-	}
+        QStringList out;
+        out += s + QString::number(port);
+        out += s + QString::number(port + 1);
+        out += s + QString::number(port + 2);
+        return out;
+    } else // Probably a path spec
+    {
+        QStringList out;
+        out += baseSpec + "-out";
+        out += baseSpec + "-out-stream";
+        out += baseSpec + "-in";
+        return out;
+    }
 }
 
-class ZRoutes::Private
-{
+class ZRoutes::Private {
 public:
-	class Item
-	{
-	public:
-		QString spec;
-		std::unique_ptr<ZhttpManager> manager;
-		int refs;
-		bool markedForRemoval;
+    class Item {
+    public:
+        QString spec;
+        std::unique_ptr<ZhttpManager> manager;
+        int refs;
+        bool markedForRemoval;
 
-		Item(const QString &_spec, std::unique_ptr<ZhttpManager> _manager) :
-			spec(_spec),
-			manager(std::move(_manager)),
-			refs(0),
-			markedForRemoval(false)
-		{
-		}
-	};
+        Item(const QString &_spec, std::unique_ptr<ZhttpManager> _manager)
+            : spec(_spec), manager(std::move(_manager)), refs(0), markedForRemoval(false) {}
+    };
 
-	ZRoutes *q;
-	QByteArray instanceId;
-	QStringList defaultOutSpecs;
-	QStringList defaultOutStreamSpecs;
-	QStringList defaultInSpecs;
-	Item *defaultItem;
-	QHash<QString, Item*> itemsBySpec;
-	QHash<ZhttpManager*, Item*> itemsByManager;
-	std::unique_ptr<Timer> cleanupTimer;
-	Connection cleanupTimerConnection;
+    ZRoutes *q;
+    QByteArray instanceId;
+    QStringList defaultOutSpecs;
+    QStringList defaultOutStreamSpecs;
+    QStringList defaultInSpecs;
+    Item *defaultItem;
+    QHash<QString, Item *> itemsBySpec;
+    QHash<ZhttpManager *, Item *> itemsByManager;
+    std::unique_ptr<Timer> cleanupTimer;
+    Connection cleanupTimerConnection;
 
-	Private(ZRoutes *_q) :
-		q(_q),
-		defaultItem(0)
-	{
-		cleanupTimer = std::make_unique<Timer>();
-		cleanupTimerConnection = cleanupTimer->timeout.connect(boost::bind(&Private::removeUnused, this));
-		cleanupTimer->setInterval(10000);
-		cleanupTimer->start();
-	}
+    Private(ZRoutes *_q) : q(_q), defaultItem(0) {
+        cleanupTimer = std::make_unique<Timer>();
+        cleanupTimerConnection =
+            cleanupTimer->timeout.connect(boost::bind(&Private::removeUnused, this));
+        cleanupTimer->setInterval(10000);
+        cleanupTimer->start();
+    }
 
-	~Private()
-	{
-		qDeleteAll(itemsBySpec);
-		delete defaultItem;
-	}
+    ~Private() {
+        qDeleteAll(itemsBySpec);
+        delete defaultItem;
+    }
 
-	Item *ensureDefaultItem()
-	{
-		if(!defaultItem)
-		{
-			std::unique_ptr<ZhttpManager> manager = std::make_unique<ZhttpManager>();
-			manager->setInstanceId(instanceId);
-			manager->setClientOutSpecs(defaultOutSpecs);
-			manager->setClientOutStreamSpecs(defaultOutStreamSpecs);
-			manager->setClientInSpecs(defaultInSpecs);
+    Item *ensureDefaultItem() {
+        if (!defaultItem) {
+            std::unique_ptr<ZhttpManager> manager = std::make_unique<ZhttpManager>();
+            manager->setInstanceId(instanceId);
+            manager->setClientOutSpecs(defaultOutSpecs);
+            manager->setClientOutStreamSpecs(defaultOutStreamSpecs);
+            manager->setClientInSpecs(defaultInSpecs);
 
-			defaultItem = new Item(QString(), std::move(manager));
-		}
+            defaultItem = new Item(QString(), std::move(manager));
+        }
 
-		return defaultItem;
-	}
+        return defaultItem;
+    }
 
-	Item *ensureItem(const DomainMap::ZhttpRoute &route)
-	{
-		Item *i = itemsBySpec.value(route.baseSpec);
-		if(!i)
-		{
-			std::unique_ptr<ZhttpManager> manager = std::make_unique<ZhttpManager>();
-			manager->setInstanceId(instanceId);
-			manager->setIpcFileMode(route.ipcFileMode);
-			manager->setBind(true);
+    Item *ensureItem(const DomainMap::ZhttpRoute &route) {
+        Item *i = itemsBySpec.value(route.baseSpec);
+        if (!i) {
+            std::unique_ptr<ZhttpManager> manager = std::make_unique<ZhttpManager>();
+            manager->setInstanceId(instanceId);
+            manager->setIpcFileMode(route.ipcFileMode);
+            manager->setBind(true);
 
-			if(route.req)
-			{
-				manager->setClientReqSpecs(QStringList() << route.baseSpec);
-			}
-			else
-			{
-				QStringList specs = baseSpecToSpecs(route.baseSpec);
-				manager->setClientOutSpecs(QStringList() << specs[0]);
-				manager->setClientOutStreamSpecs(QStringList() << specs[1]);
-				manager->setClientInSpecs(QStringList() << specs[2]);
-			}
+            if (route.req) {
+                manager->setClientReqSpecs(QStringList() << route.baseSpec);
+            } else {
+                QStringList specs = baseSpecToSpecs(route.baseSpec);
+                manager->setClientOutSpecs(QStringList() << specs[0]);
+                manager->setClientOutStreamSpecs(QStringList() << specs[1]);
+                manager->setClientInSpecs(QStringList() << specs[2]);
+            }
 
-			i = new Item(route.baseSpec, std::move(manager));
-			itemsBySpec.insert(route.baseSpec, i);
-			itemsByManager.insert(i->manager.get(), i);
-		}
+            i = new Item(route.baseSpec, std::move(manager));
+            itemsBySpec.insert(route.baseSpec, i);
+            itemsByManager.insert(i->manager.get(), i);
+        }
 
-		return i;
-	}
+        return i;
+    }
 
-	void tryRemoveItem(Item *i)
-	{
-		if(i->refs == 0 && i->manager->connectionCount() == 0)
-			removeItem(i);
-		else
-			i->markedForRemoval = true;
-	}
+    void tryRemoveItem(Item *i) {
+        if (i->refs == 0 && i->manager->connectionCount() == 0)
+            removeItem(i);
+        else
+            i->markedForRemoval = true;
+    }
 
-	void removeItem(Item *i)
-	{
-		log_debug("zroutes: removing %s", qPrintable(i->spec));
+    void removeItem(Item *i) {
+        log_debug("zroutes: removing %s", qPrintable(i->spec));
 
-		assert(i->refs == 0 && i->manager->connectionCount() == 0);
-		itemsBySpec.remove(i->spec);
-		itemsByManager.remove(i->manager.get());
-		delete i;
-	}
+        assert(i->refs == 0 && i->manager->connectionCount() == 0);
+        itemsBySpec.remove(i->spec);
+        itemsByManager.remove(i->manager.get());
+        delete i;
+    }
 
-	void removeUnused()
-	{
-		QList<Item*> toRemove;
-		QHashIterator<QString, Item*> it(itemsBySpec);
-		while(it.hasNext())
-		{
-			it.next();
-			Item *i = it.value();
+    void removeUnused() {
+        QList<Item *> toRemove;
+        QHashIterator<QString, Item *> it(itemsBySpec);
+        while (it.hasNext()) {
+            it.next();
+            Item *i = it.value();
 
-			if(i->markedForRemoval && i->refs == 0 && i->manager->connectionCount() == 0)
-				toRemove += i;
-		}
+            if (i->markedForRemoval && i->refs == 0 && i->manager->connectionCount() == 0)
+                toRemove += i;
+        }
 
-		foreach(Item *i, toRemove)
-			removeItem(i);
-	}
+        foreach (Item *i, toRemove)
+            removeItem(i);
+    }
 };
 
-ZRoutes::ZRoutes()
-{
-	d = new Private(this);
+ZRoutes::ZRoutes() { d = new Private(this); }
+
+ZRoutes::~ZRoutes() { delete d; }
+
+void ZRoutes::setInstanceId(const QByteArray &id) { d->instanceId = id; }
+
+void ZRoutes::setDefaultOutSpecs(const QStringList &specs) { d->defaultOutSpecs = specs; }
+
+void ZRoutes::setDefaultOutStreamSpecs(const QStringList &specs) {
+    d->defaultOutStreamSpecs = specs;
 }
 
-ZRoutes::~ZRoutes()
-{
-	delete d;
+void ZRoutes::setDefaultInSpecs(const QStringList &specs) { d->defaultInSpecs = specs; }
+
+void ZRoutes::setup(const QList<DomainMap::ZhttpRoute> &routes) {
+    d->ensureDefaultItem();
+
+    QList<DomainMap::ZhttpRoute> toAdd;
+    foreach (const DomainMap::ZhttpRoute &route, routes) {
+        if (!d->itemsBySpec.contains(route.baseSpec))
+            toAdd += route;
+    }
+
+    QStringList toRemove;
+    QHashIterator<QString, Private::Item *> it(d->itemsBySpec);
+    while (it.hasNext()) {
+        it.next();
+        const QString &spec = it.key();
+
+        bool found = false;
+        foreach (const DomainMap::ZhttpRoute &route, routes) {
+            if (route.baseSpec == spec) {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            toRemove += spec;
+    }
+
+    foreach (const QString &spec, toRemove) {
+        Private::Item *i = d->itemsBySpec.value(spec);
+        assert(i);
+
+        d->tryRemoveItem(i);
+    }
+
+    foreach (const DomainMap::ZhttpRoute &route, toAdd) {
+        log_debug("zroutes: adding %s", qPrintable(route.baseSpec));
+        d->ensureItem(route);
+    }
 }
 
-void ZRoutes::setInstanceId(const QByteArray &id)
-{
-	d->instanceId = id;
+ZhttpManager *ZRoutes::defaultManager() { return d->ensureDefaultItem()->manager.get(); }
+
+ZhttpManager *ZRoutes::managerForRoute(const DomainMap::ZhttpRoute &route) {
+    return d->ensureItem(route)->manager.get();
 }
 
-void ZRoutes::setDefaultOutSpecs(const QStringList &specs)
-{
-	d->defaultOutSpecs = specs;
+void ZRoutes::addRef(ZhttpManager *zhttpManager) {
+    Private::Item *i =
+        (d->defaultItem->manager.get() == zhttpManager ? d->defaultItem
+                                                       : d->itemsByManager.value(zhttpManager));
+    assert(i);
+    ++(i->refs);
 }
 
-void ZRoutes::setDefaultOutStreamSpecs(const QStringList &specs)
-{
-	d->defaultOutStreamSpecs = specs;
-}
-
-void ZRoutes::setDefaultInSpecs(const QStringList &specs)
-{
-	d->defaultInSpecs = specs;
-}
-
-void ZRoutes::setup(const QList<DomainMap::ZhttpRoute> &routes)
-{
-	d->ensureDefaultItem();
-
-	QList<DomainMap::ZhttpRoute> toAdd;
-	foreach(const DomainMap::ZhttpRoute &route, routes)
-	{
-		if(!d->itemsBySpec.contains(route.baseSpec))
-			toAdd += route;
-	}
-
-	QStringList toRemove;
-	QHashIterator<QString, Private::Item*> it(d->itemsBySpec);
-	while(it.hasNext())
-	{
-		it.next();
-		const QString &spec = it.key();
-
-		bool found = false;
-		foreach(const DomainMap::ZhttpRoute &route, routes)
-		{
-			if(route.baseSpec == spec)
-			{
-				found = true;
-				break;
-			}
-		}
-		if(!found)
-			toRemove += spec;
-	}
-
-	foreach(const QString &spec, toRemove)
-	{
-		Private::Item *i = d->itemsBySpec.value(spec);
-		assert(i);
-
-		d->tryRemoveItem(i);
-	}
-
-	foreach(const DomainMap::ZhttpRoute &route, toAdd)
-	{
-		log_debug("zroutes: adding %s", qPrintable(route.baseSpec));
-		d->ensureItem(route);
-	}
-}
-
-ZhttpManager *ZRoutes::defaultManager()
-{
-	return d->ensureDefaultItem()->manager.get();
-}
-
-ZhttpManager *ZRoutes::managerForRoute(const DomainMap::ZhttpRoute &route)
-{
-	return d->ensureItem(route)->manager.get();
-}
-
-void ZRoutes::addRef(ZhttpManager *zhttpManager)
-{
-	Private::Item *i = (d->defaultItem->manager.get() == zhttpManager ? d->defaultItem : d->itemsByManager.value(zhttpManager));
-	assert(i);
-	++(i->refs);
-}
-
-void ZRoutes::removeRef(ZhttpManager *zhttpManager)
-{
-	Private::Item *i = (d->defaultItem->manager.get() == zhttpManager ? d->defaultItem : d->itemsByManager.value(zhttpManager));
-	assert(i);
-	assert(i->refs > 0);
-	--(i->refs);
+void ZRoutes::removeRef(ZhttpManager *zhttpManager) {
+    Private::Item *i =
+        (d->defaultItem->manager.get() == zhttpManager ? d->defaultItem
+                                                       : d->itemsByManager.value(zhttpManager));
+    assert(i);
+    assert(i->refs > 0);
+    --(i->refs);
 }

--- a/src/proxy/zroutes.h
+++ b/src/proxy/zroutes.h
@@ -24,32 +24,32 @@
 #ifndef ZROUTES_H
 #define ZROUTES_H
 
-#include "zhttpmanager.h"
 #include "domainmap.h"
+#include "zhttpmanager.h"
 
-/// Manages the initialization, storage, and lookup mapping of the ZhttpManager instance for each route
-class ZRoutes
-{
+/// Manages the initialization, storage, and lookup mapping of the ZhttpManager
+/// instance for each route
+class ZRoutes {
 public:
-	ZRoutes();
-	~ZRoutes();
+    ZRoutes();
+    ~ZRoutes();
 
-	void setInstanceId(const QByteArray &id);
-	void setDefaultOutSpecs(const QStringList &specs);
-	void setDefaultOutStreamSpecs(const QStringList &specs);
-	void setDefaultInSpecs(const QStringList &specs);
+    void setInstanceId(const QByteArray &id);
+    void setDefaultOutSpecs(const QStringList &specs);
+    void setDefaultOutStreamSpecs(const QStringList &specs);
+    void setDefaultInSpecs(const QStringList &specs);
 
-	void setup(const QList<DomainMap::ZhttpRoute> &routes);
+    void setup(const QList<DomainMap::ZhttpRoute> &routes);
 
-	ZhttpManager *defaultManager();
-	ZhttpManager *managerForRoute(const DomainMap::ZhttpRoute &route);
+    ZhttpManager *defaultManager();
+    ZhttpManager *managerForRoute(const DomainMap::ZhttpRoute &route);
 
-	void addRef(ZhttpManager *zhttpManager);
-	void removeRef(ZhttpManager *zhttpManager);
+    void addRef(ZhttpManager *zhttpManager);
+    void removeRef(ZhttpManager *zhttpManager);
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/proxy/zrpcchecker.cpp
+++ b/src/proxy/zrpcchecker.cpp
@@ -23,224 +23,165 @@
 
 #include "zrpcchecker.h"
 
-#include <assert.h>
-#include <QHash>
 #include "timer.h"
 #include "zrpcrequest.h"
+#include <QHash>
+#include <assert.h>
 
 #define CHECK_TIMEOUT 8
 
 using std::map;
 
-class ZrpcChecker::Private
-{
+class ZrpcChecker::Private {
 public:
-	class Item
-	{
-	public:
-		ZrpcRequest *req;
-		bool owned;
+    class Item {
+    public:
+        ZrpcRequest *req;
+        bool owned;
 
-		Item() :
-			req(0),
-			owned(false)
-		{
-		}
+        Item() : req(0), owned(false) {}
 
-		~Item()
-		{
-			if(owned)
-				delete req;
-		}
-	};
+        ~Item() {
+            if (owned)
+                delete req;
+        }
+    };
 
-	struct ZrpcReqConnections{
-		Connection finishedConnection;
-		Connection destroyedConnection;
-	};
+    struct ZrpcReqConnections {
+        Connection finishedConnection;
+        Connection destroyedConnection;
+    };
 
-	ZrpcChecker *q;
-	bool avail;
-	std::unique_ptr<Timer> timer;
-	QHash<ZrpcRequest*, Item*> requestsByReq;
-	map<ZrpcRequest*, ZrpcReqConnections> reqConnectionMap;
-	Connection timerConnection;
+    ZrpcChecker *q;
+    bool avail;
+    std::unique_ptr<Timer> timer;
+    QHash<ZrpcRequest *, Item *> requestsByReq;
+    map<ZrpcRequest *, ZrpcReqConnections> reqConnectionMap;
+    Connection timerConnection;
 
-	Private(ZrpcChecker *_q) :
-		q(_q),
-		avail(true)
-	{
-		timer = std::make_unique<Timer>();
-		timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
-		timer->setSingleShot(true);
-	}
+    Private(ZrpcChecker *_q) : q(_q), avail(true) {
+        timer = std::make_unique<Timer>();
+        timerConnection = timer->timeout.connect(boost::bind(&Private::timer_timeout, this));
+        timer->setSingleShot(true);
+    }
 
-	~Private()
-	{
-		cleanup();
-	}
+    ~Private() { cleanup(); }
 
-	void cleanup()
-	{
-		if(timer)
-		{
-			timerConnection.disconnect();
-			timer.reset();
-		}
+    void cleanup() {
+        if (timer) {
+            timerConnection.disconnect();
+            timer.reset();
+        }
 
-		QHashIterator<ZrpcRequest*, Item*> it(requestsByReq);
-		while(it.hasNext())
-		{
-			it.next();
-			Item *i = it.value();
-			reqConnectionMap.erase(i->req);
-			delete i;
-		}
+        QHashIterator<ZrpcRequest *, Item *> it(requestsByReq);
+        while (it.hasNext()) {
+            it.next();
+            Item *i = it.value();
+            reqConnectionMap.erase(i->req);
+            delete i;
+        }
 
-		requestsByReq.clear();
-	}
+        requestsByReq.clear();
+    }
 
-	void restartCountdown()
-	{
-		timer->start(CHECK_TIMEOUT * 1000);
-	}
+    void restartCountdown() { timer->start(CHECK_TIMEOUT * 1000); }
 
-	void watch(ZrpcRequest *req)
-	{
-		Item *i = requestsByReq.value(req);
-		if(i)
-			return; // Already watching
+    void watch(ZrpcRequest *req) {
+        Item *i = requestsByReq.value(req);
+        if (i)
+            return; // Already watching
 
-		reqConnectionMap[req] = {
-			req->finished.connect(boost::bind(&Private::req_finished, this, req)),
-			req->destroyed.connect(boost::bind(&Private::req_destroyed, this, req))
-		};
+        reqConnectionMap[req] = {
+            req->finished.connect(boost::bind(&Private::req_finished, this, req)),
+            req->destroyed.connect(boost::bind(&Private::req_destroyed, this, req))};
 
-		i = new Item;
-		i->req = req;
-		i->owned = false;
-		requestsByReq.insert(req, i);
+        i = new Item;
+        i->req = req;
+        i->owned = false;
+        requestsByReq.insert(req, i);
 
-		// Start the clock if we haven't yet
-		if(!timer->isActive())
-			restartCountdown();
-	}
+        // Start the clock if we haven't yet
+        if (!timer->isActive())
+            restartCountdown();
+    }
 
-	void give(ZrpcRequest *req)
-	{
-		Item *i = requestsByReq.value(req);
-		if(i)
-		{
-			// Take over ownership
-			i->owned = true;
-		}
-		else
-		{
-			// If we aren't watching (or were watching, but no
-			// longer watching), then just delete what we were
-			// given
-			reqConnectionMap.erase(req);
-			delete req;
-		}
-	}
+    void give(ZrpcRequest *req) {
+        Item *i = requestsByReq.value(req);
+        if (i) {
+            // Take over ownership
+            i->owned = true;
+        } else {
+            // If we aren't watching (or were watching, but no
+            // longer watching), then just delete what we were
+            // given
+            reqConnectionMap.erase(req);
+            delete req;
+        }
+    }
 
-	void handleSuccess()
-	{
-		avail = true;
+    void handleSuccess() {
+        avail = true;
 
-		// Success means we restart (or stop) the clock
-		if(!requestsByReq.isEmpty())
-			restartCountdown();
-		else
-			timer->stop();
-	}
+        // Success means we restart (or stop) the clock
+        if (!requestsByReq.isEmpty())
+            restartCountdown();
+        else
+            timer->stop();
+    }
 
-	void handleError()
-	{
-		if(!requestsByReq.isEmpty())
-		{
-			// Let the clock keep running
-		}
-		else
-		{
-			// Stop clock and immediately indicate unavailability
-			timer->stop();
-			avail = false;
-		}
-	}
+    void handleError() {
+        if (!requestsByReq.isEmpty()) {
+            // Let the clock keep running
+        } else {
+            // Stop clock and immediately indicate unavailability
+            timer->stop();
+            avail = false;
+        }
+    }
 
-	void req_finished(ZrpcRequest *req)
-	{
-		Item *i = requestsByReq.value(req);
-		assert(i);
+    void req_finished(ZrpcRequest *req) {
+        Item *i = requestsByReq.value(req);
+        assert(i);
 
-		bool success = req->success();
-		ZrpcRequest::ErrorCondition e = req->errorCondition();
+        bool success = req->success();
+        ZrpcRequest::ErrorCondition e = req->errorCondition();
 
-		reqConnectionMap.erase(req);
-		requestsByReq.remove(req);
-		delete i;
+        reqConnectionMap.erase(req);
+        requestsByReq.remove(req);
+        delete i;
 
-		if(success)
-		{
-			handleSuccess();
-		}
-		else
-		{
-			if(e == ZrpcRequest::ErrorTimeout || e == ZrpcRequest::ErrorUnavailable)
-			{
-				handleError();
-			}
-			else
-			{
-				// Any other error is fine, it means the inspector is responding
-				handleSuccess();
-			}
-		}
-	}
+        if (success) {
+            handleSuccess();
+        } else {
+            if (e == ZrpcRequest::ErrorTimeout || e == ZrpcRequest::ErrorUnavailable) {
+                handleError();
+            } else {
+                // Any other error is fine, it means the inspector is responding
+                handleSuccess();
+            }
+        }
+    }
 
-	void req_destroyed(ZrpcRequest *req)
-	{
-		Item *i = requestsByReq.value(req);
-		assert(i);
+    void req_destroyed(ZrpcRequest *req) {
+        Item *i = requestsByReq.value(req);
+        assert(i);
 
-		reqConnectionMap.erase(req);
-		requestsByReq.remove(req);
-		delete i;
-	}
+        reqConnectionMap.erase(req);
+        requestsByReq.remove(req);
+        delete i;
+    }
 
-	void timer_timeout()
-	{
-		avail = false;
-	}
+    void timer_timeout() { avail = false; }
 };
 
-ZrpcChecker::ZrpcChecker()
-{
-	d = new Private(this);
-}
+ZrpcChecker::ZrpcChecker() { d = new Private(this); }
 
-ZrpcChecker::~ZrpcChecker()
-{
-	delete d;
-}
-        
-bool ZrpcChecker::isInterfaceAvailable() const
-{
-	return d->avail;
-}
+ZrpcChecker::~ZrpcChecker() { delete d; }
 
-void ZrpcChecker::setInterfaceAvailable(bool available)
-{
-	d->avail = available;
-}
-        
-void ZrpcChecker::watch(ZrpcRequest *req)
-{
-	d->watch(req);
-}
+bool ZrpcChecker::isInterfaceAvailable() const { return d->avail; }
 
-void ZrpcChecker::give(ZrpcRequest *req)
-{
-	d->give(req);
-}
+void ZrpcChecker::setInterfaceAvailable(bool available) { d->avail = available; }
+
+void ZrpcChecker::watch(ZrpcRequest *req) { d->watch(req); }
+
+void ZrpcChecker::give(ZrpcRequest *req) { d->give(req); }

--- a/src/proxy/zrpcchecker.h
+++ b/src/proxy/zrpcchecker.h
@@ -30,26 +30,26 @@ using Connection = boost::signals2::scoped_connection;
 
 class ZrpcRequest;
 
-/// Watches ZRPC requests for success/failure to determine if the handler is reachable
+/// Watches ZRPC requests for success/failure to determine if the handler is
+/// reachable
 ///
 /// All requests should be passed to this class for monitoring. Use
 /// watch() to have it monitor a request, but not own it. Use give() to have
 /// this class take ownership of an already-watched request.
-class ZrpcChecker
-{
+class ZrpcChecker {
 public:
-	ZrpcChecker();
-	~ZrpcChecker();
+    ZrpcChecker();
+    ~ZrpcChecker();
 
-	bool isInterfaceAvailable() const;
-	void setInterfaceAvailable(bool available);
+    bool isInterfaceAvailable() const;
+    void setInterfaceAvailable(bool available);
 
-	void watch(ZrpcRequest *req);
-	void give(ZrpcRequest *req);
+    void watch(ZrpcRequest *req);
+    void give(ZrpcRequest *req);
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/runner/connmgrservice.cpp
+++ b/src/runner/connmgrservice.cpp
@@ -22,135 +22,110 @@
 
 #include "connmgrservice.h"
 
-#include <QDir>
-#include <QProcess>
-#include "url.h"
 #include "log.h"
 #include "template.h"
+#include "url.h"
+#include <QDir>
+#include <QProcess>
 
-ConnmgrService::ConnmgrService(
-	const QString &name,
-	const QString &binFile,
-	const QString &runDir,
-	const QString &logDir,
-	const QString &ipcPrefix,
-	const QString &filePrefix,
-	int logLevel,
-	const QString &certsDir,
-	int clientBufferSize,
-	int maxconn,
-	bool allowCompression,
-	const QList<ListenPort> &ports,
-	bool enableClient)
-{
-	args_ += binFile;
+ConnmgrService::ConnmgrService(const QString &name, const QString &binFile, const QString &runDir,
+                               const QString &logDir, const QString &ipcPrefix,
+                               const QString &filePrefix, int logLevel, const QString &certsDir,
+                               int clientBufferSize, int maxconn, bool allowCompression,
+                               const QList<ListenPort> &ports, bool enableClient) {
+    args_ += binFile;
 
-	if(!logDir.isEmpty())
-	{
-		setStandardOutputFile(QDir(logDir).filePath(filePrefix + name + ".log"));
-	}
+    if (!logDir.isEmpty()) {
+        setStandardOutputFile(QDir(logDir).filePath(filePrefix + name + ".log"));
+    }
 
-	if(logLevel >= 0)
-		args_ += "--log-level=" + QString::number(logLevel);
+    if (logLevel >= 0)
+        args_ += "--log-level=" + QString::number(logLevel);
 
-	args_ += "--buffer-size=" + QString::number(clientBufferSize);
+    args_ += "--buffer-size=" + QString::number(clientBufferSize);
 
-	args_ += "--stream-maxconn=" + QString::number(maxconn);
+    args_ += "--stream-maxconn=" + QString::number(maxconn);
 
-	if(allowCompression)
-		args_ += "--compression";
+    if (allowCompression)
+        args_ += "--compression";
 
-	if(!ports.isEmpty())
-	{
-		// Server mode
+    if (!ports.isEmpty()) {
+        // Server mode
 
-		bool usingSsl = false;
+        bool usingSsl = false;
 
-		foreach(const ListenPort &p, ports)
-		{
-			if(!p.localPath.isEmpty())
-			{
-				QString arg = "--listen=" + p.localPath + ",local,stream";
+        foreach (const ListenPort &p, ports) {
+            if (!p.localPath.isEmpty()) {
+                QString arg = "--listen=" + p.localPath + ",local,stream";
 
-				if(p.mode >= 0)
-					arg += ",mode=" + QString::number(p.mode, 8);
+                if (p.mode >= 0)
+                    arg += ",mode=" + QString::number(p.mode, 8);
 
-				if(!p.user.isEmpty())
-					arg += ",user=" + p.user;
+                if (!p.user.isEmpty())
+                    arg += ",user=" + p.user;
 
-				if(!p.group.isEmpty())
-					arg += ",group=" + p.group;
+                if (!p.group.isEmpty())
+                    arg += ",group=" + p.group;
 
-				args_ += arg;
-			}
-			else
-			{
-				Url url;
-				url.setHost(!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
-				url.setPort(p.port);
+                args_ += arg;
+            } else {
+                Url url;
+                url.setHost(!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
+                url.setPort(p.port);
 
-				QString arg = "--listen=" + url.authority() + ",stream";
+                QString arg = "--listen=" + url.authority() + ",stream";
 
-				if(p.ssl)
-				{
-					usingSsl = true;
+                if (p.ssl) {
+                    usingSsl = true;
 
-					arg += ",tls,default-cert=default_" + QString::number(p.port);
-				}
+                    arg += ",tls,default-cert=default_" + QString::number(p.port);
+                }
 
-				args_ += arg;
-			}
-		}
+                args_ += arg;
+            }
+        }
 
-		args_ += "--zclient-stream=ipc://" + runDir + "/" + ipcPrefix + "connmgr";
+        args_ += "--zclient-stream=ipc://" + runDir + "/" + ipcPrefix + "connmgr";
 
-		if(usingSsl)
-			args_ += "--tls-identities-dir=" + certsDir;
-	}
+        if (usingSsl)
+            args_ += "--tls-identities-dir=" + certsDir;
+    }
 
-	if(enableClient)
-	{
-		// Client mode
+    if (enableClient) {
+        // Client mode
 
-		args_ += "--zserver-stream=ipc://" + runDir + "/" + ipcPrefix + "connmgr-client";
+        args_ += "--zserver-stream=ipc://" + runDir + "/" + ipcPrefix + "connmgr-client";
 
-		args_ += "--deny-out-internal";
-	}
+        args_ += "--deny-out-internal";
+    }
 
-	setName(name);
-	setPidFile(QDir(runDir).filePath(filePrefix + name + ".pid"));
+    setName(name);
+    setPidFile(QDir(runDir).filePath(filePrefix + name + ".pid"));
 }
 
-QStringList ConnmgrService::arguments() const
-{
-	return args_;
-}
+QStringList ConnmgrService::arguments() const { return args_; }
 
-bool ConnmgrService::hasClientMode(const QString &binFile)
-{
-	QProcess proc;
+bool ConnmgrService::hasClientMode(const QString &binFile) {
+    QProcess proc;
 
-	proc.start(binFile, QStringList() << "--help");
+    proc.start(binFile, QStringList() << "--help");
 
-	if(!proc.waitForFinished(-1))
-	{
-		log_error("Failed to run connmgr: process error: %d", proc.error());
-		return false;
-	}
+    if (!proc.waitForFinished(-1)) {
+        log_error("Failed to run connmgr: process error: %d", proc.error());
+        return false;
+    }
 
-	if(proc.exitStatus() != QProcess::NormalExit)
-	{
-		log_error("Failed to run connmgr: process did not exit normally");
-		return false;
-	}
+    if (proc.exitStatus() != QProcess::NormalExit) {
+        log_error("Failed to run connmgr: process did not exit normally");
+        return false;
+    }
 
-	int code = proc.exitCode();
-	if(proc.exitCode() != 0)
-	{
-		log_error("connmgr returned non-zero status: %d", code);
-		return false;
-	}
+    int code = proc.exitCode();
+    if (proc.exitCode() != 0) {
+        log_error("connmgr returned non-zero status: %d", code);
+        return false;
+    }
 
-	QByteArray output = proc.readAllStandardOutput();
-	return output.contains("--zserver-stream");
+    QByteArray output = proc.readAllStandardOutput();
+    return output.contains("--zserver-stream");
 }

--- a/src/runner/connmgrservice.h
+++ b/src/runner/connmgrservice.h
@@ -23,35 +23,24 @@
 #ifndef CONNMGRSERVICE_H
 #define CONNMGRSERVICE_H
 
-#include "service.h"
 #include "listenport.h"
+#include "service.h"
 
-class ConnmgrService : public Service
-{
+class ConnmgrService : public Service {
 public:
-	ConnmgrService(
-		const QString &name,
-		const QString &binFile,
-		const QString &runDir,
-		const QString &logDir,
-		const QString &ipcPrefix,
-		const QString &filePrefix,
-		int logLevel,
-		const QString &certsDir,
-		int clientBufferSize,
-		int maxconn,
-		bool allowCompression,
-		const QList<ListenPort> &ports,
-		bool enableClient);
+    ConnmgrService(const QString &name, const QString &binFile, const QString &runDir,
+                   const QString &logDir, const QString &ipcPrefix, const QString &filePrefix,
+                   int logLevel, const QString &certsDir, int clientBufferSize, int maxconn,
+                   bool allowCompression, const QList<ListenPort> &ports, bool enableClient);
 
-	static bool hasClientMode(const QString &binFile);
+    static bool hasClientMode(const QString &binFile);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QStringList arguments() const;
+    virtual QStringList arguments() const;
 
 private:
-	QStringList args_;
+    QStringList args_;
 };
 
 #endif

--- a/src/runner/listenport.h
+++ b/src/runner/listenport.h
@@ -25,34 +25,28 @@
 
 #include <QHostAddress>
 
-class ListenPort
-{
+class ListenPort {
 public:
-	QHostAddress addr;
-	int port;
-	bool ssl;
-	QString localPath;
-	int mode;
-	QString user;
-	QString group;
+    QHostAddress addr;
+    int port;
+    bool ssl;
+    QString localPath;
+    int mode;
+    QString user;
+    QString group;
 
-	ListenPort() :
-		port(-1),
-		ssl(false),
-		mode(-1)
-	{
-	}
+    ListenPort() : port(-1), ssl(false), mode(-1) {}
 
-	ListenPort(const QHostAddress &_addr, int _port, bool _ssl, const QString &_localPath = QString(), int _mode = -1, const QString &_user = QString(), const QString &_group = QString()) :
-		addr(_addr),
-		port(_port),
-		ssl(_ssl),
-		localPath(_localPath),
-		mode(_mode),
-		user(_user),
-		group(_group)
-	{
-	}
+    ListenPort(const QHostAddress &_addr, int _port, bool _ssl,
+               const QString &_localPath = QString(), int _mode = -1,
+               const QString &_user = QString(), const QString &_group = QString())
+        : addr(_addr),
+          port(_port),
+          ssl(_ssl),
+          localPath(_localPath),
+          mode(_mode),
+          user(_user),
+          group(_group) {}
 };
 
 #endif

--- a/src/runner/m2adapterservice.cpp
+++ b/src/runner/m2adapterservice.cpp
@@ -22,71 +22,58 @@
 
 #include "m2adapterservice.h"
 
-#include <QDir>
-#include <QProcess>
 #include "log.h"
 #include "template.h"
 #include "variant.h"
+#include <QDir>
+#include <QProcess>
 
-M2AdapterService::M2AdapterService(
-	const QString &binFile,
-	const QString &configTemplateFile,
-	const QString &runDir,
-	const QString &logDir,
-	const QString &ipcPrefix,
-	const QString &filePrefix,
-	int logLevel,
-	const QList<int> &ports)
-{
-	args_ += binFile;
-	args_ += "--config=" + QDir(runDir).filePath(filePrefix + "m2adapter.conf");
+M2AdapterService::M2AdapterService(const QString &binFile, const QString &configTemplateFile,
+                                   const QString &runDir, const QString &logDir,
+                                   const QString &ipcPrefix, const QString &filePrefix,
+                                   int logLevel, const QList<int> &ports) {
+    args_ += binFile;
+    args_ += "--config=" + QDir(runDir).filePath(filePrefix + "m2adapter.conf");
 
-	if(!logDir.isEmpty())
-	{
-		args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "m2adapter.log");
-		setStandardOutputFile(QProcess::nullDevice());
-	}
+    if (!logDir.isEmpty()) {
+        args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "m2adapter.log");
+        setStandardOutputFile(QProcess::nullDevice());
+    }
 
-	if(logLevel >= 0)
-		args_ += "--loglevel=" + QString::number(logLevel);
+    if (logLevel >= 0)
+        args_ += "--loglevel=" + QString::number(logLevel);
 
-	configTemplateFile_ = configTemplateFile;
-	runDir_ = runDir;
-	ipcPrefix_ = ipcPrefix;
-	filePrefix_ = filePrefix;
-	ports_ = ports;
+    configTemplateFile_ = configTemplateFile;
+    runDir_ = runDir;
+    ipcPrefix_ = ipcPrefix;
+    filePrefix_ = filePrefix;
+    ports_ = ports;
 
-	setName("m2a");
-	setPidFile(QDir(runDir).filePath(filePrefix + "m2adapter.pid"));
+    setName("m2a");
+    setPidFile(QDir(runDir).filePath(filePrefix + "m2adapter.pid"));
 }
 
-QStringList M2AdapterService::arguments() const
-{
-	return args_;
-}
+QStringList M2AdapterService::arguments() const { return args_; }
 
-bool M2AdapterService::acceptSighup() const
-{
-	return true;
-}
+bool M2AdapterService::acceptSighup() const { return true; }
 
-bool M2AdapterService::preStart()
-{
-	VariantList portStrs;
-	foreach(int port, ports_)
-		portStrs += QString::number(port);
+bool M2AdapterService::preStart() {
+    VariantList portStrs;
+    foreach (int port, ports_)
+        portStrs += QString::number(port);
 
-	VariantMap context;
-	context["ports"] = portStrs;
-	context["rundir"] = runDir_;
-	context["ipc_prefix"] = ipcPrefix_;
+    VariantMap context;
+    context["ports"] = portStrs;
+    context["rundir"] = runDir_;
+    context["ipc_prefix"] = ipcPrefix_;
 
-	QString error;
-	if(!Template::renderFile(configTemplateFile_, QDir(runDir_).filePath(filePrefix_ + "m2adapter.conf"), context, &error))
-	{
-		log_error("Failed to generate m2adapter config file: %s", qPrintable(error));
-		return false;
-	}
+    QString error;
+    if (!Template::renderFile(configTemplateFile_,
+                              QDir(runDir_).filePath(filePrefix_ + "m2adapter.conf"), context,
+                              &error)) {
+        log_error("Failed to generate m2adapter config file: %s", qPrintable(error));
+        return false;
+    }
 
-	return true;
+    return true;
 }

--- a/src/runner/m2adapterservice.h
+++ b/src/runner/m2adapterservice.h
@@ -25,32 +25,25 @@
 
 #include "service.h"
 
-class M2AdapterService : public Service
-{
+class M2AdapterService : public Service {
 public:
-	M2AdapterService(
-		const QString &binFile,
-		const QString &configTemplateFile,
-		const QString &runDir,
-		const QString &logDir,
-		const QString &ipcPrefix,
-		const QString &filePrefix,
-		int logLevel,
-		const QList<int> &ports);
+    M2AdapterService(const QString &binFile, const QString &configTemplateFile,
+                     const QString &runDir, const QString &logDir, const QString &ipcPrefix,
+                     const QString &filePrefix, int logLevel, const QList<int> &ports);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QStringList arguments() const;
-	virtual bool acceptSighup() const;
-	virtual bool preStart();
+    virtual QStringList arguments() const;
+    virtual bool acceptSighup() const;
+    virtual bool preStart();
 
 private:
-	QStringList args_;
-	QString configTemplateFile_;
-	QString runDir_;
-	QString ipcPrefix_;
-	QString filePrefix_;
-	QList<int> ports_;
+    QStringList args_;
+    QString configTemplateFile_;
+    QString runDir_;
+    QString ipcPrefix_;
+    QString filePrefix_;
+    QList<int> ports_;
 };
 
 #endif

--- a/src/runner/mongrel2service.cpp
+++ b/src/runner/mongrel2service.cpp
@@ -23,201 +23,165 @@
 #include "mongrel2service.h"
 #include "tnetstring.h"
 
+#include "log.h"
+#include "template.h"
+#include "variant.h"
 #include <QDateTime>
 #include <QDir>
 #include <QProcess>
-#include "log.h"
-#include "variant.h"
-#include "template.h"
 
-Mongrel2Service::Mongrel2Service(
-	const QString &binFile,
-	const QString &configFile,
-	const QString &serverName,
-	const QString &runDir,
-	const QString &logDir,
-	const QString &filePrefix,
-	int port,
-	bool ssl,
-	int logLevel) :
-	logLevel_(logLevel)
-{
-	args_ += binFile;
-	args_ += configFile;
-	args_ += serverName;
+Mongrel2Service::Mongrel2Service(const QString &binFile, const QString &configFile,
+                                 const QString &serverName, const QString &runDir,
+                                 const QString &logDir, const QString &filePrefix, int port,
+                                 bool ssl, int logLevel)
+    : logLevel_(logLevel) {
+    args_ += binFile;
+    args_ += configFile;
+    args_ += serverName;
 
-	setName(QString("m2 %1:%2").arg(ssl ? "https" : "http", QString::number(port)));
+    setName(QString("m2 %1:%2").arg(ssl ? "https" : "http", QString::number(port)));
 
-	// Delete stale pid file, if any
-	QString pidFile = QDir(runDir).filePath(filePrefix + "mongrel2_" + QString::number(port) + ".pid");
-	QFile::remove(pidFile);
+    // Delete stale pid file, if any
+    QString pidFile =
+        QDir(runDir).filePath(filePrefix + "mongrel2_" + QString::number(port) + ".pid");
+    QFile::remove(pidFile);
 
-	if(!logDir.isEmpty())
-	{
-		setStandardOutputFile(QDir(logDir).filePath(filePrefix + "mongrel2_" + QString::number(port) + ".log"));
-	}
+    if (!logDir.isEmpty()) {
+        setStandardOutputFile(
+            QDir(logDir).filePath(filePrefix + "mongrel2_" + QString::number(port) + ".log"));
+    }
 }
 
-bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, int maxconn, const QList<ListenPort> &ports, int logLevel)
-{
-	VariantList vinterfaces;
+bool Mongrel2Service::generateConfigFile(const QString &m2shBinFile,
+                                         const QString &configTemplateFile, const QString &runDir,
+                                         const QString &logDir, const QString &ipcPrefix,
+                                         const QString &filePrefix, const QString &certsDir,
+                                         int clientBufferSize, int maxconn,
+                                         const QList<ListenPort> &ports, int logLevel) {
+    VariantList vinterfaces;
 
-	foreach(const ListenPort &p, ports)
-	{
-		if(!p.localPath.isEmpty())
-		{
-			log_error("Cannot use local_ports option with mongrel2");
-			return false;
-		}
+    foreach (const ListenPort &p, ports) {
+        if (!p.localPath.isEmpty()) {
+            log_error("Cannot use local_ports option with mongrel2");
+            return false;
+        }
 
-		VariantMap v;
-		v["addr"] = (!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
-		v["port"] = p.port;
-		v["ssl"] = p.ssl;
-		vinterfaces += v;
-	}
+        VariantMap v;
+        v["addr"] = (!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
+        v["port"] = p.port;
+        v["ssl"] = p.ssl;
+        vinterfaces += v;
+    }
 
-	VariantMap context;
-	context["interfaces"] = vinterfaces;
-	context["rundir"] = runDir;
-	context["logdir"] = logDir;
-	context["loglevel"] = logLevel;
-	context["certdir"] = certsDir;
-	context["ipc_prefix"] = ipcPrefix;
-	context["file_prefix"] = filePrefix;
-	context["limits_buffer_size"] = clientBufferSize;
-	context["disable_access_logging"] = (logLevel >= LOG_LEVEL_INFO) ? 0 : 1;
-	context["superpoll_max_fd"] = maxconn + 1000;
+    VariantMap context;
+    context["interfaces"] = vinterfaces;
+    context["rundir"] = runDir;
+    context["logdir"] = logDir;
+    context["loglevel"] = logLevel;
+    context["certdir"] = certsDir;
+    context["ipc_prefix"] = ipcPrefix;
+    context["file_prefix"] = filePrefix;
+    context["limits_buffer_size"] = clientBufferSize;
+    context["disable_access_logging"] = (logLevel >= LOG_LEVEL_INFO) ? 0 : 1;
+    context["superpoll_max_fd"] = maxconn + 1000;
 
-	QString error;
-	if(!Template::renderFile(configTemplateFile, QDir(runDir).filePath(filePrefix + "mongrel2.conf"), context, &error))
-	{
-		log_error("Failed to generate mongrel2 config file: %s", qPrintable(error));
-		return false;
-	}
+    QString error;
+    if (!Template::renderFile(configTemplateFile,
+                              QDir(runDir).filePath(filePrefix + "mongrel2.conf"), context,
+                              &error)) {
+        log_error("Failed to generate mongrel2 config file: %s", qPrintable(error));
+        return false;
+    }
 
-	QStringList args;
-	args << "load";
-	args << "-config" << QDir(runDir).filePath(filePrefix + "mongrel2.conf");
-	args << "-db" << QDir(runDir).filePath(filePrefix + "mongrel2.sqlite");
+    QStringList args;
+    args << "load";
+    args << "-config" << QDir(runDir).filePath(filePrefix + "mongrel2.conf");
+    args << "-db" << QDir(runDir).filePath(filePrefix + "mongrel2.sqlite");
 
-	int ret = QProcess::execute(m2shBinFile, args);
-	if(ret != 0)
-	{
-		log_error("Failed to run m2sh");
-		return false;
-	}
+    int ret = QProcess::execute(m2shBinFile, args);
+    if (ret != 0) {
+        log_error("Failed to run m2sh");
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
-QStringList Mongrel2Service::arguments() const
-{
-	return args_;
+QStringList Mongrel2Service::arguments() const { return args_; }
+
+bool Mongrel2Service::acceptSighup() const { return true; }
+
+bool Mongrel2Service::alwaysLogStatus() const { return true; }
+
+QString Mongrel2Service::filterLogLine(const int level, const QString &line) const {
+    if (level > logLevel_) {
+        return QString();
+    }
+    QString tstr = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
+    switch (level) {
+    case LOG_LEVEL_DEBUG:
+        return "[DEBUG] " + tstr + " " + line;
+    case LOG_LEVEL_INFO:
+        return "[INFO] " + tstr + " " + line;
+    case LOG_LEVEL_WARNING:
+        return "[WARN] " + tstr + " " + line;
+    default:
+        return "[ERR] " + tstr + " " + line;
+    }
 }
 
-bool Mongrel2Service::acceptSighup() const
-{
-	return true;
-}
+QString Mongrel2Service::formatLogLine(const QString &line) const {
+    if (line.isEmpty()) {
+        return line;
+    }
 
-bool Mongrel2Service::alwaysLogStatus() const
-{
-	return true;
-}
+    TnetString::Type type;
+    int dataOffset;
+    int dataSize;
+    bool isTnetString = TnetString::check(qPrintable(line), 0, &type, &dataOffset, &dataSize);
+    // If line is a valid tnet string, it most probably is an access log entry
+    if (isTnetString) {
+        return filterLogLine(LOG_LEVEL_INFO, line);
+    }
 
-QString Mongrel2Service::filterLogLine(const int level, const QString &line) const
-{
-	if(level > logLevel_)
-	{
-		return QString();
-	}
-	QString tstr = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
-	switch(level)
-	{
-		case LOG_LEVEL_DEBUG:
-			return "[DEBUG] " + tstr + " " + line;
-		case LOG_LEVEL_INFO:
-			return "[INFO] " + tstr + " " + line;
-		case LOG_LEVEL_WARNING:
-			return "[WARN] " + tstr + " " + line;
-		default:
-			return "[ERR] " + tstr + " " + line;
-	}
-}
-
-QString Mongrel2Service::formatLogLine(const QString &line) const
-{
-	if(line.isEmpty())
-	{
-		return line;
-	}
-
-	TnetString::Type type;
-	int dataOffset;
-	int dataSize;
-	bool isTnetString = TnetString::check(qPrintable(line), 0, &type, &dataOffset, &dataSize);
-	// If line is a valid tnet string, it most probably is an access log entry
-	if(isTnetString)
-	{
-		return filterLogLine(LOG_LEVEL_INFO, line);
-	}
-
-	int at = line.indexOf('[');
-	int end;
-	int level;
-	if(at == -1)
-	{
-		QString debugTag("DEBUG");
-		at = line.indexOf(debugTag);
-		if(at == -1)
-		{
-			return filterLogLine(LOG_LEVEL_WARNING, "Can't parse mongrel2 log: " + line);
-		}
-		else
-		{
-			end = at + debugTag.length();
-			level = LOG_LEVEL_DEBUG;
-		}
-	}
-	else
-	{
-		end = line.indexOf(']', at);
-		if(end == -1)
-		{
-			return filterLogLine(LOG_LEVEL_WARNING, "Can't parse mongrel2 log: " + line);
-		}
+    int at = line.indexOf('[');
+    int end;
+    int level;
+    if (at == -1) {
+        QString debugTag("DEBUG");
+        at = line.indexOf(debugTag);
+        if (at == -1) {
+            return filterLogLine(LOG_LEVEL_WARNING, "Can't parse mongrel2 log: " + line);
+        } else {
+            end = at + debugTag.length();
+            level = LOG_LEVEL_DEBUG;
+        }
+    } else {
+        end = line.indexOf(']', at);
+        if (end == -1) {
+            return filterLogLine(LOG_LEVEL_WARNING, "Can't parse mongrel2 log: " + line);
+        }
 
 #if QT_VERSION >= 0x060000
-		QStringView s = QStringView(line).mid(at + 1, end - at - 1);
+        QStringView s = QStringView(line).mid(at + 1, end - at - 1);
 #else
-		QStringRef s = line.midRef(at + 1, end - at - 1);
+        QStringRef s = line.midRef(at + 1, end - at - 1);
 #endif
-		if(s.compare(QLatin1String("DEBUG")) == 0)
-		{
-			level = LOG_LEVEL_DEBUG;
-		}
-		else if(s.compare(QLatin1String("INFO")) == 0)
-		{
-			level = LOG_LEVEL_INFO;
-		}
-		else if(s.compare(QLatin1String("ERROR")) == 0)
-		{
-			level = LOG_LEVEL_ERROR;
-		}
-		else if(s.compare(QLatin1String("WARN")) == 0)
-		{
-			level = LOG_LEVEL_WARNING;
-		}
-		else
-		{
-			return filterLogLine(LOG_LEVEL_WARNING, "Can't parse severity: " + line);
-		}
-	}
+        if (s.compare(QLatin1String("DEBUG")) == 0) {
+            level = LOG_LEVEL_DEBUG;
+        } else if (s.compare(QLatin1String("INFO")) == 0) {
+            level = LOG_LEVEL_INFO;
+        } else if (s.compare(QLatin1String("ERROR")) == 0) {
+            level = LOG_LEVEL_ERROR;
+        } else if (s.compare(QLatin1String("WARN")) == 0) {
+            level = LOG_LEVEL_WARNING;
+        } else {
+            return filterLogLine(LOG_LEVEL_WARNING, "Can't parse severity: " + line);
+        }
+    }
 
-	if(line.size() > end + 1 && line.at(end + 1) == ' ')
-	{
-		end++;
-	}
-	return filterLogLine(level, line.mid(end + 1));
+    if (line.size() > end + 1 && line.at(end + 1) == ' ') {
+        end++;
+    }
+    return filterLogLine(level, line.mid(end + 1));
 }

--- a/src/runner/mongrel2service.h
+++ b/src/runner/mongrel2service.h
@@ -23,40 +23,36 @@
 #ifndef MONGREL2SERVICE_H
 #define MONGREL2SERVICE_H
 
-#include "service.h"
 #include "listenport.h"
+#include "service.h"
 
-class Mongrel2Service : public Service
-{
-	Q_OBJECT
+class Mongrel2Service : public Service {
+    Q_OBJECT
 
 public:
-	Mongrel2Service(
-		const QString &binFile,
-		const QString &configFile,
-		const QString &serverName,
-		const QString &runDir,
-		const QString &logDir,
-		const QString &filePrefix,
-		int port,
-		bool ssl,
-		int logLevel);
+    Mongrel2Service(const QString &binFile, const QString &configFile, const QString &serverName,
+                    const QString &runDir, const QString &logDir, const QString &filePrefix,
+                    int port, bool ssl, int logLevel);
 
-	static bool generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile, const QString &runDir, const QString &logDir, const QString &ipcPrefix, const QString &filePrefix, const QString &certsDir, int clientBufferSize, int maxconn, const QList<ListenPort> &ports, int logLevel);
+    static bool generateConfigFile(const QString &m2shBinFile, const QString &configTemplateFile,
+                                   const QString &runDir, const QString &logDir,
+                                   const QString &ipcPrefix, const QString &filePrefix,
+                                   const QString &certsDir, int clientBufferSize, int maxconn,
+                                   const QList<ListenPort> &ports, int logLevel);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QStringList arguments() const;
-	virtual bool acceptSighup() const;
-	virtual bool alwaysLogStatus() const;
-	virtual QString formatLogLine(const QString &line) const;
+    virtual QStringList arguments() const;
+    virtual bool acceptSighup() const;
+    virtual bool alwaysLogStatus() const;
+    virtual QString formatLogLine(const QString &line) const;
 
 private:
-	QStringList args_;
-	QString prefix_;
-	int logLevel_;
+    QStringList args_;
+    QString prefix_;
+    int logLevel_;
 
-	QString filterLogLine(int, const QString&) const;
+    QString filterLogLine(int, const QString &) const;
 };
 
 #endif

--- a/src/runner/pushpinhandlerservice.cpp
+++ b/src/runner/pushpinhandlerservice.cpp
@@ -25,44 +25,31 @@
 #include <QDir>
 #include <QProcess>
 
-PushpinHandlerService::PushpinHandlerService(
-	const QString &binFile,
-	const QString &configFile,
-	const QString &runDir,
-	const QString &logDir,
-	const QString &ipcPrefix,
-	const QString &filePrefix,
-	int portOffset,
-	int logLevel)
-{
-	args_ += binFile;
-	args_ += "--config=" + configFile;
+PushpinHandlerService::PushpinHandlerService(const QString &binFile, const QString &configFile,
+                                             const QString &runDir, const QString &logDir,
+                                             const QString &ipcPrefix, const QString &filePrefix,
+                                             int portOffset, int logLevel) {
+    args_ += binFile;
+    args_ += "--config=" + configFile;
 
-	if(!ipcPrefix.isEmpty())
-		args_ += "--ipc-prefix=" + ipcPrefix;
+    if (!ipcPrefix.isEmpty())
+        args_ += "--ipc-prefix=" + ipcPrefix;
 
-	if(portOffset > 0)
-		args_ += "--port-offset=" + QString::number(portOffset);
+    if (portOffset > 0)
+        args_ += "--port-offset=" + QString::number(portOffset);
 
-	if(!logDir.isEmpty())
-	{
-		args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "pushpin-handler.log");
-		setStandardOutputFile(QProcess::nullDevice());
-	}
+    if (!logDir.isEmpty()) {
+        args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "pushpin-handler.log");
+        setStandardOutputFile(QProcess::nullDevice());
+    }
 
-	if(logLevel >= 0)
-		args_ += "--loglevel=" + QString::number(logLevel);
+    if (logLevel >= 0)
+        args_ += "--loglevel=" + QString::number(logLevel);
 
-	setName("handler");
-	setPidFile(QDir(runDir).filePath(filePrefix + "pushpin-handler.pid"));
+    setName("handler");
+    setPidFile(QDir(runDir).filePath(filePrefix + "pushpin-handler.pid"));
 }
 
-QStringList PushpinHandlerService::arguments() const
-{
-	return args_;
-}
+QStringList PushpinHandlerService::arguments() const { return args_; }
 
-bool PushpinHandlerService::acceptSighup() const
-{
-	return true;
-}
+bool PushpinHandlerService::acceptSighup() const { return true; }

--- a/src/runner/pushpinhandlerservice.h
+++ b/src/runner/pushpinhandlerservice.h
@@ -25,26 +25,19 @@
 
 #include "service.h"
 
-class PushpinHandlerService : public Service
-{
+class PushpinHandlerService : public Service {
 public:
-	PushpinHandlerService(
-		const QString &binFile,
-		const QString &configFile,
-		const QString &runDir,
-		const QString &logDir,
-		const QString &ipcPrefix,
-		const QString &filePrefix,
-		int portOffset,
-		int logLevel);
+    PushpinHandlerService(const QString &binFile, const QString &configFile, const QString &runDir,
+                          const QString &logDir, const QString &ipcPrefix,
+                          const QString &filePrefix, int portOffset, int logLevel);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QStringList arguments() const;
-	virtual bool acceptSighup() const;
+    virtual QStringList arguments() const;
+    virtual bool acceptSighup() const;
 
 private:
-	QStringList args_;
+    QStringList args_;
 };
 
 #endif

--- a/src/runner/pushpinproxyservice.cpp
+++ b/src/runner/pushpinproxyservice.cpp
@@ -25,44 +25,31 @@
 #include <QDir>
 #include <QProcess>
 
-PushpinProxyService::PushpinProxyService(
-	const QString &binFile,
-	const QString &configFile,
-	const QString &runDir,
-	const QString &logDir,
-	const QString &ipcPrefix,
-	const QString &filePrefix,
-	int logLevel,
-	const QStringList &routeLines)
-{
-	args_ += binFile;
-	args_ += "--config=" + configFile;
+PushpinProxyService::PushpinProxyService(const QString &binFile, const QString &configFile,
+                                         const QString &runDir, const QString &logDir,
+                                         const QString &ipcPrefix, const QString &filePrefix,
+                                         int logLevel, const QStringList &routeLines) {
+    args_ += binFile;
+    args_ += "--config=" + configFile;
 
-	if(!ipcPrefix.isEmpty())
-		args_ += "--ipc-prefix=" + ipcPrefix;
+    if (!ipcPrefix.isEmpty())
+        args_ += "--ipc-prefix=" + ipcPrefix;
 
-	if(!logDir.isEmpty())
-	{
-		args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "pushpin-proxy.log");
-		setStandardOutputFile(QProcess::nullDevice());
-	}
+    if (!logDir.isEmpty()) {
+        args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "pushpin-proxy.log");
+        setStandardOutputFile(QProcess::nullDevice());
+    }
 
-	if(logLevel >= 0)
-		args_ += "--loglevel=" + QString::number(logLevel);
+    if (logLevel >= 0)
+        args_ += "--loglevel=" + QString::number(logLevel);
 
-	foreach(const QString &route, routeLines)
-		args_ += "--route=" + route;
+    foreach (const QString &route, routeLines)
+        args_ += "--route=" + route;
 
-	setName("proxy");
-	setPidFile(QDir(runDir).filePath(filePrefix + "pushpin-proxy.pid"));
+    setName("proxy");
+    setPidFile(QDir(runDir).filePath(filePrefix + "pushpin-proxy.pid"));
 }
 
-QStringList PushpinProxyService::arguments() const
-{
-	return args_;
-}
+QStringList PushpinProxyService::arguments() const { return args_; }
 
-bool PushpinProxyService::acceptSighup() const
-{
-	return true;
-}
+bool PushpinProxyService::acceptSighup() const { return true; }

--- a/src/runner/pushpinproxyservice.h
+++ b/src/runner/pushpinproxyservice.h
@@ -25,26 +25,19 @@
 
 #include "service.h"
 
-class PushpinProxyService : public Service
-{
+class PushpinProxyService : public Service {
 public:
-	PushpinProxyService(
-		const QString &binFile,
-		const QString &configFile,
-		const QString &runDir,
-		const QString &logDir,
-		const QString &ipcPrefix,
-		const QString &filePrefix,
-		int logLevel,
-		const QStringList &routeLines);
+    PushpinProxyService(const QString &binFile, const QString &configFile, const QString &runDir,
+                        const QString &logDir, const QString &ipcPrefix, const QString &filePrefix,
+                        int logLevel, const QStringList &routeLines);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QStringList arguments() const;
-	virtual bool acceptSighup() const;
+    virtual QStringList arguments() const;
+    virtual bool acceptSighup() const;
 
 private:
-	QStringList args_;
+    QStringList args_;
 };
 
 #endif

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -22,830 +22,746 @@
 
 #include "runnerapp.h"
 
-#include <QCoreApplication>
+#include "config.h"
+#include "connmgrservice.h"
+#include "listenport.h"
+#include "log.h"
+#include "m2adapterservice.h"
+#include "mongrel2service.h"
+#include "processquit.h"
+#include "pushpinhandlerservice.h"
+#include "pushpinproxyservice.h"
+#include "rust/bindings.h"
+#include "settings.h"
+#include "url.h"
+#include "zurlservice.h"
 #include <QCommandLineParser>
-#include <QStringList>
+#include <QCoreApplication>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QDir>
-#include "url.h"
+#include <QStringList>
 #include <QUrlQuery>
-#include "rust/bindings.h"
-#include "processquit.h"
-#include "log.h"
-#include "settings.h"
-#include "listenport.h"
-#include "connmgrservice.h"
-#include "mongrel2service.h"
-#include "m2adapterservice.h"
-#include "zurlservice.h"
-#include "pushpinproxyservice.h"
-#include "pushpinhandlerservice.h"
-#include "config.h"
 
-struct ServiceConnections{
-	Connection startedConnection;
-	Connection stoppedConnection;
-	Connection logConnection;
-	Connection errConnection;
+struct ServiceConnections {
+    Connection startedConnection;
+    Connection stoppedConnection;
+    Connection logConnection;
+    Connection errConnection;
 };
 
-static void trimlist(QStringList *list)
-{
-	for(int n = 0; n < list->count(); ++n)
-	{
-		if((*list)[n].isEmpty())
-		{
-			list->removeAt(n);
-			--n; // Adjust position
-		}
-	}
+static void trimlist(QStringList *list) {
+    for (int n = 0; n < list->count(); ++n) {
+        if ((*list)[n].isEmpty()) {
+            list->removeAt(n);
+            --n; // Adjust position
+        }
+    }
 }
 
-static bool ensureDir(const QString &path)
-{
-	QDir dir(path);
-	if(dir.exists())
-		return true;
+static bool ensureDir(const QString &path) {
+    QDir dir(path);
+    if (dir.exists())
+        return true;
 
-	return QDir().mkpath(dir.absolutePath());
+    return QDir().mkpath(dir.absolutePath());
 }
 
-static QPair<QHostAddress, int> parsePort(const QString &s)
-{
-	// If the string doesn't contain a colon character, assume it's a port
-	// number by itself
-	if(!s.contains(':'))
-		return QPair<QHostAddress, int>(QHostAddress(), s.toInt());
+static QPair<QHostAddress, int> parsePort(const QString &s) {
+    // If the string doesn't contain a colon character, assume it's a port
+    // number by itself
+    if (!s.contains(':'))
+        return QPair<QHostAddress, int>(QHostAddress(), s.toInt());
 
-	// Otherwise, assume it's an address:port combination
+    // Otherwise, assume it's an address:port combination
 
-	// Parse with Url in order to support bracketed IPv6 notation
-	Url url{Url::fromUserInput(s)};
+    // Parse with Url in order to support bracketed IPv6 notation
+    Url url{Url::fromUserInput(s)};
 
-	return QPair<QHostAddress, int>(QHostAddress(url.host()), url.port());
+    return QPair<QHostAddress, int>(QHostAddress(url.host()), url.port());
 }
 
-QMap<QString, int> parseLogLevel(const QStringList &parts, QString *errorMessage)
-{
-	QMap<QString, int> levels;
+QMap<QString, int> parseLogLevel(const QStringList &parts, QString *errorMessage) {
+    QMap<QString, int> levels;
 
-	foreach(const QString &part, parts)
-	{
-		if(part.isEmpty())
-		{
-			*errorMessage = "log level component cannot be empty";
-			return QMap<QString, int>();
-		}
+    foreach (const QString &part, parts) {
+        if (part.isEmpty()) {
+            *errorMessage = "log level component cannot be empty";
+            return QMap<QString, int>();
+        }
 
-		int at = part.indexOf(':');
-		if(at != -1)
-		{
-			if(at == 0)
-			{
-				*errorMessage = "log level component name cannot be empty";
-				return QMap<QString, int>();
-			}
+        int at = part.indexOf(':');
+        if (at != -1) {
+            if (at == 0) {
+                *errorMessage = "log level component name cannot be empty";
+                return QMap<QString, int>();
+            }
 
-			QString name = part.mid(0, at);
+            QString name = part.mid(0, at);
 
-			bool ok;
-			int x = part.mid(at + 1).toInt(&ok);
-			if(!ok || x < 0)
-			{
-				*errorMessage = QString("log level for service %1 must be greater than or equal to 0").arg(name);
-				return QMap<QString, int>();
-			}
+            bool ok;
+            int x = part.mid(at + 1).toInt(&ok);
+            if (!ok || x < 0) {
+                *errorMessage =
+                    QString("log level for service %1 must be greater than or equal to 0")
+                        .arg(name);
+                return QMap<QString, int>();
+            }
 
-			levels[name] = x;
-		}
-		else
-		{
-			bool ok;
-			int x = part.toInt(&ok);
-			if(!ok || x < 0)
-			{
-				*errorMessage = "log level must be greater than or equal to 0";
-				return QMap<QString, int>();
-			}
+            levels[name] = x;
+        } else {
+            bool ok;
+            int x = part.toInt(&ok);
+            if (!ok || x < 0) {
+                *errorMessage = "log level must be greater than or equal to 0";
+                return QMap<QString, int>();
+            }
 
-			levels[""] = x;
-		}
-	}
+            levels[""] = x;
+        }
+    }
 
-	return levels;
+    return levels;
 }
 
-enum CommandLineParseResult
-{
-	CommandLineOk,
-	CommandLineError,
-	CommandLineVersionRequested,
-	CommandLineHelpRequested
+enum CommandLineParseResult {
+    CommandLineOk,
+    CommandLineError,
+    CommandLineVersionRequested,
+    CommandLineHelpRequested
 };
 
-class RunnerArgsData
-{
+class RunnerArgsData {
 public:
-	QString configFile;
-	QString logFile;
-	QMap<QString, int> logLevels;
-	bool mergeOutput;
-	QPair<QHostAddress,int> port;
-	int id;
-	QStringList routeLines;
+    QString configFile;
+    QString logFile;
+    QMap<QString, int> logLevels;
+    bool mergeOutput;
+    QPair<QHostAddress, int> port;
+    int id;
+    QStringList routeLines;
 
-	RunnerArgsData() :
-		mergeOutput(false),
-		id(-1)
-	{
-	}
+    RunnerArgsData() : mergeOutput(false), id(-1) {}
 };
 
-static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, RunnerArgsData *args, QString *errorMessage)
-{
-	parser->setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
-	const QCommandLineOption configFileOption("config", "Config file.", "file");
-	parser->addOption(configFileOption);
-	const QCommandLineOption logFileOption("logfile", "File to log to.", "file");
-	parser->addOption(logFileOption);
-	const QCommandLineOption logLevelOption("loglevel", "Log level (default: 2).", "x");
-	parser->addOption(logLevelOption);
-	const QCommandLineOption verboseOption("verbose", "Verbose output. Same as --loglevel=3.");
-	parser->addOption(verboseOption);
-	const QCommandLineOption mergeOutputOption(QStringList() << "m" << "merge-output", "Combine output of subprocesses.");
-	parser->addOption(mergeOutputOption);
-	const QCommandLineOption portOption("port", "Run a single HTTP server instance.", "[addr:]port");
-	parser->addOption(portOption);
-	const QCommandLineOption idOption("id", "Set instance ID (needed to run multiple instances).", "x");
-	parser->addOption(idOption);
-	const QCommandLineOption routeOption("route", "Add route (overrides routes file).", "line");
-	parser->addOption(routeOption);
-	const QCommandLineOption helpOption = parser->addHelpOption();
-	const QCommandLineOption versionOption = parser->addVersionOption();
+static CommandLineParseResult parseCommandLine(QCommandLineParser *parser, RunnerArgsData *args,
+                                               QString *errorMessage) {
+    parser->setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+    const QCommandLineOption configFileOption("config", "Config file.", "file");
+    parser->addOption(configFileOption);
+    const QCommandLineOption logFileOption("logfile", "File to log to.", "file");
+    parser->addOption(logFileOption);
+    const QCommandLineOption logLevelOption("loglevel", "Log level (default: 2).", "x");
+    parser->addOption(logLevelOption);
+    const QCommandLineOption verboseOption("verbose", "Verbose output. Same as --loglevel=3.");
+    parser->addOption(verboseOption);
+    const QCommandLineOption mergeOutputOption(QStringList() << "m" << "merge-output",
+                                               "Combine output of subprocesses.");
+    parser->addOption(mergeOutputOption);
+    const QCommandLineOption portOption("port", "Run a single HTTP server instance.",
+                                        "[addr:]port");
+    parser->addOption(portOption);
+    const QCommandLineOption idOption("id", "Set instance ID (needed to run multiple instances).",
+                                      "x");
+    parser->addOption(idOption);
+    const QCommandLineOption routeOption("route", "Add route (overrides routes file).", "line");
+    parser->addOption(routeOption);
+    const QCommandLineOption helpOption = parser->addHelpOption();
+    const QCommandLineOption versionOption = parser->addVersionOption();
 
-	if(!parser->parse(QCoreApplication::arguments()))
-	{
-		*errorMessage = parser->errorText();
-		return CommandLineError;
-	}
+    if (!parser->parse(QCoreApplication::arguments())) {
+        *errorMessage = parser->errorText();
+        return CommandLineError;
+    }
 
-	if(parser->isSet(versionOption))
-		return CommandLineVersionRequested;
+    if (parser->isSet(versionOption))
+        return CommandLineVersionRequested;
 
-	if(parser->isSet(helpOption))
-		return CommandLineHelpRequested;
+    if (parser->isSet(helpOption))
+        return CommandLineHelpRequested;
 
-	if(parser->isSet(configFileOption))
-		args->configFile = parser->value(configFileOption);
+    if (parser->isSet(configFileOption))
+        args->configFile = parser->value(configFileOption);
 
-	if(parser->isSet(logFileOption))
-		args->logFile = parser->value(logFileOption);
+    if (parser->isSet(logFileOption))
+        args->logFile = parser->value(logFileOption);
 
-	if(parser->isSet(logLevelOption))
-	{
-		QStringList parts = parser->value(logLevelOption).split(',');
-		QMap<QString, int> levels = parseLogLevel(parts, errorMessage);
-		if(levels.isEmpty())
-		{
-			return CommandLineError;
-		}
+    if (parser->isSet(logLevelOption)) {
+        QStringList parts = parser->value(logLevelOption).split(',');
+        QMap<QString, int> levels = parseLogLevel(parts, errorMessage);
+        if (levels.isEmpty()) {
+            return CommandLineError;
+        }
 
-		args->logLevels = levels;
-	}
+        args->logLevels = levels;
+    }
 
-	if(parser->isSet(verboseOption))
-	{
-		args->logLevels.clear();
-		args->logLevels[""] = 3;
-	}
+    if (parser->isSet(verboseOption)) {
+        args->logLevels.clear();
+        args->logLevels[""] = 3;
+    }
 
-	if(parser->isSet(mergeOutputOption))
-		args->mergeOutput = true;
+    if (parser->isSet(mergeOutputOption))
+        args->mergeOutput = true;
 
-	if(parser->isSet(portOption))
-	{
-		args->port = parsePort(parser->value(portOption));
-		if(args->port.second < 1)
-		{
-			*errorMessage = "port must be greater than or equal to 1";
-			return CommandLineError;
-		}
-	}
+    if (parser->isSet(portOption)) {
+        args->port = parsePort(parser->value(portOption));
+        if (args->port.second < 1) {
+            *errorMessage = "port must be greater than or equal to 1";
+            return CommandLineError;
+        }
+    }
 
-	if(parser->isSet(idOption))
-	{
-		bool ok;
-		int x = parser->value(idOption).toInt(&ok);
-		if(!ok || x < 0)
-		{
-			*errorMessage = "id must be greater than or equal to 0";
-			return CommandLineError;
-		}
+    if (parser->isSet(idOption)) {
+        bool ok;
+        int x = parser->value(idOption).toInt(&ok);
+        if (!ok || x < 0) {
+            *errorMessage = "id must be greater than or equal to 0";
+            return CommandLineError;
+        }
 
-		args->id = x;
-	}
+        args->id = x;
+    }
 
-	if(parser->isSet(routeOption))
-	{
-		foreach(const QString &r, parser->values(routeOption))
-			args->routeLines += r;
-	}
+    if (parser->isSet(routeOption)) {
+        foreach (const QString &r, parser->values(routeOption))
+            args->routeLines += r;
+    }
 
-	return CommandLineOk;
+    return CommandLineOk;
 }
 
-class RunnerApp::Private
-{
+class RunnerApp::Private {
 public:
-	RunnerApp *q;
-	RunnerArgsData args;
-	QList<Service*> services;
-	bool stopping;
-	bool errored;
-	Connection quitConnection;
-	Connection hupConnection;
-	map<Service*, ServiceConnections> serviceConnectionMap;
-
-	Private(RunnerApp *_q) :
-		q(_q),
-		stopping(false),
-		errored(false)
-	{
-		quitConnection = ProcessQuit::instance()->quit.connect(boost::bind(&Private::processQuit, this));
-		hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&Private::reload, this));
-	}
-
-	void start()
-	{
-		QCoreApplication::setApplicationName("pushpin");
-		QCoreApplication::setApplicationVersion(Config::get().version);
-
-		QCommandLineParser parser;
-		parser.setApplicationDescription("Reverse proxy for realtime web services.");
-
-		QString errorMessage;
-		switch(parseCommandLine(&parser, &args, &errorMessage))
-		{
-			case CommandLineOk:
-				break;
-			case CommandLineError:
-				fprintf(stderr, "error: %s\n\n%s", qPrintable(errorMessage), qPrintable(parser.helpText()));
-				q->quit(1);
-				return;
-			case CommandLineVersionRequested:
-				printf("%s %s\n", qPrintable(QCoreApplication::applicationName()),
-					qPrintable(QCoreApplication::applicationVersion()));
-				q->quit(0);
-				return;
-			case CommandLineHelpRequested:
-				parser.showHelp();
-				Q_UNREACHABLE();
-		}
-
-		if(!args.logFile.isEmpty())
-		{
-			if(!log_setFile(args.logFile))
-			{
-				log_error("failed to open log file: %s", qPrintable(args.logFile));
-				q->quit(1);
-				return;
-			}
-		}
-
-		QStringList configFileList;
-
-		if(!args.configFile.isEmpty())
-		{
-			configFileList += args.configFile;
-		}
-		else
-		{
-			// ./config
-			configFileList += QDir("config").absoluteFilePath("pushpin.conf");
-
-			// Same dir as executable (NOTE: deprecated)
-			configFileList += QDir(".").absoluteFilePath("pushpin.conf");
-
-			// ./examples/config
-			configFileList += QDir("examples/config").absoluteFilePath("pushpin.conf");
-
-			// Default
-			configFileList += QDir(Config::get().configDir).filePath("pushpin.conf");
-		}
-
-		QString configFile;
-
-		foreach(const QString &f, configFileList)
-		{
-			if(QFileInfo(f).isFile())
-			{
-				configFile = f;
-				break;
-			}
-		}
-
-		if(configFile.isEmpty())
-		{
-			log_error("no configuration file found. Tried: %s", qPrintable(configFileList.join(" ")));
-			q->quit(1);
-			return;
-		}
-
-		// QSettings doesn't inform us if the config file can't be accessed,
-		// so do that ourselves
-		{
-			QFile file(configFile);
-			if(!file.open(QIODevice::ReadOnly))
-			{
-				log_error("failed to open %s", qPrintable(configFile));
-				q->quit(1);
-				return;
-			}
-		}
-
-		int defaultArgsLevel = args.logLevels.value("", LOG_LEVEL_INFO);
-		log_setOutputLevel(args.logLevels.value("runner", defaultArgsLevel));
-
-		log_debug("starting...");
-
-		if(args.configFile.isEmpty())
-			log_info("using config: %s", qPrintable(configFile));
-
-		Settings settings(configFile);
-
-		QString exeDir = QCoreApplication::applicationDirPath();
-
-		// NOTE: libdir in config file is deprecated
-		QString libDir = settings.value("global/libdir").toString();
-
-		if(!libDir.isEmpty())
-		{
-			libDir = QDir(libDir).absoluteFilePath("runner");
-		}
-		else
-		{
-			if(QFile::exists("src/bin/pushpin.rs"))
-			{
-				// Running in tree
-				libDir = QFileInfo("src/runner").absoluteFilePath();
-			}
-			else
-			{
-				// Use compiled value
-				libDir = QDir(Config::get().libDir).absoluteFilePath("runner");
-			}
-		}
-
-		QString ipcPrefix = settings.value("global/ipc_prefix", "pushpin-").toString();
-
-		QString configDir = QFileInfo(configFile).dir().filePath("runner");
-
-		QStringList serviceNames = settings.value("runner/services").toStringList();
-		trimlist(&serviceNames);
-
-		QStringList httpPortStrs = settings.value("runner/http_port").toStringList();
-		trimlist(&httpPortStrs);
-
-		QStringList httpsPortStrs = settings.value("runner/https_ports").toStringList();
-		trimlist(&httpsPortStrs);
-
-		QStringList localPortStrs = settings.value("runner/local_ports").toStringList();
-		trimlist(&localPortStrs);
-
-		QString runDir;
-		if(settings.contains("global/rundir"))
-		{
-			runDir = settings.value("global/rundir").toString();
-		}
-		else
-		{
-			log_warning("rundir in [runner] section is deprecated. put in [global]");
-			runDir = settings.value("runner/rundir").toString();
-		}
-
-		runDir = QDir(runDir).absolutePath();
-
-		QString logDir = settings.value("runner/logdir").toString();
-		logDir = QDir(logDir).absolutePath();
-
-		QMap<QString, int> logLevels;
-
-		QStringList logLevelParts = settings.value("runner/log_level").toStringList();
-		if(!logLevelParts.isEmpty())
-		{
-			logLevels = parseLogLevel(logLevelParts, &errorMessage);
-			if(logLevels.isEmpty())
-			{
-				fprintf(stderr, "error: %s\n", qPrintable(errorMessage));
-				q->quit(1);
-				return;
-			}
-		}
-
-		// Command line overrides config file
-		if(!args.logLevels.isEmpty())
-			logLevels = args.logLevels;
-
-		// If default log level not provided, use info level
-		int defaultLevel = logLevels.value("", 2);
-
-		// NOTE: since we only finally set the log level here, earlier
-		// log messages outside the default level will be lost (if any)
-		log_setOutputLevel(logLevels.value("runner", defaultLevel));
-
-		int clientBufferSize = settings.value("runner/client_buffer_size", 8192).toInt();
-		int clientMaxConnections = settings.value("runner/client_maxconn", 50000).toInt();
-
-		bool allowCompression = settings.value("runner/allow_compression").toBool();
-
-		QString targetDir;
-		if(ffi::is_debug_build())
-			targetDir = QDir(exeDir).filePath("target/debug");
-		else
-			targetDir = QDir(exeDir).filePath("target/release");
-
-		QString m2aBin = "m2adapter";
-		QFileInfo fi(QDir(targetDir).filePath("m2adapter"));
-		if(fi.isFile())
-			m2aBin = fi.canonicalFilePath();
-
-		QString connmgrBin = "pushpin-connmgr";
-		fi = QFileInfo(QDir(targetDir).filePath("pushpin-connmgr"));
-		if(fi.isFile())
-			connmgrBin = fi.canonicalFilePath();
-
-		QString proxyBin = "pushpin-proxy";
-		fi = QFileInfo(QDir(targetDir).filePath("pushpin-proxy"));
-		if(fi.isFile())
-			proxyBin = fi.canonicalFilePath();
-
-		QString handlerBin = "pushpin-handler";
-		fi = QFileInfo(QDir(targetDir).filePath("pushpin-handler"));
-		if(fi.isFile())
-			handlerBin = fi.canonicalFilePath();
-
-		if(!ensureDir(runDir))
-		{
-			log_error("failed to create directory: %s", qPrintable(runDir));
-			q->quit(1);
-			return;
-		}
-
-		if(!args.mergeOutput && !ensureDir(logDir))
-		{
-			log_error("failed to create directory: %s", qPrintable(logDir));
-			q->quit(1);
-			return;
-		}
-
-		int portOffset = 0;
-		QString filePrefix;
-
-		QList<ListenPort> ports;
-
-		if(args.port.second > 0)
-		{
-			// If port specified then instantiate a single http server
-			ports += ListenPort(args.port.first, args.port.second, false);
-		}
-		else
-		{
-			foreach(const QString &httpPortStr, httpPortStrs)
-			{
-				QPair<QHostAddress, int> p = parsePort(httpPortStr);
-				if(p.second < 0)
-				{
-					log_error("invalid http port: %s", qPrintable(httpPortStr));
-					q->quit(1);
-					return;
-				}
-
-				ports += ListenPort(p.first, p.second, false);
-			}
-
-			foreach(const QString &httpsPortStr, httpsPortStrs)
-			{
-				QPair<QHostAddress, int> p = parsePort(httpsPortStr);
-				if(p.second < 1)
-				{
-					log_error("invalid https port: %s", qPrintable(httpsPortStr));
-					q->quit(1);
-					return;
-				}
-
-				ports += ListenPort(p.first, p.second, true);
-			}
-
-			foreach(const QString &localPortStr, localPortStrs)
-			{
-				Url path = Url::fromEncoded(localPortStr.toUtf8());
-				if(!path.isValid())
-				{
-					log_error("invalid local port: %s", qPrintable(localPortStr));
-					q->quit(1);
-					return;
-				}
-
-				QUrlQuery query(path.query());
-
-				int mode = -1;
-				if(query.hasQueryItem("mode"))
-				{
-					QString modeStr = query.queryItemValue("mode");
-					bool ok = false;
-					mode = modeStr.toInt(&ok, 8);
-					if(!ok)
-					{
-						log_error("invalid mode: %s", qPrintable(modeStr));
-						q->quit(1);
-						return;
-					}
-				}
-
-				QString user = query.queryItemValue("user");
-				QString group = query.queryItemValue("group");
-
-				ports += ListenPort(QHostAddress(), 0, true, path.path(), mode, user, group);
-			}
-		}
-
-		if(ports.isEmpty())
-		{
-			log_error("no server ports configured");
-			q->quit(1);
-			return;
-		}
-
-		if(args.id >= 0)
-		{
-			ipcPrefix = QString("p%1-").arg(args.id);
-			portOffset = args.id * 10;
-			filePrefix = ipcPrefix;
-		}
-
-		if(logLevels.contains("pushpin-proxy"))
-		{
-			logLevels["proxy"] = logLevels["pushpin-proxy"];
-			logLevels.remove("pushpin-proxy");
-		}
-
-		if(logLevels.contains("pushpin-handler"))
-		{
-			logLevels["handler"] = logLevels["pushpin-handler"];
-			logLevels.remove("pushpin-handler");
-		}
-
-		if(serviceNames.contains("condure"))
-		{
-			serviceNames.removeAll("condure");
-			serviceNames += "connmgr";
-		}
-
-		if(serviceNames.contains("pushpin-proxy"))
-		{
-			serviceNames.removeAll("pushpin-proxy");
-			serviceNames += "proxy";
-		}
-
-		if(serviceNames.contains("pushpin-handler"))
-		{
-			serviceNames.removeAll("pushpin-handler");
-			serviceNames += "handler";
-		}
-
-		if(serviceNames.contains("connmgr") && (serviceNames.contains("mongrel2") || serviceNames.contains("m2adapter")))
-		{
-			log_error("cannot enable the connmgr service at the same time as mongrel2 or m2adapter");
-			q->quit(1);
-			return;
-		}
-
-		if(serviceNames.contains("connmgr"))
-		{
-			QString certsDir = QDir(configDir).filePath("certs");
-
-			bool useClient = false;
-
-			if(!serviceNames.contains("zurl") && ConnmgrService::hasClientMode(connmgrBin))
-				useClient = true;
-
-			services += new ConnmgrService("connmgr", connmgrBin, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevels.value("connmgr", defaultLevel), certsDir, clientBufferSize, clientMaxConnections, allowCompression, ports, useClient);
-		}
-
-		if(serviceNames.contains("mongrel2"))
-		{
-			QString m2Bin = "mongrel2";
-			if(settings.contains("runner/mongrel2_bin"))
-				m2Bin = settings.value("runner/mongrel2_bin").toString();
-
-			QString m2shBin = "m2sh";
-			if(settings.contains("runner/m2sh_bin"))
-				m2shBin = settings.value("runner/m2sh_bin").toString();
-
-			QString certsDir = QDir(configDir).filePath("certs");
-			if(!Mongrel2Service::generateConfigFile(m2shBin, QDir(libDir).filePath("mongrel2.conf.template"), runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, certsDir, clientBufferSize, clientMaxConnections, ports, logLevels.value("mongrel2", defaultLevel)))
-			{
-				q->quit(1);
-				return;
-			}
-
-			foreach(const ListenPort &p, ports)
-				services += new Mongrel2Service(m2Bin, QDir(runDir).filePath(QString("%1mongrel2.sqlite").arg(filePrefix)), "default_" + QString::number(p.port), runDir, !args.mergeOutput ? logDir : QString(), filePrefix, p.port, p.ssl, logLevels.value("mongrel2", defaultLevel));
-		}
-
-		if(serviceNames.contains("m2adapter"))
-		{
-			QList<int> portsOnly;
-			foreach(const ListenPort &p, ports)
-				portsOnly += p.port;
-
-			services += new M2AdapterService(m2aBin, QDir(libDir).filePath("m2adapter.conf.template"), runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevels.value("m2adapter", defaultLevel), portsOnly);
-		}
-
-		if(serviceNames.contains("zurl"))
-		{
-			QString zurlBin = "zurl";
-			if(settings.contains("runner/zurl_bin"))
-				zurlBin = settings.value("runner/zurl_bin").toString();
-
-			services += new ZurlService(zurlBin, QDir(libDir).filePath("zurl.conf.template"), runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevels.value("zurl", defaultLevel));
-		}
-
-		if(serviceNames.contains("proxy"))
-			services += new PushpinProxyService(proxyBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, logLevels.value("proxy", defaultLevel), args.routeLines);
-
-		if(serviceNames.contains("handler"))
-			services += new PushpinHandlerService(handlerBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, portOffset, logLevels.value("handler", defaultLevel));
-
-		foreach(Service *s, services)
-		{
-			serviceConnectionMap[s] = {
-				s->started.connect(boost::bind(&Private::service_started, this)),
-				s->stopped.connect(boost::bind(&Private::service_stopped, this, s)),
-				s->logLine.connect(boost::bind(&Private::service_logLine, this, boost::placeholders::_1, s)),
-				s->error.connect(boost::bind(&Private::service_error, this, boost::placeholders::_1, s))
-			};
-
-			if(!args.mergeOutput || s->alwaysLogStatus())
-				log_info("starting %s", qPrintable(s->name()));
-
-			s->start();
-		}
-	}
+    RunnerApp *q;
+    RunnerArgsData args;
+    QList<Service *> services;
+    bool stopping;
+    bool errored;
+    Connection quitConnection;
+    Connection hupConnection;
+    map<Service *, ServiceConnections> serviceConnectionMap;
+
+    Private(RunnerApp *_q) : q(_q), stopping(false), errored(false) {
+        quitConnection =
+            ProcessQuit::instance()->quit.connect(boost::bind(&Private::processQuit, this));
+        hupConnection = ProcessQuit::instance()->hup.connect(boost::bind(&Private::reload, this));
+    }
+
+    void start() {
+        QCoreApplication::setApplicationName("pushpin");
+        QCoreApplication::setApplicationVersion(Config::get().version);
+
+        QCommandLineParser parser;
+        parser.setApplicationDescription("Reverse proxy for realtime web services.");
+
+        QString errorMessage;
+        switch (parseCommandLine(&parser, &args, &errorMessage)) {
+        case CommandLineOk:
+            break;
+        case CommandLineError:
+            fprintf(stderr, "error: %s\n\n%s", qPrintable(errorMessage),
+                    qPrintable(parser.helpText()));
+            q->quit(1);
+            return;
+        case CommandLineVersionRequested:
+            printf("%s %s\n", qPrintable(QCoreApplication::applicationName()),
+                   qPrintable(QCoreApplication::applicationVersion()));
+            q->quit(0);
+            return;
+        case CommandLineHelpRequested:
+            parser.showHelp();
+            Q_UNREACHABLE();
+        }
+
+        if (!args.logFile.isEmpty()) {
+            if (!log_setFile(args.logFile)) {
+                log_error("failed to open log file: %s", qPrintable(args.logFile));
+                q->quit(1);
+                return;
+            }
+        }
+
+        QStringList configFileList;
+
+        if (!args.configFile.isEmpty()) {
+            configFileList += args.configFile;
+        } else {
+            // ./config
+            configFileList += QDir("config").absoluteFilePath("pushpin.conf");
+
+            // Same dir as executable (NOTE: deprecated)
+            configFileList += QDir(".").absoluteFilePath("pushpin.conf");
+
+            // ./examples/config
+            configFileList += QDir("examples/config").absoluteFilePath("pushpin.conf");
+
+            // Default
+            configFileList += QDir(Config::get().configDir).filePath("pushpin.conf");
+        }
+
+        QString configFile;
+
+        foreach (const QString &f, configFileList) {
+            if (QFileInfo(f).isFile()) {
+                configFile = f;
+                break;
+            }
+        }
+
+        if (configFile.isEmpty()) {
+            log_error("no configuration file found. Tried: %s",
+                      qPrintable(configFileList.join(" ")));
+            q->quit(1);
+            return;
+        }
+
+        // QSettings doesn't inform us if the config file can't be accessed,
+        // so do that ourselves
+        {
+            QFile file(configFile);
+            if (!file.open(QIODevice::ReadOnly)) {
+                log_error("failed to open %s", qPrintable(configFile));
+                q->quit(1);
+                return;
+            }
+        }
+
+        int defaultArgsLevel = args.logLevels.value("", LOG_LEVEL_INFO);
+        log_setOutputLevel(args.logLevels.value("runner", defaultArgsLevel));
+
+        log_debug("starting...");
+
+        if (args.configFile.isEmpty())
+            log_info("using config: %s", qPrintable(configFile));
+
+        Settings settings(configFile);
+
+        QString exeDir = QCoreApplication::applicationDirPath();
+
+        // NOTE: libdir in config file is deprecated
+        QString libDir = settings.value("global/libdir").toString();
+
+        if (!libDir.isEmpty()) {
+            libDir = QDir(libDir).absoluteFilePath("runner");
+        } else {
+            if (QFile::exists("src/bin/pushpin.rs")) {
+                // Running in tree
+                libDir = QFileInfo("src/runner").absoluteFilePath();
+            } else {
+                // Use compiled value
+                libDir = QDir(Config::get().libDir).absoluteFilePath("runner");
+            }
+        }
+
+        QString ipcPrefix = settings.value("global/ipc_prefix", "pushpin-").toString();
+
+        QString configDir = QFileInfo(configFile).dir().filePath("runner");
+
+        QStringList serviceNames = settings.value("runner/services").toStringList();
+        trimlist(&serviceNames);
+
+        QStringList httpPortStrs = settings.value("runner/http_port").toStringList();
+        trimlist(&httpPortStrs);
+
+        QStringList httpsPortStrs = settings.value("runner/https_ports").toStringList();
+        trimlist(&httpsPortStrs);
+
+        QStringList localPortStrs = settings.value("runner/local_ports").toStringList();
+        trimlist(&localPortStrs);
+
+        QString runDir;
+        if (settings.contains("global/rundir")) {
+            runDir = settings.value("global/rundir").toString();
+        } else {
+            log_warning("rundir in [runner] section is deprecated. put in [global]");
+            runDir = settings.value("runner/rundir").toString();
+        }
+
+        runDir = QDir(runDir).absolutePath();
+
+        QString logDir = settings.value("runner/logdir").toString();
+        logDir = QDir(logDir).absolutePath();
+
+        QMap<QString, int> logLevels;
+
+        QStringList logLevelParts = settings.value("runner/log_level").toStringList();
+        if (!logLevelParts.isEmpty()) {
+            logLevels = parseLogLevel(logLevelParts, &errorMessage);
+            if (logLevels.isEmpty()) {
+                fprintf(stderr, "error: %s\n", qPrintable(errorMessage));
+                q->quit(1);
+                return;
+            }
+        }
+
+        // Command line overrides config file
+        if (!args.logLevels.isEmpty())
+            logLevels = args.logLevels;
+
+        // If default log level not provided, use info level
+        int defaultLevel = logLevels.value("", 2);
+
+        // NOTE: since we only finally set the log level here, earlier
+        // log messages outside the default level will be lost (if any)
+        log_setOutputLevel(logLevels.value("runner", defaultLevel));
+
+        int clientBufferSize = settings.value("runner/client_buffer_size", 8192).toInt();
+        int clientMaxConnections = settings.value("runner/client_maxconn", 50000).toInt();
+
+        bool allowCompression = settings.value("runner/allow_compression").toBool();
+
+        QString targetDir;
+        if (ffi::is_debug_build())
+            targetDir = QDir(exeDir).filePath("target/debug");
+        else
+            targetDir = QDir(exeDir).filePath("target/release");
+
+        QString m2aBin = "m2adapter";
+        QFileInfo fi(QDir(targetDir).filePath("m2adapter"));
+        if (fi.isFile())
+            m2aBin = fi.canonicalFilePath();
+
+        QString connmgrBin = "pushpin-connmgr";
+        fi = QFileInfo(QDir(targetDir).filePath("pushpin-connmgr"));
+        if (fi.isFile())
+            connmgrBin = fi.canonicalFilePath();
+
+        QString proxyBin = "pushpin-proxy";
+        fi = QFileInfo(QDir(targetDir).filePath("pushpin-proxy"));
+        if (fi.isFile())
+            proxyBin = fi.canonicalFilePath();
+
+        QString handlerBin = "pushpin-handler";
+        fi = QFileInfo(QDir(targetDir).filePath("pushpin-handler"));
+        if (fi.isFile())
+            handlerBin = fi.canonicalFilePath();
+
+        if (!ensureDir(runDir)) {
+            log_error("failed to create directory: %s", qPrintable(runDir));
+            q->quit(1);
+            return;
+        }
+
+        if (!args.mergeOutput && !ensureDir(logDir)) {
+            log_error("failed to create directory: %s", qPrintable(logDir));
+            q->quit(1);
+            return;
+        }
+
+        int portOffset = 0;
+        QString filePrefix;
+
+        QList<ListenPort> ports;
+
+        if (args.port.second > 0) {
+            // If port specified then instantiate a single http server
+            ports += ListenPort(args.port.first, args.port.second, false);
+        } else {
+            foreach (const QString &httpPortStr, httpPortStrs) {
+                QPair<QHostAddress, int> p = parsePort(httpPortStr);
+                if (p.second < 0) {
+                    log_error("invalid http port: %s", qPrintable(httpPortStr));
+                    q->quit(1);
+                    return;
+                }
+
+                ports += ListenPort(p.first, p.second, false);
+            }
+
+            foreach (const QString &httpsPortStr, httpsPortStrs) {
+                QPair<QHostAddress, int> p = parsePort(httpsPortStr);
+                if (p.second < 1) {
+                    log_error("invalid https port: %s", qPrintable(httpsPortStr));
+                    q->quit(1);
+                    return;
+                }
+
+                ports += ListenPort(p.first, p.second, true);
+            }
+
+            foreach (const QString &localPortStr, localPortStrs) {
+                Url path = Url::fromEncoded(localPortStr.toUtf8());
+                if (!path.isValid()) {
+                    log_error("invalid local port: %s", qPrintable(localPortStr));
+                    q->quit(1);
+                    return;
+                }
+
+                QUrlQuery query(path.query());
+
+                int mode = -1;
+                if (query.hasQueryItem("mode")) {
+                    QString modeStr = query.queryItemValue("mode");
+                    bool ok = false;
+                    mode = modeStr.toInt(&ok, 8);
+                    if (!ok) {
+                        log_error("invalid mode: %s", qPrintable(modeStr));
+                        q->quit(1);
+                        return;
+                    }
+                }
+
+                QString user = query.queryItemValue("user");
+                QString group = query.queryItemValue("group");
+
+                ports += ListenPort(QHostAddress(), 0, true, path.path(), mode, user, group);
+            }
+        }
+
+        if (ports.isEmpty()) {
+            log_error("no server ports configured");
+            q->quit(1);
+            return;
+        }
+
+        if (args.id >= 0) {
+            ipcPrefix = QString("p%1-").arg(args.id);
+            portOffset = args.id * 10;
+            filePrefix = ipcPrefix;
+        }
+
+        if (logLevels.contains("pushpin-proxy")) {
+            logLevels["proxy"] = logLevels["pushpin-proxy"];
+            logLevels.remove("pushpin-proxy");
+        }
+
+        if (logLevels.contains("pushpin-handler")) {
+            logLevels["handler"] = logLevels["pushpin-handler"];
+            logLevels.remove("pushpin-handler");
+        }
+
+        if (serviceNames.contains("condure")) {
+            serviceNames.removeAll("condure");
+            serviceNames += "connmgr";
+        }
+
+        if (serviceNames.contains("pushpin-proxy")) {
+            serviceNames.removeAll("pushpin-proxy");
+            serviceNames += "proxy";
+        }
+
+        if (serviceNames.contains("pushpin-handler")) {
+            serviceNames.removeAll("pushpin-handler");
+            serviceNames += "handler";
+        }
+
+        if (serviceNames.contains("connmgr") &&
+            (serviceNames.contains("mongrel2") || serviceNames.contains("m2adapter"))) {
+            log_error("cannot enable the connmgr service at the same time as "
+                      "mongrel2 or m2adapter");
+            q->quit(1);
+            return;
+        }
+
+        if (serviceNames.contains("connmgr")) {
+            QString certsDir = QDir(configDir).filePath("certs");
+
+            bool useClient = false;
+
+            if (!serviceNames.contains("zurl") && ConnmgrService::hasClientMode(connmgrBin))
+                useClient = true;
+
+            services += new ConnmgrService(
+                "connmgr", connmgrBin, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix,
+                filePrefix, logLevels.value("connmgr", defaultLevel), certsDir, clientBufferSize,
+                clientMaxConnections, allowCompression, ports, useClient);
+        }
+
+        if (serviceNames.contains("mongrel2")) {
+            QString m2Bin = "mongrel2";
+            if (settings.contains("runner/mongrel2_bin"))
+                m2Bin = settings.value("runner/mongrel2_bin").toString();
+
+            QString m2shBin = "m2sh";
+            if (settings.contains("runner/m2sh_bin"))
+                m2shBin = settings.value("runner/m2sh_bin").toString();
+
+            QString certsDir = QDir(configDir).filePath("certs");
+            if (!Mongrel2Service::generateConfigFile(
+                    m2shBin, QDir(libDir).filePath("mongrel2.conf.template"), runDir,
+                    !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix, certsDir,
+                    clientBufferSize, clientMaxConnections, ports,
+                    logLevels.value("mongrel2", defaultLevel))) {
+                q->quit(1);
+                return;
+            }
+
+            foreach (const ListenPort &p, ports)
+                services += new Mongrel2Service(
+                    m2Bin, QDir(runDir).filePath(QString("%1mongrel2.sqlite").arg(filePrefix)),
+                    "default_" + QString::number(p.port), runDir,
+                    !args.mergeOutput ? logDir : QString(), filePrefix, p.port, p.ssl,
+                    logLevels.value("mongrel2", defaultLevel));
+        }
+
+        if (serviceNames.contains("m2adapter")) {
+            QList<int> portsOnly;
+            foreach (const ListenPort &p, ports)
+                portsOnly += p.port;
+
+            services += new M2AdapterService(
+                m2aBin, QDir(libDir).filePath("m2adapter.conf.template"), runDir,
+                !args.mergeOutput ? logDir : QString(), ipcPrefix, filePrefix,
+                logLevels.value("m2adapter", defaultLevel), portsOnly);
+        }
+
+        if (serviceNames.contains("zurl")) {
+            QString zurlBin = "zurl";
+            if (settings.contains("runner/zurl_bin"))
+                zurlBin = settings.value("runner/zurl_bin").toString();
+
+            services += new ZurlService(zurlBin, QDir(libDir).filePath("zurl.conf.template"),
+                                        runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix,
+                                        filePrefix, logLevels.value("zurl", defaultLevel));
+        }
+
+        if (serviceNames.contains("proxy"))
+            services += new PushpinProxyService(
+                proxyBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix,
+                filePrefix, logLevels.value("proxy", defaultLevel), args.routeLines);
+
+        if (serviceNames.contains("handler"))
+            services += new PushpinHandlerService(
+                handlerBin, configFile, runDir, !args.mergeOutput ? logDir : QString(), ipcPrefix,
+                filePrefix, portOffset, logLevels.value("handler", defaultLevel));
+
+        foreach (Service *s, services) {
+            serviceConnectionMap[s] = {
+                s->started.connect(boost::bind(&Private::service_started, this)),
+                s->stopped.connect(boost::bind(&Private::service_stopped, this, s)),
+                s->logLine.connect(
+                    boost::bind(&Private::service_logLine, this, boost::placeholders::_1, s)),
+                s->error.connect(
+                    boost::bind(&Private::service_error, this, boost::placeholders::_1, s))};
+
+            if (!args.mergeOutput || s->alwaysLogStatus())
+                log_info("starting %s", qPrintable(s->name()));
+
+            s->start();
+        }
+    }
 
 private:
-	QString tryInsertPrefix(const QString &line, const QString &prefix)
-	{
-		if(line.startsWith('['))
-		{
-			// Find third space and insert the service name
-			int at = 0;
-			for(int n = 0; n < 3 && at != -1; ++n)
-			{
-				at = line.indexOf(' ', at);
-				if(at != -1)
-					++at;
-			}
+    QString tryInsertPrefix(const QString &line, const QString &prefix) {
+        if (line.startsWith('[')) {
+            // Find third space and insert the service name
+            int at = 0;
+            for (int n = 0; n < 3 && at != -1; ++n) {
+                at = line.indexOf(' ', at);
+                if (at != -1)
+                    ++at;
+            }
 
-			if(at != -1)
-			{
-				QString out = line;
-				out.insert(at, prefix);
-				return out;
-			}
-		}
+            if (at != -1) {
+                QString out = line;
+                out.insert(at, prefix);
+                return out;
+            }
+        }
 
-		return line;
-	}
+        return line;
+    }
 
-	void stopAll()
-	{
-		foreach(Service *s, services)
-		{
-			if(!args.mergeOutput || s->alwaysLogStatus())
-				log_info("stopping %s", qPrintable(s->name()));
+    void stopAll() {
+        foreach (Service *s, services) {
+            if (!args.mergeOutput || s->alwaysLogStatus())
+                log_info("stopping %s", qPrintable(s->name()));
 
-			s->stop();
-		}
-	}
+            s->stop();
+        }
+    }
 
-	void checkStopped()
-	{
-		if(services.isEmpty())
-		{
-			log_debug("stopped");
-			doQuit();
-		}
-	}
+    void checkStopped() {
+        if (services.isEmpty()) {
+            log_debug("stopped");
+            doQuit();
+        }
+    }
 
-	void doQuit()
-	{
-		q->quit(errored ? 1 : 0);
-	}
+    void doQuit() { q->quit(errored ? 1 : 0); }
 
-	void service_started()
-	{
-		bool allStarted = true;
-		foreach(Service *s, services)
-		{
-			if(!s->isStarted())
-			{
-				allStarted = false;
-				break;
-			}
-		}
+    void service_started() {
+        bool allStarted = true;
+        foreach (Service *s, services) {
+            if (!s->isStarted()) {
+                allStarted = false;
+                break;
+            }
+        }
 
-		if(allStarted)
-			log_debug("started");
-	}
+        if (allStarted)
+            log_debug("started");
+    }
 
-	void service_stopped(Service *s)
-	{
-		serviceConnectionMap.erase(s);
+    void service_stopped(Service *s) {
+        serviceConnectionMap.erase(s);
 
-		services.removeAll(s);
-		delete s;
+        services.removeAll(s);
+        delete s;
 
-		checkStopped();
-	}
+        checkStopped();
+    }
 
-	void service_logLine(const QString &line, Service *s)
-	{
-		QString out = tryInsertPrefix(s->formatLogLine(line), '[' + s->name() + "] ");
-		if(!out.isEmpty()) {
-			log_raw(qPrintable(out));
-		}
-	}
+    void service_logLine(const QString &line, Service *s) {
+        QString out = tryInsertPrefix(s->formatLogLine(line), '[' + s->name() + "] ");
+        if (!out.isEmpty()) {
+            log_raw(qPrintable(out));
+        }
+    }
 
-	void service_error(const QString &error, Service *s)
-	{
-		log_error("%s: %s", qPrintable(s->name()), qPrintable(error));
+    void service_error(const QString &error, Service *s) {
+        log_error("%s: %s", qPrintable(s->name()), qPrintable(error));
 
-		serviceConnectionMap.erase(s);
+        serviceConnectionMap.erase(s);
 
-		services.removeAll(s);
-		delete s;
+        services.removeAll(s);
+        delete s;
 
-		errored = true;
+        errored = true;
 
-		if(stopping)
-		{
-			checkStopped();
-		}
-		else
-		{
-			// Shutdown if we receive an unexpected error from any service
-			stopping = true;
-			stopAll();
-		}
-	}
+        if (stopping) {
+            checkStopped();
+        } else {
+            // Shutdown if we receive an unexpected error from any service
+            stopping = true;
+            stopAll();
+        }
+    }
 
-	void reload()
-	{
-		log_info("reloading");
-		log_rotate();
+    void reload() {
+        log_info("reloading");
+        log_rotate();
 
-		foreach(Service *s, services)
-		{
-			if(s->acceptSighup())
-				s->sendSighup();
-		}
-	}
+        foreach (Service *s, services) {
+            if (s->acceptSighup())
+                s->sendSighup();
+        }
+    }
 
-	void processQuit()
-	{
-		if(!stopping)
-		{
-			// Let a potential "^C" get overwritten
-			printf("\r");
+    void processQuit() {
+        if (!stopping) {
+            // Let a potential "^C" get overwritten
+            printf("\r");
 
-			stopping = true;
-			ProcessQuit::reset(); // Allow user to quit again
+            stopping = true;
+            ProcessQuit::reset(); // Allow user to quit again
 
-			log_info("stopping...");
-			stopAll();
-		}
-		else
-		{
-			qDeleteAll(services);
+            log_info("stopping...");
+            stopAll();
+        } else {
+            qDeleteAll(services);
 
-			ProcessQuit::cleanup();
+            ProcessQuit::cleanup();
 
-			// If we were already stopping, then exit immediately
-			doQuit();
-		}
-	}
+            // If we were already stopping, then exit immediately
+            doQuit();
+        }
+    }
 };
 
-RunnerApp::RunnerApp() {
-	d = std::make_unique<Private>(this);
-}
+RunnerApp::RunnerApp() { d = std::make_unique<Private>(this); }
 
 RunnerApp::~RunnerApp() = default;
 
-void RunnerApp::start()
-{
-	d->start();
-}
-
+void RunnerApp::start() { d->start(); }

--- a/src/runner/runnerapp.h
+++ b/src/runner/runnerapp.h
@@ -30,20 +30,19 @@ using std::map;
 using SignalInt = boost::signals2::signal<void(int)>;
 using Connection = boost::signals2::scoped_connection;
 
-class RunnerApp
-{
+class RunnerApp {
 public:
-	RunnerApp();
-	~RunnerApp();
+    RunnerApp();
+    ~RunnerApp();
 
-	void start();
+    void start();
 
-	SignalInt quit;
+    SignalInt quit;
 
 private:
-	class Private;
-	friend class Private;
-	std::unique_ptr<Private> d;
+    class Private;
+    friend class Private;
+    std::unique_ptr<Private> d;
 };
 
 #endif

--- a/src/runner/runnermain.cpp
+++ b/src/runner/runnermain.cpp
@@ -20,38 +20,33 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "runnerapp.h"
 #include <QCoreApplication>
 #include <QTimer>
-#include "runnerapp.h"
 
-class RunnerAppMain
-{
+class RunnerAppMain {
 public:
-	RunnerApp *app;
+    RunnerApp *app;
 
-	void start()
-	{
-		app = new RunnerApp;
-		app->quit.connect(boost::bind(&RunnerAppMain::app_quit, this, boost::placeholders::_1));
-		app->start();
-	}
+    void start() {
+        app = new RunnerApp;
+        app->quit.connect(boost::bind(&RunnerAppMain::app_quit, this, boost::placeholders::_1));
+        app->start();
+    }
 
-	void app_quit(int returnCode)
-	{
-		delete app;
-		QCoreApplication::exit(returnCode);
-	}
+    void app_quit(int returnCode) {
+        delete app;
+        QCoreApplication::exit(returnCode);
+    }
 };
 
 extern "C" {
 
-int runner_main(int argc, char **argv)
-{
-	QCoreApplication qapp(argc, argv);
+int runner_main(int argc, char **argv) {
+    QCoreApplication qapp(argc, argv);
 
-	RunnerAppMain appMain;
-	QTimer::singleShot(0, [&appMain]() {appMain.start();});
-	return qapp.exec();
+    RunnerAppMain appMain;
+    QTimer::singleShot(0, [&appMain]() { appMain.start(); });
+    return qapp.exec();
 }
-
 }

--- a/src/runner/service.cpp
+++ b/src/runner/service.cpp
@@ -22,367 +22,289 @@
 
 #include "service.h"
 
-#include <sys/types.h>
-#include <signal.h>
-#include <unistd.h>
-#include <QTimer>
+#include "log.h"
 #include <QFile>
 #include <QProcess>
-#include "log.h"
+#include <QTimer>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #define STOP_TIMEOUT 4000
 
-static void setupChild()
-{
-	signal(SIGINT, SIG_IGN);
+static void setupChild() {
+    signal(SIGINT, SIG_IGN);
 
-	// subprocesses hopefully respect SIG_IGN, but are not required
-	// To. In case subprocess might reinstate a SIGINT handler,
-	// detach from process group to ensure ctrl-c in a shell
-	// doesn't cause SIGINT to be sent directly to subprocesses
-	setpgid(0, 0);
+    // subprocesses hopefully respect SIG_IGN, but are not required
+    // To. In case subprocess might reinstate a SIGINT handler,
+    // detach from process group to ensure ctrl-c in a shell
+    // doesn't cause SIGINT to be sent directly to subprocesses
+    setpgid(0, 0);
 }
 
-class ServiceProcess : public QProcess
-{
-	Q_OBJECT
+class ServiceProcess : public QProcess {
+    Q_OBJECT
 
 public:
-	ServiceProcess(QObject *parent = 0) :
-		QProcess(parent)
-	{
+    ServiceProcess(QObject *parent = 0) : QProcess(parent) {
 #if QT_VERSION >= 0x060000
-		setChildProcessModifier(setupChild);
+        setChildProcessModifier(setupChild);
 #endif
-	}
+    }
 
 #if QT_VERSION < 0x060000
-	// Reimplemented
-	virtual void setupChildProcess()
-	{
-		setupChild();
-	}
+    // Reimplemented
+    virtual void setupChildProcess() { setupChild(); }
 #endif
 };
 
-class Service::Private : public QObject
-{
-	Q_OBJECT
+class Service::Private : public QObject {
+    Q_OBJECT
 
 public:
-	enum State
-	{
-		NotStarted,
-		Starting,
-		Started,
-		Stopping,
-		Stopped
-	};
+    enum State { NotStarted, Starting, Started, Stopping, Stopped };
 
-	Service *q;
-	State state;
-	QString name;
-	QString outputFile;
-	QString pidFile;
-	QProcess *proc;
-	bool terminateAfterStarted;
-	bool sentKill;
-	QTimer *timer;
+    Service *q;
+    State state;
+    QString name;
+    QString outputFile;
+    QString pidFile;
+    QProcess *proc;
+    bool terminateAfterStarted;
+    bool sentKill;
+    QTimer *timer;
 
-	Private(Service *_q) :
-		QObject(_q),
-		q(_q),
-		state(NotStarted),
-		proc(0),
-		terminateAfterStarted(false),
-		sentKill(false)
-	{
-		timer = new QTimer(this);
-		connect(timer, &QTimer::timeout, this, &Private::timer_timeout);
+    Private(Service *_q)
+        : QObject(_q),
+          q(_q),
+          state(NotStarted),
+          proc(0),
+          terminateAfterStarted(false),
+          sentKill(false) {
+        timer = new QTimer(this);
+        connect(timer, &QTimer::timeout, this, &Private::timer_timeout);
 
-		timer->setSingleShot(true);
-	}
+        timer->setSingleShot(true);
+    }
 
-	~Private()
-	{
-		timer->stop();
+    ~Private() {
+        timer->stop();
 
-		if(state == Starting || state == Started || state == Stopping)
-		{
-			proc->disconnect(this);
-			proc->setParent(0);
+        if (state == Starting || state == Started || state == Stopping) {
+            proc->disconnect(this);
+            proc->setParent(0);
 
-			if(!sentKill)
-			{
-				sentKill = true;
-				state = Stopping;
-				log_warning("%s running while needing to exit, forcing quit", qPrintable(name));
-				proc->kill();
+            if (!sentKill) {
+                sentKill = true;
+                state = Stopping;
+                log_warning("%s running while needing to exit, forcing quit", qPrintable(name));
+                proc->kill();
 
-				if(!pidFile.isEmpty())
-					QFile::remove(pidFile);
-			}
-			proc->waitForFinished();
-		}
+                if (!pidFile.isEmpty())
+                    QFile::remove(pidFile);
+            }
+            proc->waitForFinished();
+        }
 
-		cleanup();
+        cleanup();
 
-		timer->disconnect(this);
-		timer->setParent(0);
-		timer->deleteLater();
-	}
+        timer->disconnect(this);
+        timer->setParent(0);
+        timer->deleteLater();
+    }
 
-	void cleanup()
-	{
-		timer->stop();
+    void cleanup() {
+        timer->stop();
 
-		if(proc)
-		{
-			proc->disconnect(this);
-			proc->setParent(0);
-			proc->deleteLater();
-			proc = 0;
-		}
-	}
+        if (proc) {
+            proc->disconnect(this);
+            proc->setParent(0);
+            proc->deleteLater();
+            proc = 0;
+        }
+    }
 
-	void start()
-	{
-		proc = new ServiceProcess(this);
+    void start() {
+        proc = new ServiceProcess(this);
 
-		connect(proc, &QProcess::started, this, &Private::proc_started);
-		connect(proc, &QProcess::readyReadStandardOutput, this, &Private::proc_readyRead);
-		connect(proc, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished), this, &Private::proc_finished);
-		connect(proc, static_cast<void(QProcess::*)(QProcess::ProcessError)>(&QProcess::errorOccurred), this, &Private::proc_errorOccurred);
+        connect(proc, &QProcess::started, this, &Private::proc_started);
+        connect(proc, &QProcess::readyReadStandardOutput, this, &Private::proc_readyRead);
+        connect(proc,
+                static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+                this, &Private::proc_finished);
+        connect(proc,
+                static_cast<void (QProcess::*)(QProcess::ProcessError)>(&QProcess::errorOccurred),
+                this, &Private::proc_errorOccurred);
 
-		proc->setProcessChannelMode(QProcess::MergedChannels);
-		proc->setReadChannel(QProcess::StandardOutput);
+        proc->setProcessChannelMode(QProcess::MergedChannels);
+        proc->setReadChannel(QProcess::StandardOutput);
 
-		if(!outputFile.isEmpty())
-			proc->setStandardOutputFile(outputFile, QIODevice::Append);
+        if (!outputFile.isEmpty())
+            proc->setStandardOutputFile(outputFile, QIODevice::Append);
 
-		state = Starting;
+        state = Starting;
 
-		QStringList args = q->arguments();
+        QStringList args = q->arguments();
 
-		log_debug("running: %s", qPrintable(args.join(' ')));
+        log_debug("running: %s", qPrintable(args.join(' ')));
 
-		proc->start(args[0], args.mid(1));
-	}
+        proc->start(args[0], args.mid(1));
+    }
 
-	void stop()
-	{
-		if(state == Starting)
-		{
-			terminateAfterStarted = true;
-		}
-		else if(state == Started)
-		{
-			doStop();
-		}
-	}
+    void stop() {
+        if (state == Starting) {
+            terminateAfterStarted = true;
+        } else if (state == Started) {
+            doStop();
+        }
+    }
 
 private:
-	void doStop()
-	{
-		state = Stopping;
-		timer->start(STOP_TIMEOUT);
-		proc->terminate();
-	}
+    void doStop() {
+        state = Stopping;
+        timer->start(STOP_TIMEOUT);
+        proc->terminate();
+    }
 
-	bool writePidFile(const QString &file, int pid)
-	{
-		QFile f(file);
-		if(!f.open(QFile::WriteOnly | QFile::Truncate))
-			return false;
+    bool writePidFile(const QString &file, int pid) {
+        QFile f(file);
+        if (!f.open(QFile::WriteOnly | QFile::Truncate))
+            return false;
 
-		if(f.write(QByteArray::number(pid) + '\n') == -1)
-			return false;
+        if (f.write(QByteArray::number(pid) + '\n') == -1)
+            return false;
 
-		return true;
-	}
+        return true;
+    }
 
 private slots:
-	void doError(const QString &str)
-	{
-		q->error(str);
-	}
+    void doError(const QString &str) { q->error(str); }
 
-	void proc_started()
-	{
-		if(!pidFile.isEmpty())
-		{
-			if(!writePidFile(pidFile, proc->processId()))
-				log_error("failed to write pid file: %s", qPrintable(pidFile));
-		}
+    void proc_started() {
+        if (!pidFile.isEmpty()) {
+            if (!writePidFile(pidFile, proc->processId()))
+                log_error("failed to write pid file: %s", qPrintable(pidFile));
+        }
 
-		state = Started;
-		q->started();
+        state = Started;
+        q->started();
 
-		if(terminateAfterStarted)
-			doStop();
-	}
+        if (terminateAfterStarted)
+            doStop();
+    }
 
-	void proc_readyRead()
-	{
-		while(proc->canReadLine())
-		{
-			QByteArray line = proc->readLine();
-			if(!line.isEmpty() && line[line.length() - 1] == '\n')
-				line.truncate(line.length() - 1);
+    void proc_readyRead() {
+        while (proc->canReadLine()) {
+            QByteArray line = proc->readLine();
+            if (!line.isEmpty() && line[line.length() - 1] == '\n')
+                line.truncate(line.length() - 1);
 
-			q->logLine(QString::fromLocal8Bit(line));
-		}
-	}
+            q->logLine(QString::fromLocal8Bit(line));
+        }
+    }
 
-	void proc_finished(int exitCode, QProcess::ExitStatus exitStatus)
-	{
-		if(!pidFile.isEmpty())
-			QFile::remove(pidFile);
+    void proc_finished(int exitCode, QProcess::ExitStatus exitStatus) {
+        if (!pidFile.isEmpty())
+            QFile::remove(pidFile);
 
-		if(state != Stopping)
-		{
-			state = Stopped;
-			cleanup();
-			q->error("Exited unexpectedly");
-			return;
-		}
+        if (state != Stopping) {
+            state = Stopped;
+            cleanup();
+            q->error("Exited unexpectedly");
+            return;
+        }
 
-		state = Stopped;
-		cleanup();
+        state = Stopped;
+        cleanup();
 
-		if(exitStatus == QProcess::CrashExit)
-		{
-			if(sentKill)
-				q->stopped();
-			else
-				q->error("Exited uncleanly");
-			return;
-		}
+        if (exitStatus == QProcess::CrashExit) {
+            if (sentKill)
+                q->stopped();
+            else
+                q->error("Exited uncleanly");
+            return;
+        }
 
-		if(exitCode != 0)
-		{
-			q->error("Unexpected return code: " + QString::number(exitCode));
-			return;
-		}
+        if (exitCode != 0) {
+            q->error("Unexpected return code: " + QString::number(exitCode));
+            return;
+        }
 
-		q->stopped();
-	}
+        q->stopped();
+    }
 
-	void proc_errorOccurred(QProcess::ProcessError error)
-	{
-		if(error == QProcess::FailedToStart)
-		{
-			QString program = proc->program();
-			state = Stopped;
-			cleanup();
+    void proc_errorOccurred(QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            QString program = proc->program();
+            state = Stopped;
+            cleanup();
 
-			q->error("Error running: " + program);
-		}
-		else
-		{
-			// Other errors are followed by finished(), so we don't
-			// need to handle them here
-		}
-	}
+            q->error("Error running: " + program);
+        } else {
+            // Other errors are followed by finished(), so we don't
+            // need to handle them here
+        }
+    }
 
-	void timer_timeout()
-	{
-		if(!sentKill)
-		{
-			sentKill = true;
-			log_warning("%s taking too long, forcing quit", qPrintable(name));
-			proc->kill();
-		}
-	}
+    void timer_timeout() {
+        if (!sentKill) {
+            sentKill = true;
+            log_warning("%s taking too long, forcing quit", qPrintable(name));
+            proc->kill();
+        }
+    }
 };
 
-Service::Service(QObject *parent) :
-	QObject(parent)
-{
-	d = new Private(this);
+Service::Service(QObject *parent) : QObject(parent) { d = new Private(this); }
+
+Service::~Service() { delete d; }
+
+QString Service::name() const { return d->name; }
+
+bool Service::acceptSighup() const { return false; }
+
+bool Service::alwaysLogStatus() const { return false; }
+
+bool Service::isStarted() const {
+    return (d->state != Private::NotStarted && d->state != Private::Starting);
 }
 
-Service::~Service()
-{
-	delete d;
+bool Service::preStart() {
+    // By default do nothing
+    return true;
 }
 
-QString Service::name() const
-{
-	return d->name;
+void Service::start() {
+    if (!preStart()) {
+        QString str = "Failure preparing to start";
+        QMetaObject::invokeMethod(d, "doError", Qt::QueuedConnection, Q_ARG(QString, str));
+        return;
+    }
+
+    d->start();
 }
 
-bool Service::acceptSighup() const
-{
-	return false;
+void Service::postStart() {
+    // By default do nothing
 }
 
-bool Service::alwaysLogStatus() const
-{
-	return false;
+void Service::stop() { d->stop(); }
+
+void Service::postStop() {
+    // By default do nothing
 }
 
-bool Service::isStarted() const
-{
-	return (d->state != Private::NotStarted && d->state != Private::Starting);
+QString Service::formatLogLine(const QString &line) const { return line; }
+
+void Service::sendSighup() {
+    if (d->proc)
+        ::kill(d->proc->processId(), SIGHUP);
 }
 
-bool Service::preStart()
-{
-	// By default do nothing
-	return true;
-}
+void Service::setName(const QString &name) { d->name = name; }
 
-void Service::start()
-{
-	if(!preStart())
-	{
-		QString str = "Failure preparing to start";
-		QMetaObject::invokeMethod(d, "doError", Qt::QueuedConnection, Q_ARG(QString, str));
-		return;
-	}
+void Service::setStandardOutputFile(const QString &file) { d->outputFile = file; }
 
-	d->start();
-}
-
-void Service::postStart()
-{
-	// By default do nothing
-}
-
-void Service::stop()
-{
-	d->stop();
-}
-
-void Service::postStop()
-{
-	// By default do nothing
-}
-
-QString Service::formatLogLine(const QString &line) const {
-	return line;
-}
-
-void Service::sendSighup()
-{
-	if(d->proc)
-		::kill(d->proc->processId(), SIGHUP);
-}
-
-void Service::setName(const QString &name)
-{
-	d->name = name;
-}
-
-void Service::setStandardOutputFile(const QString &file)
-{
-	d->outputFile = file;
-}
-
-void Service::setPidFile(const QString &file)
-{
-	d->pidFile = file;
-}
+void Service::setPidFile(const QString &file) { d->pidFile = file; }
 
 #include "service.moc"

--- a/src/runner/service.h
+++ b/src/runner/service.h
@@ -28,46 +28,45 @@
 #include <boost/signals2.hpp>
 
 using Signal = boost::signals2::signal<void()>;
-using SignalStr = boost::signals2::signal<void(const QString&)>;
+using SignalStr = boost::signals2::signal<void(const QString &)>;
 using Connection = boost::signals2::scoped_connection;
 
-class Service : public QObject
-{
-	Q_OBJECT
+class Service : public QObject {
+    Q_OBJECT
 
 public:
-	Service(QObject *parent = 0);
-	~Service();
+    Service(QObject *parent = 0);
+    ~Service();
 
-	QString name() const;
+    QString name() const;
 
-	virtual QStringList arguments() const = 0;
-	virtual bool acceptSighup() const;
-	virtual bool alwaysLogStatus() const;
-	virtual bool isStarted() const;
+    virtual QStringList arguments() const = 0;
+    virtual bool acceptSighup() const;
+    virtual bool alwaysLogStatus() const;
+    virtual bool isStarted() const;
 
-	virtual bool preStart();
-	virtual void start();
-	virtual void postStart();
-	virtual void stop();
-	virtual void postStop();
-	virtual QString formatLogLine(const QString &line) const;
+    virtual bool preStart();
+    virtual void start();
+    virtual void postStart();
+    virtual void stop();
+    virtual void postStop();
+    virtual QString formatLogLine(const QString &line) const;
 
-	void sendSighup();
+    void sendSighup();
 
-	Signal started;
-	Signal stopped;
-	SignalStr logLine;
-	SignalStr error;
+    Signal started;
+    Signal stopped;
+    SignalStr logLine;
+    SignalStr error;
 
 protected:
-	void setName(const QString &name);
-	void setStandardOutputFile(const QString &file);
-	void setPidFile(const QString &file);
+    void setName(const QString &name);
+    void setStandardOutputFile(const QString &file);
+    void setPidFile(const QString &file);
 
 private:
-	class Private;
-	Private *d;
+    class Private;
+    Private *d;
 };
 
 #endif

--- a/src/runner/template.cpp
+++ b/src/runner/template.cpp
@@ -28,476 +28,387 @@
 
 #include "template.h"
 
-#include <QFile>
+#include "log.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include "log.h"
+#include <QFile>
 
 namespace Template {
 
-class TemplateItem
-{
+class TemplateItem {
 public:
-	enum Type
-	{
-		Root,
-		Content,
-		Expression,
-		If,
-		For
-	};
+    enum Type { Root, Content, Expression, If, For };
 
-	Type type;
-	QString data;
-	QList<TemplateItem> children;
+    Type type;
+    QString data;
+    QList<TemplateItem> children;
 
-	TemplateItem() :
-		type((Type)-1)
-	{
-	}
+    TemplateItem() : type((Type)-1) {}
 
-	TemplateItem(Type _type, const QString &_data) :
-		type(_type),
-		data(_data)
-	{
-	}
+    TemplateItem(Type _type, const QString &_data) : type(_type), data(_data) {}
 };
 
-enum ControlType
-{
-	ControlNone,
-	ControlIf,
-	ControlFor
-};
+enum ControlType { ControlNone, ControlIf, ControlFor };
 
-static QList<TemplateItem> parseContent(const QString &content, int *pos, ControlType ctype, QString *error)
-{
-	QList<TemplateItem> out;
-	QString curContent;
-	bool closed = false;
+static QList<TemplateItem> parseContent(const QString &content, int *pos, ControlType ctype,
+                                        QString *error) {
+    QList<TemplateItem> out;
+    QString curContent;
+    bool closed = false;
 
-	for(int n = *pos; n < content.length(); ++n)
-	{
-		QChar c = content[n];
+    for (int n = *pos; n < content.length(); ++n) {
+        QChar c = content[n];
 
-		if(n + 1 < content.length() && c == '{' && (content[n + 1] == '{' || content[n + 1] == '%'))
-		{
-			if(!curContent.isEmpty())
-			{
-				out += TemplateItem(TemplateItem::Content, curContent);
-				curContent.clear();
-			}
+        if (n + 1 < content.length() && c == '{' &&
+            (content[n + 1] == '{' || content[n + 1] == '%')) {
+            if (!curContent.isEmpty()) {
+                out += TemplateItem(TemplateItem::Content, curContent);
+                curContent.clear();
+            }
 
-			++n;
+            ++n;
 
-			if(content[n] == '{')
-			{
-				if(n + 1 >= content.length())
-				{
-					*error = "EOF reached while parsing directive";
-					return QList<TemplateItem>();
-				}
+            if (content[n] == '{') {
+                if (n + 1 >= content.length()) {
+                    *error = "EOF reached while parsing directive";
+                    return QList<TemplateItem>();
+                }
 
-				++n;
+                ++n;
 
-				int end = content.indexOf("}}", n);
-				if(end == -1)
-				{
-					*error = "no matching }}";
-					return QList<TemplateItem>();
-				}
+                int end = content.indexOf("}}", n);
+                if (end == -1) {
+                    *error = "no matching }}";
+                    return QList<TemplateItem>();
+                }
 
-				QString s = content.mid(n, end - n).simplified();
-				n = end + 2;
+                QString s = content.mid(n, end - n).simplified();
+                n = end + 2;
 
-				out += TemplateItem(TemplateItem::Expression, s);
-			}
-			else if(content[n] == '%')
-			{
-				if(n + 1 >= content.length())
-				{
-					*error = "EOF reached while parsing directive";
-					return QList<TemplateItem>();
-				}
+                out += TemplateItem(TemplateItem::Expression, s);
+            } else if (content[n] == '%') {
+                if (n + 1 >= content.length()) {
+                    *error = "EOF reached while parsing directive";
+                    return QList<TemplateItem>();
+                }
 
-				++n;
+                ++n;
 
-				int end = content.indexOf("%}", n);
-				if(end == -1)
-				{
-					*error = "no matching %}";
-					return QList<TemplateItem>();
-				}
+                int end = content.indexOf("%}", n);
+                if (end == -1) {
+                    *error = "no matching %}";
+                    return QList<TemplateItem>();
+                }
 
-				QString s = content.mid(n, end - n).simplified();
-				n = end + 2;
+                QString s = content.mid(n, end - n).simplified();
+                n = end + 2;
 
-				QString stype;
-				int at = s.indexOf(' ');
-				if(at != -1)
-				{
-					stype = s.mid(0, at);
-					s = s.mid(at + 1);
-				}
-				else
-				{
-					stype = s;
-					s.clear();
-				}
+                QString stype;
+                int at = s.indexOf(' ');
+                if (at != -1) {
+                    stype = s.mid(0, at);
+                    s = s.mid(at + 1);
+                } else {
+                    stype = s;
+                    s.clear();
+                }
 
-				if(stype == "if" || stype == "for")
-				{
-					TemplateItem t;
-					ControlType ct;
-					t.data = s;
+                if (stype == "if" || stype == "for") {
+                    TemplateItem t;
+                    ControlType ct;
+                    t.data = s;
 
-					if(stype == "if")
-					{
-						t.type = TemplateItem::If;
-						ct = ControlIf;
-					}
-					else // For
-					{
-						t.type = TemplateItem::For;
-						ct = ControlFor;
-					}
+                    if (stype == "if") {
+                        t.type = TemplateItem::If;
+                        ct = ControlIf;
+                    } else // For
+                    {
+                        t.type = TemplateItem::For;
+                        ct = ControlFor;
+                    }
 
-					*pos = n;
-					QString error_;
-					t.children = parseContent(content, pos, ct, &error_);
-					if(!error_.isEmpty())
-					{
-						*error = error_;
-						return QList<TemplateItem>();
-					}
+                    *pos = n;
+                    QString error_;
+                    t.children = parseContent(content, pos, ct, &error_);
+                    if (!error_.isEmpty()) {
+                        *error = error_;
+                        return QList<TemplateItem>();
+                    }
 
-					out += t;
-					n = *pos;
-				}
-				else if(stype == "endif" || stype == "endfor")
-				{
-					ControlType endType;
-					if(stype == "endif")
-						endType = ControlIf;
-					else // For
-						endType = ControlFor;
+                    out += t;
+                    n = *pos;
+                } else if (stype == "endif" || stype == "endfor") {
+                    ControlType endType;
+                    if (stype == "endif")
+                        endType = ControlIf;
+                    else // For
+                        endType = ControlFor;
 
-					if(endType != ctype)
-					{
-						QString expected;
-						if(ctype == ControlIf)
-							expected = "endif";
-						else
-							expected = "endfor";
+                    if (endType != ctype) {
+                        QString expected;
+                        if (ctype == ControlIf)
+                            expected = "endif";
+                        else
+                            expected = "endfor";
 
-						*error = QString("encountered \"%1\" while expecting \"%2\"").arg(stype, expected);
-						return QList<TemplateItem>();
-					}
+                        *error = QString("encountered \"%1\" while expecting \"%2\"")
+                                     .arg(stype, expected);
+                        return QList<TemplateItem>();
+                    }
 
-					*pos = n;
-					closed = true;
-					break;
-				}
-				else
-				{
-					// Unknown control type
-					*error = QString("unknown control directive \"%1\"").arg(stype);
-					return QList<TemplateItem>();
-				}
-			}
+                    *pos = n;
+                    closed = true;
+                    break;
+                } else {
+                    // Unknown control type
+                    *error = QString("unknown control directive \"%1\"").arg(stype);
+                    return QList<TemplateItem>();
+                }
+            }
 
-			--n; // Adjust position
-		}
-		else
-		{
-			curContent += c;
-		}
+            --n; // Adjust position
+        } else {
+            curContent += c;
+        }
 
-		*pos = n;
-	}
+        *pos = n;
+    }
 
-	if(ctype != ControlNone && !closed)
-	{
-		QString ctypeStr;
-		if(ctype == ControlIf)
-			ctypeStr = "if";
-		else // ControlFor
-			ctypeStr = "for";
+    if (ctype != ControlNone && !closed) {
+        QString ctypeStr;
+        if (ctype == ControlIf)
+            ctypeStr = "if";
+        else // ControlFor
+            ctypeStr = "for";
 
-		*error = "directive \"%1\" not closed";
-		return QList<TemplateItem>();
-	}
+        *error = "directive \"%1\" not closed";
+        return QList<TemplateItem>();
+    }
 
-	if(!curContent.isEmpty())
-	{
-		out += TemplateItem(TemplateItem::Content, curContent);
-		curContent.clear();
-	}
+    if (!curContent.isEmpty()) {
+        out += TemplateItem(TemplateItem::Content, curContent);
+        curContent.clear();
+    }
 
-	error->clear();
-	return out;
+    error->clear();
+    return out;
 }
 
 // Handles lookup by exact name or dot-notation for children
-static Variant getVar(const QString &s, const VariantMap &context)
-{
-	int at = s.indexOf('.');
-	if(at != -1)
-	{
-		QString parent = s.mid(0, at);
-		QString member = s.mid(at + 1);
-		if(parent.isEmpty() || !context.contains(parent))
-			return Variant();
+static Variant getVar(const QString &s, const VariantMap &context) {
+    int at = s.indexOf('.');
+    if (at != -1) {
+        QString parent = s.mid(0, at);
+        QString member = s.mid(at + 1);
+        if (parent.isEmpty() || !context.contains(parent))
+            return Variant();
 
-		Variant subContext = context[parent];
-		if(typeId(subContext) != VariantType::Map)
-			return Variant();
+        Variant subContext = context[parent];
+        if (typeId(subContext) != VariantType::Map)
+            return Variant();
 
-		return getVar(member, subContext.toMap());
-	}
-	else
-	{
-		if(!context.contains(s))
-			return Variant();
+        return getVar(member, subContext.toMap());
+    } else {
+        if (!context.contains(s))
+            return Variant();
 
-		return context[s];
-	}
+        return context[s];
+    }
 }
 
-static QString renderExpression(const QString &exp, const VariantMap &context)
-{
-	// For now all we support is variable lookups. No fancy expressions
+static QString renderExpression(const QString &exp, const VariantMap &context) {
+    // For now all we support is variable lookups. No fancy expressions
 
-	Variant val = getVar(exp, context);
-	if(!val.isValid())
-		return QString();
+    Variant val = getVar(exp, context);
+    if (!val.isValid())
+        return QString();
 
-	return val.toString();
+    return val.toString();
 }
 
-static bool evalCondition(const QString &s, const VariantMap &context)
-{
-	// For now all we support is variable test with optional negation
+static bool evalCondition(const QString &s, const VariantMap &context) {
+    // For now all we support is variable test with optional negation
 
-	if(s.startsWith("not "))
-	{
-		return !evalCondition(s.mid(4), context);
-	}
-	else
-	{
-		Variant val = getVar(s, context);
-		if(typeId(val) == VariantType::String)
-			return !val.toString().isEmpty();
-		else if(typeId(val) == VariantType::Bool)
-			return val.toBool();
-		else if(canConvert(val, VariantType::Int))
-			return (val.toInt() != 0);
-		else
-			return false;
-	}
+    if (s.startsWith("not ")) {
+        return !evalCondition(s.mid(4), context);
+    } else {
+        Variant val = getVar(s, context);
+        if (typeId(val) == VariantType::String)
+            return !val.toString().isEmpty();
+        else if (typeId(val) == VariantType::Bool)
+            return val.toBool();
+        else if (canConvert(val, VariantType::Int))
+            return (val.toInt() != 0);
+        else
+            return false;
+    }
 }
 
-static VariantList parseFor(const QString &s, QString *iterVarName, const VariantMap &context, QString *error)
-{
-	// For now all we support is "varname in map"
+static VariantList parseFor(const QString &s, QString *iterVarName, const VariantMap &context,
+                            QString *error) {
+    // For now all we support is "varname in map"
 
-	int at = s.indexOf(" in ");
-	if(at == -1)
-	{
-		*error = "\"for\" directive must be of the form: \"for variable in container\"";
-		return VariantList();
-	}
+    int at = s.indexOf(" in ");
+    if (at == -1) {
+        *error = "\"for\" directive must be of the form: \"for variable in container\"";
+        return VariantList();
+    }
 
-	*iterVarName = s.mid(0, at);
-	QString containerName = s.mid(at + 4);
+    *iterVarName = s.mid(0, at);
+    QString containerName = s.mid(at + 4);
 
-	Variant container = getVar(containerName, context);
-	if(typeId(container) != VariantType::List)
-	{
-		*error = "\"for\" container must be a list";
-		return VariantList();
-	}
+    Variant container = getVar(containerName, context);
+    if (typeId(container) != VariantType::List) {
+        *error = "\"for\" container must be a list";
+        return VariantList();
+    }
 
-	return container.toList();
+    return container.toList();
 }
 
-static QString renderInternal(const TemplateItem &item, const VariantMap &context, QString *error)
-{
-	QString out;
+static QString renderInternal(const TemplateItem &item, const VariantMap &context, QString *error) {
+    QString out;
 
-	if(item.type == TemplateItem::Root)
-	{
-		foreach(const TemplateItem &i, item.children)
-		{
-			out += renderInternal(i, context, error);
-			if(!error->isEmpty())
-				return QString();
-		}
-	}
-	else if(item.type == TemplateItem::Content)
-	{
-		out += item.data;
-	}
-	else if(item.type == TemplateItem::Expression)
-	{
-		out += renderExpression(item.data, context);
-	}
-	else if(item.type == TemplateItem::If)
-	{
-		if(evalCondition(item.data, context))
-		{
-			foreach(const TemplateItem &i, item.children)
-			{
-				out += renderInternal(i, context, error);
-				if(!error->isEmpty())
-					return QString();
-			}
-		}
-	}
-	else if(item.type == TemplateItem::For)
-	{
-		QString iterVarName;
-		VariantList forItems = parseFor(item.data, &iterVarName, context, error);
-		if(!error->isEmpty())
-			return QString();
+    if (item.type == TemplateItem::Root) {
+        foreach (const TemplateItem &i, item.children) {
+            out += renderInternal(i, context, error);
+            if (!error->isEmpty())
+                return QString();
+        }
+    } else if (item.type == TemplateItem::Content) {
+        out += item.data;
+    } else if (item.type == TemplateItem::Expression) {
+        out += renderExpression(item.data, context);
+    } else if (item.type == TemplateItem::If) {
+        if (evalCondition(item.data, context)) {
+            foreach (const TemplateItem &i, item.children) {
+                out += renderInternal(i, context, error);
+                if (!error->isEmpty())
+                    return QString();
+            }
+        }
+    } else if (item.type == TemplateItem::For) {
+        QString iterVarName;
+        VariantList forItems = parseFor(item.data, &iterVarName, context, error);
+        if (!error->isEmpty())
+            return QString();
 
-		for(int n = 0; n < forItems.count(); ++n)
-		{
-			const Variant &forItem = forItems[n];
+        for (int n = 0; n < forItems.count(); ++n) {
+            const Variant &forItem = forItems[n];
 
-			VariantMap loop;
-			loop["first"] = (n == 0);
-			loop["last"] = (n == forItems.count() - 1);
+            VariantMap loop;
+            loop["first"] = (n == 0);
+            loop["last"] = (n == forItems.count() - 1);
 
-			VariantMap tmp = context;
-			tmp[iterVarName] = forItem;
-			tmp["loop"] = loop;
+            VariantMap tmp = context;
+            tmp[iterVarName] = forItem;
+            tmp["loop"] = loop;
 
-			foreach(const TemplateItem &i, item.children)
-			{
-				out += renderInternal(i, tmp, error);
-				if(!error->isEmpty())
-					return QString();
-			}
-		}
-	}
+            foreach (const TemplateItem &i, item.children) {
+                out += renderInternal(i, tmp, error);
+                if (!error->isEmpty())
+                    return QString();
+            }
+        }
+    }
 
-	return out;
+    return out;
 }
 
-static void dumpItem(const TemplateItem &item, int depth = 0)
-{
-	for(int n = 0; n < depth; ++n)
-		printf(" ");
+static void dumpItem(const TemplateItem &item, int depth = 0) {
+    for (int n = 0; n < depth; ++n)
+        printf(" ");
 
-	if(item.type == TemplateItem::Root)
-	{
-		printf("root\n");
-		foreach(const TemplateItem &i, item.children)
-			dumpItem(i, depth + 2);
-	}
-	else if(item.type == TemplateItem::Content)
-	{
-		printf("content: [%s]\n", qPrintable(item.data));
-	}
-	else if(item.type == TemplateItem::Expression)
-	{
-		printf("expression: [%s]\n", qPrintable(item.data));
-	}
-	else if(item.type == TemplateItem::If)
-	{
-		printf("if: [%s]\n", qPrintable(item.data));
-		foreach(const TemplateItem &i, item.children)
-			dumpItem(i, depth + 2);
-	}
-	else if(item.type == TemplateItem::For)
-	{
-		printf("for: [%s]\n", qPrintable(item.data));
-		foreach(const TemplateItem &i, item.children)
-			dumpItem(i, depth + 2);
-	}
+    if (item.type == TemplateItem::Root) {
+        printf("root\n");
+        foreach (const TemplateItem &i, item.children)
+            dumpItem(i, depth + 2);
+    } else if (item.type == TemplateItem::Content) {
+        printf("content: [%s]\n", qPrintable(item.data));
+    } else if (item.type == TemplateItem::Expression) {
+        printf("expression: [%s]\n", qPrintable(item.data));
+    } else if (item.type == TemplateItem::If) {
+        printf("if: [%s]\n", qPrintable(item.data));
+        foreach (const TemplateItem &i, item.children)
+            dumpItem(i, depth + 2);
+    } else if (item.type == TemplateItem::For) {
+        printf("for: [%s]\n", qPrintable(item.data));
+        foreach (const TemplateItem &i, item.children)
+            dumpItem(i, depth + 2);
+    }
 }
 
-QString render(const QString &content, const VariantMap &context, QString *error)
-{
-	TemplateItem root;
-	root.type = TemplateItem::Root;
-	int pos = 0;
-	QString error_;
-	root.children = parseContent(content, &pos, ControlNone, &error_);
-	if(!error_.isEmpty())
-	{
-		if(error)
-			*error = error_;
-		return QString();
-	}
+QString render(const QString &content, const VariantMap &context, QString *error) {
+    TemplateItem root;
+    root.type = TemplateItem::Root;
+    int pos = 0;
+    QString error_;
+    root.children = parseContent(content, &pos, ControlNone, &error_);
+    if (!error_.isEmpty()) {
+        if (error)
+            *error = error_;
+        return QString();
+    }
 
-	QString result = renderInternal(root, context, &error_);
-	if(!error_.isEmpty())
-	{
-		if(error)
-			*error = error_;
-		return QString();
-	}
+    QString result = renderInternal(root, context, &error_);
+    if (!error_.isEmpty()) {
+        if (error)
+            *error = error_;
+        return QString();
+    }
 
-	return result;
+    return result;
 }
 
-bool renderFile(const QString &inFile, const QString &outFile, const VariantMap &context, QString *error)
-{
-	QFile in(inFile);
-	if(!in.open(QFile::ReadOnly | QFile::Text))
-	{
-		if(error)
-			*error = QString("error reading file \"%1\"").arg(inFile);
-		return false;
-	}
+bool renderFile(const QString &inFile, const QString &outFile, const VariantMap &context,
+                QString *error) {
+    QFile in(inFile);
+    if (!in.open(QFile::ReadOnly | QFile::Text)) {
+        if (error)
+            *error = QString("error reading file \"%1\"").arg(inFile);
+        return false;
+    }
 
-	QString inFileData = QString::fromLocal8Bit(in.readAll());
-	in.close();
+    QString inFileData = QString::fromLocal8Bit(in.readAll());
+    in.close();
 
-	QString error_;
-	QString outFileData = render(inFileData, context, &error_);
-	if(outFileData.isNull())
-	{
-		if(error)
-			*error = QString("error rendering template: %1").arg(error_);
-		return false;
-	}
+    QString error_;
+    QString outFileData = render(inFileData, context, &error_);
+    if (outFileData.isNull()) {
+        if (error)
+            *error = QString("error rendering template: %1").arg(error_);
+        return false;
+    }
 
-	QFile out(outFile);
-	if(!out.open(QFile::WriteOnly | QFile::Truncate))
-	{
-		if(error)
-			*error = QString("error writing file \"%1\"").arg(outFile);
-		return false;
-	}
+    QFile out(outFile);
+    if (!out.open(QFile::WriteOnly | QFile::Truncate)) {
+        if (error)
+            *error = QString("error writing file \"%1\"").arg(outFile);
+        return false;
+    }
 
-	int ret = out.write(outFileData.toLocal8Bit());
-	if(ret == -1)
-	{
-		if(error)
-			*error = QString("error writing file \"%1\"").arg(outFile);
-		return false;
-	}
+    int ret = out.write(outFileData.toLocal8Bit());
+    if (ret == -1) {
+        if (error)
+            *error = QString("error writing file \"%1\"").arg(outFile);
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
-void dumpTemplate(const QString &content)
-{
-	TemplateItem root;
-	root.type = TemplateItem::Root;
-	int pos = 0;
-	QString error;
-	root.children = parseContent(content, &pos, ControlNone, &error);
-	if(!error.isEmpty())
-	{
-		printf("error parsing template: %s\n", qPrintable(error));
-		return;
-	}
+void dumpTemplate(const QString &content) {
+    TemplateItem root;
+    root.type = TemplateItem::Root;
+    int pos = 0;
+    QString error;
+    root.children = parseContent(content, &pos, ControlNone, &error);
+    if (!error.isEmpty()) {
+        printf("error parsing template: %s\n", qPrintable(error));
+        return;
+    }
 
-	dumpItem(root);
+    dumpItem(root);
 }
 
-}
+} // namespace Template

--- a/src/runner/template.h
+++ b/src/runner/template.h
@@ -23,16 +23,17 @@
 #ifndef TEMPLATE_H
 #define TEMPLATE_H
 
-#include <QString>
 #include "variant.h"
+#include <QString>
 
 namespace Template {
 
 QString render(const QString &content, const VariantMap &context, QString *error = 0);
-bool renderFile(const QString &inFile, const QString &outFile, const VariantMap &context, QString *error = 0);
+bool renderFile(const QString &inFile, const QString &outFile, const VariantMap &context,
+                QString *error = 0);
 
 void dumpTemplate(const QString &content);
 
-}
+} // namespace Template
 
 #endif

--- a/src/runner/templatetest.cpp
+++ b/src/runner/templatetest.cpp
@@ -21,44 +21,44 @@
  * $FANOUT_END_LICENSE$
  */
 
+#include "template.h"
 #include "test.h"
 #include "variant.h"
-#include "template.h"
 
-static void render()
-{
-	VariantMap context;
-	context["place"] = "world";
+static void render() {
+    VariantMap context;
+    context["place"] = "world";
 
-	VariantMap user;
-	user["first"] = "john";
-	user["last"] = "smith";
-	context["user"] = user;
+    VariantMap user;
+    user["first"] = "john";
+    user["last"] = "smith";
+    context["user"] = user;
 
-	VariantList fruits;
-	fruits.append("apple");
-	fruits.append("banana");
-	context["fruits"] = fruits;
+    VariantList fruits;
+    fruits.append("apple");
+    fruits.append("banana");
+    context["fruits"] = fruits;
 
-	QString content("hello {{ place }}!");
-	QString output = Template::render(content, context);
-	TEST_ASSERT_EQ(output, QString("hello world!"));
+    QString content("hello {{ place }}!");
+    QString output = Template::render(content, context);
+    TEST_ASSERT_EQ(output, QString("hello world!"));
 
-	content = QString("hello {% if formal %}{{ user.last }}{% endif %}{% if not formal %}{{ user.first }}{% endif %}!");
-	output = Template::render(content, context);
-	TEST_ASSERT_EQ(output, QString("hello john!"));
-	context["formal"] = true;
-	output = Template::render(content, context);
-	TEST_ASSERT_EQ(output, QString("hello smith!"));
+    content = QString("hello {% if formal %}{{ user.last }}{% endif %}{% if not "
+                      "formal %}{{ user.first }}{% endif %}!");
+    output = Template::render(content, context);
+    TEST_ASSERT_EQ(output, QString("hello john!"));
+    context["formal"] = true;
+    output = Template::render(content, context);
+    TEST_ASSERT_EQ(output, QString("hello smith!"));
 
-	content = QString("please eat {% for f in fruits %}{% if not loop.first %} and {% endif %}fresh {{ f }}s{% endfor %}.");
-	output = Template::render(content, context);
-	TEST_ASSERT_EQ(output, QString("please eat fresh apples and fresh bananas."));
+    content = QString("please eat {% for f in fruits %}{% if not loop.first %} "
+                      "and {% endif %}fresh {{ f }}s{% endfor %}.");
+    output = Template::render(content, context);
+    TEST_ASSERT_EQ(output, QString("please eat fresh apples and fresh bananas."));
 }
 
-extern "C" int template_test(ffi::TestException *out_ex)
-{
-	TEST_CATCH(render());
+extern "C" int template_test(ffi::TestException *out_ex) {
+    TEST_CATCH(render());
 
-	return 0;
+    return 0;
 }

--- a/src/runner/zurlservice.cpp
+++ b/src/runner/zurlservice.cpp
@@ -22,66 +22,52 @@
 
 #include "zurlservice.h"
 
-#include <QDir>
-#include <QProcess>
 #include "log.h"
 #include "template.h"
 #include "variant.h"
+#include <QDir>
+#include <QProcess>
 
-ZurlService::ZurlService(
-	const QString &binFile,
-	const QString &configTemplateFile,
-	const QString &runDir,
-	const QString &logDir,
-	const QString &ipcPrefix,
-	const QString &filePrefix,
-	int logLevel)
-{
-	args_ += binFile;
-	args_ += "--config=" + QDir(runDir).filePath(filePrefix + "zurl.conf");
+ZurlService::ZurlService(const QString &binFile, const QString &configTemplateFile,
+                         const QString &runDir, const QString &logDir, const QString &ipcPrefix,
+                         const QString &filePrefix, int logLevel) {
+    args_ += binFile;
+    args_ += "--config=" + QDir(runDir).filePath(filePrefix + "zurl.conf");
 
-	if(!logDir.isEmpty())
-	{
-		args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "zurl.log");
-		setStandardOutputFile(QProcess::nullDevice());
-	}
+    if (!logDir.isEmpty()) {
+        args_ += "--logfile=" + QDir(logDir).filePath(filePrefix + "zurl.log");
+        setStandardOutputFile(QProcess::nullDevice());
+    }
 
-	if(logLevel >= 3)
-		args_ += "--verbose";
-	else
-		args_ += "--loglevel=" + QString::number(logLevel);
+    if (logLevel >= 3)
+        args_ += "--verbose";
+    else
+        args_ += "--loglevel=" + QString::number(logLevel);
 
-	configTemplateFile_ = configTemplateFile;
-	runDir_ = runDir;
-	ipcPrefix_ = ipcPrefix;
-	filePrefix_ = filePrefix;
+    configTemplateFile_ = configTemplateFile;
+    runDir_ = runDir;
+    ipcPrefix_ = ipcPrefix;
+    filePrefix_ = filePrefix;
 
-	setName("zurl");
-	setPidFile(QDir(runDir).filePath(filePrefix + "zurl.pid"));
+    setName("zurl");
+    setPidFile(QDir(runDir).filePath(filePrefix + "zurl.pid"));
 }
 
-QStringList ZurlService::arguments() const
-{
-	return args_;
-}
+QStringList ZurlService::arguments() const { return args_; }
 
-bool ZurlService::acceptSighup() const
-{
-	return true;
-}
+bool ZurlService::acceptSighup() const { return true; }
 
-bool ZurlService::preStart()
-{
-	VariantMap context;
-	context["rundir"] = runDir_;
-	context["ipc_prefix"] = ipcPrefix_;
+bool ZurlService::preStart() {
+    VariantMap context;
+    context["rundir"] = runDir_;
+    context["ipc_prefix"] = ipcPrefix_;
 
-	QString error;
-	if(!Template::renderFile(configTemplateFile_, QDir(runDir_).filePath(filePrefix_ + "zurl.conf"), context, &error))
-	{
-		log_error("Failed to generate zurl config file: %s", qPrintable(error));
-		return false;
-	}
+    QString error;
+    if (!Template::renderFile(configTemplateFile_,
+                              QDir(runDir_).filePath(filePrefix_ + "zurl.conf"), context, &error)) {
+        log_error("Failed to generate zurl config file: %s", qPrintable(error));
+        return false;
+    }
 
-	return true;
+    return true;
 }

--- a/src/runner/zurlservice.h
+++ b/src/runner/zurlservice.h
@@ -25,30 +25,24 @@
 
 #include "service.h"
 
-class ZurlService : public Service
-{
+class ZurlService : public Service {
 public:
-	ZurlService(
-		const QString &binFile,
-		const QString &configTemplateFile,
-		const QString &runDir,
-		const QString &logDir,
-		const QString &ipcPrefix,
-		const QString &filePrefix,
-		int logLevel);
+    ZurlService(const QString &binFile, const QString &configTemplateFile, const QString &runDir,
+                const QString &logDir, const QString &ipcPrefix, const QString &filePrefix,
+                int logLevel);
 
-	// Reimplemented
+    // Reimplemented
 
-	virtual QStringList arguments() const;
-	virtual bool acceptSighup() const;
-	virtual bool preStart();
+    virtual QStringList arguments() const;
+    virtual bool acceptSighup() const;
+    virtual bool preStart();
 
 private:
-	QString configTemplateFile_;
-	QString runDir_;
-	QString ipcPrefix_;
-	QString filePrefix_;
-	QStringList args_;
+    QString configTemplateFile_;
+    QString runDir_;
+    QString ipcPrefix_;
+    QString filePrefix_;
+    QStringList args_;
 };
 
 #endif


### PR DESCRIPTION
We should autoformat the C++ code similar to how we use rustfmt for the Rust code. This PR uses `clang-format` to reformat all of the C++ code to a consistent, modern style. I did not attempt to preserve the existing style which was doing some things I think we should phase out, such as braces on new lines. This change only contains the reformatting and nothing else. Later, we can add a `.clang-format` file, update CI to enforce style, etc.

To review, I suggest performing the same mass reformatting locally and confirming the resulting diff is the same as this one. To do that:

* Install `clang-format`

* Add the following `.clang-format` file to the root of the project:

```
Language: Cpp
BasedOnStyle: LLVM

# Use 4 spaces to match rustfmt
IndentWidth: 4
ContinuationIndentWidth: 4
ConstructorInitializerIndentWidth: 4

# Keep braces on the same line (Rust/Modern C++ style)
BreakBeforeBraces: Attach

# Clean layout
ConstructorInitializerAllOnOneLineOrOnePerLine: true
AccessModifierOffset: -4
ColumnLimit: 100
```

* Run `find src -name "*.cpp" -o -name "*.h" | xargs clang-format -i` from the project root. As far as I can tell, clang-format can't crawl a project tree on its own so we have to use something like `find` to hit every file.