### PR TITLE
proxy/handler: send logs via the rust log crate

### DIFF
--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -27,6 +27,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include "rust/bindings.h"
+
 Q_GLOBAL_STATIC(QMutex, g_mutex)
 static int g_level = LOG_LEVEL_DEBUG;
 static QElapsedTimer g_time;
@@ -44,6 +46,16 @@ static void log(const char *s) {
 }
 
 static void log(int level, const char *fmt, va_list ap) {
+    // Check if Rust logger is initialized
+    if (ffi::log_initialized()) {
+        // Send formatted message directly to Rust logger
+        QString str = QString::vasprintf(fmt, ap);
+        ffi::log_log(level, str.toUtf8().data());
+        return;
+    }
+
+    // Fall back to C++ logging system
+
     g_mutex()->lock();
     int current_level = g_level;
     int elapsed;
@@ -171,4 +183,14 @@ void log_debug(const char *fmt, ...) {
     va_end(ap);
 }
 
-void log_raw(const char *s) { log(s); }
+void log_raw(const char *s) {
+    // Check if Rust logger is initialized
+    if (ffi::log_initialized()) {
+        // Send raw message to Rust logger (already formatted with level, timestamp, etc.)
+        ffi::log_log_raw(s);
+        return;
+    }
+
+    // Fall back to C++ logging system
+    log(s);
+}

--- a/src/core/log.rs
+++ b/src/core/log.rs
@@ -22,7 +22,7 @@ use crate::core::net::{AsyncUnixListener, AsyncUnixStream};
 use crate::core::reactor::Reactor;
 use crate::core::select::{select_2, Select2};
 use crate::core::task::{get_reactor, CancellationSender, CancellationToken};
-use log::{debug, warn, LevelFilter, Log, Metadata, Record};
+use log::{debug, error, warn, LevelFilter, Log, Metadata, Record};
 use mio::net::UnixListener;
 use std::fmt::Write as _;
 use std::fs::File;
@@ -166,7 +166,7 @@ impl Log for SimpleLogger {
             log::Level::Trace => "TRACE",
         };
 
-        if record.level() <= log::Level::Info {
+        if record.level() <= log::Level::Info || record.target().is_empty() {
             writeln!(&mut output, "[{}] {} {}", lname, ts, record.args())
                 .expect("failed to write log output");
         } else {
@@ -561,4 +561,125 @@ impl Log for DebugLogger {
     }
 
     fn flush(&self) {}
+}
+
+mod ffi {
+    use super::*;
+    use std::ffi::{c_char, c_int, CStr};
+    use std::fs::OpenOptions;
+
+    /// If `output_file` is non-null, attempt to configure logging to the
+    /// specified file. If `output_file` is null, log to stdout.
+    ///
+    /// Returns 0 on success, or non-zero if there was a problem opening
+    /// the log file. In the latter case, the logging system will still be
+    /// initialized, but will be configured log to stdout instead of a file,
+    /// and a file error message will be logged.
+    #[no_mangle]
+    pub extern "C" fn log_init(output_file: *const c_char) -> c_int {
+        let (output_file, file_error) = if !output_file.is_null() {
+            let f = unsafe {
+                CStr::from_ptr(output_file)
+                    .to_str()
+                    .expect("output_file must be utf-8")
+            };
+
+            match OpenOptions::new().create(true).append(true).open(f) {
+                Ok(f) => (Some(f), None),
+                Err(e) => (None, Some((f, e))),
+            }
+        } else {
+            (None, None)
+        };
+
+        ensure_init_simple_logger(output_file, false);
+
+        // Allow all log levels globally so individual loggers can limit as they choose
+        log::set_max_level(LevelFilter::Trace);
+
+        let logger = get_simple_logger();
+
+        log::set_logger(logger).unwrap();
+        logger.set_max_level(LevelFilter::Trace);
+
+        // Log any file opening error after initializing the logger
+        if let Some((f, e)) = file_error {
+            error!("failed to open log file {f}: {e}");
+            return -1;
+        }
+
+        0
+    }
+
+    #[no_mangle]
+    pub extern "C" fn log_initialized() -> c_int {
+        if LOGGER.get().is_some() {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn log_set_level(level: c_int) {
+        let level = match level {
+            core::i32::MIN..=0 => log::LevelFilter::Error,
+            1 => log::LevelFilter::Warn,
+            2 => log::LevelFilter::Info,
+            3 => log::LevelFilter::Debug,
+            4..=core::i32::MAX => log::LevelFilter::Trace,
+        };
+
+        get_simple_logger().set_max_level(level);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn log_log(level: c_int, message: *const c_char) {
+        if message.is_null() {
+            return;
+        }
+
+        let message = unsafe {
+            match CStr::from_ptr(message).to_str() {
+                Ok(s) => s,
+                Err(_) => return, // Invalid UTF-8, skip
+            }
+        };
+
+        let rust_level = match level {
+            0 => log::Level::Error, // LOG_LEVEL_ERROR
+            1 => log::Level::Warn,  // LOG_LEVEL_WARNING
+            2 => log::Level::Info,  // LOG_LEVEL_INFO
+            3 => log::Level::Debug, // LOG_LEVEL_DEBUG
+            _ => log::Level::Debug, // Default to debug for unknown levels
+        };
+
+        // The default log target is the current Rust module, but this isn't
+        // meaningful when logging via FFI, so let's set an empty target.
+        log::log!(target: "", rust_level, "{}", message);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn log_log_raw(message: *const c_char) {
+        if message.is_null() {
+            return;
+        }
+
+        let message = unsafe {
+            match CStr::from_ptr(message).to_str() {
+                Ok(s) => s,
+                Err(_) => return, // Invalid UTF-8, skip
+            }
+        };
+
+        let logger = get_simple_logger();
+
+        let mut output = match &logger.output_file {
+            Some(f) => SharedOutput::File(f),
+            None => SharedOutput::Stdout(io::stdout()),
+        };
+
+        // Write raw message directly to output (assuming it's already formatted)
+        writeln!(&mut output, "{}", message).expect("failed to write log output");
+    }
 }

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -161,19 +161,15 @@ extern "C" {
 int handler_init(const ffi::HandlerCliArgs *argsFfi) {
     HandlerArgsData args(argsFfi);
 
-    // Set the log level
-    if (args.logLevel != -1)
-        log_setOutputLevel(args.logLevel);
+    if (!args.logFile.isEmpty())
+        ffi::log_init(args.logFile.toUtf8().data());
     else
-        log_setOutputLevel(LOG_LEVEL_INFO);
+        ffi::log_init(nullptr);
 
-    // Set the log file if specified
-    if (!args.logFile.isEmpty()) {
-        if (!log_setFile(args.logFile)) {
-            log_error("failed to open log file: %s", qPrintable(args.logFile));
-            return 1;
-        }
-    }
+    if (args.logLevel != -1)
+        ffi::log_set_level(args.logLevel);
+    else
+        ffi::log_set_level(LOG_LEVEL_INFO);
 
     log_debug("starting...");
 

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -348,19 +348,15 @@ extern "C" {
 int proxy_init(const ffi::ProxyCliArgs *argsFfi) {
     ProxyArgsData args(argsFfi);
 
-    // Set the log level
-    if (args.logLevel != -1)
-        log_setOutputLevel(args.logLevel);
+    if (!args.logFile.isEmpty())
+        ffi::log_init(args.logFile.toUtf8().data());
     else
-        log_setOutputLevel(LOG_LEVEL_INFO);
+        ffi::log_init(nullptr);
 
-    // Set the log file if specified
-    if (!args.logFile.isEmpty()) {
-        if (!log_setFile(args.logFile)) {
-            log_error("failed to open log file: %s", qPrintable(args.logFile));
-            return 1;
-        }
-    }
+    if (args.logLevel != -1)
+        ffi::log_set_level(args.logLevel);
+    else
+        ffi::log_set_level(LOG_LEVEL_INFO);
 
     log_debug("starting...");
 


### PR DESCRIPTION
Currently, when calling C++ code from Rust, any logging performed by the C++ code won't behave properly unless the C++ logger is also initialized. We have similar problems going the other direction. This PR attempts to consolidate all logging from either language to use the Rust logger by:

* Adding FFI functions for initializing the Rust logger and writing messages to it.
* Updating the C++ logging functions to write log messages to the Rust logger if it has been initialized.
* Updating proxy and handler to initialize the Rust logger at startup instead of the C++ logger.

If the Rust logger is not initialized then the C++ logging functions will behave based on the C++ logger configuration. The only programs left doing this are the legacy runner and m2adapter, which are deprecated.