### PR TITLE
list: fix circular reference leaks in rc tests

### DIFF
--- a/src/core/list.rs
+++ b/src/core/list.rs
@@ -719,6 +719,9 @@ mod tests {
         assert_eq!(be.clone_link(n1.to_ref(), Relation::Next), Some(n2.clone()));
         assert_eq!(be.clone_link(n2.to_ref(), Relation::Prev), Some(n1));
         assert_eq!(be.clone_link(n2.to_ref(), Relation::Next), None);
+
+        // Cleanup
+        while a.pop_front(&mut be).is_some() {}
     }
 
     fn generic_iter<B, A>(mut b: B, mut l: List<B>, add: A)
@@ -739,6 +742,9 @@ mod tests {
         assert_eq!(it.next(), Some(n2));
         assert_eq!(it.next(), Some(n3));
         assert_eq!(it.next(), None);
+
+        // Cleanup
+        while l.pop_front(&mut b).is_some() {}
     }
 
     #[test]


### PR DESCRIPTION
Unlike slab-based lists, dropping Rc-based lists doesn't necessarily drop the nodes since the nodes maintain strong, bidirectional references to each other. The simple fix is to remove each individual node from such lists before dropping the list. We aren't using Rc-based lists anywhere yet so the leaks are only in these tests.