### PR TITLE
when looking up routes by id, constrain to request path as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub mod ffi {
         pub fn domainmap_entry_params(
             handle: *mut DomainMap,
             route_id: *const libc::c_char,
+            path: *const libc::c_char,
             params: *mut DomainMapRouteParams,
         ) -> libc::c_int;
     }

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -863,7 +863,7 @@ DomainMap::Entry DomainMap::entry(Protocol proto, bool ssl, const QString &domai
     return best->toEntry();
 }
 
-DomainMap::Entry DomainMap::entry(const QString &id) const {
+DomainMap::Entry DomainMap::entry(const QString &id, const QByteArray &path) const {
     QMutexLocker locker(&d->thread->worker->m);
 
     if (!d->thread->worker->rulesById.contains(id))
@@ -873,6 +873,10 @@ DomainMap::Entry DomainMap::entry(const QString &id) const {
 
     // This can happen if there were duplicate route IDs
     if (r->id.isEmpty())
+        return Entry();
+
+    // If a request path was provided, check it against the route's path prefix.
+    if (!path.isNull() && !path.startsWith(r->pathBeg))
         return Entry();
 
     return r->toEntry();
@@ -917,13 +921,15 @@ DomainMap *domainmap_create(const char *filename) {
 
 void domainmap_destroy(DomainMap *handle) { delete handle; }
 
-int domainmap_entry_params(DomainMap *handle, const char *route_id, DomainMapRouteParams *params) {
+int domainmap_entry_params(DomainMap *handle, const char *route_id, const char *path,
+                           DomainMapRouteParams *params) {
     if (!handle || !route_id || !params) {
         return -1;
     }
 
     QString qroute_id = QString::fromUtf8(route_id);
-    DomainMap::Entry entry = handle->entry(qroute_id);
+    QByteArray qpath(path);
+    DomainMap::Entry entry = handle->entry(qroute_id, path);
 
     if (entry.isNull()) {
         return -1;

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -125,6 +125,8 @@ public:
 
         bool isNull() const { return targets.isEmpty(); }
 
+        bool matchesPath(const QByteArray &path) { return path.startsWith(pathBeg); }
+
         QByteArray statsRoute() const {
             if (separateStats)
                 return id;
@@ -153,7 +155,11 @@ public:
 
     bool isIdShared(const QString &id) const;
     Entry entry(Protocol proto, bool ssl, const QString &domain, const QByteArray &path) const;
-    Entry entry(const QString &id) const;
+
+    /// Look up entry by ID, optionally constrained by a request path. If a request path is not
+    /// provided, then the caller must call `entry.matchesPath()` before attempting to process a
+    /// request. This is necessary for path-rewriting rules to work properly.
+    Entry entry(const QString &id, const QByteArray &path = QByteArray()) const;
 
     QList<ZhttpRoute> zhttpRoutes() const;
 

--- a/src/proxy/domainmap.rs
+++ b/src/proxy/domainmap.rs
@@ -48,16 +48,35 @@ impl DomainMap {
     }
 
     /// Look up route parameters by route ID
-    pub fn lookup(&self, route_id: &str) -> Option<RouteParams> {
+    pub fn lookup(&self, route_id: &str, path: Option<&str>) -> Option<RouteParams> {
         let c_route_id = match CString::new(route_id) {
             Ok(s) => s,
             Err(_) => return None,
         };
 
+        let c_path = if let Some(path) = path {
+            match CString::new(path) {
+                Ok(s) => Some(s),
+                Err(_) => return None,
+            }
+        } else {
+            None
+        };
+
+        let c_path_ptr = match c_path {
+            Some(s) => s.as_ptr(),
+            None => ptr::null(),
+        };
+
         let mut ffi_params = crate::ffi::DomainMapRouteParams { log_level: 0 };
 
         let result = unsafe {
-            crate::ffi::domainmap_entry_params(self.handle, c_route_id.as_ptr(), &mut ffi_params)
+            crate::ffi::domainmap_entry_params(
+                self.handle,
+                c_route_id.as_ptr(),
+                c_path_ptr,
+                &mut ffi_params,
+            )
         };
 
         if result == 0 {

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -598,7 +598,7 @@ public:
         // Look up the route
         DomainMap::Entry route;
         if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-            route = domainMap->entry(routeId);
+            route = domainMap->entry(routeId, encPath);
         else
             route = domainMap->entry(DomainMap::WebSocket, isSecure, host, encPath);
 

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -281,7 +281,7 @@ public:
 
             // Look up the route
             if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-                route = domainMap->entry(routeId);
+                route = domainMap->entry(routeId, encPath);
             else
                 route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
 
@@ -400,7 +400,7 @@ public:
 
         // Look up the route
         if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-            route = domainMap->entry(routeId);
+            route = domainMap->entry(routeId, encPath);
         else
             route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
 


### PR DESCRIPTION
Routes are looked up either by properties of a request (scheme, domain, path prefix) or by ID. However, if a route with path-rewriting rules is looked up by ID and then used for routing a request, it is possible for the request path to get corrupted if it doesn't match the expected prefix, as described in #48292.

There are a couple of ways this can happen:

* When the handler makes a request on behalf of an existing session. For example, if the first request of a session matches on route `*,id=foo,path_beg=/foo target:80`, and `target` responds with `Grip-Link: </bar/123>; rel=next`, then the request to `/bar/123` will use the same route even though it doesn't match the prefix.
* When using the `Pushpin-Route` header to select a route by ID. For example, `Pushpin-Route: foo` will match route `id=foo,path_beg=/foo target:80` regardless of the request path.

This PR makes it so lookups by ID can optionally be constrained to a request path, and does that in all the cases when a route is being used to process a request. There is one place where we look up a route by ID to inspect it without actually routing to it, so lookups without path constraint remain possible. The `matchesPath()` method is also added so checks can be done after the fact.

This partially addresses #48292, since the resulting effect is handler-originated requests that have mismatching paths are rejected instead of corrupted. The full fix will be to allow such requests to rematch on a different route, probably via external routing, which I'll follow up about after this PR lands.