### PR TITLE
remove c++ logging system and always log to the rust logger

### DIFF
--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -21,88 +21,11 @@
 
 #include "log.h"
 
-#include <QDateTime>
-#include <QElapsedTimer>
-#include <QMutex>
-#include <QString>
 #include <stdarg.h>
-#include <stdio.h>
-
-#include "rust/bindings.h"
-
-Q_GLOBAL_STATIC(QMutex, g_mutex)
-static int g_level = LOG_LEVEL_DEBUG;
-static QElapsedTimer g_time;
-static QString *g_filename;
-static FILE *g_file;
-
-static void log(const char *s) {
-    FILE *out;
-    if (g_file)
-        out = g_file;
-    else
-        out = stdout;
-    fprintf(out, "%s\n", s);
-    fflush(out);
-}
 
 static void log(int level, const char *fmt, va_list ap) {
-    // Check if Rust logger is initialized
-    if (ffi::log_initialized()) {
-        // Send formatted message directly to Rust logger
-        QString str = QString::vasprintf(fmt, ap);
-        ffi::log_log(level, str.toUtf8().data());
-        return;
-    }
-
-    // Fall back to C++ logging system
-
-    g_mutex()->lock();
-    int current_level = g_level;
-    int elapsed;
-    if (g_time.isValid())
-        elapsed = g_time.elapsed();
-    else
-        elapsed = -1;
-    g_mutex()->unlock();
-
-    if (level <= current_level) {
-        QString str = QString::vasprintf(fmt, ap);
-
-        const char *lstr;
-        switch (level) {
-        case LOG_LEVEL_ERROR:
-            lstr = "ERR";
-            break;
-        case LOG_LEVEL_WARNING:
-            lstr = "WARN";
-            break;
-        case LOG_LEVEL_INFO:
-            lstr = "INFO";
-            break;
-        case LOG_LEVEL_DEBUG:
-        default:
-            lstr = "DEBUG";
-            break;
-        }
-
-        QString tstr;
-        if (elapsed != -1) {
-            QTime t(0, 0);
-            t = t.addMSecs(elapsed);
-            tstr = t.toString("HH:mm:ss.zzz");
-        } else {
-            tstr = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
-        }
-
-        FILE *out;
-        if (g_file)
-            out = g_file;
-        else
-            out = stdout;
-        fprintf(out, "[%s] %s %s\n", lstr, qPrintable(tstr), qPrintable(str));
-        fflush(out);
-    }
+    QString str = QString::vasprintf(fmt, ap);
+    ffi::log_log(level, str.toUtf8().data());
 }
 
 bool log_init(const QString &outputFile) {
@@ -116,57 +39,12 @@ bool log_init(const QString &outputFile) {
     return (ret == 0);
 }
 
-void log_startClock() {
-    QMutexLocker locker(g_mutex());
-    g_time.start();
-}
+int log_outputLevel() { return ffi::log_get_level(); }
 
-int log_outputLevel() {
-    if (ffi::log_initialized()) {
-        return ffi::log_get_level();
-    }
+void log_setOutputLevel(int level) { ffi::log_set_level(level); }
 
-    QMutexLocker locker(g_mutex());
-    return g_level;
-}
-
-void log_setOutputLevel(int level) {
-    if (ffi::log_initialized()) {
-        ffi::log_set_level(level);
-        return;
-    }
-
-    QMutexLocker locker(g_mutex());
-    g_level = level;
-}
-
-bool log_setFile(const QString &fname) {
-    QMutexLocker locker(g_mutex());
-    if (g_file) {
-        fclose(g_file);
-        delete g_filename;
-        g_filename = 0;
-        g_file = 0;
-    }
-    if (fname.isEmpty())
-        return true;
-    FILE *f = fopen(fname.toLocal8Bit().data(), "a");
-    if (!f)
-        return false;
-    setbuf(f, NULL);
-    g_filename = new QString(fname);
-    g_file = f;
-    return true;
-}
-
-bool log_rotate() {
-    QMutexLocker locker(g_mutex());
-    if (!g_file)
-        return true;
-    if (!freopen(g_filename->toLocal8Bit().data(), "a", g_file))
-        return false;
-    setbuf(g_file, NULL);
-    return true;
+bool log_rotate(const QString &outputFile) {
+    return (ffi::log_rotate(outputFile.toUtf8().data()) == 0);
 }
 
 void log(int level, const char *fmt, ...) {
@@ -204,14 +82,4 @@ void log_debug(const char *fmt, ...) {
     va_end(ap);
 }
 
-void log_raw(const char *s) {
-    // Check if Rust logger is initialized
-    if (ffi::log_initialized()) {
-        // Send raw message to Rust logger (already formatted with level, timestamp, etc.)
-        ffi::log_log_raw(s);
-        return;
-    }
-
-    // Fall back to C++ logging system
-    log(s);
-}
+void log_raw(const char *s) { ffi::log_log_raw(s); }

--- a/src/core/log.h
+++ b/src/core/log.h
@@ -35,11 +35,9 @@ enum LogLevel {
 
 bool log_init(const QString &outputFile = QString());
 
-void log_startClock();
 int log_outputLevel();
 void log_setOutputLevel(int level);
-bool log_setFile(const QString &fname);
-bool log_rotate();
+bool log_rotate(const QString &outputFile);
 
 void log(int level, const char *fmt, ...);
 void log_error(const char *fmt, ...);

--- a/src/core/log.rs
+++ b/src/core/log.rs
@@ -98,14 +98,17 @@ fn write_record<W: fmt::Write>(record: &Record, dest: &mut W) {
 
 enum SharedOutput<'a> {
     Stdout(io::Stdout),
-    File(&'a Mutex<File>),
+    File(&'a Mutex<Option<File>>),
 }
 
 impl fmt::Write for SharedOutput<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let ret = match self {
             Self::Stdout(o) => o.write_all(s.as_bytes()),
-            Self::File(o) => (*o).lock().unwrap().write_all(s.as_bytes()),
+            Self::File(o) => match &mut *(*o).lock().unwrap() {
+                Some(o) => o.write_all(s.as_bytes()),
+                None => Ok(()),
+            },
         };
 
         ret.map_err(|_| fmt::Error)
@@ -114,7 +117,10 @@ impl fmt::Write for SharedOutput<'_> {
     fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
         let ret = match self {
             Self::Stdout(o) => o.write_fmt(args),
-            Self::File(o) => (*o).lock().unwrap().write_fmt(args),
+            Self::File(o) => match &mut *(*o).lock().unwrap() {
+                Some(o) => o.write_fmt(args),
+                None => Ok(()),
+            },
         };
 
         ret.map_err(|_| fmt::Error)
@@ -142,7 +148,12 @@ impl Default for AtomicLevelFilter {
 
 pub struct SimpleLogger {
     max_level: AtomicLevelFilter,
-    output_file: Option<Mutex<File>>,
+
+    // The outer Option is read-only, for quick detection of the output mode. The inner Option
+    // should be Some unless a log rotation fails, in which case it can be set to None to disable
+    // output.
+    output_file: Option<Mutex<Option<File>>>,
+
     runner_mode: bool,
 }
 
@@ -210,7 +221,7 @@ static LOGGER: OnceLock<SimpleLogger> = OnceLock::new();
 pub fn ensure_init_simple_logger(output_file: Option<File>, runner_mode: bool) {
     LOGGER.get_or_init(|| SimpleLogger {
         max_level: AtomicLevelFilter::default(),
-        output_file: output_file.map(Mutex::new),
+        output_file: output_file.map(|f| Mutex::new(Some(f))),
         runner_mode,
     });
 }
@@ -610,15 +621,6 @@ mod ffi {
     }
 
     #[no_mangle]
-    pub extern "C" fn log_initialized() -> c_int {
-        if LOGGER.get().is_some() {
-            1
-        } else {
-            0
-        }
-    }
-
-    #[no_mangle]
     pub extern "C" fn log_get_level() -> c_int {
         let level = match LOGGER.get() {
             Some(logger) if logger.is_active() => logger.max_level(),
@@ -638,6 +640,51 @@ mod ffi {
     #[no_mangle]
     pub extern "C" fn log_set_level(level: c_int) {
         get_simple_logger().set_max_level(int_to_level(level).to_level_filter());
+    }
+
+    /// Returns 0 on success or if file output was not configured.
+    ///
+    /// SAFETY: `output_file` must be valid.
+    #[no_mangle]
+    pub extern "C" fn log_rotate(output_file: *const c_char) -> c_int {
+        assert!(!output_file.is_null());
+
+        let f = unsafe {
+            CStr::from_ptr(output_file)
+                .to_str()
+                .expect("output_file must be utf-8")
+        };
+
+        let logger = get_simple_logger();
+
+        let Some(output_file) = &logger.output_file else {
+            return 0;
+        };
+
+        let mut output_file = output_file.lock().unwrap();
+
+        // Close the file, if any
+        *output_file = None;
+
+        let new_output_file = match OpenOptions::new().create(true).append(true).open(f) {
+            Ok(f) => f,
+            Err(e) => {
+                // Log to standard output since we can't log to the file
+                write_record(
+                    &Record::builder()
+                        .args(format_args!("failed to reopen log file {f}: {e}"))
+                        .level(log::Level::Error)
+                        .build(),
+                    &mut SharedOutput::Stdout(io::stdout()),
+                );
+
+                return -1;
+            }
+        };
+
+        *output_file = Some(new_output_file);
+
+        0
     }
 
     /// SAFETY: `message` must be valid.

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -149,8 +149,6 @@ public:
     std::shared_ptr<RateLimiter> limiter;
 
     TestState(std::function<void(int)> loop_wait) {
-        log_setOutputLevel(LOG_LEVEL_WARNING);
-
         QDir outDir(qgetenv("OUT_DIR"));
         QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 

--- a/src/handler/handlerapp.cpp
+++ b/src/handler/handlerapp.cpp
@@ -79,7 +79,7 @@ static QString firstSpec(const QString &s, int peerCount) {
     return s;
 }
 
-static int runLoop(const HandlerEngine::Configuration &config) {
+static int runLoop(const QString &logFile, const HandlerEngine::Configuration &config) {
     // Includes worst-case subscriptions and update registrations
     int timersPerSession = qMax(TIMERS_PER_HTTPSESSION, TIMERS_PER_WSSESSION) +
                            (config.connectionSubscriptionMax * TIMERS_PER_SUBSCRIPTION) +
@@ -127,7 +127,7 @@ static int runLoop(const HandlerEngine::Configuration &config) {
 
             ProcessQuit::instance()->hup.connect([&] {
                 log_info("reloading");
-                log_rotate();
+                log_rotate(logFile);
                 engine->reload();
             });
 
@@ -341,6 +341,6 @@ int handler_init(const ffi::HandlerCliArgs *argsFfi) {
     config.prometheusPort = prometheusPort;
     config.prometheusPrefix = prometheusPrefix;
 
-    return runLoop(config);
+    return runLoop(args.logFile, config);
 }
 }

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -283,9 +283,6 @@ public:
     Wrapper *wrapper;
 
     TestState(std::function<void(int)> loop_wait) {
-        log_setOutputLevel(LOG_LEVEL_WARNING);
-        // log_setOutputLevel(LOG_LEVEL_DEBUG);
-
         QDir outDir(qgetenv("OUT_DIR"));
         QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -20,6 +20,7 @@ pub mod cliargs;
 mod tests {
     use crate::core::test::{run_cpp, TestException};
     use crate::ffi;
+    use test_log::test;
 
     fn filter_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -477,17 +477,13 @@ public:
     }
 
     bool init() {
+        if (!log_init(args.logFile))
+            return false;
+
         if (args.logLevel != -1)
             log_setOutputLevel(args.logLevel);
         else
             log_setOutputLevel(LOG_LEVEL_INFO);
-
-        if (!args.logFile.isEmpty()) {
-            if (!log_setFile(args.logFile)) {
-                log_error("failed to open log file: %s", qPrintable(args.logFile));
-                return false;
-            }
-        }
 
         log_info("starting...");
 
@@ -2550,7 +2546,7 @@ private slots:
 
     void reload() {
         log_info("reloading");
-        log_rotate();
+        log_rotate(args.logFile);
     }
 
     void doQuit() {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -21,6 +21,7 @@ pub mod domainmap;
 mod tests {
     use crate::core::test::{run_cpp, TestException};
     use crate::ffi;
+    use test_log::test;
 
     fn websocketoverhttp_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call

--- a/src/proxy/proxyapp.cpp
+++ b/src/proxy/proxyapp.cpp
@@ -237,8 +237,8 @@ public:
     }
 };
 
-static int runLoop(const Engine::Configuration &config, const QStringList &routeLines,
-                   const QString &routesFile, int workerCount) {
+static int runLoop(const QString &logFile, const Engine::Configuration &config,
+                   const QStringList &routeLines, const QString &routesFile, int workerCount) {
     // Plenty for the main thread
     int timersMax = 100;
 
@@ -286,7 +286,7 @@ static int runLoop(const Engine::Configuration &config, const QStringList &route
 
         ProcessQuit::instance()->hup.connect([&] {
             log_info("reloading");
-            log_rotate();
+            log_rotate(logFile);
             domainMap->reload();
         });
 
@@ -564,6 +564,6 @@ int proxy_init(const ffi::ProxyCliArgs *argsFfi) {
     config.prometheusPort = prometheusPort;
     config.prometheusPrefix = prometheusPrefix;
 
-    return runLoop(config, args.routeLines, routesFile, workerCount);
+    return runLoop(args.logFile, config, args.routeLines, routesFile, workerCount);
 }
 }

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -551,9 +551,6 @@ public:
     TestState(std::function<void(int)> loop_wait) {
         qRegisterMetaType<QList<StatsPacket>>();
 
-        log_setOutputLevel(LOG_LEVEL_WARNING);
-        // log_setOutputLevel(LOG_LEVEL_DEBUG);
-
         QDir rootDir(qgetenv("CARGO_MANIFEST_DIR"));
         QDir configDir(rootDir.filePath("src/proxy"));
         QDir outDir(qgetenv("OUT_DIR"));

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -150,8 +150,6 @@ public:
     std::unique_ptr<ZhttpManager> zhttpOut;
 
     TestState(std::function<void(int)> loop_wait) {
-        log_setOutputLevel(LOG_LEVEL_WARNING);
-
         QDir outDir(qgetenv("OUT_DIR"));
         QDir workDir(QDir::current().relativeFilePath(outDir.filePath("test-work")));
 

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -273,12 +273,9 @@ public:
             Q_UNREACHABLE();
         }
 
-        if (!args.logFile.isEmpty()) {
-            if (!log_setFile(args.logFile)) {
-                log_error("failed to open log file: %s", qPrintable(args.logFile));
-                q->quit(1);
-                return;
-            }
+        if (!log_init(args.logFile)) {
+            q->quit(1);
+            return;
         }
 
         QStringList configFileList;
@@ -729,7 +726,7 @@ private:
 
     void reload() {
         log_info("reloading");
-        log_rotate();
+        log_rotate(args.logFile);
 
         foreach (Service *s, services) {
             if (s->acceptSighup())


### PR DESCRIPTION
This changes the C++ logging API to always use the FFI so that we have only have one logging system. I was inspired to do this after a debugging session where I noticed the two systems setting different logging levels, resulting in unexpected output.

The C++ apps expect the logging system to be able to do log rotation, so that's been added to the FFI.

As a bonus of always sending everything through the Rust logger we get a nicer way to enable logs in C++ tests. Previously, several C++ tests offered a commented-out line for setting a more verbose level that needed to be manually uncommented. Now, C++ tests can simply be annotated with `test_log::test` just like any other test, and output can be controlled with `RUST_LOG`.

```
% RUST_LOG=info cargo test proxyengine -- --nocapture 
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running unittests src/lib.rs (target/debug/deps/pushpin-df1593ba352fb3ca)

running 1 test
[INFO ] routes loaded with 3 entries
[INFO ] GET http://example/path?a=b -> origin:80 code=200 11
...
```

I manually tested log rotation, including log rotation failure.