### PR TITLE
ensure routes added via cli arg have an id

### DIFF
--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -244,9 +244,6 @@ public:
                 continue;
             }
 
-            if (r.id.isEmpty())
-                r.id = r.idFromCondition();
-
             AddRuleResult ret = addRule(r, &all, &domainMap, &idMap);
             if (ret != AddRuleOk) {
                 if (ret == AddRuleNoDomainOrId)
@@ -641,6 +638,9 @@ private:
 
         if (!ok)
             return false;
+
+        if (r.id.isEmpty())
+            r.id = r.idFromCondition();
 
         *rule = r;
         return true;


### PR DESCRIPTION
Each route must have an ID, and one will be generated if the user does not explicitly specify one. However, this is not working for routes provided via the command line.

In other words, a route in a routes file like below will be given an id:

```
* test
```

Whereas a route line passed via arg like below will not be given an id:

```
% ./pushpin --route "* test"
```

This PR moves where we assign the default ID so that it applies to both code paths.