### PR TITLE
add ffi and rust wrapper for domainmap

### DIFF
--- a/src/core/defercall.cpp
+++ b/src/core/defercall.cpp
@@ -25,6 +25,7 @@
 #include "event.h"
 #include "eventloop.h"
 #include "timer.h"
+#include <QCoreApplication>
 #include <QMetaObject>
 #include <QObject>
 #include <boost/signals2.hpp>
@@ -37,6 +38,9 @@ class ThreadWake : public QObject {
 public:
     ThreadWake() : customRegId_(-1), wakeQueued_(false) {
         EventLoop *loop = EventLoop::instance();
+
+        // Require an event loop to avoid queuing up idle events
+        assert(loop || QCoreApplication::instance());
 
         if (loop) {
             auto [regId, sr] = loop->registerCustom(ThreadWake::cb_ready, this);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,25 @@ pub mod ffi {
     #[cfg(test)]
     use crate::core::test::TestException;
 
+    // Route parameters struct for FFI (matches C++ struct)
+    #[repr(C)]
+    pub struct DomainMapRouteParams {
+        pub log_level: libc::c_int,
+    }
+
+    // Opaque handle to C++ DomainMap
+    pub enum DomainMap {}
+
+    import_cpp! {
+        pub fn domainmap_create(filename: *const libc::c_char) -> *mut DomainMap;
+        pub fn domainmap_destroy(handle: *mut DomainMap);
+        pub fn domainmap_entry_params(
+            handle: *mut DomainMap,
+            route_id: *const libc::c_char,
+            params: *mut DomainMapRouteParams,
+        ) -> libc::c_int;
+    }
+
     #[cfg(test)]
     import_cpptest! {
         pub fn cowbytearray_test(out_ex: *mut TestException) -> libc::c_int;

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "routesfile.h"
 #include "timer.h"
+#include <QCoreApplication>
 #include <QDir>
 #include <QFile>
 #include <QHash>
@@ -723,6 +724,8 @@ public:
         }
 
         thread.join();
+
+        log_debug("domainmap thread stopped");
     }
 
     void start() {
@@ -742,6 +745,8 @@ public:
     }
 
     void run() {
+        log_debug("domainmap thread started");
+
         // Will unlock during exec
         m.lock();
 
@@ -770,9 +775,13 @@ public:
     DomainMap *q;
     Thread *thread;
     Connection changedConnection;
-    DeferCall deferCall;
+    std::unique_ptr<DeferCall> deferCall;
 
-    Private(DomainMap *_q) : q(_q), thread(0) {}
+    Private(DomainMap *_q) : q(_q), thread(0) {
+        // Only emit signals in the current thread if there is an event loop
+        if (EventLoop::instance() || QCoreApplication::instance())
+            deferCall = std::make_unique<DeferCall>();
+    }
 
     ~Private() {
         changedConnection.disconnect();
@@ -792,10 +801,12 @@ public:
 private:
     // NOTE: called from worker thread
     void workerChanged() {
-        deferCall.defer([=] {
-            // NOTE: called from outer thread
-            doChanged();
-        });
+        if (deferCall) {
+            deferCall->defer([=] {
+                // NOTE: called from outer thread
+                doChanged();
+            });
+        }
     }
 
     void doChanged() { q->changed(); }
@@ -896,3 +907,42 @@ bool DomainMap::addRouteLine(const QString &line) {
     QMutexLocker locker(&d->thread->worker->m);
     return d->thread->worker->addRouteLine(line);
 }
+
+// FFI functions for Rust integration
+extern "C" {
+
+// Route parameters struct for FFI
+struct DomainMapRouteParams {
+    int log_level;
+};
+
+DomainMap *domainmap_create(const char *filename) {
+    if (!filename) {
+        return nullptr;
+    }
+
+    QString qfilename = QString::fromUtf8(filename);
+    return new DomainMap(qfilename);
+}
+
+void domainmap_destroy(DomainMap *handle) { delete handle; }
+
+int domainmap_entry_params(DomainMap *handle, const char *route_id, DomainMapRouteParams *params) {
+    if (!handle || !route_id || !params) {
+        return -1;
+    }
+
+    QString qroute_id = QString::fromUtf8(route_id);
+    DomainMap::Entry entry = handle->entry(qroute_id);
+
+    if (entry.isNull()) {
+        return -1;
+    }
+
+    // Extract route parameters
+    params->log_level = entry.logLevel;
+
+    return 0;
+}
+
+} // extern "C"

--- a/src/proxy/domainmap.rs
+++ b/src/proxy/domainmap.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * This file is part of Pushpin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::ffi::CString;
+use std::os::raw::c_int;
+use std::ptr;
+
+/// Route parameters returned by DomainMap lookups
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct RouteParams {
+    pub log_level: c_int,
+}
+
+/// Rust wrapper for DomainMap FFI
+pub struct DomainMap {
+    handle: *mut crate::ffi::DomainMap,
+}
+
+impl DomainMap {
+    /// Create a new DomainMap instance
+    pub fn new(filename: &str) -> Self {
+        let c_filename = CString::new(filename).expect("filename contains null byte");
+
+        let handle = unsafe { crate::ffi::domainmap_create(c_filename.as_ptr()) };
+
+        assert!(
+            !handle.is_null(),
+            "domainmap_create should never return null"
+        );
+
+        DomainMap { handle }
+    }
+
+    /// Look up route parameters by route ID
+    pub fn lookup(&self, route_id: &str) -> Option<RouteParams> {
+        let c_route_id = match CString::new(route_id) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+
+        let mut ffi_params = crate::ffi::DomainMapRouteParams { log_level: 0 };
+
+        let result = unsafe {
+            crate::ffi::domainmap_entry_params(self.handle, c_route_id.as_ptr(), &mut ffi_params)
+        };
+
+        if result == 0 {
+            Some(RouteParams {
+                log_level: ffi_params.log_level,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for DomainMap {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                crate::ffi::domainmap_destroy(self.handle);
+            }
+            self.handle = ptr::null_mut();
+        }
+    }
+}
+
+// Ensure the handle type is Send and Sync since DomainMap uses internal locking
+// The C++ DomainMap is thread-safe with internal QMutex locking
+unsafe impl Send for DomainMap {}
+unsafe impl Sync for DomainMap {}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -15,6 +15,7 @@
  */
 
 pub mod cliargs;
+pub mod domainmap;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This makes `DomainMap` available to Rust, without actually using it anywhere yet. For now the API is minimal, only allowing looking up the `log_level` of a route by ID.

Normally, `DomainMap` emits a signal whenever the routes file changes, but this only makes sense if there is a C++-managed event loop in the thread that instantiated it otherwise the queued signals may pile up. To make `DomainMap` usable in Rust apps that won't have such an event loop, this PR makes it so signals are only emitted when one is detected. An assertion is also added to `DeferCall` to prevent doing the wrong thing by accident.

Manually tested with the following local change:

```diff
--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -473,6 +473,10 @@ impl App {
 pub fn run(config: &Config) -> Result<(), Box<dyn Error>> {
     debug!("starting...");
 
+    let domainmap = crate::proxy::domainmap::DomainMap::new("routes");
+    let params = domainmap.lookup("example").unwrap();
+    info!("example log_level={}", params.log_level);
+
     {
         let a = match App::new(config) {
             Ok(a) => a,
```

Results:

```
% cat routes 
* test
example.com,id=example,log_level=1 test

% bin/pushpin-connmgr --log-level 3         
[DEBUG] 2026-04-29 11:24:51.670 [pushpin::connmgr] starting...
[DEBUG] 2026-04-29 11:24:51.670 domainmap thread started
[DEBUG] 2026-04-29 11:24:51.672 routes by domain:
[DEBUG] 2026-04-29 11:24:51.672   (default): test
[DEBUG] 2026-04-29 11:24:51.672   example.com: test
[INFO] 2026-04-29 11:24:51.672 routes loaded with 2 entries
[INFO] 2026-04-29 11:24:51.672 example log_level=1
...
[INFO] 2026-04-29 11:24:54.140 routes file changed, reloading
[DEBUG] 2026-04-29 11:24:55.133 routes by domain:
[DEBUG] 2026-04-29 11:24:55.133   (default): test
[DEBUG] 2026-04-29 11:24:55.133   example.com: test
[INFO] 2026-04-29 11:24:55.133 routes loaded with 2 entries
...
^C[INFO] 2026-04-29 11:25:00.778 stopping...
...
[DEBUG] 2026-04-29 11:25:00.784 [pushpin::connmgr] stopped
[DEBUG] 2026-04-29 11:25:00.785 domainmap thread stopped
```