### PR TITLE
jwt: return null key if config string empty

### DIFF
--- a/src/core/jwt.cpp
+++ b/src/core/jwt.cpp
@@ -72,7 +72,7 @@ EncodingKey EncodingKey::fromConfigString(const QString &s, const QDir &baseDir)
             keyFile = QFileInfo(baseDir, keyFile).filePath();
 
         return fromFile(keyFile);
-    } else {
+    } else if (!s.isEmpty()) {
         QByteArray secret;
 
         if (s.startsWith("base64:"))
@@ -81,6 +81,8 @@ EncodingKey EncodingKey::fromConfigString(const QString &s, const QDir &baseDir)
             secret = s.toUtf8();
 
         return fromSecret(secret);
+    } else {
+        return EncodingKey();
     }
 }
 
@@ -124,7 +126,7 @@ DecodingKey DecodingKey::fromConfigString(const QString &s, const QDir &baseDir)
             keyFile = QFileInfo(baseDir, keyFile).filePath();
 
         return fromFile(keyFile);
-    } else {
+    } else if (!s.isEmpty()) {
         QByteArray secret;
 
         if (s.startsWith("base64:"))
@@ -133,6 +135,8 @@ DecodingKey DecodingKey::fromConfigString(const QString &s, const QDir &baseDir)
             secret = s.toUtf8();
 
         return fromSecret(secret);
+    } else {
+        return DecodingKey();
     }
 }
 

--- a/src/core/jwttest.cpp
+++ b/src/core/jwttest.cpp
@@ -112,6 +112,30 @@ static void invalidKey() {
     TEST_ASSERT(vclaim.isNull());
 }
 
+static void loadKey() {
+    {
+        Jwt::EncodingKey k;
+        TEST_ASSERT(k.isNull());
+
+        k = Jwt::EncodingKey::fromConfigString("secret");
+        TEST_ASSERT(!k.isNull());
+
+        k = Jwt::EncodingKey::fromConfigString("");
+        TEST_ASSERT(k.isNull());
+    }
+
+    {
+        Jwt::DecodingKey k;
+        TEST_ASSERT(k.isNull());
+
+        k = Jwt::DecodingKey::fromConfigString("secret");
+        TEST_ASSERT(!k.isNull());
+
+        k = Jwt::DecodingKey::fromConfigString("");
+        TEST_ASSERT(k.isNull());
+    }
+}
+
 static void es256EncodeDecode() {
     Jwt::EncodingKey privateKey = Jwt::EncodingKey::fromPem(QByteArray(test_ec_private_key_pem));
     TEST_ASSERT(!privateKey.isNull());
@@ -178,6 +202,7 @@ extern "C" int jwt_test(ffi::TestException *out_ex) {
     TEST_CATCH(validToken());
     TEST_CATCH(validTokenBinaryKey());
     TEST_CATCH(invalidKey());
+    TEST_CATCH(loadKey());
     TEST_CATCH(es256EncodeDecode());
     TEST_CATCH(rs256EncodeDecode());
 


### PR DESCRIPTION
Currently, when a config param for specifying a key is empty it will end up creating a valid key of zero length. I noticed this in the debug logs when omitting `upstream_key`:

```
[DEBUG] 2026-05-29 09:05:24.697 [proxy] requestsession: 0xbed090300 signature present but invalid: eyJ0eX...
```


The intended behavior for such an empty param is to not create a key at all. This PR corrects the behavior by making `{EncodingKey|DecodingKey}::fromConfigString` return a null key when given an empty string.

Note that zero length keys are still possible to create with `{EncodingKey|DecodingKey}::fromSecret`.