### PR TITLE
reflow c++ comments using 100 char line limit, plus corrections

### DIFF
--- a/src/core/bufferlist.cpp
+++ b/src/core/bufferlist.cpp
@@ -62,8 +62,7 @@ QByteArray BufferList::mid(int pos, int size) const {
     int offset;
     findPos(pos, &at, &offset);
 
-    // If we're reading the exact size of the current buffer, cheaply
-    // return it
+    // If we're reading the exact size of the current buffer, cheaply return it
     if (offset == 0 && bufs_[at].size() == toRead)
         return bufs_[at];
 
@@ -114,8 +113,7 @@ QByteArray BufferList::take(int size) {
 
     assert(!bufs_.isEmpty());
 
-    // If we're reading the exact size of the first buffer, cheaply
-    // return it
+    // If we're reading the exact size of the first buffer, cheaply return it
     if (offset_ == 0 && bufs_.first().size() == toRead) {
         size_ -= toRead;
         return bufs_.takeFirst();

--- a/src/core/cowbytearray.h
+++ b/src/core/cowbytearray.h
@@ -71,9 +71,8 @@ private:
     QByteArray &inner_;
 };
 
-// QByteArray-like class that currently forwards to an inner QByteArray, to
-// assist with reducing direct dependency on Qt. The API is designed to allow
-// cheap conversion to/from QByteArray.
+// QByteArray-like class that currently forwards to an inner QByteArray, to assist with reducing
+// direct dependency on Qt. The API is designed to allow cheap conversion to/from QByteArray.
 class CowByteArray {
 public:
     CowByteArray() = default;
@@ -164,10 +163,9 @@ inline CowByteArray CowByteArrayRef::mid(ssize_t pos, ssize_t len) const {
     return inner_.mid(pos, len);
 }
 
-// QList-like class for working with CowByteArray that currently forwards to
-// an inner QList<QByteArray>, to assist with reducing direct dependency on
-// Qt. The API is designed to allow cheap conversion to/from
-// QList<QByteArray> and to allow cheap conversions of inserts/lookups
+// QList-like class for working with CowByteArray that currently forwards to an inner
+// QList<QByteArray>, to assist with reducing direct dependency on Qt. The API is designed to allow
+// cheap conversion to/from QList<QByteArray> and to allow cheap conversions of inserts/lookups
 // to/from QByteArray.
 class CowByteArrayList {
 public:

--- a/src/core/cowbytearraytest.cpp
+++ b/src/core/cowbytearraytest.cpp
@@ -77,8 +77,7 @@ static void methods() {
     TEST_ASSERT_EQ(a.size(), 5);
     TEST_ASSERT_EQ(a.length(), 5);
 
-    // Data (const and non)
-    // data is null-terminated but the null is not counted in the size
+    // Data (const and non). The data is null-terminated but the null is not counted in the size
     TEST_ASSERT_EQ(strcmp(std::as_const(a).data(), "hello"), 0);
     TEST_ASSERT_EQ(strcmp(a.data(), "hello"), 0);
 

--- a/src/core/cowstring.h
+++ b/src/core/cowstring.h
@@ -20,9 +20,8 @@
 #include "cowbytearray.h"
 #include <QString>
 
-// QString-like class that currently forwards to an inner QString, to
-// assist with reducing direct dependency on Qt. The API is designed to allow
-// cheap conversion to/from QString.
+// QString-like class that currently forwards to an inner QString, to assist with reducing direct
+// dependency on Qt. The API is designed to allow cheap conversion to/from QString.
 class CowString {
 public:
     CowString() = default;

--- a/src/core/defercall.cpp
+++ b/src/core/defercall.cpp
@@ -56,10 +56,9 @@ public:
             EventLoop::instance()->deregister(customRegId_);
     }
 
-    // Requests the awake signal to be emitted from the object's event loop
-    // at the next opportunity. This is safe to call from another thread. If
-    // this is called multiple times before the signal is emitted, the signal
-    // will only be emitted once.
+    // Requests the awake signal to be emitted from the object's event loop at the next opportunity.
+    // This is safe to call from another thread. If this is called multiple times before the signal
+    // is emitted, the signal will only be emitted once.
     void wake() {
         std::lock_guard<std::mutex> guard(mutex_);
 
@@ -155,8 +154,7 @@ private:
         {
             std::lock_guard<std::mutex> guard(callsMutex_);
 
-            // Process all calls queued so far, but not any that may get queued
-            // during processing
+            // Process all calls queued so far, but not any that may get queued during processing
             ready.swap(calls_);
         }
 
@@ -178,8 +176,8 @@ private:
     void timer_timeout() {
         process();
 
-        // No need to re-arm the timer. If new calls were queued during
-        // processing, add() will have taken care of that
+        // No need to re-arm the timer. If new calls were queued during processing, add() will have
+        // taken care of that
     }
 
     void threadWake_awake() { process(); }
@@ -220,9 +218,8 @@ DeferCall::DeferCall()
 
         EventLoop *loop = EventLoop::instance();
         if (loop) {
-            // We use the manager pointer to uniquely identify the handler
-            // registration even though the handler function doesn't do
-            // anything with it
+            // We use the manager pointer to uniquely identify the handler registration even though
+            // the handler function doesn't do anything with it
             loop->addCleanupHandler(eventloop_cleanup_handler, localManager.get());
         }
     }
@@ -246,8 +243,7 @@ void DeferCall::defer(std::function<void()> handler) {
         manager = it->second.get();
     }
 
-    // Manager keeps a weak pointer, so we can invalidate pending calls by
-    // simply deleting them
+    // Manager keeps a weak pointer, so we can invalidate pending calls by simply deleting them
     manager->add(c);
 }
 

--- a/src/core/defercall.h
+++ b/src/core/defercall.h
@@ -36,12 +36,10 @@ public:
     DeferCall();
     ~DeferCall();
 
-    // Queue handler to be called after returning to the event loop. If
-    // handler contains references, they must outlive DeferCall. The
-    // recommended usage is for each object needing to perform deferred calls
-    // to keep a DeferCall as a member variable, and only refer to the
-    // object's own data in the handler. That way, any references are
-    // guaranteed to live long enough.
+    // Queue handler to be called after returning to the event loop. If handler contains references,
+    // they must outlive DeferCall. The recommended usage is for each object needing to perform
+    // deferred calls to keep a DeferCall as a member variable, and only refer to the object's own
+    // data in the handler. That way, any references are guaranteed to live long enough.
     void defer(std::function<void()> handler);
 
     int pendingCount() const { return deferredCalls_->size(); }

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -25,8 +25,8 @@
 #include "test.h"
 #include <thread>
 
-// loop_advance should process enough events to cause the calls to run,
-// Without sleeping, in order to prove the calls are run immediately
+// loop_advance should process enough events to cause the calls to run, Without sleeping, in order
+// to prove the calls are run immediately
 static std::tuple<int, int> runDeferCall(std::function<void()> loop_advance) {
     DeferCall deferCall;
     int count = 0;
@@ -42,15 +42,14 @@ static std::tuple<int, int> runDeferCall(std::function<void()> loop_advance) {
     return {deferCall.pendingCount(), count};
 }
 
-// Spawns a thread, triggers the deferCall from it, then waits for thread to
-// finish
+// Spawns a thread, triggers the deferCall from it, then waits for thread to finish
 static void callNonLocal(DeferCall *deferCall, std::function<void()> handler) {
     std::thread thread([=] { deferCall->defer(handler); });
     thread.join();
 }
 
-// loop_advance should process enough events to cause the calls to run,
-// Without sleeping, in order to prove the calls are run immediately
+// loop_advance should process enough events to cause the calls to run, Without sleeping, in order
+// to prove the calls are run immediately
 static std::tuple<int, int> runNonLocal(std::function<void()> loop_advance) {
     DeferCall deferCall;
     int count = 0;
@@ -115,8 +114,7 @@ static void managerCleanup() {
         DeferCall::global()->defer([&] { ++count; });
     });
 
-    // Cleanup should process deferred calls queued so far as well as
-    // those queued during processing
+    // Cleanup should process deferred calls queued so far as well as those queued during processing
     DeferCall::cleanup();
     TEST_ASSERT_EQ(count, 2);
 }

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -25,7 +25,7 @@
 #include "test.h"
 #include <thread>
 
-// loop_advance should process enough events to cause the calls to run, Without sleeping, in order
+// loop_advance should process enough events to cause the calls to run, without sleeping, in order
 // to prove the calls are run immediately
 static std::tuple<int, int> runDeferCall(std::function<void()> loop_advance) {
     DeferCall deferCall;
@@ -48,7 +48,7 @@ static void callNonLocal(DeferCall *deferCall, std::function<void()> handler) {
     thread.join();
 }
 
-// loop_advance should process enough events to cause the calls to run, Without sleeping, in order
+// loop_advance should process enough events to cause the calls to run, without sleeping, in order
 // to prove the calls are run immediately
 static std::tuple<int, int> runNonLocal(std::function<void()> loop_advance) {
     DeferCall deferCall;

--- a/src/core/eventloop.cpp
+++ b/src/core/eventloop.cpp
@@ -30,9 +30,8 @@ EventLoop::EventLoop(int capacity) : taskManaged_(false) {
 }
 
 EventLoop::EventLoop(ffi::EventLoopRaw *inner) : inner_(inner), taskManaged_(true) {
-    // Instance is task-managed, meaning the task owns the inner handle and
-    // will manage where g_instance points. The instance should not destroy
-    // the inner handle nor modify g_instance.
+    // Instance is task-managed, meaning the task owns the inner handle and will manage where
+    // g_instance points. The instance should not destroy the inner handle nor modify g_instance.
 }
 
 EventLoop::~EventLoop() {
@@ -121,9 +120,8 @@ void EventLoop::setup_cb(void *ctx, const ffi::EventLoopRaw *l) {
     // Only one per thread allowed
     assert(!g_instance);
 
-    // The task provides a const pointer but the EventLoop class needs a
-    // non-const pointer. However, we promise not to call any non-const
-    // methods with it.
+    // The task provides a const pointer but the EventLoop class needs a non-const pointer. However,
+    // we promise not to call any non-const methods with it.
     ffi::EventLoopRaw *inner = (ffi::EventLoopRaw *)l;
 
     g_instance = new EventLoop(inner);

--- a/src/core/eventloop.h
+++ b/src/core/eventloop.h
@@ -48,10 +48,9 @@ public:
 
     static EventLoop *instance();
 
-    /// Returns a future that constructs an event loop and executes it
-    /// asynchronously. `setup` is called just prior to executing, and `done`
-    /// is called when the event loop exits. `setup` and `done` must point
-    /// to functions that live as long as the returned future.
+    /// Returns a future that constructs an event loop and executes it asynchronously. `setup` is
+    /// called just prior to executing, and `done` is called when the event loop exits. `setup` and
+    /// `done` must point to functions that live as long as the returned future.
     static ffi::UnitFuture *task(int capacity, std::function<void()> *setup,
                                  std::function<void(int)> *done);
 

--- a/src/core/executor.h
+++ b/src/core/executor.h
@@ -28,10 +28,10 @@ public:
 
     bool run(std::function<bool(std::optional<int>)> park);
 
-    /// Spawns `fut` on the executor in the current thread. Returns true on
-    /// success or false on error. An error can occur if there is no executor in
-    /// the current thread or if the executor is at capacity. This function takes
-    /// ownership of `fut` regardless of whether spawning is successful.
+    /// Spawns `fut` on the executor in the current thread. Returns true on success or false on
+    /// error. An error can occur if there is no executor in the current thread or if the executor
+    /// is at capacity. This function takes ownership of `fut` regardless of whether spawning is
+    /// successful.
     static bool currentSpawn(ffi::UnitFuture *fut);
 
 private:

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -102,8 +102,8 @@ static void logPacket(int level, const Variant &data, const QString &contentFiel
         hdata.remove(contentField);
         meta = hdata;
     } else {
-        // If data isn't a hash, then we can't extract content, so
-        // the meta part will be the entire data
+        // If data isn't a hash, then we can't extract content, so the meta part will be the entire
+        // data
         meta = data;
     }
 

--- a/src/core/processquit.cpp
+++ b/src/core/processquit.cpp
@@ -81,8 +81,7 @@ public:
     void unixWatchAdd(int sig) {
         struct sigaction sa;
         sigaction(sig, NULL, &sa);
-        // If the signal is ignored, don't take it over.  This is
-        // recommended by the glibc manual
+        // If the signal is ignored, don't take it over.  This is recommended by the glibc manual
         if (sa.sa_handler == SIG_IGN)
             return;
         sigemptyset(&(sa.sa_mask));
@@ -94,8 +93,7 @@ public:
     void unixWatchRemove(int sig) {
         struct sigaction sa;
         sigaction(sig, NULL, &sa);
-        // Ignored means we skipped it earlier, so we should
-        // skip it again
+        // Ignored means we skipped it earlier, so we should skip it again
         if (sa.sa_handler == SIG_IGN)
             return;
         sigemptyset(&(sa.sa_mask));

--- a/src/core/processquit.h
+++ b/src/core/processquit.h
@@ -32,37 +32,34 @@ using Connection = boost::signals2::scoped_connection;
 /**
    \brief Listens for termination requests
 
-   ProcessQuit listens for requests to terminate the application process.  These
-are the signals SIGINT, SIGHUP, and SIGTERM.
+   ProcessQuit listens for requests to terminate the application process.  These are the signals
+SIGINT, SIGHUP, and SIGTERM.
 
-   For GUI programs, ProcessQuit is not a substitute for QSessionManager.  The
-only safe way to handle termination of a GUI program in the usual way is to use
-QSessionManager.  However, ProcessQuit does give additional benefit to GUI
-programs that might be terminated unconventionally, so it can't hurt to support
-both.
+   For GUI programs, ProcessQuit is not a substitute for QSessionManager.  The only safe way to
+handle termination of a GUI program in the usual way is to use QSessionManager.  However,
+ProcessQuit does give additional benefit to GUI programs that might be terminated unconventionally,
+so it can't hurt to support both.
 
-   When a termination request is received, the application should exit
-gracefully, and generally without user interaction.  Otherwise, it is at risk of
-being terminated outside of its control.
+   When a termination request is received, the application should exit gracefully, and generally
+without user interaction.  Otherwise, it is at risk of being terminated outside of its control.
 
    Using ProcessQuit is easy, and it usually amounts to a single line:
    \code
 myapp.connect(ProcessQuit::instance(), SIGNAL(quit()), SLOT(do_quit()));
    \endcode
 
-   Calling instance() returns a pointer to the global ProcessQuit instance,
-which will be created if necessary.  The quit() signal is emitted when a request
-to terminate is received.    The quit() signal is only emitted once, future
-termination requests are ignored.  Call reset() to allow the quit() signal to be
-emitted again.
+   Calling instance() returns a pointer to the global ProcessQuit instance, which will be created if
+necessary.  The quit() signal is emitted when a request to terminate is received.    The quit()
+signal is only emitted once, future termination requests are ignored.  Call reset() to allow the
+quit() signal to be emitted again.
 */
 class ProcessQuit {
 public:
     /**
        \brief Returns the global ProcessQuit instance
 
-       If the global instance does not exist yet, it will be created, and the
-       termination handlers will be installed.
+       If the global instance does not exist yet, it will be created, and the termination handlers
+       will be installed.
 
        \sa cleanup
     */
@@ -71,12 +68,11 @@ public:
     /**
        \brief Allows the quit() signal to be emitted again
 
-       ProcessQuit only emits the quit() signal once, so that if a user repeatedly
-       presses Ctrl-C or sends SIGTERM, your shutdown slot will not be called
-       multiple times.  This is normally the desired behavior, but if you are
-       ignoring the termination request then you may want to allow future
-       notifications.  Calling this function will allow the quit() signal to be
-       emitted again, if a new termination request arrives.
+       ProcessQuit only emits the quit() signal once, so that if a user repeatedly presses Ctrl-C or
+       sends SIGTERM, your shutdown slot will not be called multiple times.  This is normally the
+       desired behavior, but if you are ignoring the termination request then you may want to allow
+       future notifications.  Calling this function will allow the quit() signal to be emitted
+       again, if a new termination request arrives.
 
        \sa quit
     */
@@ -85,10 +81,9 @@ public:
     /**
        \brief Frees all resources used by ProcessQuit
 
-       This function will free any resources used by ProcessQuit, including the
-       global instance, and the termination handlers will be uninstalled (reverted
-       to default).  Future termination requests will cause the application to
-       exit abruptly.
+       This function will free any resources used by ProcessQuit, including the global instance, and
+       the termination handlers will be uninstalled (reverted to default).  Future termination
+       requests will cause the application to exit abruptly.
 
        \sa instance
     */

--- a/src/core/readwrite.h
+++ b/src/core/readwrite.h
@@ -24,8 +24,8 @@ class ReadWrite {
 public:
     virtual ~ReadWrite() = default;
 
-    // Size < 0 means default read size
-    // returns buffer of bytes read. Null buffer means error. Empty means end
+    // Size < 0 means default read size returns buffer of bytes read. Null buffer means error. Empty
+    // means end
     virtual QByteArray read(int size = -1) = 0;
 
     // Returns amount accepted, or -1 for error

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -56,16 +56,15 @@ Settings::Settings(const QString &fileName) : include_(0), portOffset_(0) {
 
     QString includeFile = valueRaw("global/include").toString();
 
-    // if include is exactly "internal.conf", rewrite relative to libdir
-    // TODO: remove this hack at next major version
+    // if include is exactly "internal.conf", rewrite relative to libdir. TODO: remove this hack at
+    // next major version
     if (includeFile == "internal.conf")
         includeFile = "{libdir}/internal.conf";
 
     includeFile = resolveVars(includeFile);
 
     if (!includeFile.isEmpty()) {
-        // If include is a relative path, then use it relative to the config file
-        // location
+        // If include is a relative path, then use it relative to the config file location
         QFileInfo fi(includeFile);
         if (fi.isRelative())
             includeFile = QFileInfo(QFileInfo(fileName).absoluteDir(), includeFile).filePath();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -56,8 +56,8 @@ Settings::Settings(const QString &fileName) : include_(0), portOffset_(0) {
 
     QString includeFile = valueRaw("global/include").toString();
 
-    // if include is exactly "internal.conf", rewrite relative to libdir. TODO: remove this hack at
-    // next major version
+    // If include is exactly "internal.conf", rewrite relative to libdir.
+    // TODO: remove this hack at next major version
     if (includeFile == "internal.conf")
         includeFile = "{libdir}/internal.conf";
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -28,8 +28,7 @@
 
 class QSettings;
 
-/// Stores the application settings loaded from the command line arguments and
-/// the config file
+/// Stores the application settings loaded from the command line arguments and the config file
 class Settings {
 public:
     Settings(const QString &fileName);

--- a/src/core/simplehttpserver.cpp
+++ b/src/core/simplehttpserver.cpp
@@ -186,10 +186,6 @@ private:
             reqHeaders += HttpHeader(name, val);
         }
 
-        // log_debug("httpserver: IN method=[%s] uri=[%s] 1.1=%s",
-        // qPrintable(method), uri.data(), version1dot0 ? "no" : "yes");
-        // foreach(const HttpHeader &h, reqHeaders)
-        //	log_debug("httpserver:   [%s] [%s]", h.first.data(), h.second.data());
         log_debug("httpserver: IN %s %s", qPrintable(method), uri.data());
 
         return true;

--- a/src/core/socketnotifier.h
+++ b/src/core/socketnotifier.h
@@ -29,11 +29,10 @@ public:
         Write = 0x02,
     };
 
-    // Initializes notifier with interest and considers the socket ready for
-    // the specified interest. Readiness must be cleared via clearReadiness()
-    // in order for the activated signal to be emitted. The expected way to
-    // use this class is to initialize it, perform I/O until progress can no
-    // longer be made, clear readiness, then await the signal.
+    // Initializes notifier with interest and considers the socket ready for the specified interest.
+    // Readiness must be cleared via clearReadiness() in order for the activated signal to be
+    // emitted. The expected way to use this class is to initialize it, perform I/O until progress
+    // can no longer be made, clear readiness, then await the signal.
     SocketNotifier(int socket, uint8_t interest);
 
     ~SocketNotifier();

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -1475,9 +1475,9 @@ void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId
         lastReport -= reportOffset;
 
     if (d->reportInterval > 0) {
-        // Check if this connection should replace a lingering external one note: this iterates over
-        // all the known external sources, which at at the time of this writing is almost certainly
-        // just 1 (a single pushpin-proxy source).
+        // Check if this connection should replace a lingering external one.
+        // Note: this iterates over all the known external sources, which at at the time of this
+        // writing is almost certainly just 1 (a single pushpin-proxy source).
         QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo *>> it(
             d->externalConnectionInfoByFrom);
         while (it.hasNext()) {
@@ -1741,9 +1741,9 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
             }
         }
 
-        // If the connection exists under a different from address, remove it. note: this iterates
-        // over all the known external sources, which at at the time of this writing is almost
-        // certainly just 1 (a single pushpin-proxy source).
+        // If the connection exists under a different from address, remove it.
+        // note: this iterates over all the known external sources, which at at the time of this
+        // writing is almost certainly just 1 (a single pushpin-proxy source).
         QList<Private::ConnectionInfo *> toDelete;
         QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo *>> it(
             d->externalConnectionInfoByFrom);

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -610,10 +610,9 @@ public:
             RetryInfo &ri = retryInfoBySource[c->from];
             ri.connectionInfoBySeq.remove(c->retrySeq);
 
-            // FIXME: we keep the source entry even when there are no more
-            // connections, to avoid resetting the seq value. If there is
-            // a lot of proxy instance churn, retryInfoBySource could
-            // fill up with unused entries that will never be cleaned up.
+            // FIXME: we keep the source entry even when there are no more connections, to avoid
+            // resetting the seq value. If there is a lot of proxy instance churn, retryInfoBySource
+            // could fill up with unused entries that will never be cleaned up.
         }
 
         if (c->lastRefresh >= 0) {
@@ -957,15 +956,14 @@ public:
                 ConnectionInfo *c = static_cast<ConnectionInfo *>(obj);
 
                 if (c->linger) {
-                    // In linger mode, next refresh is set to the time we should
-                    // delete the connection rather than refresh
+                    // In linger mode, next refresh is set to the time we should delete the
+                    // connection rather than refresh
 
                     connectionInfoRefreshBuckets[c->refreshBucket].remove(c);
                     c->lastRefresh = -1;
 
-                    // Note: we don't send a disconnect message when the
-                    // linger expires. The assumption is that the handler
-                    // owns the connection now
+                    // Note: we don't send a disconnect message when the linger expires. The
+                    // assumption is that the handler owns the connection now
 
                     removeConnection(c);
                     delete c;
@@ -995,8 +993,8 @@ public:
                 Subscription *s = static_cast<Subscription *>(obj);
 
                 if (s->linger) {
-                    // In linger mode, next refresh is set to the time we should
-                    // delete the subscription rather than refresh
+                    // In linger mode, next refresh is set to the time we should delete the
+                    // subscription rather than refresh
 
                     subscriptionRefreshBuckets[s->refreshBucket].remove(s);
                     s->lastRefresh = -1;
@@ -1306,9 +1304,8 @@ private:
         QList<StatsPacket> reportPackets;
         QList<Report *> toDelete;
 
-        // Note: here we iterate over all reports, which will be one per
-        // route ID. This could become a problem if there are thousands
-        // of route IDs (at which point we can consider bucketing)
+        // Note: here we iterate over all reports, which will be one per route ID. This could become
+        // a problem if there are thousands of route IDs (at which point we can consider bucketing)
         QHashIterator<QByteArray, Report *> it(reports);
         while (it.hasNext()) {
             it.next();
@@ -1478,10 +1475,9 @@ void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId
         lastReport -= reportOffset;
 
     if (d->reportInterval > 0) {
-        // Check if this connection should replace a lingering external one
-        // note: this iterates over all the known external sources, which at
-        // at the time of this writing is almost certainly just 1 (a single
-        // pushpin-proxy source).
+        // Check if this connection should replace a lingering external one note: this iterates over
+        // all the known external sources, which at at the time of this writing is almost certainly
+        // just 1 (a single pushpin-proxy source).
         QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo *>> it(
             d->externalConnectionInfoByFrom);
         while (it.hasNext()) {
@@ -1501,10 +1497,9 @@ void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId
         }
     }
 
-    // If we already had an entry, silently overwrite it. This can
-    // happen if we sent an accepted connection off to the handler,
-    // kept it lingering in our table, and then the handler passed
-    // it back to us for retrying
+    // If we already had an entry, silently overwrite it. This can happen if we sent an accepted
+    // connection off to the handler, kept it lingering in our table, and then the handler passed it
+    // back to us for retrying
     Private::ConnectionInfo *c = d->connectionInfoById.value(id);
     if (c) {
         replacing = true;
@@ -1528,8 +1523,7 @@ void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId
     d->updateConnectionsMax(c->routeId, now);
 
     if (d->reportInterval > 0) {
-        // Only immediately count a minute if an offset wasn't set and we weren't
-        // replacing
+        // Only immediately count a minute if an offset wasn't set and we weren't replacing
         if (reportOffset < 0 && !replacing) {
             Private::Report *report = d->getOrCreateReport(c->routeId);
 
@@ -1737,8 +1731,7 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
                     return false;
                 }
 
-                // Otherwise, remove local connection and it will be replaced with
-                // external
+                // Otherwise, remove local connection and it will be replaced with external
 
                 replacing = true;
                 lastReport = c->lastReport;
@@ -1748,10 +1741,9 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
             }
         }
 
-        // If the connection exists under a different from address, remove it.
-        // note: this iterates over all the known external sources, which at
-        // at the time of this writing is almost certainly just 1 (a single
-        // pushpin-proxy source).
+        // If the connection exists under a different from address, remove it. note: this iterates
+        // over all the known external sources, which at at the time of this writing is almost
+        // certainly just 1 (a single pushpin-proxy source).
         QList<Private::ConnectionInfo *> toDelete;
         QHashIterator<QByteArray, QHash<QByteArray, Private::ConnectionInfo *>> it(
             d->externalConnectionInfoByFrom);

--- a/src/core/statsmanager.h
+++ b/src/core/statsmanager.h
@@ -30,8 +30,7 @@
 
 class QHostAddress;
 
-/// Collects and reports statistics via ZeroMQ (internal) and Prometheus
-/// (external) on:
+/// Collects and reports statistics via ZeroMQ (internal) and Prometheus (external) on:
 /// - Connections
 /// - Subscriptions
 /// - Messages sent/received
@@ -72,8 +71,8 @@ public:
     int removeConnection(const QByteArray &id, bool linger,
                          const QByteArray &source = QByteArray()); // Return unreported time
 
-    // Manager automatically refreshes, but it may be useful to force a
-    // send before removing with linger
+    // Manager automatically refreshes, but it may be useful to force a send before removing with
+    // linger
     void refreshConnection(const QByteArray &id);
 
     void addSubscription(const QString &mode, const QString &channel, uint32_t subscriberCount);
@@ -91,9 +90,8 @@ public:
 
     bool checkConnection(const QByteArray &id) const;
 
-    // Conn, conn-max, and report packets received from the proxy should be
-    // passed into this method. returns true if the packet should not also be
-    // forwarded on
+    // Conn, conn-max, and report packets received from the proxy should be passed into this method.
+    // returns true if the packet should not also be forwarded on
     bool processExternalPacket(const StatsPacket &packet, bool mergeConnectionReport);
 
     // Directly send, for proxy->handler pass-through

--- a/src/core/statusreasons.cpp
+++ b/src/core/statusreasons.cpp
@@ -27,8 +27,7 @@
 
 namespace StatusReasons {
 
-// IANA assignments
-// http://www.iana.org/assignments/http-status-codes/http-status-codes.xml
+// IANA assignments http://www.iana.org/assignments/http-status-codes/http-status-codes.xml
 
 const char *getReasonRaw(int code) {
     switch (code) {

--- a/src/core/tcpstream.h
+++ b/src/core/tcpstream.h
@@ -40,8 +40,8 @@ public:
     // Returns true if connection starting, false on error
     bool connect(const QHostAddress &addr, uint16_t port);
 
-    // Returns true if connected, false on error. If errorCondition() returns
-    // ENOTCONN, then it is not fatal and the socket is still connecting
+    // Returns true if connected, false on error. If errorCondition() returns ENOTCONN, then it is
+    // not fatal and the socket is still connecting
     bool checkConnected();
 
     // Reimplemented

--- a/src/core/tcpstreamtest.cpp
+++ b/src/core/tcpstreamtest.cpp
@@ -181,8 +181,8 @@ static void runIo(std::function<void()> loop_wait) {
         received += buf;
     }
 
-    // Now read as much as possible on the client side. This helps the
-    // server side gain writability sooner
+    // Now read as much as possible on the client side. This helps the server side gain writability
+    // sooner
     while (true) {
         QByteArray buf = client.read(100000);
 

--- a/src/core/test.h
+++ b/src/core/test.h
@@ -67,22 +67,20 @@ inline void test_assert_eq(const T1 &left, const T2 &right, const char *file, in
     }
 }
 
-// If cond is false, throws an exception with similar message as rust's assert
-// macro
+// If cond is false, throws an exception with similar message as rust's assert macro
 #define TEST_ASSERT(cond)                                                                          \
     do {                                                                                           \
         test_assert(static_cast<bool>(cond), #cond, __FILE__, __LINE__);                           \
     } while (false)
 
-// if left != right, throws an exception with similar message as rust's
-// assert_eq macro
+// if left != right, throws an exception with similar message as rust's assert_eq macro
 #define TEST_ASSERT_EQ(left, right)                                                                \
     do {                                                                                           \
         test_assert_eq(left, right, __FILE__, __LINE__);                                           \
     } while (false)
 
-// for running a test and catching an exception if any. expects local variable
-// ffi::TestException* out_ex to exist
+// for running a test and catching an exception if any. expects local variable ffi::TestException*
+// out_ex to exist
 #define TEST_CATCH(statement)                                                                      \
     try {                                                                                          \
         statement;                                                                                 \
@@ -91,9 +89,8 @@ inline void test_assert_eq(const T1 &left, const T2 &right, const char *file, in
         return 1;                                                                                  \
     }
 
-// Expects a test function that takes a wait function as an argument. The wait
-// function can be used by the test to wait for a number of milliseconds while
-// the event loop runs.
+// Expects a test function that takes a wait function as an argument. The wait function can be used
+// by the test to wait for a number of milliseconds while the event loop runs.
 void test_with_event_loop(std::function<void(std::function<void(int)>)> f);
 
 #endif

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -24,7 +24,7 @@
 #include "eventloop.h"
 #include "test.h"
 
-// loop_advance should process enough events to cause the timers to Activate, without sleeping, in
+// loop_advance should process enough events to cause the timers to activate, without sleeping, in
 // order to prove timeouts of zero are processed immediately
 static int runZeroTimeout(std::function<void()> loop_advance) {
     Timer t;

--- a/src/core/timertest.cpp
+++ b/src/core/timertest.cpp
@@ -24,9 +24,8 @@
 #include "eventloop.h"
 #include "test.h"
 
-// loop_advance should process enough events to cause the timers to
-// Activate, without sleeping, in order to prove timeouts of zero are
-// processed immediately
+// loop_advance should process enough events to cause the timers to Activate, without sleeping, in
+// order to prove timeouts of zero are processed immediately
 static int runZeroTimeout(std::function<void()> loop_advance) {
     Timer t;
     t.setSingleShot(true);

--- a/src/core/unixstream.h
+++ b/src/core/unixstream.h
@@ -38,8 +38,8 @@ public:
     // Returns true if connection starting, false on error
     bool connect(const QString &path);
 
-    // Returns true if connected, false on error. If errorCondition() returns
-    // ENOTCONN, then it is not fatal and the socket is still connecting
+    // Returns true if connected, false on error. If errorCondition() returns ENOTCONN, then it is
+    // not fatal and the socket is still connecting
     bool checkConnected();
 
     // Reimplemented

--- a/src/core/unixstreamtest.cpp
+++ b/src/core/unixstreamtest.cpp
@@ -189,8 +189,8 @@ static void runIo(std::function<void()> loop_wait) {
         received += buf;
     }
 
-    // Now read as much as possible on the client side. This helps the
-    // server side gain writability sooner
+    // Now read as much as possible on the client side. This helps the server side gain writability
+    // sooner
     while (true) {
         QByteArray buf = client.read(100000);
 

--- a/src/core/url.h
+++ b/src/core/url.h
@@ -19,8 +19,7 @@
 
 #include <QUrl>
 
-// Type alias for URL handling - this will be replaced with a custom
-// implementation later
+// Type alias for URL handling - this will be replaced with a custom implementation later
 using Url = QUrl;
 
 #endif // URL_H

--- a/src/core/variant.h
+++ b/src/core/variant.h
@@ -34,8 +34,7 @@ using VariantHash = QVariantHash;
 using VariantMap = QVariantMap;
 using VariantList = QVariantList;
 
-// Note: typeId() and canConvert() functions are already provided by qtcompat.h
-// Since Variant = QVariant (alias), those functions work directly with our
-// types
+// Note: typeId() and canConvert() functions are already provided by qtcompat.h Since Variant =
+// QVariant (alias), those functions work directly with our types
 
 #endif

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -310,8 +310,8 @@ public:
     void startKeepAlive() {
         if (multi) {
             if (keepAliveTimer->isActive()) {
-                // Need to flush the current keepalive, since the
-                // manager registration may extend the timeout
+                // Need to flush the current keepalive, since the manager registration may extend
+                // the timeout
                 keepAlive_timeout();
 
                 keepAliveTimer->stop();
@@ -387,8 +387,8 @@ public:
 
                 q->bytesWritten(0);
             } else if (!requestBodyBuf.isEmpty() && outCredits > 0) {
-                // If we have data to send, and the credits to do so, then send data.
-                // also send credits if we need to.
+                // If we have data to send, and the credits to do so, then send data. also send
+                // credits if we need to.
 
                 QByteArray buf = requestBodyBuf.take(outCredits);
 
@@ -414,8 +414,7 @@ public:
             }
         } else if (state == ClientReceiving) {
             if (pendingInCredits > 0) {
-                // If we have no data to send but we need to send credits, do at least
-                // that
+                // If we have no data to send but we need to send credits, do at least that
                 ZhttpRequestPacket p;
                 p.type = ZhttpRequestPacket::Credit;
                 p.credits = pendingInCredits;
@@ -844,8 +843,7 @@ public:
                     return;
                 }
 
-                // For req mode, wait until request is fully supplied then send in one
-                // packet
+                // For req mode, wait until request is fully supplied then send in one packet
                 if (bodyFinished) {
                     ZhttpRequestPacket p;
                     p.type = ZhttpRequestPacket::Data;
@@ -875,8 +873,7 @@ public:
                     q->bytesWritten(p.body.size());
                 }
             } else {
-                // NOTE: not quite sure why we do this. Maybe to avoid a
-                // zhttp PUSH/SUB race?
+                // NOTE: not quite sure why we do this. Maybe to avoid a zhttp PUSH/SUB race?
                 if (!manager->canWriteImmediately()) {
                     state = Stopped;
                     errored = true;
@@ -893,9 +890,8 @@ public:
                 p.headers = requestHeaders;
 
                 if (!sendBodyAfterAck) {
-                    // Even though we don't have credits yet, we can act
-                    // like we do on the first packet. We'll still cap
-                    // our potential size though.
+                    // Even though we don't have credits yet, we can act like we do on the first
+                    // packet. We'll still cap our potential size though.
                     p.body = requestBodyBuf.take(IDEAL_CREDITS);
                 }
 

--- a/src/core/zmqsocket.cpp
+++ b/src/core/zmqsocket.cpp
@@ -430,8 +430,7 @@ public:
 
     void tryWrite() {
         while (canWrite && !pendingWrites.empty()) {
-            // Whether this write succeeds or not, we assume we
-            // can't write afterwards
+            // Whether this write succeeds or not, we assume we can't write afterwards
             canWrite = false;
 
             if (zmqWrite(pendingWrites.front())) {

--- a/src/core/zmqsocket.h
+++ b/src/core/zmqsocket.h
@@ -47,13 +47,11 @@ public:
     // 0 means drop queue and don't block, -1 means infinite (default = -1)
     void setShutdownWaitTime(int msecs);
 
-    // If enabled, messages are queued internally until the socket is able
-    // to accept them. The messagesWritten signal is emitted once writes
-    // have succeeded. Otherwise, messages are passed directly to
-    // zmq_send and dropped if they can't be written. Default enabled.
-    // disabling the queue is good for socket types where the HWM has a
-    // drop policy. Enabling the queue is good when the HWM has a
-    // blocking policy.
+    // If enabled, messages are queued internally until the socket is able to accept them. The
+    // messagesWritten signal is emitted once writes have succeeded. Otherwise, messages are passed
+    // directly to zmq_send and dropped if they can't be written. Default enabled. disabling the
+    // queue is good for socket types where the HWM has a drop policy. Enabling the queue is good
+    // when the HWM has a blocking policy.
     void setWriteQueueEnabled(bool enable);
 
     void subscribe(const CowByteArray &filter);
@@ -83,10 +81,9 @@ public:
 
     bool canRead() const;
 
-    // Returns true if this object believes the next write to zmq will
-    // succeed immediately. Note that it starts out false until the
-    // value is discovered. Also note that the write could still end up
-    // needing to be queued, if the conditions change in between.
+    // Returns true if this object believes the next write to zmq will succeed immediately. Note
+    // that it starts out false until the value is discovered. Also note that the write could still
+    // end up needing to be queued, if the conditions change in between.
     bool canWriteImmediately() const;
 
     CowByteArrayList read();

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -204,8 +204,8 @@ public:
     void startKeepAlive() {
         if (multi) {
             if (keepAliveTimer->isActive()) {
-                // Need to flush the current keepalive, since the
-                // manager registration may extend the timeout
+                // Need to flush the current keepalive, since the manager registration may extend
+                // the timeout
                 keepAlive_timeout();
 
                 keepAliveTimer->stop();
@@ -327,8 +327,8 @@ public:
                     break;
                 }
 
-                // If we have data to send, and the credits to do so, then send data.
-                // also send credits if we need to.
+                // If we have data to send, and the credits to do so, then send data. also send
+                // credits if we need to.
 
                 Frame f = nextFrame;
                 bool outFrameDone = false;

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -464,16 +464,13 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 
     passthroughData["route"] = context.route.toUtf8();
 
-    // If dest link points to the same service as the current request,
-    // then we can assume the network would send the request back to
-    // us, so we can handle it internally. If the link points to a
-    // different service, then we can't make this assumption and need
-    // to make the request over the network. Note that such a request
-    // could still end up looping back to us
+    // If dest link points to the same service as the current request, then we can assume the
+    // network would send the request back to us, so we can handle it internally. If the link points
+    // to a different service, then we can't make this assumption and need to make the request over
+    // the network. Note that such a request could still end up looping back to us
     if (destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() &&
         destPort == currentPort) {
-        // Tell the proxy that we prefer the request to be handled
-        // internally, using the same route
+        // Tell the proxy that we prefer the request to be handled internally, using the same route
         passthroughData["prefer-internal"] = true;
     }
 
@@ -527,8 +524,8 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
     assert(context.limiter);
 
     if (!context.limiter->addAction(key, new RequestAction(inner))) {
-        // The limiter shouldn't have an hwm, but let's handle the error
-        // here in case one is ever added
+        // The limiter shouldn't have an hwm, but let's handle the error here in case one is ever
+        // added
 
         Result r;
         r.errorMessage = "network request limit reached";

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -88,8 +88,8 @@ static int runLoop(const HandlerEngine::Configuration &config) {
     // Enough timers for sessions, plus an extra 100 for misc
     int timersMax = (config.connectionsMax * timersPerSession) + 100;
 
-    // Enough for control requests and prometheus requests, plus an
-    // extra 100 for misc. Client sessions don't use socket notifiers
+    // Enough for control requests and prometheus requests, plus an extra 100 for misc. Client
+    // sessions don't use socket notifiers
     int socketNotifiersMax = (SOCKETNOTIFIERS_PER_SIMPLEHTTPREQUEST *
                               (CONTROL_CONNECTIONS_MAX + PROMETHEUS_CONNECTIONS_MAX)) +
                              100;
@@ -173,8 +173,7 @@ int handler_init(const ffi::HandlerCliArgs *argsFfi) {
 
     log_debug("starting...");
 
-    // QSettings doesn't inform us if the config file can't be opened, so do that
-    // ourselves
+    // QSettings doesn't inform us if the config file can't be opened, so do that ourselves
     {
         QFile file(args.configFile);
         if (!file.open(QIODevice::ReadOnly)) {

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -1298,7 +1298,7 @@ public:
             }
 
             if (config.pushInSubConnect) {
-                // Some sane TCP keep-alive settings idle=30, cnt=6, intvl=5
+                // Some sane TCP keep-alive settings: idle=30, cnt=6, intvl=5
                 inSubSock->setTcpKeepAliveEnabled(true);
                 inSubSock->setTcpKeepAliveParameters(30, 6, 5);
             }

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -239,10 +239,9 @@ private:
         result["no-proxy"] = false;
 
         if (autoShare && requestData.method == "GET") {
-            // Auto share matches requests based on URI path (not query) and
-            // Grip-Last headers. The reason the query part is not
-            // considered is because it may vary per client and Grip-Last
-            // supersedes whatever is in the query
+            // Auto share matches requests based on URI path (not query) and Grip-Last headers. The
+            // reason the query part is not considered is because it may vary per client and
+            // Grip-Last supersedes whatever is in the query
 
             Url uri = requestData.uri;
             uri.setQuery(QString()); // Remove the query part
@@ -428,10 +427,9 @@ public:
             stats->removeConnection(cid, false);
     }
 
-    // NOTE: to ensure sequential processing of conn-max packets, this
-    // method must process any such packets contained within the accept
-    // request before returning. The conn-max packets must not be processed
-    // asynchronously
+    // NOTE: to ensure sequential processing of conn-max packets, this method must process any such
+    // packets contained within the accept request before returning. The conn-max packets must not
+    // be processed asynchronously
     void start() {
         VariantHash args = req->args();
 
@@ -705,10 +703,9 @@ public:
             lastIds.insert(params[0].first.asQByteArray(), params.get("last-id").asQByteArray());
         }
 
-        // We need to "atomically" process conn-max packets and add
-        // connections to the stats manager. We do this by processing the
-        // conn-max packets above and adding to the stats manager below,
-        // without returning to the event loop in between
+        // We need to "atomically" process conn-max packets and add connections to the stats
+        // manager. We do this by processing the conn-max packets above and adding to the stats
+        // manager below, without returning to the event loop in between
         foreach (const RequestState &rs, requestStates) {
             QByteArray cid = rs.rid.first + ':' + rs.rid.second;
 
@@ -740,8 +737,7 @@ public:
     }
 
     QList<std::shared_ptr<HttpSession>> takeSessions() {
-        // Swap instead of std::move since sessions is a member and should have a
-        // known state
+        // Swap instead of std::move since sessions is a member and should have a known state
         QList<std::shared_ptr<HttpSession>> out;
         out.swap(sessions);
         return out;
@@ -822,8 +818,8 @@ private:
             return;
         }
 
-        // Don't relay these headers. Their meaning is handled by
-        // zurl and they only apply to the outgoing hop.
+        // Don't relay these headers. Their meaning is handled by zurl and they only apply to the
+        // outgoing hop.
         instruct.response.headers.removeAll("Connection");
         instruct.response.headers.removeAll("Keep-Alive");
         instruct.response.headers.removeAll("Content-Encoding");
@@ -901,8 +897,8 @@ private:
                         cs->publishLastIds.remove(name);
                         conflict = true;
 
-                        // NOTE: don't exit loop here. We want to clear
-                        // the last ids of all conflicting channels
+                        // NOTE: don't exit loop here. We want to clear the last ids of all
+                        // conflicting channels
                     }
                 }
             }
@@ -947,8 +943,8 @@ private:
                     rp.inspectInfo.userData = inspectInfo.userData;
                 }
 
-                // If prev-id set on channels, set as inspect lastids so the proxy
-                // will pass as Grip-Last in the next request
+                // If prev-id set on channels, set as inspect lastids so the proxy will pass as
+                // Grip-Last in the next request
                 foreach (const Instruct::Channel &c, instruct.channels) {
                     if (!c.prevId.isNull()) {
                         if (!rp.haveInspectInfo) {
@@ -1031,8 +1027,8 @@ private:
                 &cs->publishLastIds, httpSessionUpdateManager, connectionSubscriptionMax);
         }
 
-        // Engine should directly connect to this and register the holds
-        // immediately, to avoid a race with the lastId check
+        // Engine should directly connect to this and register the holds immediately, to avoid a
+        // race with the lastId check
         sessionsReady();
 
         setFinished(true);
@@ -1302,8 +1298,7 @@ public:
             }
 
             if (config.pushInSubConnect) {
-                // Some sane TCP keep-alive settings
-                // idle=30, cnt=6, intvl=5
+                // Some sane TCP keep-alive settings idle=30, cnt=6, intvl=5
                 inSubSock->setTcpKeepAliveEnabled(true);
                 inSubSock->setTcpKeepAliveParameters(30, 6, 5);
             }
@@ -1484,9 +1479,8 @@ public:
 
 private:
     void handlePublishItem(const PublishItem &item) {
-        // Only sequence if someone is listening, because we
-        // clear lastId on unsubscribe and don't want it to
-        // be set again until after a subscription returns
+        // Only sequence if someone is listening, because we clear lastId on unsubscribe and don't
+        // want it to be set again until after a subscription returns
 
         bool seq = (!item.noSeq && cs.subs.contains(item.channel));
 
@@ -1742,10 +1736,9 @@ private:
             return;
 
         if (req->method() == "accept") {
-            // NOTE: to ensure sequential processing of conn-max packets,
-            // we need to process any such packets contained within the
-            // accept request immediately before returning to the event loop.
-            // the start() call will do this
+            // NOTE: to ensure sequential processing of conn-max packets, we need to process any
+            // such packets contained within the accept request immediately before returning to the
+            // event loop. the start() call will do this
 
             AcceptWorker *w =
                 new AcceptWorker(req, stateClient.get(), &cs, zhttpIn.get(), zhttpOut.get(),
@@ -1902,12 +1895,10 @@ private:
 
             QSet<HttpSession *> sessions = cs.streamSessionsByChannel.value(item.channel);
             foreach (HttpSession *hs, sessions) {
-                // Note: we used to assert that the session was currently a
-                // stream hold and subscribed to the target channel,
-                // however with the new grip-link stuff it is possible for
-                // the session to temporarily switch to NoHold, and for
-                // channels to become unsubscribed. So we'll do a
-                // conditional statement instead
+                // Note: we used to assert that the session was currently a stream hold and
+                // subscribed to the target channel, however with the new grip-link stuff it is
+                // possible for the session to temporarily switch to NoHold, and for channels to
+                // become unsubscribed. So we'll do a conditional statement instead
                 if (!hs->channels().contains(item.channel))
                     continue;
 
@@ -1959,8 +1950,8 @@ private:
 
             log_debug("relaying to %d http-response subscribers", responseSessions.count());
 
-            // FIXME: if bodyPatch is used then body is empty. We should
-            // really be calculating blocks after applying patch
+            // FIXME: if bodyPatch is used then body is empty. We should really be calculating
+            // blocks after applying patch
 
             int blocks;
             if (item.size >= 0)
@@ -2143,8 +2134,8 @@ private:
     void acceptWorker_sessionsReady(AcceptWorker *w) {
         QList<std::shared_ptr<HttpSession>> sessions = w->takeSessions();
         foreach (const std::shared_ptr<HttpSession> &hs, sessions) {
-            // NOTE: for performance reasons we do not call hs->setParent and
-            // instead leave the object unparented
+            // NOTE: for performance reasons we do not call hs->setParent and instead leave the
+            // object unparented
 
             hs->subscribeCallback().add(Private::hs_subscribe_cb, this);
             hs->unsubscribeCallback().add(Private::hs_unsubscribe_cb, this);
@@ -2189,8 +2180,8 @@ private:
     }
 
     void stats_unsubscribed(const QString &mode, const QString &channel) {
-        // NOTE: this callback may be invoked while looping over certain structures,
-        // so be careful what you touch
+        // NOTE: this callback may be invoked while looping over certain structures, so be careful
+        // what you touch
 
         Q_UNUSED(mode);
 
@@ -2394,8 +2385,8 @@ private:
             // Any other type must be for a known cid
             WsSession *s = cs.wsSessions.value(QString::fromUtf8(item.cid)).get();
             if (!s) {
-                // Send cancel, causing the proxy to close the connection. Client
-                // will need to retry to repair
+                // Send cancel, causing the proxy to close the connection. Client will need to retry
+                // to repair
                 WsControlPacket::Item i;
                 i.cid = item.cid;
                 i.type = WsControlPacket::Item::Cancel;
@@ -2676,8 +2667,7 @@ private:
                 bool localReplaced = stats->processExternalPacket(p, false);
 
                 if (!localReplaced) {
-                    // Forward the packet. This will stamp the from field and keep the
-                    // rest
+                    // Forward the packet. This will stamp the from field and keep the rest
                     stats->sendPacket(p);
                 }
             }

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -240,9 +240,8 @@ public:
         if (!instruct.nextLink.isEmpty())
             nextUri = currentUri.resolved(instruct.nextLink);
 
-        // Only work with a gone link provided at initialization time. This
-        // way each request can have a unique gone link, and still share
-        // instructions from next link fetches
+        // Only work with a gone link provided at initialization time. This way each request can
+        // have a unique gone link, and still share instructions from next link fetches
         if (!instruct.goneLink.isEmpty())
             goneUri = currentUri.resolved(instruct.goneLink);
     }
@@ -325,12 +324,11 @@ public:
 
     void update(Priority priority) {
         if (state == Proxying || state == SendingQueue) {
-            // If we are already in the process of updating, flag to update
-            // again after current one finishes
+            // If we are already in the process of updating, flag to update again after current one
+            // finishes
 
             if (needUpdate) {
-                // If needUpdate was already flagged, then raise
-                // priority if needed
+                // If needUpdate was already flagged, then raise priority if needed
                 if (priority == HighPriority)
                     needUpdatePriority = priority;
             } else {
@@ -598,9 +596,8 @@ private:
             }
         } else // StreamHold
         {
-            // If conflict on first hold, immediately recover. We don't
-            // do this on subsequent holds because there may be queued
-            // messages available to resolve the conflict
+            // If conflict on first hold, immediately recover. We don't do this on subsequent holds
+            // because there may be queued messages available to resolve the conflict
             if (first) {
                 bool conflict = false;
                 foreach (const Instruct::Channel &c, instruct.channels) {
@@ -615,8 +612,8 @@ private:
                             publishLastIds->remove(name);
                             conflict = true;
 
-                            // NOTE: don't exit loop here. We want to clear
-                            // the last ids of all conflicting channels
+                            // NOTE: don't exit loop here. We want to clear the last ids of all
+                            // conflicting channels
                         }
                     }
                 }
@@ -652,8 +649,8 @@ private:
                 break;
             }
 
-            // If there are items to send, this will send them. If there are
-            // no items to send, this will end up changing state to Holding
+            // If there are items to send, this will send them. If there are no items to send, this
+            // will end up changing state to Holding
             sendQueue();
         }
     }
@@ -748,9 +745,9 @@ private:
             fc.trusted = adata.trusted;
             fc.limiter = filterLimiter;
 
-            // May call messageFiltersFinished immediately. If it does, queue
-            // processing will continue. Else, the loop will end and queue
-            // processing will resume after the filters finish
+            // May call messageFiltersFinished immediately. If it does, queue processing will
+            // continue. Else, the loop will end and queue processing will resume after the filters
+            // finish
             messageFilters->start(fc, body);
         }
 
@@ -764,10 +761,9 @@ private:
                 // Client buffer can only be full in stream mode
                 assert(instruct.holdMode == Instruct::StreamHold);
 
-                // NOTE: we can end up here multiple times in a single pass
-                // of the queue if the client buffer becomes full multiple
-                // times. So, whatever happens here should be idempotent and
-                // cheap.
+                // NOTE: we can end up here multiple times in a single pass of the queue if the
+                // client buffer becomes full multiple times. So, whatever happens here should be
+                // idempotent and cheap.
 
                 // Turn off timers until we're able to send again
                 timer->stop();
@@ -779,8 +775,8 @@ private:
     }
 
     void sendQueueDone() {
-        // if the state changed during queue processing (e.g. to Closing),
-        // Then we want to leave the state alone and do nothing else
+        // if the state changed during queue processing (e.g. to Closing), Then we want to leave the
+        // state alone and do nothing else
         if (state != SendingQueue)
             return;
 
@@ -822,8 +818,8 @@ private:
                     // Need to compact headers into a map
                     VariantMap vheaders;
                     foreach (const HttpHeader &h, headers) {
-                        // Don't add the same header name twice. We'll collect all values
-                        // for a single header
+                        // Don't add the same header name twice. We'll collect all values for a
+                        // single header
                         bool found = false;
                         for (auto it = vheaders.constBegin(); it != vheaders.constEnd(); ++it) {
                             const QString &name = it.key();
@@ -971,8 +967,8 @@ private:
                 rp.inspectInfo.userData = adata.inspectInfo.userData;
             }
 
-            // If prev-id set on channels, set as inspect lastids so the proxy
-            // will pass as Grip-Last in the next request
+            // If prev-id set on channels, set as inspect lastids so the proxy will pass as
+            // Grip-Last in the next request
             QHashIterator<QString, Instruct::Channel> it(channels);
             while (it.hasNext()) {
                 it.next();
@@ -1036,16 +1032,14 @@ private:
 
         passthroughData["route"] = adata.route.toUtf8();
 
-        // If next link points to the same service as the current request,
-        // then we can assume the network would send the request back to
-        // us, so we can handle it internally. If the link points to a
-        // different service, then we can't make this assumption and need
-        // to make the request over the network. Note that such a request
-        // could still end up looping back to us
+        // If next link points to the same service as the current request, then we can assume the
+        // network would send the request back to us, so we can handle it internally. If the link
+        // points to a different service, then we can't make this assumption and need to make the
+        // request over the network. Note that such a request could still end up looping back to us
         if (destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() &&
             destPort == currentPort) {
-            // Tell the proxy that we prefer the request to be handled
-            // internally, using the same route
+            // Tell the proxy that we prefer the request to be handled internally, using the same
+            // route
             passthroughData["prefer-internal"] = true;
         }
 
@@ -1094,8 +1088,8 @@ private:
 
             if (state == Proxying) {
                 if (outReq->bytesAvailable() > 0) {
-                    // Stop keep alive timer only if we have to send data. If the
-                    // response body is empty, then the timer is left alone
+                    // Stop keep alive timer only if we have to send data. If the response body is
+                    // empty, then the timer is left alone
                     timer->stop();
 
                     int avail = req->writeBytesAvailable();
@@ -1292,8 +1286,8 @@ private:
             if (sendAction == Filter::Drop)
                 return;
 
-            // NOTE: http-response mode doesn't support a close
-            // action since it's better to send a real response
+            // NOTE: http-response mode doesn't support a close action since it's better to send a
+            // real response
 
             if (f.action == PublishFormat::Send) {
                 respond(f.code, f.reason, f.headers, content, exposeHeaders);
@@ -1369,8 +1363,8 @@ private:
         } else if (state == Proxying) {
             tryProcessOutReq();
         } else if (state == SendingQueue) {
-            // In this state, the writeBytesChanged signal is only
-            // interesting if it indicates write bytes are available
+            // In this state, the writeBytesChanged signal is only interesting if it indicates write
+            // bytes are available
 
             if (req->writeBytesAvailable() > 0)
                 processPublishQueue();
@@ -1407,10 +1401,9 @@ private:
                     return;
                 }
 
-                // Accept the instruct as soon as it's available, so we can
-                // use its filters. If response processing ends up failing
-                // later on, the session will error out and the instruct
-                // won't be used for anything else
+                // Accept the instruct as soon as it's available, so we can use its filters. If
+                // response processing ends up failing later on, the session will error out and the
+                // instruct won't be used for anything else
                 instruct = i;
 
                 // Apply ResponseContent filters of all channels

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -553,8 +553,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
                     return Instruct();
                 }
 
-                // If code was supplied in json instruct, then
-                // we need to clear the default reason
+                // If code was supplied in json instruct, then we need to clear the default reason
                 newResponse.reason.clear();
             }
 

--- a/src/handler/sequencer.h
+++ b/src/handler/sequencer.h
@@ -39,8 +39,7 @@ public:
     void setWaitMax(int msecs);
     void setIdCacheTtl(int secs);
 
-    // Seq = false means ID cache handling only
-    // note: may emit signals
+    // Seq = false means ID cache handling only. NOTE: may emit signals
     void addItem(const PublishItem &item, bool seq = true);
 
     void clearPendingForChannel(const QString &channel);

--- a/src/handler/sequencer.h
+++ b/src/handler/sequencer.h
@@ -39,7 +39,8 @@ public:
     void setWaitMax(int msecs);
     void setIdCacheTtl(int secs);
 
-    // Seq = false means ID cache handling only. NOTE: may emit signals
+    // Seq = false means ID cache handling only.
+    // note: may emit signals
     void addItem(const PublishItem &item, bool seq = true);
 
     void clearPendingForChannel(const QString &channel);

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -126,9 +126,9 @@ void WsSession::processPublishQueue() {
         filtersFinishedConnection = filters->finished.connect(
             boost::bind(&WsSession::filtersFinished, this, boost::placeholders::_1));
 
-        // Websocket sessions currently don't support previous IDs on
-        // subscriptions, but we still need to populate the channel names in
-        // in the filter context even if all the values will be null
+        // Websocket sessions currently don't support previous IDs on subscriptions, but we still
+        // need to populate the channel names in in the filter context even if all the values will
+        // be null
         QHash<QString, QString> prevIds;
         QHashIterator<QString, Instruct::Channel> it(channels);
         while (it.hasNext()) {
@@ -147,9 +147,8 @@ void WsSession::processPublishQueue() {
         fc.trusted = targetTrusted;
         fc.limiter = filterLimiter;
 
-        // May call filtersFinished immediately. If it does, queue processing
-        // will continue. Else, the loop will end and queue processing will
-        // resume after the filters finish
+        // May call filtersFinished immediately. If it does, queue processing will continue. Else,
+        // the loop will end and queue processing will resume after the filters finish
         filters->start(fc, f.body);
     }
 

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -1170,8 +1170,8 @@ public:
 
                 handleConnectionBytesWritten(conn, written, true);
 
-                // If we had any pending writes to make, now's the time. note: this might delete the
-                // connection but that's fine
+                // If we had any pending writes to make, now's the time.
+                // note: this might delete the connection but that's fine
                 m2_tryWriteQueued(conn);
             }
         }

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -288,8 +288,7 @@ public:
                 if (outCredits > 0)
                     return true;
             } else {
-                // If we aren't using outCredits, then limit pending packets
-                // to hardcoded m2 value
+                // If we aren't using outCredits, then limit pending packets to hardcoded m2 value
                 if (packetsPending < M2_PENDING_MAX)
                     return true;
             }
@@ -496,8 +495,7 @@ public:
         if (configFile.isEmpty())
             configFile = QDir(Config::get().configDir).filePath("m2adapter.conf");
 
-        // QSettings doesn't inform us if the config file doesn't exist, so do that
-        // ourselves
+        // QSettings doesn't inform us if the config file doesn't exist, so do that ourselves
         {
             QFile file(configFile);
             if (!file.open(QIODevice::ReadOnly)) {
@@ -1066,14 +1064,12 @@ public:
     }
 
     void m2_writeErrorClose(const QByteArray &sender, const QByteArray &id) {
-        // Same as closing. In the future we may want to send something interesting
-        // first.
+        // Same as closing. In the future we may want to send something interesting first.
         m2_writeClose(sender, id);
     }
 
     void m2_writeErrorClose(M2Connection *conn) {
-        // Same as closing. In the future we may want to send something interesting
-        // first.
+        // Same as closing. In the future we may want to send something interesting first.
         m2_writeClose(conn);
     }
 
@@ -1147,8 +1143,7 @@ public:
 
         Variant rows = vhash["rows"];
 
-        // Once we get at least one successful response then we flag the port as
-        // working
+        // Once we get at least one successful response then we flag the port as working
         if (!controlPorts[index].works) {
             controlPorts[index].works = true;
             log_debug("control port index=%d works", index);
@@ -1175,8 +1170,8 @@ public:
 
                 handleConnectionBytesWritten(conn, written, true);
 
-                // If we had any pending writes to make, now's the time.
-                // note: this might delete the connection but that's fine
+                // If we had any pending writes to make, now's the time. note: this might delete the
+                // connection but that's fine
                 m2_tryWriteQueued(conn);
             }
         }
@@ -1242,8 +1237,7 @@ public:
         if (s->inHandoff)
             return;
 
-        // Address could be empty here if we're handling write of non-sequenced
-        // response
+        // Address could be empty here if we're handling write of non-sequenced response
         if (giveCredits && !s->zhttpAddress.isEmpty()) {
             ZhttpRequestPacket zreq;
             zreq.type = ZhttpRequestPacket::Credit;
@@ -1254,8 +1248,7 @@ public:
     }
 
     void endSession(Session *s, const QByteArray &errorCondition = QByteArray()) {
-        // If we are in handoff or haven't received a worker ack, then queue the
-        // state
+        // If we are in handoff or haven't received a worker ack, then queue the state
         if (s->inHandoff || s->zhttpAddress.isEmpty()) {
             if (!errorCondition.isEmpty())
                 s->errorCondition = errorCondition;
@@ -1441,8 +1434,8 @@ public:
 
         // A session without a connection is just waiting to report error
         if (!s->conn) {
-            // If we were in handoff, it's okay to send right now since we'd
-            // be clearing the handoff state later on in this method anyway
+            // If we were in handoff, it's okay to send right now since we'd be clearing the handoff
+            // state later on in this method anyway
             if (!s->zhttpAddress.isEmpty()) {
                 ZhttpRequestPacket zreq;
                 if (!s->errorCondition.isEmpty()) {
@@ -1475,9 +1468,8 @@ public:
             s->refreshBucket = smallestSessionRefreshBucket();
             sessionRefreshBuckets[s->refreshBucket] += s;
 
-            // In order to have been in a handoff state, we would have
-            // had to receive a from address sometime earlier, so it
-            // should be safe to call zhttp_out_write with session.
+            // In order to have been in a handoff state, we would have had to receive a from address
+            // sometime earlier, so it should be safe to call zhttp_out_write with session.
 
             if (multiWasTurnedOn) {
                 // Acknowledge the feature
@@ -1492,10 +1484,9 @@ public:
                     ZhttpRequestPacket zreq;
                     zreq.type = ZhttpRequestPacket::Data;
 
-                    // Send credits too, if needed (though this probably can't happen,
-                    // since http data flows only in one direction at a time. We
-                    // can't have pending request body data while at the same
-                    // time be acking received response body data).
+                    // Send credits too, if needed (though this probably can't happen, since http
+                    // data flows only in one direction at a time. We can't have pending request
+                    // body data while at the same time be acking received response body data).
                     if (s->pendingInCredits > 0) {
                         zreq.credits = s->pendingInCredits;
                         s->pendingInCredits = 0;
@@ -1547,8 +1538,8 @@ public:
                 // Respond with data if we have body data or this is the first packet
                 if (!zresp.body.isEmpty() || firstDataPacket) {
                     if (firstDataPacket) {
-                        // Use flow control if the control port works and the response is
-                        // more than one packet
+                        // Use flow control if the control port works and the response is more than
+                        // one packet
                         if ((s->conn->outCreditsEnabled ||
                              controlPorts[s->conn->identIndex].works) &&
                             zresp.more)
@@ -2173,14 +2164,12 @@ public:
                         statusTimer->start();
                 }
 
-                // If we were in the middle of requesting control info when this
-                // http request arrived, then there's a chance the control
-                // response won't account for this request (for example if the
-                // control response was generated and was in the middle of being
-                // delivered when this http request arrived). We'll flag the
-                // connection as "new" in this case, so in the control response
-                // handler we know to skip over it until the next control
-                // request.
+                // If we were in the middle of requesting control info when this http request
+                // arrived, then there's a chance the control response won't account for this
+                // request (for example if the control response was generated and was in the middle
+                // of being delivered when this http request arrived). We'll flag the connection as
+                // "new" in this case, so in the control response handler we know to skip over it
+                // until the next control request.
                 if (controlPorts[index].state == ControlPort::ExpectingResponse)
                     conn->isNew = true;
             }

--- a/src/m2adapter/m2requestpacket.cpp
+++ b/src/m2adapter/m2requestpacket.cpp
@@ -34,8 +34,7 @@ static bool isAllCaps(const QString &s) {
     for (int n = 0; n < s.length(); ++n) {
         QChar c = s[n];
 
-        // Non-letters are allowed, so what we really check against is
-        // lowercase
+        // Non-letters are allowed, so what we really check against is lowercase
         if (c.isLower())
             return false;
     }
@@ -251,8 +250,8 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in) {
     QByteArray uploadStartRaw = m2headers.value("x-mongrel2-upload-start");
     QByteArray uploadDoneRaw = m2headers.value("x-mongrel2-upload-done");
     if (!uploadDoneRaw.isEmpty()) {
-        // These headers must match for the packet to be valid. Not
-        // sure why mongrel2 can't enforce this for us but whatever
+        // These headers must match for the packet to be valid. Not sure why mongrel2 can't enforce
+        // this for us but whatever
         if (uploadStartRaw != uploadDoneRaw)
             return false;
 

--- a/src/proxy/connectionmanager.h
+++ b/src/proxy/connectionmanager.h
@@ -29,8 +29,8 @@
 class WebSocket;
 class WsProxySession;
 
-/// Manages mapping between WebSocket connections and their connection IDs
-/// and tracks which proxy session owns each connection
+/// Manages mapping between WebSocket connections and their connection IDs and tracks which proxy
+/// session owns each connection
 class ConnectionManager {
 public:
     ConnectionManager();

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -328,8 +328,7 @@ public:
     }
 
     void fileChanged() {
-        // Inotify tends to give us extra events so let's hang around a
-        // little bit before reloading
+        // Inotify tends to give us extra events so let's hang around a little bit before reloading
         if (!t.isActive()) {
             log_info("routes file changed, reloading");
             t.start(1000);

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -35,8 +35,8 @@
 using Signal = boost::signals2::signal<void()>;
 using Connection = boost::signals2::scoped_connection;
 
-/// Offers fast access to the routes file. The table is maintained
-/// by a background thread so that file access doesn't cause blocking.
+/// Offers fast access to the routes file. The table is maintained by a background thread so that
+/// file access doesn't cause blocking.
 class DomainMap {
 public:
     class JsonpConfig {
@@ -147,8 +147,8 @@ public:
     DomainMap(const QString &fileName);
     ~DomainMap();
 
-    // Shouldn't really ever need to call this, but it's here in case the
-    // underlying file watching doesn't work
+    // Shouldn't really ever need to call this, but it's here in case the underlying file watching
+    // doesn't work
     void reload();
 
     bool isIdShared(const QString &id) const;

--- a/src/proxy/inspectrequest.h
+++ b/src/proxy/inspectrequest.h
@@ -30,8 +30,7 @@ class HttpRequestData;
 class InspectData;
 class ZrpcManager;
 
-/// Requests handler decision on whether to proxy HTTP request to backend or
-/// accept it
+/// Requests handler decision on whether to proxy HTTP request to backend or accept it
 class InspectRequest : public ZrpcRequest {
 public:
     InspectRequest(ZrpcManager *manager);

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -360,8 +360,7 @@ int proxy_init(const ffi::ProxyCliArgs *argsFfi) {
 
     log_debug("starting...");
 
-    // QSettings doesn't inform us if the config file can't be opened, so do that
-    // ourselves
+    // QSettings doesn't inform us if the config file can't be opened, so do that ourselves
     {
         QFile file(args.configFile);
         if (!file.open(QIODevice::ReadOnly)) {
@@ -486,8 +485,7 @@ int proxy_init(const ffi::ProxyCliArgs *argsFfi) {
     foreach (const QString &s, origHeadersNeedMarkStr)
         origHeadersNeedMark += s.toUtf8();
 
-    // If routesFile is a relative path, then use it relative to the config file
-    // location
+    // If routesFile is a relative path, then use it relative to the config file location
     QFileInfo fi(routesFile);
     if (fi.isRelative())
         routesFile = QFileInfo(configDir, routesFile).filePath();

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -128,8 +128,8 @@ public:
     ~Private() {
         destroying = true;
 
-        // Need to delete all objects that may have connections before
-        // deleting zhttpmanagers/zroutes
+        // Need to delete all objects that may have connections before deleting
+        // zhttpmanagers/zroutes
 
         QHashIterator<ProxySession *, ProxyItem *> it(proxyItemsBySession);
         while (it.hasNext()) {
@@ -397,8 +397,7 @@ public:
         } else
             log_debug("reusing proxysession");
 
-        // ProxySession will take it from here
-        // TODO: use callbacks for performance
+        // ProxySession will take it from here. TODO: use callbacks for performance
         reqSessionConnectionMap.erase(rs);
 
         ps->add(rs);
@@ -508,9 +507,8 @@ public:
                                inspectChecker.get(), accept.get(), stats.get());
 
         if (passthroughData.isValid() && !preferInternal) {
-            // Passthrough request with preferInternal=false. In this case,
-            // set up a direct route, using some settings from the original
-            // route
+            // Passthrough request with preferInternal=false. In this case, set up a direct route,
+            // using some settings from the original route
 
             DomainMap::Entry originalRoute;
             if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
@@ -538,9 +536,9 @@ public:
 
             rs->setRoute(route);
         } else {
-            // Regular request (with or without a route ID), or a passthrough
-            // request with preferInternal=true. In that case, use domainmap
-            // for lookup, with route ID if available
+            // Regular request (with or without a route ID), or a passthrough request with
+            // preferInternal=true. In that case, use domainmap for lookup, with route ID if
+            // available
 
             rs->setRouteId(routeId);
         }
@@ -677,8 +675,8 @@ private:
     }
 
     void rs_inspected(const InspectData &idata, RequestSession *rs) {
-        // If we get here, then the request must be proxied. If it was to be
-        // directly accepted, then finishedByAccept would have been emitted instead
+        // If we get here, then the request must be proxied. If it was to be directly accepted, then
+        // finishedByAccept would have been emitted instead
         assert(idata.doProxy);
 
         doProxy(rs, &idata);
@@ -832,9 +830,9 @@ private:
             if (!p.route.isEmpty())
                 rs->setRouteId(QString::fromUtf8(p.route));
 
-            // Note: if the routing table was changed, there's a chance the request
-            // might get a different route id this time around. This could confuse
-            // stats processors tracking route+connection mappings.
+            // Note: if the routing table was changed, there's a chance the request might get a
+            // different route id this time around. This could confuse stats processors tracking
+            // route+connection mappings.
             rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin, req.jsonpCallback,
                            req.jsonpExtendedResponse, req.unreportedTime, p.retrySeq);
 

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -397,7 +397,8 @@ public:
         } else
             log_debug("reusing proxysession");
 
-        // ProxySession will take it from here. TODO: use callbacks for performance
+        // ProxySession will take it from here.
+        // TODO: use callbacks for performance
         reqSessionConnectionMap.erase(rs);
 
         ps->add(rs);

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -402,10 +402,9 @@ private:
                     } else {
                         zresp.headers += HttpHeader("Content-Type", "text/plain");
                         if (large) {
-                            // Grip-Link required to trigger accept after
-                            // sending large response. Note that the link
-                            // won't be followed in this test since that's
-                            // not a proxy issue
+                            // Grip-Link required to trigger accept after sending large response.
+                            // Note that the link won't be followed in this test since that's not a
+                            // proxy issue
                             zresp.headers += HttpHeader("Grip-Link", "</path3>; rel=next");
                             zresp.body =
                                 QByteArray(PROXY_MAX_ACCEPT_RESPONSE_BODY + 10000, 'a') + '\n';
@@ -1209,12 +1208,12 @@ static void acceptWithRetry(TestState &state, std::function<void(int)> loop_wait
     TEST_ASSERT_EQ(p.serverContentBytesSent, contentBytes);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    101); // "200" + "OK + "Content-Type" + "application/grip-instruct" +
-                         // "Content-Length": "94" + "200" + "OK" + "Content-Type" +
-                         // "text/plain" + "Content-Length" + "11"
-    TEST_ASSERT_EQ(p.serverContentBytesReceived,
-                   105); // "{ \"hold\": { \"mode\": \"response\", \"channels\": [
-                         // { \"name\": \"test-channel\", \"prev-id\": \"1\" } ] }
-                         // }" + "hello world"
+                         // "Content-Length": "94" + "200" + "OK" + "Content-Type" + "text/plain" +
+                         // "Content-Length" + "11"
+    TEST_ASSERT_EQ(
+        p.serverContentBytesReceived,
+        105); // "{ \"hold\": { \"mode\": \"response\", \"channels\": [
+              // { \"name\": \"test-channel\", \"prev-id\": \"1\" } ] } }" + "hello world"
 }
 
 static void passthroughShared(TestState &state, std::function<void(int)> loop_wait) {
@@ -1271,8 +1270,8 @@ static void passthroughShared(TestState &state, std::function<void(int)> loop_wa
     TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
     TEST_ASSERT_EQ(p.clientHeaderBytesSent,
                    86); // "200" + "OK" + "Content-Type" + "text/plain" +
-                        // "Content-Length" + "11" + "200" + "OK" + "Content-Type"
-                        // + "text/plain" + "Content-Length" + "11"
+                        // "Content-Length" + "11" + "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
     TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
                                                 reqData.method, reqData.uri, reqData.headers));
@@ -1369,8 +1368,8 @@ static void passthroughSharedPost(TestState &state, std::function<void(int)> loo
                    22); // "hello world" + "hello world"
     TEST_ASSERT_EQ(p.clientHeaderBytesSent,
                    86); // "200" + "OK" + "Content-Type" + "text/plain" +
-                        // "Content-Length" + "11" + "200" + "OK" + "Content-Type"
-                        // + "text/plain" + "Content-Length" + "11"
+                        // "Content-Length" + "11" + "200" + "OK" + "Content-Type" + "text/plain" +
+                        // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
     TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
                                                 reqData.method, reqData.uri, reqData.headers));

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -185,8 +185,8 @@ public:
 
     void cleanup() {
         foreach (SessionItem *si, sessionItems) {
-            // Emitting a signal here is gross, but this way the engine cleans up the
-            // request sessions
+            // Emitting a signal here is gross, but this way the engine cleans up the request
+            // sessions
             q->requestSessionDestroyed(si->rs, false);
             delete si->rs;
             delete si;
@@ -212,8 +212,7 @@ public:
         if (rs->isRetry())
             si->countClientReceivedBytes = false;
 
-        // Internal requests originate internally and should not have client bytes
-        // counted
+        // Internal requests originate internally and should not have client bytes counted
         if (rs->request()->passthroughData().isValid()) {
             si->countClientReceivedBytes = false;
             si->countClientSentBytes = false;
@@ -473,8 +472,7 @@ public:
     }
 
     void tryRequestRead() {
-        // If the state changed before input finished, then
-        // stop reading input
+        // If the state changed before input finished, then stop reading input
         if (state != Requesting)
             return;
 
@@ -545,21 +543,19 @@ public:
 
                     si->rs->respondCannotAccept();
                 } else {
-                    // If we already started responding, then only provide an
-                    // error message in debug mode
+                    // If we already started responding, then only provide an error message in debug
+                    // mode
 
                     if (si->rs->debugEnabled()) {
-                        // If debug enabled, append the message at the end.
-                        // this may ruin the content, but hey it's debug
-                        // mode
+                        // If debug enabled, append the message at the end. this may ruin the
+                        // content, but hey it's debug mode
                         QByteArray buf = "\n\nAccept service unavailable\n";
 
                         si->bytesToWrite += buf.size();
                         si->rs->writeResponseBody(buf);
                         si->rs->endResponseBody();
                     } else {
-                        // If debug not enabled, then the best we can do is
-                        // disconnect
+                        // If debug not enabled, then the best we can do is disconnect
                         si->state = SessionItem::Responded;
                         si->unclean = true;
                         si->bytesToWrite = -1;
@@ -603,21 +599,19 @@ public:
                                          si->rs->debugEnabled() ? debugErrorMessage : errorMessage);
                 } else // Responding
                 {
-                    // If we already started responding, then only provide a
-                    // rejection message in debug mode
+                    // If we already started responding, then only provide a rejection message in
+                    // debug mode
 
                     if (si->rs->debugEnabled()) {
-                        // If debug enabled, append the message at the end.
-                        // this may ruin the content, but hey it's debug
-                        // mode
+                        // If debug enabled, append the message at the end. this may ruin the
+                        // content, but hey it's debug mode
                         QByteArray buf = "\n\n" + debugErrorMessage.toUtf8() + '\n';
 
                         si->bytesToWrite += buf.size();
                         si->rs->writeResponseBody(buf);
                         si->rs->endResponseBody();
                     } else {
-                        // If debug not enabled, then the best we can do is
-                        // disconnect
+                        // If debug not enabled, then the best we can do is disconnect
                         si->state = SessionItem::Responded;
                         si->unclean = true;
                         si->bytesToWrite = -1;
@@ -673,8 +667,8 @@ public:
 
     // This method emits signals
     void tryResponseRead() {
-        // If we're not buffering, then don't read (instead, sync to slowest
-        // receiver before reading again)
+        // If we're not buffering, then don't read (instead, sync to slowest receiver before reading
+        // again)
         if (!buffering && pendingWrites())
             return;
 
@@ -715,13 +709,12 @@ public:
                     (gripHold == "stream" ||
                      (gripHold.isEmpty() && !gripNextLinkParam.isEmpty())) &&
                     !usingBuildIdFilter) {
-                    // Sending the initial response from the proxy means
-                    // we need to do some of the handler's job here
+                    // Sending the initial response from the proxy means we need to do some of the
+                    // handler's job here
 
-                    // NOTE: if we ever need to do more than what's
-                    // below, we should consider querying the handler
-                    // to perform these things while still letting
-                    // the proxy send the response body
+                    // NOTE: if we ever need to do more than what's below, we should consider
+                    // querying the handler to perform these things while still letting the proxy
+                    // send the response body
 
                     // No content length
                     responseData.headers.removeAll("Content-Length");
@@ -885,8 +878,8 @@ public:
     void startResponse() {
         state = Responding;
 
-        // Don't relay these headers. Their meaning is handled by
-        // zurl and they only apply to the outgoing hop.
+        // Don't relay these headers. Their meaning is handled by zurl and they only apply to the
+        // outgoing hop.
         responseData.headers.removeAll("Connection");
         responseData.headers.removeAll("Keep-Alive");
         responseData.headers.removeAll("Content-Encoding");
@@ -1104,8 +1097,8 @@ public:
             log_debug("proxysession: %p finished by passthrough", q);
             q->finished();
         } else if (wasInputRequest) {
-            // This should never happen. For there to be more than
-            // one SessionItem, inRequest must be 0.
+            // This should never happen. For there to be more than one SessionItem, inRequest must
+            // be 0.
             assert(0);
 
             rejectAll(500, "Internal Server Error", "Input request failed.");
@@ -1197,8 +1190,7 @@ public:
             adata.responseSent = acceptAfterResponding;
 
             if (!statsManager->connectionSendEnabled()) {
-                // Flush max. The count will include the connections we just
-                // unregistered
+                // Flush max. The count will include the connections we just unregistered
                 adata.connMaxPackets +=
                     statsManager->getConnMaxPacket(route.statsRoute()).toVariant();
 
@@ -1226,8 +1218,7 @@ public:
         si->state = SessionItem::Errored;
         si->bytesToWrite = -1;
 
-        // Don't destroy the RequestSession here. A finished signal will arrive
-        // next.
+        // Don't destroy the RequestSession here. A finished signal will arrive next.
     }
 
     void rs_headerBytesSent(int count, RequestSession *rs) {
@@ -1257,8 +1248,7 @@ public:
                 foreach (SessionItem *si, sessionItems)
                     logFinished(si, true);
 
-                // The requests were paused, so deleting them will leave the peer
-                // sessions active
+                // The requests were paused, so deleting them will leave the peer sessions active
 
                 QList<RequestSession *> toDestroy;
                 foreach (SessionItem *si, sessionItems) {

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -84,9 +84,8 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
         log_debug("%s: %p passing to upstream", logprefix, object);
 
     if (!trustedClient && entry.origHeaders) {
-        // Copy headers to include magic prefix, so that the original
-        // headers may be recovered later. If the client is trusted,
-        // then we assume this has been done already.
+        // Copy headers to include magic prefix, so that the original headers may be recovered
+        // later. If the client is trusted, then we assume this has been done already.
 
         HttpHeaders origHeaders;
         for (int n = 0; n < requestData->headers.count(); ++n) {
@@ -119,8 +118,7 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
         foreach (const HttpHeader &h, origHeaders)
             requestData->headers += h;
     } else if (!entry.origHeaders) {
-        // If we don't want original headers, then filter them out
-        // before proxying
+        // If we don't want original headers, then filter them out before proxying
         for (int n = 0; n < requestData->headers.count(); ++n) {
             const HttpHeader &h = requestData->headers[n];
 
@@ -131,8 +129,8 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
         }
     }
 
-    // Don't relay these headers. Their meaning is handled by
-    // mongrel2 and they only apply to the incoming hop.
+    // Don't relay these headers. Their meaning is handled by mongrel2 and they only apply to the
+    // incoming hop.
     requestData->headers.removeAll("Connection");
     requestData->headers.removeAll("Keep-Alive");
     requestData->headers.removeAll("Accept-Encoding");

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -325,8 +325,8 @@ public:
             }
         }
 
-        // NOTE: per the license, this functionality may not be removed as it
-        // is the interface for the copyright notice
+        // NOTE: per the license, this functionality may not be removed as it is the interface for
+        // the copyright notice
         if (requestData.headers.contains("Pushpin-Check")) {
             QString str = "Copyright (C) 2012-2023 Fanout, Inc.\n"
                           "Copyright (C) 2023 Fastly, Inc.\n"
@@ -426,8 +426,8 @@ public:
                                  logicalPeerAddress, isHttps, false, reportOffset);
             stats->addActivity(route.statsRoute());
 
-            // Note: we don't call addRequestsReceived here, because we're acting for
-            // an existing request
+            // Note: we don't call addRequestsReceived here, because we're acting for an existing
+            // request
         }
     }
 
@@ -473,10 +473,9 @@ public:
             in += zhttpRequest->readBody(MAX_SHARED_REQUEST_BODY - in.size());
 
             if (in.size() >= MAX_SHARED_REQUEST_BODY || zhttpRequest->isInputFinished()) {
-                // We've read as much as we can for now. If there is still
-                // more to read, then the engine will notice this and
-                // disallow sharing before passing to proxysession. At that
-                // point, proxysession will read the remainder of the data
+                // We've read as much as we can for now. If there is still more to read, then the
+                // engine will notice this and disallow sharing before passing to proxysession. At
+                // that point, proxysession will read the remainder of the data
 
                 zhttpReqConnections.readyReadConnection.disconnect();
 
@@ -604,9 +603,8 @@ public:
         Url uri = requestData.uri;
         QUrlQuery query(uri);
 
-        // Two ways to activate JSON-P:
-        // 1) callback param present
-        // 2) default callback specified in configuration and body param present
+        // Two ways to activate JSON-P: 1) callback param present 2) default callback specified in
+        // configuration and body param present
         if (!query.hasQueryItem(callbackParam) &&
             (config.defaultCallback.isEmpty() || bodyParam.isEmpty() ||
              !query.hasQueryItem(bodyParam))) {
@@ -844,15 +842,15 @@ public:
         if (!idata.doProxy) {
             state = ReceivingForAccept;
 
-            // Successful inspect indicated we should not proxy. In that case,
-            // collect the body and accept
+            // Successful inspect indicated we should not proxy. In that case, collect the body and
+            // accept
             zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(
                 boost::bind(&Private::zhttpRequest_readyRead, this));
             processIncomingRequest();
         } else {
             if (!idata.sharingKey.isEmpty()) {
-                // A request can only be shared if we've read the entire
-                // request body, so let's try to read it now
+                // A request can only be shared if we've read the entire request body, so let's try
+                // to read it now
                 state = Receiving;
 
                 zhttpReqConnections.readyReadConnection = zhttpRequest->readyRead.connect(
@@ -876,8 +874,7 @@ public:
             if (rdata.accepted) {
                 accepted = true;
 
-                // The request was paused, so deleting it will leave the peer session
-                // active
+                // The request was paused, so deleting it will leave the peer session active
                 zhttpReqConnections = ZhttpReqConnections();
                 delete zhttpRequest;
                 zhttpRequest = 0;
@@ -1028,8 +1025,7 @@ public:
                         else if (bodyRawBuf.endsWith("\n"))
                             bodyRawBuf.truncate(bodyRawBuf.size() - 1);
                     } else {
-                        // Response isn't finished. Keep any trailing newline in the output
-                        // buffer
+                        // Response isn't finished. Keep any trailing newline in the output buffer
                         if (bodyRawBuf.endsWith("\r\n")) {
                             bodyRawBuf.truncate(bodyRawBuf.size() - 2);
                             out += QByteArray("\r\n");

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -603,8 +603,9 @@ public:
         Url uri = requestData.uri;
         QUrlQuery query(uri);
 
-        // Two ways to activate JSON-P: 1) callback param present 2) default callback specified in
-        // configuration and body param present
+        // Two ways to activate JSON-P:
+        // 1) callback param present
+        // 2) default callback specified in configuration and body param present
         if (!query.hasQueryItem(callbackParam) &&
             (config.defaultCallback.isEmpty() || bodyParam.isEmpty() ||
              !query.hasQueryItem(bodyParam))) {

--- a/src/proxy/requestsession.h
+++ b/src/proxy/requestsession.h
@@ -48,8 +48,8 @@ class ZrpcChecker;
 class StatsManager;
 class XffRule;
 
-/// Manages the lifecycle of an individual HTTP request including
-/// inspection, acceptance, and response handling
+/// Manages the lifecycle of an individual HTTP request including inspection, acceptance, and
+/// response handling
 class RequestSession {
 public:
     RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager,
@@ -113,10 +113,9 @@ public:
     Signal paused;
     SignalInt headerBytesSent;
     SignalInt bodyBytesSent;
-    // This signal means some error was encountered while responding and
-    // that you should not attempt to call further response-related
-    // methods. The object remains in an active state though, and so you
-    // should still wait for finished()
+    // This signal means some error was encountered while responding and that you should not attempt
+    // to call further response-related methods. The object remains in an active state though, and
+    // so you should still wait for finished()
     Signal errorResponding;
     Signal finished;
 

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -154,8 +154,8 @@ public:
         // Can't remove unless unlinked
         assert(!s->ext);
 
-        // Note: this method assumes the session has already been removed
-        // from pendingSessions if needed
+        // Note: this method assumes the session has already been removed from pendingSessions if
+        // needed
         if (s->req)
             sessionsByRequest.remove(s->req);
         if (s->sock)
@@ -531,8 +531,8 @@ public:
 
 private:
     void req_readyRead(ZhttpRequest *req) {
-        // For a request to have been discardable, we must have read the
-        // entire input already and handed to the session
+        // For a request to have been discardable, we must have read the entire input already and
+        // handed to the session
         assert(!discardedRequests.contains(req));
 
         Session *s = sessionsByRequest.value(req);

--- a/src/proxy/sockjsmanager.h
+++ b/src/proxy/sockjsmanager.h
@@ -36,8 +36,7 @@ class ZhttpRequest;
 class ZWebSocket;
 class SockJsSession;
 
-/// Manages SockJS sessions and routes clients using WebSocket, XHR, or JSONP
-/// comms
+/// Manages SockJS sessions and routes clients using WebSocket, XHR, or JSONP comms
 class SockJsManager {
 public:
     SockJsManager(const QString &sockJsUrl);

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -717,8 +717,8 @@ public:
                 if (error)
                     break;
 
-                // note: inBytes may exceed BUFFER_SIZE at this point, but
-                // It shouldn't be by more than double
+                // note: inBytes may exceed BUFFER_SIZE at this point, but it shouldn't be by more
+                // than double
 
                 inFrames += frames;
                 inBytes += bytes;

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -37,9 +37,9 @@ class ZhttpRequest;
 class ZWebSocket;
 class SockJsManager;
 
-/// SockJS session for incoming client connections that converts XHR-polling,
-/// JSONP, and native WebSocket into unified WebSocket-style messaging with
-/// session state management, keepalive handling, and request queueing
+/// SockJS session for incoming client connections that converts XHR-polling, JSONP, and native
+/// WebSocket into unified WebSocket-style messaging with session state management, keepalive
+/// handling, and request queueing
 class SockJsSession : public WebSocket {
 public:
     ~SockJsSession();

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -394,8 +394,8 @@ private:
         bool cscm = canSendCompleteMessage();
 
         if (!cscm && writeBytesAvailable() == 0) {
-            // Write buffer maxed with incomplete message. This is
-            // unrecoverable. Update to throw error right away.
+            // Write buffer maxed with incomplete message. This is unrecoverable. Update to throw
+            // error right away.
             return true;
         }
 
@@ -614,37 +614,33 @@ private:
         int contentRemoved = removeContentFromFrames(&outFrames, nonCloseContentBytesAccepted);
         int framesRemoved = outFramesCountOrig - outFrames.count();
 
-        // Guaranteed to succeed, since reqContentSize represents the initial
-        // data in outFrames and we guard against too large of an input
+        // Guaranteed to succeed, since reqContentSize represents the initial data in outFrames and
+        // we guard against too large of an input
         assert(contentRemoved == nonCloseContentBytesAccepted);
 
         outContentSize -= contentRemoved;
 
-        // If we couldn't fit all pending data in the request, then require
-        // progress to be made
+        // If we couldn't fit all pending data in the request, then require progress to be made
         if (reqMaxed && framesRemoved == 0 && contentRemoved == 0) {
             updating = false;
             queueError(ErrorGeneric);
             return;
         }
 
-        // FramesRemoved could exceed reqFrames if any zero-sized frames are
-        // appended to outFrames before acceptance, causing them to be
-        // removed even though they weren't in the request
+        // FramesRemoved could exceed reqFrames if any zero-sized frames are appended to outFrames
+        // before acceptance, causing them to be removed even though they weren't in the request
         outFramesReplay = qMax(reqFrames - framesRemoved, 0);
 
         outContentReplay = reqContentSize - contentRemoved;
 
         if (reqClose) {
             if (nonCloseContentBytesAccepted < reqContentSize) {
-                // If server didn't accept all content before close, then don't close
-                // yet
+                // If server didn't accept all content before close, then don't close yet
                 reqClose = false;
             } else {
-                // Server accepted all content before close. In that case, we
-                // require the server to also accept the close. Partial
-                // acceptance is meant for waiting for more data and from
-                // this point there won't be any more data.
+                // Server accepted all content before close. In that case, we require the server to
+                // also accept the close. Partial acceptance is meant for waiting for more data and
+                // from this point there won't be any more data.
                 if (contentBytesAccepted < reqContentSizeWithClose) {
                     cleanup();
                     q->error();
@@ -798,9 +794,8 @@ private:
                 q->peerClosed();
             }
         } else if (closeSent && keepAliveInterval == -1) {
-            // If there are no keep alives, then the server has only one
-            // chance to respond to a close. If it doesn't, then
-            // consider the connection uncleanly disconnected.
+            // If there are no keep alives, then the server has only one chance to respond to a
+            // close. If it doesn't, then consider the connection uncleanly disconnected.
             disconnected = true;
         }
 
@@ -843,8 +838,8 @@ private:
             break;
         case ZhttpRequest::ErrorGeneric:
         case ZhttpRequest::ErrorTimeout:
-            // These errors mean the server may have been reached, so
-            // only retry if the request body wasn't completely sent
+            // These errors mean the server may have been reached, so only retry if the request body
+            // wasn't completely sent
             if (reqPendingBytes > 0)
                 retry = true;
             break;
@@ -899,8 +894,7 @@ private:
 };
 
 void WebSocketOverHttp::DisconnectManager::deleteSocket(WebSocketOverHttp *sock) {
-    // Ensure state is Idle to prevent the destructor from re-adding it to the
-    // manager
+    // Ensure state is Idle to prevent the destructor from re-adding it to the manager
     sock->d->cleanup();
 
     delete sock;
@@ -1117,15 +1111,13 @@ int WebSocketOverHttp::removeContentFromFrames(QList<WebSocket::Frame> *frames, 
         WebSocket::Frame::Type ftype = f.type;
         bool more = f.more;
 
-        // Only remove frame of a multipart message if we can carry over
-        // the type
+        // Only remove frame of a multipart message if we can carry over the type
         if (more && frames->count() < 2)
             break;
 
         frames->removeFirst();
 
-        // If removed frame was part of a multipart message, carry over
-        // the type
+        // If removed frame was part of a multipart message, carry over the type
         if (more) {
             assert(!frames->isEmpty());
             frames->first().type = ftype;

--- a/src/proxy/websocketoverhttp.h
+++ b/src/proxy/websocketoverhttp.h
@@ -35,8 +35,7 @@ using Connection = boost::signals2::scoped_connection;
 
 class ZhttpManager;
 
-/// Implements WebSocket protocol over HTTP long-polling for outgoing backend
-/// connections
+/// Implements WebSocket protocol over HTTP for outgoing backend connections
 class WebSocketOverHttp : public WebSocket {
 public:
     class Event {
@@ -100,23 +99,19 @@ public:
     Signal aboutToSendRequest;
     Signal disconnected;
 
-    // Creates events from `frames`. The returned events are guaranteed to
-    // represent 0 or more full messages from `frames`, where the first
-    // represented frame is a non-continuation frame. This matches the
-    // expectations of `removeContentFromFrames()`, in order to enable
-    // removing the frames afterwards.
+    // Creates events from `frames`. The returned events are guaranteed to represent 0 or more full
+    // messages from `frames`, where the first represented frame is a non-continuation frame. This
+    // matches the expectations of `removeContentFromFrames()`, in order to enable removing the
+    // frames afterwards.
     static QList<Event> framesToEvents(const QList<Frame> &frames, int eventsMax, int contentMax,
                                        bool *ok, int *framesRepresented, int *contentRepresented);
 
-    // Remove `count` content bytes from the beginning of `frames`, removing
-    // frames (including 0-sized frames) when their content is entirely removed.
-    // when a frame is removed from a multipart message, the original type is
-    // carried over into the next frame, which means the first frame can't be a
-    // continuation.
-    // returns the actual number of content bytes removed, which may be less than
-    // `count` if there are not enough content bytes available, or if a frame in
-    // a multipart message needs to be removed and there is no frame after it to
-    // retain the type.
+    // Remove `count` content bytes from the beginning of `frames`, removing frames (including
+    // 0-sized frames) when their content is entirely removed. when a frame is removed from a
+    // multipart message, the original type is carried over into the next frame, which means the
+    // first frame can't be a continuation. returns the actual number of content bytes removed,
+    // which may be less than `count` if there are not enough content bytes available, or if a frame
+    // in a multipart message needs to be removed and there is no frame after it to retain the type.
     static int removeContentFromFrames(QList<WebSocket::Frame> *frames, int count);
 
 private:

--- a/src/proxy/wscontrolmanager.h
+++ b/src/proxy/wscontrolmanager.h
@@ -29,8 +29,8 @@
 
 class WsControlSession;
 
-/// Creates and tracks WebSocket control sessions and manages the shared ZMQ
-/// init and stream channel sockets used for handler communication
+/// Creates and tracks WebSocket control sessions and manages the shared ZMQ init and stream
+/// channel sockets used for handler communication
 class WsControlManager {
 public:
     WsControlManager();

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -35,9 +35,9 @@ using Signal = boost::signals2::signal<void()>;
 
 class WsControlManager;
 
-/// Handles communication with the handler for controlling an active WebSocket
-/// connection including sending GRIP control messages, managing channel
-/// subscriptions, and coordinating keepalives
+/// Handles communication with the handler for controlling an active WebSocket connection
+/// including sending GRIP control messages, managing channel subscriptions, and coordinating
+/// keepalives
 class WsControlSession {
 public:
     ~WsControlSession();

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -327,8 +327,7 @@ public:
 
     void cleanupOutSock() {
         if (outSock) {
-            // Ensure the socket has an updated Grip-Sig to use during its
-            // destruction process
+            // Ensure the socket has an updated Grip-Sig to use during its destruction process
             updateGripSig();
 
             outWSConnection = WSConnections();
@@ -953,9 +952,8 @@ public:
         if (type == WebSocket::Frame::Continuation)
             return;
 
-        // If we have no socket to write to, say the data was written anyway.
-        // this is not quite correct but better than leaving the send event
-        // dangling
+        // If we have no socket to write to, say the data was written anyway. this is not quite
+        // correct but better than leaving the send event dangling
         if (!inSock || inSock->state() != WebSocket::Connected) {
             wsControl->sendEventWritten();
             return;

--- a/src/proxy/wsproxysession.h
+++ b/src/proxy/wsproxysession.h
@@ -44,8 +44,7 @@ class StatsManager;
 class ConnectionManager;
 class XffRule;
 
-/// Proxies WebSocket requests to backends with GRIP streaming and request
-/// sharing
+/// Proxies WebSocket requests to backends, with GRIP capability
 class WsProxySession {
 public:
     WsProxySession(ZRoutes *zroutes, ConnectionManager *connectionManager,

--- a/src/proxy/zroutes.h
+++ b/src/proxy/zroutes.h
@@ -27,8 +27,8 @@
 #include "domainmap.h"
 #include "zhttpmanager.h"
 
-/// Manages the initialization, storage, and lookup mapping of the ZhttpManager
-/// instance for each route
+/// Manages the initialization, storage, and lookup mapping of the ZhttpManager instance for each
+/// route
 class ZRoutes {
 public:
     ZRoutes();

--- a/src/proxy/zrpcchecker.cpp
+++ b/src/proxy/zrpcchecker.cpp
@@ -111,9 +111,8 @@ public:
             // Take over ownership
             i->owned = true;
         } else {
-            // If we aren't watching (or were watching, but no
-            // longer watching), then just delete what we were
-            // given
+            // If we aren't watching (or were watching, but no longer watching), then just delete
+            // what we were given
             reqConnectionMap.erase(req);
             delete req;
         }

--- a/src/proxy/zrpcchecker.h
+++ b/src/proxy/zrpcchecker.h
@@ -30,12 +30,10 @@ using Connection = boost::signals2::scoped_connection;
 
 class ZrpcRequest;
 
-/// Watches ZRPC requests for success/failure to determine if the handler is
-/// reachable
-///
-/// All requests should be passed to this class for monitoring. Use
-/// watch() to have it monitor a request, but not own it. Use give() to have
-/// this class take ownership of an already-watched request.
+/// Watches ZRPC requests for success/failure to determine if the handler is reachable. All
+/// requests should be passed to this class for monitoring. Use watch() to have it monitor a
+/// request, but not own it. Use give() to have this class take ownership of an already-watched
+/// request.
 class ZrpcChecker {
 public:
     ZrpcChecker();

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -68,8 +68,7 @@ static bool ensureDir(const QString &path) {
 }
 
 static QPair<QHostAddress, int> parsePort(const QString &s) {
-    // If the string doesn't contain a colon character, assume it's a port
-    // number by itself
+    // If the string doesn't contain a colon character, assume it's a port number by itself
     if (!s.contains(':'))
         return QPair<QHostAddress, int>(QHostAddress(), s.toInt());
 
@@ -316,8 +315,7 @@ public:
             return;
         }
 
-        // QSettings doesn't inform us if the config file can't be accessed,
-        // so do that ourselves
+        // QSettings doesn't inform us if the config file can't be accessed, so do that ourselves
         {
             QFile file(configFile);
             if (!file.open(QIODevice::ReadOnly)) {
@@ -402,8 +400,8 @@ public:
         // If default log level not provided, use info level
         int defaultLevel = logLevels.value("", 2);
 
-        // NOTE: since we only finally set the log level here, earlier
-        // log messages outside the default level will be lost (if any)
+        // NOTE: since we only finally set the log level here, earlier log messages outside the
+        // default level will be lost (if any)
         log_setOutputLevel(logLevels.value("runner", defaultLevel));
 
         int clientBufferSize = settings.value("runner/client_buffer_size", 8192).toInt();

--- a/src/runner/service.cpp
+++ b/src/runner/service.cpp
@@ -35,10 +35,9 @@
 static void setupChild() {
     signal(SIGINT, SIG_IGN);
 
-    // subprocesses hopefully respect SIG_IGN, but are not required
-    // To. In case subprocess might reinstate a SIGINT handler,
-    // detach from process group to ensure ctrl-c in a shell
-    // doesn't cause SIGINT to be sent directly to subprocesses
+    // subprocesses hopefully respect SIG_IGN, but are not required To. In case subprocess might
+    // reinstate a SIGINT handler, detach from process group to ensure ctrl-c in a shell doesn't
+    // cause SIGINT to be sent directly to subprocesses
     setpgid(0, 0);
 }
 
@@ -241,8 +240,7 @@ private slots:
 
             q->error("Error running: " + program);
         } else {
-            // Other errors are followed by finished(), so we don't
-            // need to handle them here
+            // Other errors are followed by finished(), so we don't need to handle them here
         }
     }
 

--- a/src/runner/template.cpp
+++ b/src/runner/template.cpp
@@ -21,10 +21,9 @@
  * $FANOUT_END_LICENSE$
  */
 
-// NOTE: this is a basic jinja-like template engine. Its abilities are
-// minimal, because at the time of this writing our templates aren't very
-// complex. If someday we need more template functionality, we should
-// consider throwing this code away and using a real template library.
+// NOTE: this is a basic jinja-like template engine. Its abilities are minimal, because at the time
+// of this writing our templates aren't very complex. If someday we need more template
+// functionality, we should consider throwing this code away and using a real template library.
 
 #include "template.h"
 


### PR DESCRIPTION
When I performed the mass reformatting of C++ files in this repo, I first ran clang-format with an 80 char line limit which split comment lines. Then I ran it again with a 100 char line limit but the comments stayed split at 80 chars. It seems clang-format doesn't "reflow" comments if the limit is increased. To repair this, I used a script to merge sequential comment lines into single lines and then used clang-format to reformat all the files again. This properly split the comments at 100 chars. I also manually cleaned up some comments that weren't quite right.