### PR TITLE
don't mention the host in route lookup errors

### DIFF
--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -354,12 +354,11 @@ public:
             return;
         }
 
-        log_debug("requestsession: %p %s has %d routes", q, qPrintable(host),
-                  route.targets.count());
+        log_debug("requestsession: %p route has %d targets", q, route.targets.count());
 
         if (route.isNull()) {
             state = WaitingForResponse;
-            respondError(502, "Bad Gateway", QString("No route for host: %1").arg(host));
+            respondError(502, "Bad Gateway", "Route not found");
             return;
         }
 
@@ -405,12 +404,11 @@ public:
         else
             route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
 
-        log_debug("requestsession: %p %s has %d routes", q, qPrintable(host),
-                  route.targets.count());
+        log_debug("requestsession: %p route has %d targets", q, route.targets.count());
 
         if (route.isNull()) {
             state = WaitingForResponse;
-            respondError(502, "Bad Gateway", QString("No route for host: %1").arg(host));
+            respondError(502, "Bad Gateway", "Route not found");
             return;
         }
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -371,11 +371,10 @@ public:
 
         route = entry;
 
-        log_debug("wsproxysession: %p %s has %d routes", q, qPrintable(host),
-                  route.targets.count());
+        log_debug("wsproxysession: %p route has %d targets", q, route.targets.count());
 
         if (route.isNull()) {
-            reject(false, 502, "Bad Gateway", QString("No route for host: %1").arg(host));
+            reject(false, 502, "Bad Gateway", "Route not found");
             return;
         }
 


### PR DESCRIPTION
Currently, when Pushpin can't find a suitable route for an incoming request, it responds with the error: "No route for host: {hostname}". This can be misleading since routes can match on other conditions and matching by hostname is optional.

This PR changes the error message to simply "Route not found" with no details. It could be interesting to add actually useful details instead of removing details, but since doing that well could leak details about private configuration it would need to be opt-in. For now, I think a vague message is still better than what we have.