### PR TITLE
update build image to use latest clang-format

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -3,7 +3,18 @@ FROM --platform=$BUILDPLATFORM ubuntu:24.04
 ENV TZ=US \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -qq update && apt-get install -y zstd git pkg-config curl make g++ libssl-dev libzmq3-dev qt6-base-dev libboost-dev clang-format black
+# apt repo for clang
+RUN apt-get -qq update && apt-get install -y lsb-release software-properties-common gnupg curl
+RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key -sSf | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc) main" | tee /etc/apt/sources.list.d/llvm.list
+RUN apt-get -qq update
+
+# install clang-format
+RUN apt-get install -y clang-format-20
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
+
+# install remaining dependencies
+RUN apt-get install -y zstd git pkg-config make g++ libssl-dev libzmq3-dev qt6-base-dev libboost-dev black
 
 # install toolchain
 RUN curl https://sh.rustup.rs -sSf | \


### PR DESCRIPTION
In #48328, the C++ files were reformatted using clang-format version 22 from Homebrew. However, the version in the build image is 18 and produces different formatting results, which means we can't use it for enforcement in CI. This PR updates the build image to use version 20, which is the latest stable and for our purposes it appears to be compatible with 22.

I'm not sure why the Homebrew formula is of an unstable release but I guess we can just be happy the versions are compatible at this time. It is possible to access version 20 on Homebrew by installing the LLVM formula, but this is a bit heavy handed and since it doesn't appear necessary I don't recommend it.

I pushed a new build image with these changes, so the CI jobs on this PR are using the updated image. I also posted a draft PR (#48330) based on this PR to test enforcement.