### PR TITLE
handler: fix authority matching for internal routing

### DIFF
--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -457,19 +457,20 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 
     Url destUri = currentUri.resolved(url);
 
-    int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
+    Url requestUri = context.requestUri;
+    int requestPort = requestUri.port(requestUri.scheme() == "https" ? 443 : 80);
     int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 
     VariantHash passthroughData;
 
     passthroughData["route"] = context.route.toUtf8();
 
-    // If dest link points to the same service as the current request, then we can assume the
+    // If dest link points to the same service as the original request, then we can assume the
     // network would send the request back to us, so we can handle it internally. If the link points
     // to a different service, then we can't make this assumption and need to make the request over
     // the network. Note that such a request could still end up looping back to us
-    if (destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() &&
-        destPort == currentPort) {
+    if (destUri.scheme() == requestUri.scheme() && destUri.host() == requestUri.host() &&
+        destPort == requestPort) {
         // Tell the proxy that we prefer the request to be handled internally, using the same route
         passthroughData["prefer-internal"] = true;
     }

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -58,7 +58,8 @@ public:
 
         // For network access
         ZhttpManager *zhttpOut;
-        Url currentUri;
+        Url requestUri; // What was fetched at session start
+        Url currentUri; // Where we are now, potentially after following next links
         QString route;
         bool trusted;
         std::shared_ptr<RateLimiter> limiter;

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -109,6 +109,7 @@ public:
 
         Url uri = req->requestUri();
         QByteArray body = req->readBody();
+        bool preferInternal = req->passthroughData().toMap().value("prefer-internal").toBool();
 
         if (uri.path() == "/filter/accept") {
             respondOk(req, 200, true, "");
@@ -130,8 +131,17 @@ public:
             QString prepend = subMeta["prepend"].toString();
             QString append = pubMeta["append"].toString();
 
-            if (!prepend.isEmpty() || !append.isEmpty())
-                respondOk(req, 200, true, prepend.toUtf8() + body + append.toUtf8());
+            QByteArray respBody;
+
+            if (!prepend.isEmpty() || !append.isEmpty()) {
+                respBody = prepend.toUtf8() + body + append.toUtf8();
+
+                if (!preferInternal)
+                    respBody += " (non-internal)";
+            }
+
+            if (!respBody.isEmpty())
+                respondOk(req, 200, true, respBody);
             else
                 respondOk(req, 204, true, "");
         } else if (uri.path() == "/filter/large") {
@@ -236,6 +246,7 @@ static void httpCheck(std::function<void(int)> loop_wait) {
     Filter::Context context;
     context.subscriptionMeta["url"] = "/filter/accept";
     context.zhttpOut = state.zhttpOut.get();
+    context.requestUri = "http://localhost/";
     context.currentUri = "http://localhost/";
     context.limiter = state.limiter;
 
@@ -273,6 +284,7 @@ static void httpModify(std::function<void(int)> loop_wait) {
     context.prevIds["test"] = "a";
     context.subscriptionMeta["url"] = "/filter/modify";
     context.zhttpOut = state.zhttpOut.get();
+    context.requestUri = "http://localhost/";
     context.currentUri = "http://localhost/";
     context.limiter = state.limiter;
 
@@ -306,10 +318,54 @@ static void httpModify(std::function<void(int)> loop_wait) {
     }
 }
 
+static void httpModifyExternal(std::function<void(int)> loop_wait) {
+    TestState state(loop_wait);
+
+    QStringList filterNames = QStringList() << "http-modify";
+
+    Filter::Context context;
+    context.prevIds["test"] = "a";
+    context.subscriptionMeta["url"] = "http://external/filter/modify";
+    context.zhttpOut = state.zhttpOut.get();
+    context.requestUri = "http://localhost/";
+    context.currentUri = "http://localhost/";
+    context.limiter = state.limiter;
+
+    QByteArray content = "hello world";
+
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Send);
+        TEST_ASSERT_EQ(r.content, "hello world");
+    }
+
+    context.subscriptionMeta["prepend"] = "<<<";
+    context.publishMeta["append"] = ">>>";
+
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT(r.errorMessage.isNull());
+        TEST_ASSERT_EQ(r.sendAction, Filter::Send);
+        TEST_ASSERT_EQ(r.content, "<<<hello world>>> (non-internal)");
+    }
+
+    context.subscriptionMeta.clear();
+    context.publishMeta.clear();
+    context.subscriptionMeta["url"] = "/filter/large";
+    context.responseSizeMax = 1000;
+
+    {
+        auto r = runMessageFilters(filterNames, context, content, loop_wait);
+        TEST_ASSERT_EQ(r.errorMessage, "network response exceeded 1000 bytes");
+    }
+}
+
 extern "C" int filter_test(ffi::TestException *out_ex) {
     TEST_CATCH(test_with_event_loop(messageFilters));
     TEST_CATCH(test_with_event_loop(httpCheck));
     TEST_CATCH(test_with_event_loop(httpModify));
+    TEST_CATCH(test_with_event_loop(httpModifyExternal));
 
     return 0;
 }

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -239,6 +239,8 @@ public:
             return;
         }
 
+        bool preferInternal = zreq.passthrough.toHash().value("prefer-internal").toBool();
+
         ZhttpResponsePacket zresp;
         zresp.from = "test-server";
         zresp.ids += ZhttpResponsePacket::Id(zreq.ids.first().id, serverOutSeq++);
@@ -249,7 +251,11 @@ public:
         QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
 
         zresp.headers += HttpHeader("Content-Type", "text/plain");
-        zresp.body = "this is what's next\n";
+
+        if (preferInternal)
+            zresp.body = "this is what's next\n";
+        else
+            zresp.body = "this is what's next (non-internal)\n";
 
         zresp.headers += HttpHeader("Content-Length", QByteArray::number(zresp.body.size()));
         QByteArray buf =
@@ -565,6 +571,65 @@ static void acceptNoHoldNextResponseSent(Wrapper *wrapper, std::function<void(in
     TEST_ASSERT_EQ(wrapper->responses.value(id).body, QByteArray("this is what's next\n"));
 }
 
+static void acceptNoHoldNextExternal(Wrapper *wrapper, std::function<void(int)> loop_wait) {
+    wrapper->reset();
+
+    QByteArray id = "3";
+
+    VariantHash rid;
+    rid["sender"] = QByteArray("test-client");
+    rid["id"] = id;
+
+    VariantHash reqState;
+    reqState["rid"] = rid;
+    reqState["in-seq"] = 1;
+    reqState["out-seq"] = 1;
+    reqState["out-credits"] = 1000;
+    reqState["router-resp"] = true;
+
+    VariantHash req;
+    req["method"] = QByteArray("GET");
+    req["uri"] = QByteArray("http://example.com/path");
+    VariantList reqHeaders;
+    req["headers"] = reqHeaders;
+    req["body"] = QByteArray();
+
+    VariantHash resp;
+    resp["code"] = 200;
+    resp["reason"] = QByteArray("OK");
+    VariantList respHeaders;
+    respHeaders += Variant(VariantList() << QByteArray("Content-Type") << QByteArray("text/plain"));
+    respHeaders += Variant(VariantList() << QByteArray("Grip-Link")
+                                         << QByteArray("<http://external/next>; rel=next"));
+    resp["headers"] = respHeaders;
+    resp["body"] = QByteArray("hello world\n");
+
+    VariantHash args;
+    args["requests"] = VariantList() << reqState;
+    args["request-data"] = req;
+    args["orig-request-data"] = req;
+    args["response"] = resp;
+
+    VariantHash data;
+    data["id"] = id;
+    data["method"] = QByteArray("accept");
+    data["args"] = args;
+
+    QByteArray buf = TnetString::fromVariant(data);
+    wrapper->proxyAcceptSock->write(QList<QByteArray>() << QByteArray() << buf);
+    while (!wrapper->acceptSuccess)
+        loop_wait(10);
+
+    TEST_ASSERT(wrapper->acceptValue.value("accepted").toBool());
+
+    while (!wrapper->finished)
+        loop_wait(10);
+
+    TEST_ASSERT(wrapper->responses.contains(id));
+    TEST_ASSERT_EQ(wrapper->responses.value(id).body,
+                   QByteArray("hello world\nthis is what's next (non-internal)\n"));
+}
+
 static void publishResponse(Wrapper *wrapper, std::function<void(int)> loop_wait) {
     wrapper->reset();
 
@@ -873,6 +938,7 @@ extern "C" int handlerengine_test(ffi::TestException *out_ex) {
     TEST_CATCH(runWithEventLoop(acceptNoHoldResponseSent));
     TEST_CATCH(runWithEventLoop(acceptNoHoldNext));
     TEST_CATCH(runWithEventLoop(acceptNoHoldNextResponseSent));
+    TEST_CATCH(runWithEventLoop(acceptNoHoldNextExternal));
     TEST_CATCH(runWithEventLoop(publishResponse));
     TEST_CATCH(runWithEventLoop(publishStream));
     TEST_CATCH(runWithEventLoop(publishStreamReorder));

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -740,6 +740,7 @@ private:
             fc.subscriptionMeta = instruct.meta;
             fc.publishMeta = item.meta;
             fc.zhttpOut = outZhttp;
+            fc.requestUri = req->requestUri();
             fc.currentUri = currentUri;
             fc.route = adata.route;
             fc.trusted = adata.trusted;
@@ -1025,19 +1026,20 @@ private:
             outReq->readyRead.connect(boost::bind(&Private::outReq_readyRead, this));
         errorOutConnection = outReq->error.connect(boost::bind(&Private::outReq_error, this));
 
-        int currentPort = currentUri.port(currentUri.scheme() == "https" ? 443 : 80);
+        Url requestUri = req->requestUri();
+        int requestPort = requestUri.port(requestUri.scheme() == "https" ? 443 : 80);
         int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 
         VariantHash passthroughData;
 
         passthroughData["route"] = adata.route.toUtf8();
 
-        // If next link points to the same service as the current request, then we can assume the
+        // If dest link points to the same service as the original request, then we can assume the
         // network would send the request back to us, so we can handle it internally. If the link
         // points to a different service, then we can't make this assumption and need to make the
         // request over the network. Note that such a request could still end up looping back to us
-        if (destUri.scheme() == currentUri.scheme() && destUri.host() == currentUri.host() &&
-            destPort == currentPort) {
+        if (destUri.scheme() == requestUri.scheme() && destUri.host() == requestUri.host() &&
+            destPort == requestPort) {
             // Tell the proxy that we prefer the request to be handled internally, using the same
             // route
             passthroughData["prefer-internal"] = true;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -142,6 +142,7 @@ void WsSession::processPublishQueue() {
         fc.subscriptionMeta = meta;
         fc.publishMeta = item.meta;
         fc.zhttpOut = zhttpOut;
+        fc.requestUri = requestData.uri;
         fc.currentUri = requestData.uri;
         fc.route = route;
         fc.trusted = targetTrusted;


### PR DESCRIPTION
When a backend specifies a URL for Pushpin to make a request to, which can be relative or absolute, Pushpin resolves it against the session's "current" location, kind of like a browser, to produce an absolute URL. Then it checks the URL's authority to determine if the request should be routed internally or externally. The purpose of this check is to detect if the destination is already known to reach Pushpin, in which case Pushpin can look up the backend on the spot and send the request directly, avoiding a loopback.

For example:

* Client makes to request to `https://example.com/stream`, which routes to Pushpin somehow (via DNS, load balancers, etc).
* Pushpin receives the request, finds a matching route with target `backend:8000`, and forwards the request to the backend. It considers `https://example.com/stream` to be the session's current location.
* The backend responds with `Grip-Link: </next>; rel=next`. Pushpin resolves this against `https://example.com/stream` resulting in `https://example.com/next`.
* When Pushpin is about to make a request to `https://example.com/next`, it notices the domain is the same as the current location and assumes the request will end up looping back to itself. In other words, making a request directly to `https://example.com/next` would resolve to the same IPs again, send the request through the same load balancers again, reach Pushpin again, and Pushpin would find the same matching route with target `backend:8000`. So, as a shortcut, it simply makes the request to `backend:8000` directly.

Currently, the authority check is against the current location, but this is incorrect. Instead, it should be against the original request location. It is the original request location that got the request into Pushpin in the first place. From there, any number of "next" links could change the current location to anywhere else, and two next links in a row with the same authority does not say anything about whether a request can be internally routed.

Fixes #48293.