### PR TITLE
check c++ formatting in CI and add "make fmt"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+Language: Cpp
+BasedOnStyle: LLVM
+
+# Use 4 spaces to match rustfmt
+IndentWidth: 4
+ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 4
+
+# Keep braces on the same line (Rust/Modern C++ style)
+BreakBeforeBraces: Attach
+
+# Clean layout
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AccessModifierOffset: -4
+ColumnLimit: 100

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -61,8 +61,10 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
-    - name: fmt
+    - name: format rust
       run:  RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} fmt --check
+    - name: format c++
+      run:  find src -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror -style=file
     - name: format python
       run:  black --check .
   build:

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,22 @@ endif
 
 all: postbuild
 
+fmt: cargo-fmt cpp-fmt FORCE
+
 build: FORCE
 	cargo$(cargo_toolchain) build$(cargo_flags)
+
+cargo-fmt: FORCE
+	cargo fmt
 
 cargo-test: FORCE
 	cargo$(cargo_toolchain) test$(cargo_flags) --all-features
 
 cargo-clean: FORCE
 	cargo clean
+
+cpp-fmt: FORCE
+	find src -name "*.cpp" -o -name "*.h" | xargs clang-format -i
 
 postbuild: build FORCE
 	cd postbuild && $(MAKE) -f Makefile


### PR DESCRIPTION
This adds validation for C++ file formatting. The files were already reformatted earlier (#48328), and the CI jobs on this PR confirm the validation passes.

Also, some directives are added to the Makefile:

* `make cpp-fmt` - Format C++ files only.
* `make fmt` - Format Rust and C++ files.