### PR TITLE
add ffi for rust's std thread api and use it from c++

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -21,6 +21,7 @@ HEADERS += $$PWD/processquit.h
 SOURCES += $$PWD/processquit.cpp
 
 HEADERS += \
+	$$PWD/rustthread.h \
 	$$PWD/test.h \
 	$$PWD/tnetstring.h \
 	$$PWD/httpheaders.h \
@@ -31,6 +32,7 @@ HEADERS += \
 	$$PWD/layertracker.h
 
 SOURCES += \
+	$$PWD/rustthread.cpp \
 	$$PWD/test.cpp \
 	$$PWD/tnetstring.cpp \
 	$$PWD/httpheaders.cpp \

--- a/src/core/defercalltest.cpp
+++ b/src/core/defercalltest.cpp
@@ -22,8 +22,8 @@
 
 #include "defercall.h"
 #include "eventloop.h"
+#include "rustthread.h"
 #include "test.h"
-#include <thread>
 
 // loop_advance should process enough events to cause the calls to run, without sleeping, in order
 // to prove the calls are run immediately
@@ -44,7 +44,7 @@ static std::tuple<int, int> runDeferCall(std::function<void()> loop_advance) {
 
 // Spawns a thread, triggers the deferCall from it, then waits for thread to finish
 static void callNonLocal(DeferCall *deferCall, std::function<void()> handler) {
-    std::thread thread([=] { deferCall->defer(handler); });
+    RustThread::JoinHandle thread = RustThread::spawn([=] { deferCall->defer(handler); });
     thread.join();
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,6 +35,7 @@ pub mod select;
 pub mod shuffle;
 pub mod task;
 pub mod test;
+pub mod thread;
 pub mod time;
 pub mod timer;
 pub mod tnetstring;

--- a/src/core/rustthread.cpp
+++ b/src/core/rustthread.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rustthread.h"
+
+#include <assert.h>
+
+static void call_and_delete_function(void *ctx) {
+    std::function<void()> *f = reinterpret_cast<std::function<void()> *>(ctx);
+    (*f)();
+    delete f;
+}
+
+namespace RustThread {
+
+JoinHandle::JoinHandle() : handle_(nullptr, ffi::thread_forget) {}
+
+JoinHandle::JoinHandle(ffi::ThreadJoinHandle *handle) : handle_(handle, ffi::thread_forget) {}
+
+void JoinHandle::join() {
+    if (handle_) {
+        ffi::thread_join(handle_.release());
+    }
+}
+
+JoinHandle spawn(std::function<void()> f, const std::string &name) {
+    // Move the function to the heap. The spawned thread will take care of destruction.
+    std::function<void()> *f_heap = new std::function<void()>(f);
+
+    const char *name_c = nullptr;
+    if (!name.empty())
+        name_c = name.c_str();
+
+    ffi::ThreadJoinHandle *handle =
+        ffi::thread_spawn(call_and_delete_function, reinterpret_cast<void *>(f_heap), name_c);
+    assert(handle);
+
+    return JoinHandle(handle);
+}
+
+} // namespace RustThread

--- a/src/core/rustthread.h
+++ b/src/core/rustthread.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef PUSHPIN_THREAD_H
-#define PUSHPIN_THREAD_H
+#ifndef RUST_THREAD_H
+#define RUST_THREAD_H
 
 #include "rust/bindings.h"
 #include <functional>

--- a/src/core/rustthread.h
+++ b/src/core/rustthread.h
@@ -19,6 +19,7 @@
 
 #include "rust/bindings.h"
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace RustThread {

--- a/src/core/rustthread.h
+++ b/src/core/rustthread.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PUSHPIN_THREAD_H
+#define PUSHPIN_THREAD_H
+
+#include "rust/bindings.h"
+#include <functional>
+#include <string>
+
+namespace RustThread {
+
+class JoinHandle {
+public:
+    JoinHandle();
+
+    void join();
+
+private:
+    std::unique_ptr<ffi::ThreadJoinHandle, void (*)(ffi::ThreadJoinHandle *)> handle_;
+
+    JoinHandle(ffi::ThreadJoinHandle *handle);
+
+    friend JoinHandle spawn(std::function<void()> f, const std::string &name);
+};
+
+JoinHandle spawn(std::function<void()> f, const std::string &name = "");
+
+} // namespace RustThread
+
+#endif

--- a/src/core/thread.rs
+++ b/src/core/thread.rs
@@ -105,8 +105,8 @@ mod ffi {
         assert!(!handle.is_null());
 
         // SAFETY: We assume `handle` is valid.
-        let handle = unsafe { Box::from_raw(handle).0 };
+        let thread = unsafe { Box::from_raw(handle).0 };
 
-        drop(handle);
+        drop(thread);
     }
 }

--- a/src/core/thread.rs
+++ b/src/core/thread.rs
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::thread;
+
+mod ffi {
+    use super::*;
+    use std::ffi::{c_char, CStr};
+    use std::ptr;
+
+    mod sendable_pointer {
+        pub struct SendablePointer<T>(*mut T);
+
+        impl<T> SendablePointer<T> {
+            // SAFETY: `p` must be safe to move to another thread.
+            pub unsafe fn new(p: *mut T) -> Self {
+                Self(p)
+            }
+
+            pub fn get(&self) -> *mut T {
+                self.0
+            }
+        }
+
+        unsafe impl<T> Send for SendablePointer<T> {}
+    }
+
+    use sendable_pointer::SendablePointer;
+
+    pub struct ThreadJoinHandle(thread::JoinHandle<()>);
+
+    /// `name` can be used to supply an optional name for the thread. If it is null, no explicit
+    /// name will be set on the thread.
+    //
+    /// SAFETY: `ctx` must be safe to use from another thread, and `f` must be safe to call from
+    /// another thread with `ctx` as its argument. If `name` is non-null, it must point to a valid
+    /// C string.
+    #[no_mangle]
+    pub unsafe extern "C" fn thread_spawn(
+        f: unsafe extern "C" fn(*mut libc::c_void),
+        ctx: *mut libc::c_void,
+        name: *const c_char,
+    ) -> *mut ThreadJoinHandle {
+        let name = if !name.is_null() {
+            // SAFETY: We assume `name` is valid.
+            unsafe {
+                match CStr::from_ptr(name).to_str() {
+                    Ok(s) => Some(s),
+                    Err(_) => return ptr::null_mut(), // Invalid UTF-8
+                }
+            }
+        } else {
+            None
+        };
+
+        // SAFETY: `ctx` is safe to move to another thread.
+        let ctx = unsafe { SendablePointer::new(ctx) };
+
+        let builder = thread::Builder::new();
+
+        let builder = if let Some(name) = name {
+            builder.name(name.to_string())
+        } else {
+            builder
+        };
+
+        let thread = builder.spawn(move || unsafe { f(ctx.get()) }).unwrap();
+
+        Box::into_raw(Box::new(ThreadJoinHandle(thread)))
+    }
+
+    /// Blocks until the thread completes and consumes the handle, invaliding the pointer.
+    ///
+    /// SAFETY: `handle` must point to a valid handle returned by `thread_spawn` that has not yet
+    /// been invalidated.
+    #[no_mangle]
+    pub unsafe extern "C" fn thread_join(handle: *mut ThreadJoinHandle) {
+        assert!(!handle.is_null());
+
+        // SAFETY: We assume `handle` is valid.
+        let thread = unsafe { Box::from_raw(handle).0 };
+
+        thread.join().unwrap();
+    }
+
+    /// Discards the handle and leaves the thread running, invaliding the pointer.
+    ///
+    /// SAFETY: `handle` must point to a valid handle returned by `thread_spawn` that has not yet
+    /// been invalidated.
+    #[no_mangle]
+    pub unsafe extern "C" fn thread_forget(handle: *mut ThreadJoinHandle) {
+        assert!(!handle.is_null());
+
+        // SAFETY: We assume `handle` is valid.
+        let handle = unsafe { Box::from_raw(handle).0 };
+
+        drop(handle);
+    }
+}

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -28,6 +28,7 @@
 #include "filewatcher.h"
 #include "log.h"
 #include "routesfile.h"
+#include "rustthread.h"
 #include "timer.h"
 #include <QCoreApplication>
 #include <QDir>
@@ -38,8 +39,6 @@
 #include <QTextStream>
 #include <QWaitCondition>
 #include <assert.h>
-#include <pthread.h>
-#include <thread>
 
 #define WORKER_THREAD_TIMERS 10
 #define WORKER_THREAD_SOCKETNOTIFIERS 1
@@ -708,7 +707,7 @@ private:
 class DomainMap::Thread {
 public:
     QString fileName;
-    std::thread thread;
+    RustThread::JoinHandle thread;
     std::unique_ptr<EventLoop> loop;
     std::unique_ptr<Worker> worker;
     QMutex m;
@@ -730,15 +729,7 @@ public:
     void start() {
         QMutexLocker locker(&m);
 
-        thread = std::thread([=] {
-#ifdef Q_OS_MAC
-            pthread_setname_np("domainmap");
-#else
-            pthread_setname_np(pthread_self(), "domainmap");
-#endif
-
-            run();
-        });
+        thread = RustThread::spawn([=] { run(); }, "domainmap");
 
         w.wait(&m);
     }

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -30,6 +30,7 @@
 #include "proxyargsdata.h"
 #include "proxyengine.h"
 #include "rust/bindings.h"
+#include "rustthread.h"
 #include "settings.h"
 #include "simplehttpserver.h"
 #include "timer.h"
@@ -42,9 +43,7 @@
 #include <QWaitCondition>
 #include <assert.h>
 #include <boost/algorithm/string.hpp>
-#include <pthread.h>
 #include <string>
-#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -136,7 +135,7 @@ private:
 /// Wraps an Engine instance to run in its own thread
 class EngineThread {
 public:
-    std::thread thread;
+    RustThread::JoinHandle thread;
     QMutex m;
     QWaitCondition w;
     Engine::Configuration config;
@@ -156,15 +155,7 @@ public:
 
         QMutexLocker locker(&m);
 
-        thread = std::thread([=] {
-#ifdef Q_OS_MAC
-            pthread_setname_np(name.toUtf8().data());
-#else
-            pthread_setname_np(pthread_self(), name.toUtf8().data());
-#endif
-
-            run();
-        });
+        thread = RustThread::spawn([=] { run(); }, name.toStdString());
 
         w.wait(&m);
         return (bool)worker;


### PR DESCRIPTION
After we made logging from C++ go through the Rust logger, I noticed cargo's test harness wasn't capturing the output of logging calls made from subthreads of C++ code. It seems to be a side effect of the test harness and maybe the `log` crate expecting some kind of Rust management of the thread for capturing to work. This means if C++ code spawns threads using the standard library and makes logging calls from those threads, the Rust logger ends up writing directly to stdout and cluttering the output of `cargo test`.

As a workaround, this PR adds an FFI and C++ wrapper around Rust's `std::thread` and updates the C++ code to spawn threads using that instead of through the standard library. We aren't doing anything on the C++ side that would expect some kind of C++ management of threads, so I believe this should be fine. Thread locals are managed by pthreads and shouldn't care which language did the spawning.

On the C++ side, I named the API `RustThread` instead of simply `Thread` or `thread` to avoid conflicts with existing types. It's a little ugly but it also makes it very clear what's happening at the call sites, which can't hurt.