### PR TITLE
update build image to include clang-format

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,9 +1,9 @@
-FROM --platform=linux/amd64 ubuntu:24.04
+FROM --platform=$BUILDPLATFORM ubuntu:24.04
 
 ENV TZ=US \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get install -y zstd git pkg-config curl make g++ libssl-dev libzmq3-dev qt6-base-dev libboost-dev black
+RUN apt-get -qq update && apt-get install -y zstd git pkg-config curl make g++ libssl-dev libzmq3-dev qt6-base-dev libboost-dev clang-format black
 
 # install toolchain
 RUN curl https://sh.rustup.rs -sSf | \


### PR DESCRIPTION
I pushed a new image (amd64 as usual) with these changes so the CI jobs on this PR are run against the updated image. Notably, the updated image includes the latest Rust version as well.