### PR TITLE
add proper include

### DIFF
--- a/src/core/zmqreqmessage.h
+++ b/src/core/zmqreqmessage.h
@@ -24,7 +24,7 @@
 #ifndef ZMQREQMESSAGE_H
 #define ZMQREQMESSAGE_H
 
-class CowByteArrayList;
+#include "cowbytearray.h"
 
 class ZmqReqMessage
 {


### PR DESCRIPTION
This should be an include rather than a forward declaration, which was only working by luck. We need this for the upcoming clang-format reformatting to work, since it sorts includes.