### PR TITLE
memorypool: rename Memory to MemoryPool, and use Rc internally

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -18,7 +18,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use pushpin::core::list::{RcList, RcNode, SlabList, SlabNode};
 use pushpin::core::memorypool;
 use slab::Slab;
-use std::rc::Rc;
 
 fn criterion_benchmark(c: &mut Criterion) {
     const NODE_KCOUNT: usize = 10;
@@ -56,7 +55,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let node_count = NODE_KCOUNT * 1000;
 
         // Preallocate the nodes memory
-        let nodes_memory = Rc::new(memorypool::RcMemory::new(node_count));
+        let nodes_memory = memorypool::RcMemoryPool::new(node_count);
 
         c.bench_function(&format!("mp-push-pop-x{NODE_KCOUNT}k"), |b| {
             b.iter(|| {
@@ -107,7 +106,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let node_count = NODE_KCOUNT * 1000;
 
         // Preallocate the nodes
-        let nodes_memory = Rc::new(memorypool::RcMemory::new(node_count));
+        let nodes_memory = memorypool::RcMemoryPool::new(node_count);
         let mut nodes = Vec::new();
         let mut next_value: u64 = 0;
         while nodes_memory.len() < nodes_memory.capacity() {

--- a/benches/memorypool.rs
+++ b/benches/memorypool.rs
@@ -23,7 +23,7 @@ use std::rc::Rc;
 fn bench_memorypool_rc_new<const N: usize>(c: &mut Criterion, op_kcount: usize) {
     let op_count = op_kcount * 1000;
     let bytes = mem::size_of::<[u64; N]>();
-    let memory = Rc::new(memorypool::RcMemory::new(op_count));
+    let memory = memorypool::RcMemoryPool::new(op_count);
     let instances = RefCell::new(Vec::with_capacity(op_count));
 
     c.bench_function(&format!("mp-rc-new-{bytes}b-x{op_kcount}k"), |b| {
@@ -90,7 +90,7 @@ fn bench_std_rc_new<const N: usize>(c: &mut Criterion, op_kcount: usize) {
 fn bench_memorypool_rc_drop<const N: usize>(c: &mut Criterion, op_kcount: usize) {
     let op_count = op_kcount * 1000;
     let bytes = mem::size_of::<[u64; N]>();
-    let memory = Rc::new(memorypool::RcMemory::new(op_count));
+    let memory = memorypool::RcMemoryPool::new(op_count);
     let instances = RefCell::new(Vec::with_capacity(op_count));
 
     c.bench_function(&format!("mp-rc-drp-{bytes}b-x{op_kcount}k"), |b| {
@@ -160,7 +160,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the instances
-        let memory = Rc::new(memorypool::RcMemory::new(OP_COUNT));
+        let memory = memorypool::RcMemoryPool::new(OP_COUNT);
         let mut instances = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < OP_COUNT as u64 {
@@ -213,7 +213,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the instances
-        let memory = Rc::new(memorypool::RcMemory::new(OP_COUNT));
+        let memory = memorypool::RcMemoryPool::new(OP_COUNT);
         let mut instances = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < OP_COUNT as u64 {
@@ -266,7 +266,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     {
         // Preallocate the instances
-        let memory = Rc::new(memorypool::RcMemory::new(OP_COUNT));
+        let memory = memorypool::RcMemoryPool::new(OP_COUNT);
         let mut instances = Vec::new();
         let mut next_value: u64 = 0;
         while next_value < OP_COUNT as u64 {

--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -837,8 +837,8 @@ impl Worker {
 
         let msg_retained_max = 1 + (MSG_RETAINED_PER_CONNECTION_MAX * req_maxconn);
 
-        let req_scratch_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
-        let req_req_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
+        let req_scratch_mem = memorypool::RcMemoryPool::new(msg_retained_max);
+        let req_req_mem = memorypool::RcMemoryPool::new(msg_retained_max);
 
         // max_senders is 1 per connection + 1 for this task
         let (zreq_sender, zreq_receiver) = local_channel(handle_bound, req_maxconn + 1);
@@ -1046,7 +1046,7 @@ impl Worker {
     ) {
         let reactor = Reactor::current().unwrap();
 
-        let stream_shared_mem = Rc::new(memorypool::RcMemory::new(stream_maxconn));
+        let stream_shared_mem = memorypool::RcMemoryPool::new(stream_maxconn);
 
         let zreceiver_pool = Rc::new(ChannelPool::new(stream_maxconn));
         for _ in 0..stream_maxconn {
@@ -1055,8 +1055,8 @@ impl Worker {
 
         let msg_retained_max = 1 + (MSG_RETAINED_PER_CONNECTION_MAX * stream_maxconn);
 
-        let stream_scratch_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
-        let stream_req_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
+        let stream_scratch_mem = memorypool::RcMemoryPool::new(msg_retained_max);
+        let stream_req_mem = memorypool::RcMemoryPool::new(msg_retained_max);
 
         // Bound is 1 per connection, so all connections can indicate done at once
         // max_senders is 1 per connection + 1 for this task
@@ -1668,8 +1668,8 @@ impl Client {
             let (done, _) = local_channel(1, 1);
             let (sender, _) = local_channel(1, 1);
 
-            let req_scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-            let req_req_mem = Rc::new(memorypool::RcMemory::new(1));
+            let req_scratch_mem = memorypool::RcMemoryPool::new(1);
+            let req_req_mem = memorypool::RcMemoryPool::new(1);
 
             let scratch = memorypool::Rc::try_new_in(
                 RefCell::new(zhttppacket::ParseScratch::new()),
@@ -1732,8 +1732,8 @@ impl Client {
             let conn_items = Rc::new(RefCell::new(ConnectionItems::new(1, batch)));
             let conns = Rc::new(Connections::new(conn_items, 1));
 
-            let req_scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-            let req_req_mem = Rc::new(memorypool::RcMemory::new(1));
+            let req_scratch_mem = memorypool::RcMemoryPool::new(1);
+            let req_req_mem = memorypool::RcMemoryPool::new(1);
 
             let scratch = memorypool::Rc::try_new_in(
                 RefCell::new(zhttppacket::ParseScratch::new()),
@@ -1756,7 +1756,7 @@ impl Client {
             let tls_config_cache = Arc::new(TlsConfigCache::new());
             let pool = Arc::new(ConnectionPool::new(0));
 
-            let stream_shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let stream_shared_mem = memorypool::RcMemoryPool::new(1);
 
             let shared =
                 memorypool::Rc::try_new_in(StreamSharedData::new(), &stream_shared_mem).unwrap();

--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -6346,8 +6346,8 @@ pub mod testutil {
 
     pub struct BenchServerReqHandler {
         reactor: Reactor,
-        scratch_mem: Rc<memorypool::RcMemory<RefCell<zhttppacket::ParseScratch<'static>>>>,
-        resp_mem: Rc<memorypool::RcMemory<zhttppacket::OwnedResponse>>,
+        scratch_mem: memorypool::RcMemoryPool<RefCell<zhttppacket::ParseScratch<'static>>>,
+        resp_mem: memorypool::RcMemoryPool<zhttppacket::OwnedResponse>,
         rb_tmp: Rc<TmpBuffer>,
         packet_buf: Rc<RefCell<Vec<u8>>>,
     }
@@ -6357,8 +6357,8 @@ pub mod testutil {
         pub fn new() -> Self {
             Self {
                 reactor: Reactor::new(100),
-                scratch_mem: Rc::new(memorypool::RcMemory::new(1)),
-                resp_mem: Rc::new(memorypool::RcMemory::new(1)),
+                scratch_mem: memorypool::RcMemoryPool::new(1),
+                resp_mem: memorypool::RcMemoryPool::new(1),
                 rb_tmp: Rc::new(TmpBuffer::new(1024)),
                 packet_buf: Rc::new(RefCell::new(vec![0; 2048])),
             }
@@ -6503,8 +6503,8 @@ pub mod testutil {
 
     pub struct BenchServerReqConnection {
         reactor: Reactor,
-        scratch_mem: Rc<memorypool::RcMemory<RefCell<zhttppacket::ParseScratch<'static>>>>,
-        resp_mem: Rc<memorypool::RcMemory<zhttppacket::OwnedResponse>>,
+        scratch_mem: memorypool::RcMemoryPool<RefCell<zhttppacket::ParseScratch<'static>>>,
+        resp_mem: memorypool::RcMemoryPool<zhttppacket::OwnedResponse>,
         rb_tmp: Rc<TmpBuffer>,
         packet_buf: Rc<RefCell<Vec<u8>>>,
     }
@@ -6514,8 +6514,8 @@ pub mod testutil {
         pub fn new() -> Self {
             Self {
                 reactor: Reactor::new(100),
-                scratch_mem: Rc::new(memorypool::RcMemory::new(1)),
-                resp_mem: Rc::new(memorypool::RcMemory::new(1)),
+                scratch_mem: memorypool::RcMemoryPool::new(1),
+                resp_mem: memorypool::RcMemoryPool::new(1),
                 rb_tmp: Rc::new(TmpBuffer::new(1024)),
                 packet_buf: Rc::new(RefCell::new(vec![0; 2048])),
             }
@@ -6664,9 +6664,9 @@ pub mod testutil {
 
     pub struct BenchServerStreamHandler {
         reactor: Reactor,
-        scratch_mem: Rc<memorypool::RcMemory<RefCell<zhttppacket::ParseScratch<'static>>>>,
-        resp_mem: Rc<memorypool::RcMemory<zhttppacket::OwnedResponse>>,
-        shared_mem: Rc<memorypool::RcMemory<StreamSharedData>>,
+        scratch_mem: memorypool::RcMemoryPool<RefCell<zhttppacket::ParseScratch<'static>>>,
+        resp_mem: memorypool::RcMemoryPool<zhttppacket::OwnedResponse>,
+        shared_mem: memorypool::RcMemoryPool<StreamSharedData>,
         rb_tmp: Rc<TmpBuffer>,
         packet_buf: Rc<RefCell<Vec<u8>>>,
         tmp_buf: Rc<RefCell<Vec<u8>>>,
@@ -6677,9 +6677,9 @@ pub mod testutil {
         pub fn new() -> Self {
             Self {
                 reactor: Reactor::new(100),
-                scratch_mem: Rc::new(memorypool::RcMemory::new(1)),
-                resp_mem: Rc::new(memorypool::RcMemory::new(1)),
-                shared_mem: Rc::new(memorypool::RcMemory::new(1)),
+                scratch_mem: memorypool::RcMemoryPool::new(1),
+                resp_mem: memorypool::RcMemoryPool::new(1),
+                shared_mem: memorypool::RcMemoryPool::new(1),
                 rb_tmp: Rc::new(TmpBuffer::new(1024)),
                 packet_buf: Rc::new(RefCell::new(vec![0; 2048])),
                 tmp_buf: Rc::new(RefCell::new(vec![0; 1024])),
@@ -6838,9 +6838,9 @@ pub mod testutil {
 
     pub struct BenchServerStreamConnection {
         reactor: Reactor,
-        scratch_mem: Rc<memorypool::RcMemory<RefCell<zhttppacket::ParseScratch<'static>>>>,
-        resp_mem: Rc<memorypool::RcMemory<zhttppacket::OwnedResponse>>,
-        shared_mem: Rc<memorypool::RcMemory<StreamSharedData>>,
+        scratch_mem: memorypool::RcMemoryPool<RefCell<zhttppacket::ParseScratch<'static>>>,
+        resp_mem: memorypool::RcMemoryPool<zhttppacket::OwnedResponse>,
+        shared_mem: memorypool::RcMemoryPool<StreamSharedData>,
         rb_tmp: Rc<TmpBuffer>,
         packet_buf: Rc<RefCell<Vec<u8>>>,
         tmp_buf: Rc<RefCell<Vec<u8>>>,
@@ -6851,9 +6851,9 @@ pub mod testutil {
         pub fn new() -> Self {
             Self {
                 reactor: Reactor::new(100),
-                scratch_mem: Rc::new(memorypool::RcMemory::new(1)),
-                resp_mem: Rc::new(memorypool::RcMemory::new(1)),
-                shared_mem: Rc::new(memorypool::RcMemory::new(1)),
+                scratch_mem: memorypool::RcMemoryPool::new(1),
+                resp_mem: memorypool::RcMemoryPool::new(1),
+                shared_mem: memorypool::RcMemoryPool::new(1),
                 rb_tmp: Rc::new(TmpBuffer::new(1024)),
                 packet_buf: Rc::new(RefCell::new(vec![0; 2048])),
                 tmp_buf: Rc::new(RefCell::new(vec![0; 1024])),
@@ -7076,8 +7076,8 @@ mod tests {
     fn server_req_without_body() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -7193,8 +7193,8 @@ mod tests {
     fn server_req_with_body() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -7344,8 +7344,8 @@ mod tests {
     fn server_req_pipeline() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -7511,8 +7511,8 @@ mod tests {
     fn server_req_secure() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -7651,7 +7651,7 @@ mod tests {
 
         let timeout = Duration::from_millis(5_000);
 
-        let shared_mem = Rc::new(memorypool::RcMemory::new(1));
+        let shared_mem = memorypool::RcMemoryPool::new(1);
         let shared = memorypool::Rc::try_new_in(StreamSharedData::new(), &shared_mem).unwrap();
 
         server_stream_connection_inner(
@@ -7683,8 +7683,8 @@ mod tests {
     fn server_stream_without_body() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -7806,8 +7806,8 @@ mod tests {
     fn server_stream_with_body() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -7971,8 +7971,8 @@ mod tests {
     fn server_stream_chunked() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let resp_mem = memorypool::RcMemoryPool::new(2);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -8116,8 +8116,8 @@ mod tests {
     fn server_stream_early_response() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -8245,8 +8245,8 @@ mod tests {
     fn server_stream_expand_write_buffer() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -8393,8 +8393,8 @@ mod tests {
     fn server_stream_disconnect() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let resp_mem = memorypool::RcMemoryPool::new(1);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -8527,8 +8527,8 @@ mod tests {
     fn server_websocket() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let resp_mem = memorypool::RcMemoryPool::new(2);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -8701,8 +8701,8 @@ mod tests {
     fn server_websocket_with_deflate() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let resp_mem = memorypool::RcMemoryPool::new(2);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -8898,8 +8898,8 @@ mod tests {
     fn server_websocket_expand_write_buffer() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let resp_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let resp_mem = memorypool::RcMemoryPool::new(2);
 
         let sock = Rc::new(RefCell::new(FakeSock::new()));
 
@@ -9105,8 +9105,8 @@ mod tests {
     fn client_req_without_id() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let req_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let req_mem = memorypool::RcMemoryPool::new(1);
 
         let data = concat!(
             "T74:7:headers,16:12:3:Foo,3:Bar,]]3:uri,19:https://example.co",
@@ -9214,8 +9214,8 @@ mod tests {
     fn client_req_with_id() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(1));
-        let req_mem = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_mem = memorypool::RcMemoryPool::new(1);
+        let req_mem = memorypool::RcMemoryPool::new(1);
 
         let data = concat!(
             "T83:7:headers,16:12:3:Foo,3:Bar,]]3:uri,19:https://example.co",
@@ -9405,8 +9405,8 @@ mod tests {
     fn client_stream() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let req_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let req_mem = memorypool::RcMemoryPool::new(2);
 
         let data = concat!(
             "T165:7:credits,4:1024#4:more,4:true!7:headers,34:30:12:Conten",
@@ -9439,7 +9439,7 @@ mod tests {
                 .try_clone(&reactor.local_registration_memory())
                 .unwrap();
 
-            let shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let shared_mem = memorypool::RcMemoryPool::new(1);
             let shared = memorypool::Rc::try_new_in(StreamSharedData::new(), &shared_mem).unwrap();
             let addr = ArrayVec::try_from(b"handler".as_slice()).unwrap();
             shared.set_to_addr(Some(addr));
@@ -9616,8 +9616,8 @@ mod tests {
     fn client_stream_router_resp() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let req_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let req_mem = memorypool::RcMemoryPool::new(2);
 
         let data = concat!(
             "T187:7:credits,4:1024#4:more,4:true!7:headers,34:30:12:Conten",
@@ -9651,7 +9651,7 @@ mod tests {
                 .try_clone(&reactor.local_registration_memory())
                 .unwrap();
 
-            let shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let shared_mem = memorypool::RcMemoryPool::new(1);
             let shared = memorypool::Rc::try_new_in(StreamSharedData::new(), &shared_mem).unwrap();
             let addr = ArrayVec::try_from(b"handler".as_slice()).unwrap();
             shared.set_to_addr(Some(addr));
@@ -9831,8 +9831,8 @@ mod tests {
     fn client_stream_expand_write_buffer() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let req_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let req_mem = memorypool::RcMemoryPool::new(2);
 
         let data = concat!(
             "T165:7:credits,4:1024#4:more,4:true!7:headers,34:30:12:Conten",
@@ -9865,7 +9865,7 @@ mod tests {
                 .try_clone(&reactor.local_registration_memory())
                 .unwrap();
 
-            let shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let shared_mem = memorypool::RcMemoryPool::new(1);
             let shared = memorypool::Rc::try_new_in(StreamSharedData::new(), &shared_mem).unwrap();
             let addr = ArrayVec::try_from(b"handler".as_slice()).unwrap();
             shared.set_to_addr(Some(addr));
@@ -9993,8 +9993,8 @@ mod tests {
     fn client_websocket() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let req_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let req_mem = memorypool::RcMemoryPool::new(2);
 
         let data = concat!(
             "T115:7:credits,4:1024#7:headers,16:12:3:Foo,3:Bar,]]3:uri,22:",
@@ -10026,7 +10026,7 @@ mod tests {
                 .try_clone(&reactor.local_registration_memory())
                 .unwrap();
 
-            let shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let shared_mem = memorypool::RcMemoryPool::new(1);
             let shared = memorypool::Rc::try_new_in(StreamSharedData::new(), &shared_mem).unwrap();
             let addr = ArrayVec::try_from(b"handler".as_slice()).unwrap();
             shared.set_to_addr(Some(addr));
@@ -10245,8 +10245,8 @@ mod tests {
     fn client_websocket_with_deflate() {
         let reactor = Reactor::new(100);
 
-        let scratch_mem = Rc::new(memorypool::RcMemory::new(2));
-        let req_mem = Rc::new(memorypool::RcMemory::new(2));
+        let scratch_mem = memorypool::RcMemoryPool::new(2);
+        let req_mem = memorypool::RcMemoryPool::new(2);
 
         let data = concat!(
             "T115:7:credits,4:1024#7:headers,16:12:3:Foo,3:Bar,]]3:uri,22:",
@@ -10278,7 +10278,7 @@ mod tests {
                 .try_clone(&reactor.local_registration_memory())
                 .unwrap();
 
-            let shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let shared_mem = memorypool::RcMemoryPool::new(1);
             let shared = memorypool::Rc::try_new_in(StreamSharedData::new(), &shared_mem).unwrap();
             let addr = ArrayVec::try_from(b"handler".as_slice()).unwrap();
             shared.set_to_addr(Some(addr));

--- a/src/connmgr/server.rs
+++ b/src/connmgr/server.rs
@@ -632,7 +632,7 @@ struct ConnectionStreamOpts {
     allow_compression: bool,
     sender: channel::LocalSender<zmq::Message>,
     sender_stream: channel::LocalSender<(ArrayVec<u8, 64>, zmq::Message)>,
-    stream_shared_mem: Rc<memorypool::RcMemory<StreamSharedData>>,
+    stream_shared_mem: memorypool::RcMemoryPool<StreamSharedData>,
 }
 
 enum ConnectionModeOpts {
@@ -834,7 +834,7 @@ impl Worker {
             zsockman.client_stream_handle(format!("{}-", id).as_bytes()),
         );
 
-        let stream_shared_mem = Rc::new(memorypool::RcMemory::new(stream_maxconn));
+        let stream_shared_mem = memorypool::RcMemoryPool::new(stream_maxconn);
 
         let zreceiver_pool = Rc::new(ChannelPool::new(maxconn));
         for _ in 0..maxconn {
@@ -1299,8 +1299,8 @@ impl Worker {
     ) {
         let msg_retained_max = 1 + (MSG_RETAINED_PER_CONNECTION_MAX * req_maxconn);
 
-        let req_scratch_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
-        let req_resp_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
+        let req_scratch_mem = memorypool::RcMemoryPool::new(msg_retained_max);
+        let req_resp_mem = memorypool::RcMemoryPool::new(msg_retained_max);
 
         let resume_waker = task::create_resume_waker();
 
@@ -1437,8 +1437,8 @@ impl Worker {
     ) {
         let msg_retained_max = 1 + (MSG_RETAINED_PER_CONNECTION_MAX * stream_maxconn);
 
-        let stream_scratch_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
-        let stream_resp_mem = Rc::new(memorypool::RcMemory::new(msg_retained_max));
+        let stream_scratch_mem = memorypool::RcMemoryPool::new(msg_retained_max);
+        let stream_resp_mem = memorypool::RcMemoryPool::new(msg_retained_max);
 
         let resume_waker = task::create_resume_waker();
 
@@ -2175,7 +2175,7 @@ impl Server {
                 10000,
             ));
 
-            let stream_shared_mem = Rc::new(memorypool::RcMemory::new(1));
+            let stream_shared_mem = memorypool::RcMemoryPool::new(1);
 
             let shared =
                 memorypool::Rc::try_new_in(StreamSharedData::new(), &stream_shared_mem).unwrap();

--- a/src/connmgr/zhttppacket.rs
+++ b/src/connmgr/zhttppacket.rs
@@ -1794,7 +1794,6 @@ impl OwnedResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::rc::Rc;
     use std::sync::Arc;
 
     #[test]
@@ -2042,7 +2041,7 @@ mod tests {
         )
         .as_bytes();
 
-        let scratch_memory = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_memory = memorypool::RcMemoryPool::new(1);
 
         let msg = Arc::new(zmq::Message::from(data));
         let scratch =
@@ -2068,7 +2067,7 @@ mod tests {
         )
         .as_bytes();
 
-        let scratch_memory = Rc::new(memorypool::RcMemory::new(1));
+        let scratch_memory = memorypool::RcMemoryPool::new(1);
 
         let msg = Arc::new(zmq::Message::from(data));
         let scratch =

--- a/src/core/channel.rs
+++ b/src/core/channel.rs
@@ -367,7 +367,7 @@ impl<T> LocalSender<T> {
     #[allow(clippy::result_unit_err)]
     pub fn try_clone(
         &self,
-        memory: &Rc<memorypool::RcMemory<event::LocalRegistrationEntry>>,
+        memory: &memorypool::RcMemoryPool<event::LocalRegistrationEntry>,
     ) -> Result<Self, ()> {
         let (write_reg, write_sr) = event::LocalRegistration::new(memory);
 
@@ -384,7 +384,7 @@ impl<T> LocalSender<T> {
     #[allow(clippy::result_unit_err)]
     pub fn make_receiver(
         &self,
-        memory: &Rc<memorypool::RcMemory<event::LocalRegistrationEntry>>,
+        memory: &memorypool::RcMemoryPool<event::LocalRegistrationEntry>,
     ) -> Result<LocalReceiver<T>, ()> {
         if self.channel.read_set_readiness.borrow().is_some() {
             return Err(());
@@ -454,7 +454,7 @@ impl<T> Drop for LocalReceiver<T> {
 pub fn local_channel<T>(
     bound: usize,
     max_senders: usize,
-    memory: &Rc<memorypool::RcMemory<event::LocalRegistrationEntry>>,
+    memory: &memorypool::RcMemoryPool<event::LocalRegistrationEntry>,
 ) -> (LocalSender<T>, LocalReceiver<T>) {
     let (read_reg, read_sr) = event::LocalRegistration::new(memory);
     let (write_reg, write_sr) = event::LocalRegistration::new(memory);

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -451,7 +451,7 @@ pub struct LocalRegistration {
 
 impl LocalRegistration {
     pub fn new(
-        memory: &Rc<memorypool::RcMemory<LocalRegistrationEntry>>,
+        memory: &memorypool::RcMemoryPool<LocalRegistrationEntry>,
     ) -> (Self, LocalSetReadiness) {
         let reg = memorypool::Rc::try_new_in(
             LocalRegistrationEntry {
@@ -531,7 +531,7 @@ pub struct Poller {
     poll: Poll,
     events: Events,
     custom_sources: CustomSources,
-    local_registration_memory: Rc<memorypool::RcMemory<LocalRegistrationEntry>>,
+    local_registration_memory: memorypool::RcMemoryPool<LocalRegistrationEntry>,
     local_budget: u32,
 }
 
@@ -545,7 +545,7 @@ impl Poller {
             poll,
             events,
             custom_sources,
-            local_registration_memory: Rc::new(memorypool::RcMemory::new(max_custom_sources)),
+            local_registration_memory: memorypool::RcMemoryPool::new(max_custom_sources),
             local_budget: LOCAL_BUDGET,
         })
     }
@@ -590,7 +590,7 @@ impl Poller {
         self.custom_sources.deregister(registration)
     }
 
-    pub fn local_registration_memory(&self) -> &Rc<memorypool::RcMemory<LocalRegistrationEntry>> {
+    pub fn local_registration_memory(&self) -> &memorypool::RcMemoryPool<LocalRegistrationEntry> {
         &self.local_registration_memory
     }
 

--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -20,7 +20,6 @@ use slab::Slab;
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::fmt;
 use std::marker::PhantomData;
-use std::rc::Rc;
 
 pub enum Relation {
     Prev,
@@ -413,12 +412,12 @@ pub struct NodeData<T> {
     pub value: RefCell<T>,
 }
 
-pub type NodeMemory<T> = memorypool::RcMemory<NodeData<T>>;
+pub type NodeMemory<T> = memorypool::RcMemoryPool<NodeData<T>>;
 
 pub struct RcNode<T>(memorypool::Rc<NodeData<T>>);
 
 impl<T> RcNode<T> {
-    pub fn new(value: T, memory: Option<&Rc<NodeMemory<T>>>) -> Self {
+    pub fn new(value: T, memory: Option<&NodeMemory<T>>) -> Self {
         let data = NodeData {
             prev: Cell::new(None),
             next: Cell::new(None),

--- a/src/core/memorypool.rs
+++ b/src/core/memorypool.rs
@@ -38,17 +38,17 @@ impl<T> fmt::Debug for InsertError<T> {
 // This is essentially a sharable slab for use within a single thread.
 // Operations are protected by a RefCell, however lookup operations return
 // pointers that can be used without RefCell protection.
-pub struct Memory<T> {
-    entries: RefCell<Slab<T>>,
+pub struct MemoryPool<T> {
+    entries: std::rc::Rc<RefCell<Slab<T>>>,
 }
 
-impl<T> Memory<T> {
+impl<T> MemoryPool<T> {
     pub fn new(capacity: usize) -> Self {
         // Allocate the slab with fixed capacity
         let s = Slab::with_capacity(capacity);
 
         Self {
-            entries: RefCell::new(s),
+            entries: std::rc::Rc::new(RefCell::new(s)),
         }
     }
 
@@ -64,11 +64,16 @@ impl<T> Memory<T> {
         self.entries.borrow().capacity()
     }
 
-    // Returns a pointer to the inserted entry.
-    //
-    // SAFETY: The returned pointer is guaranteed to be valid until the entry
-    // is removed or the Memory is dropped.
-    fn insert(&self, e: T) -> Result<*const T, InsertError<T>> {
+    pub fn refs(&self) -> usize {
+        std::rc::Rc::strong_count(&self.entries)
+    }
+
+    /// Returns a pointer to the inserted entry.
+    ///
+    /// # Safety
+    /// The returned pointer is guaranteed to be valid until the entry is removed or the memory
+    /// is dropped.
+    pub fn insert(&self, e: T) -> Result<*const T, InsertError<T>> {
         let mut entries = self.entries.borrow_mut();
 
         // Out of capacity. By preventing inserts beyond the capacity, we
@@ -89,9 +94,11 @@ impl<T> Memory<T> {
         Ok(entry as *const T)
     }
 
-    // SAFETY: `ptr` must be a valid pointer returned by `insert` that has
-    // not yet been removed.
-    unsafe fn remove(&self, ptr: *const T) {
+    /// Removes an entry.
+    ///
+    /// # Safety
+    /// `ptr` must be a valid pointer returned by `insert` that has not yet been removed.
+    pub unsafe fn remove(&self, ptr: *const T) {
         let mut entries = self.entries.borrow_mut();
 
         let key = entries.key_of(&*ptr);
@@ -102,7 +109,7 @@ impl<T> Memory<T> {
     // Returns a pointer to an entry if it exists.
     //
     // SAFETY: The returned pointer is guaranteed to be valid until the entry
-    // is removed or the Memory is dropped.
+    // is removed or the `MemoryPool` is dropped.
     #[cfg(test)]
     fn addr_of(&self, key: usize) -> Option<*const T> {
         let entries = self.entries.borrow();
@@ -117,6 +124,15 @@ impl<T> Memory<T> {
     }
 }
 
+impl<T> Clone for MemoryPool<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            entries: std::rc::Rc::clone(&self.entries),
+        }
+    }
+}
+
 #[cold]
 fn unlikely_abort() {
     abort();
@@ -125,7 +141,7 @@ fn unlikely_abort() {
 #[repr(C, align(2))]
 pub struct RcInner<T> {
     refs: Cell<usize>,
-    memory: Cell<Option<ManuallyDrop<std::rc::Rc<RcMemory<T>>>>>,
+    pool: Cell<Option<ManuallyDrop<RcMemoryPool<T>>>>,
     value: ManuallyDrop<T>,
 }
 
@@ -162,7 +178,7 @@ impl<T> RcInner<T> {
     }
 }
 
-pub type RcMemory<T> = Memory<RcInner<T>>;
+pub type RcMemoryPool<T> = MemoryPool<RcInner<T>>;
 
 pub struct Rc<T> {
     ptr: NonNull<RcInner<T>>,
@@ -173,7 +189,7 @@ impl<T> Rc<T> {
     pub fn new(v: T) -> Self {
         let ptr = Box::leak(Box::new(RcInner {
             refs: Cell::new(1),
-            memory: Cell::new(None),
+            pool: Cell::new(None),
             value: ManuallyDrop::new(v),
         }));
 
@@ -183,17 +199,17 @@ impl<T> Rc<T> {
         }
     }
 
-    pub fn try_new_in(v: T, memory: &std::rc::Rc<RcMemory<T>>) -> Result<Self, AllocError> {
-        let ptr = memory
+    pub fn try_new_in(v: T, pool: &RcMemoryPool<T>) -> Result<Self, AllocError> {
+        let ptr = pool
             .insert(RcInner {
                 refs: Cell::new(1),
-                memory: Cell::new(Some(ManuallyDrop::new(std::rc::Rc::clone(memory)))),
+                pool: Cell::new(Some(ManuallyDrop::new(pool.clone()))),
                 value: ManuallyDrop::new(v),
             })
             .map_err(|inner| {
                 // If inserting into the pool fails, we need to manually drop these fields
                 ManuallyDrop::into_inner(inner.0.value);
-                ManuallyDrop::into_inner(inner.0.memory.take().unwrap());
+                ManuallyDrop::into_inner(inner.0.pool.take().unwrap());
 
                 AllocError
             })?;
@@ -228,19 +244,19 @@ impl<T> Rc<T> {
         // SAFETY: This is the only time we drop the value
         unsafe { ManuallyDrop::drop(&mut self.ptr.as_mut().value) };
 
-        if let Some(memory) = self.inner().memory.take() {
-            // Slab allocations contain a std::rc::Rc to the Memory they are
-            // contained in, and we need to be careful the Memory is not
-            // dropped while an entry is being removed. To ensure this, the
-            // Rc is moved out of the entry above, and it is dropped only
-            // after the entry is removed.
+        if let Some(pool) = self.inner().pool.take() {
+            // Slab-based allocations contain a ref-counted copy of the
+            // `MemoryPool` they were allocated in, and we need to be careful
+            // the pool is not dropped while an entry is being removed. To
+            // ensure this, the pool is moved out of the entry above, and it
+            // is dropped only after the entry is removed.
 
-            let memory = ManuallyDrop::into_inner(memory);
+            let pool = ManuallyDrop::into_inner(pool);
 
             // SAFETY: While this Rc is alive, ptr is always valid
-            unsafe { memory.remove(self.ptr.as_ref()) };
+            unsafe { pool.remove(self.ptr.as_ref()) };
         } else {
-            // If there is no reference to slab memory, then the memory is
+            // If there is no handle to a `MemoryPool` then the memory is
             // managed by the system allocator. To free it, we simply convert
             // the pointer back to a Box and drop it.
 
@@ -410,45 +426,45 @@ mod tests {
 
     #[test]
     fn test_rc_in() {
-        let memory = std::rc::Rc::new(RcMemory::new(2));
-        assert_eq!(memory.len(), 0);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 1);
+        let pool = RcMemoryPool::new(2);
+        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.refs(), 1);
 
-        let e0a = Rc::try_new_in(123 as i32, &memory).unwrap();
-        assert_eq!(memory.len(), 1);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 2);
-        let p = memory.addr_of(0).unwrap();
+        let e0a = Rc::try_new_in(123 as i32, &pool).unwrap();
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.refs(), 2);
+        let p = pool.addr_of(0).unwrap();
 
         let e0b = Rc::clone(&e0a);
-        assert_eq!(memory.len(), 1);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 2);
-        assert_eq!(memory.addr_of(0).unwrap(), p);
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.refs(), 2);
+        assert_eq!(pool.addr_of(0).unwrap(), p);
 
-        let e1a = Rc::try_new_in(456 as i32, &memory).unwrap();
-        assert_eq!(memory.len(), 2);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 3);
-        assert_eq!(memory.addr_of(0).unwrap(), p);
+        let e1a = Rc::try_new_in(456 as i32, &pool).unwrap();
+        assert_eq!(pool.len(), 2);
+        assert_eq!(pool.refs(), 3);
+        assert_eq!(pool.addr_of(0).unwrap(), p);
 
         // No room
-        assert!(Rc::try_new_in(789 as i32, &memory).is_err());
-        assert_eq!(std::rc::Rc::strong_count(&memory), 3);
+        assert!(Rc::try_new_in(789 as i32, &pool).is_err());
+        assert_eq!(pool.refs(), 3);
 
         assert_eq!(*e0a, 123);
         assert_eq!(*e0b, 123);
         assert_eq!(*e1a, 456);
 
         mem::drop(e0b);
-        assert_eq!(memory.len(), 2);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 3);
-        assert_eq!(memory.addr_of(0).unwrap(), p);
+        assert_eq!(pool.len(), 2);
+        assert_eq!(pool.refs(), 3);
+        assert_eq!(pool.addr_of(0).unwrap(), p);
 
         mem::drop(e0a);
-        assert_eq!(memory.len(), 1);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 2);
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.refs(), 2);
 
         mem::drop(e1a);
-        assert_eq!(memory.len(), 0);
-        assert_eq!(std::rc::Rc::strong_count(&memory), 1);
+        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.refs(), 1);
     }
 
     #[test]

--- a/src/core/reactor.rs
+++ b/src/core/reactor.rs
@@ -726,7 +726,7 @@ impl Reactor {
 
     pub fn local_registration_memory(
         &self,
-    ) -> Rc<memorypool::RcMemory<event::LocalRegistrationEntry>> {
+    ) -> memorypool::RcMemoryPool<event::LocalRegistrationEntry> {
         self.inner.poll.borrow().local_registration_memory().clone()
     }
 

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -20,7 +20,6 @@ use crate::core::memorypool;
 use crate::core::reactor::{CustomEvented, Reactor, Registration};
 use std::future::Future;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
 
 pub struct PollFuture<F> {
@@ -82,7 +81,7 @@ pub struct CancellationToken {
 
 impl CancellationToken {
     pub fn new(
-        memory: &Rc<memorypool::RcMemory<event::LocalRegistrationEntry>>,
+        memory: &memorypool::RcMemoryPool<event::LocalRegistrationEntry>,
     ) -> (CancellationSender, Self) {
         let (read_reg, read_sr) = event::LocalRegistration::new(memory);
 


### PR DESCRIPTION
This renames the `Memory` type to `MemoryPool` for clarity. It also wraps its inner data in `std::rc::Rc` so that the type itself is ref counted and callers don't need to supply their own Rc-wrapping, which they are universally doing.