### PR TITLE
proxy: move route lookups out of requestsession

### DIFF
--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -493,7 +493,7 @@ public:
             if (data.contains("auto-share"))
                 autoShare = data["auto-share"].toBool();
         } else {
-            // Regular request
+            // Regular request, from client
 
             if (config.acceptXForwardedProto && isXForwardedProtocolTls(req->requestHeaders()))
                 req->setIsTls(true);
@@ -503,9 +503,11 @@ public:
                     QString::fromUtf8(req->requestHeaders().get("Pushpin-Route").asQByteArray());
         }
 
-        RequestSession *rs =
-            new RequestSession(config.id, domainMap, sockJsManager.get(), inspect.get(),
-                               inspectChecker.get(), accept.get(), stats.get());
+        Url uri = req->requestUri();
+        bool isSecure = (uri.scheme() == "https");
+        QString host = uri.host();
+
+        DomainMap::Entry route;
 
         if (passthroughData.isValid() && !preferInternal) {
             // Passthrough request with preferInternal=false. In this case, set up a direct route,
@@ -517,8 +519,6 @@ public:
 
             const VariantHash data = passthroughData.toHash();
 
-            DomainMap::Entry route;
-
             // Use sig settings from the original route, if available
             if (!originalRoute.isNull()) {
                 route.sigIss = originalRoute.sigIss;
@@ -526,23 +526,30 @@ public:
             }
 
             DomainMap::Target target;
-            Url uri = req->requestUri();
-            bool isHttps = (uri.scheme() == "https");
-            target.connectHost = uri.host();
-            target.connectPort = uri.port(isHttps ? 443 : 80);
-            target.ssl = isHttps;
+            target.connectHost = host;
+            target.connectPort = uri.port(isSecure ? 443 : 80);
+            target.ssl = isSecure;
             target.trusted = data["trusted"].toBool();
 
             route.targets += target;
-
-            rs->setRoute(route);
         } else {
             // Regular request (with or without a route ID), or a passthrough request with
             // preferInternal=true. In that case, use domainmap for lookup, with route ID if
             // available
 
-            rs->setRouteId(routeId);
+            QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
+
+            // Look up the route
+            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
+                route = domainMap->entry(routeId, encPath);
+            else
+                route = domainMap->entry(DomainMap::Http, isSecure, host, encPath);
         }
+
+        RequestSession *rs = new RequestSession(config.id, sockJsManager.get(), inspect.get(),
+                                                inspectChecker.get(), accept.get(), stats.get());
+
+        rs->setRoute(route);
 
         if (!passthroughData.isValid()) {
             // These only make sense on regular requests
@@ -587,7 +594,6 @@ public:
 
         bool isSecure = (requestUri.scheme() == "wss");
         QString host = requestUri.host();
-
         QByteArray encPath = requestUri.path(Url::FullyEncoded).toUtf8();
 
         QString routeId;
@@ -818,7 +824,7 @@ private:
             ZhttpRequest *zhttpRequest = zhttpIn->createRequestFromState(ss);
 
             RequestSession *rs =
-                new RequestSession(config.id, domainMap, sockJsManager.get(), inspect.get(),
+                new RequestSession(config.id, sockJsManager.get(), inspect.get(),
                                    inspectChecker.get(), accept.get(), stats.get());
 
             requestSessions += rs;
@@ -826,8 +832,20 @@ private:
             rs->setDefaultUpstreamKey(config.upstreamKey);
             rs->setXffRules(config.xffUntrustedRule, config.xffTrustedRule);
 
-            if (!p.route.isEmpty())
-                rs->setRouteId(QString::fromUtf8(p.route));
+            bool isSecure = req.https;
+            QString host = p.requestData.uri.host();
+            QByteArray encPath = p.requestData.uri.path(Url::FullyEncoded).toUtf8();
+
+            QString routeId = QString::fromUtf8(p.route);
+
+            // Look up the route
+            DomainMap::Entry route;
+            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
+                route = domainMap->entry(routeId, encPath);
+            else
+                route = domainMap->entry(DomainMap::Http, isSecure, host, encPath);
+
+            rs->setRoute(route);
 
             // Note: if the routing table was changed, there's a chance the request might get a
             // different route id this time around. This could confuse stats processors tracking

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -147,7 +147,6 @@ public:
     int workerId;
     State state;
     ZhttpRequest::Rid rid;
-    DomainMap *domainMap;
     SockJsManager *sockJsManager;
     ZrpcManager *inspectManager;
     ZrpcChecker *inspectChecker;
@@ -160,7 +159,6 @@ public:
     QHostAddress peerAddress;
     QHostAddress logicalPeerAddress;
     DomainMap::Entry route;
-    QString routeId;
     bool debug;
     bool autoCrossOrigin;
     std::unique_ptr<InspectRequest> inspectRequest;
@@ -191,14 +189,12 @@ public:
     Connection acceptFinishedConnection;
     DeferCall deferCall;
 
-    Private(RequestSession *_q, int _workerId, DomainMap *_domainMap = 0,
-            SockJsManager *_sockJsManager = 0, ZrpcManager *_inspectManager = 0,
-            ZrpcChecker *_inspectChecker = 0, ZrpcManager *_acceptManager = 0,
-            StatsManager *_stats = 0)
+    Private(RequestSession *_q, int _workerId, SockJsManager *_sockJsManager = 0,
+            ZrpcManager *_inspectManager = 0, ZrpcChecker *_inspectChecker = 0,
+            ZrpcManager *_acceptManager = 0, StatsManager *_stats = 0)
         : q(_q),
           workerId(_workerId),
           state(Stopped),
-          domainMap(_domainMap),
           sockJsManager(_sockJsManager),
           inspectManager(_inspectManager),
           inspectChecker(_inspectChecker),
@@ -275,26 +271,17 @@ public:
 
         bool isHttps = (requestData.uri.scheme() == "https");
         QString host = requestData.uri.host();
+        QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
 
-        if (route.isNull() && domainMap) {
-            QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
-
-            // Look up the route
-            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-                route = domainMap->entry(routeId, encPath);
-            else
-                route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
-
-            // Before we do anything else, see if this is a sockjs request
-            if (!route.isNull() && !route.sockJsPath.isEmpty() &&
-                encPath.startsWith(route.sockJsPath)) {
-                isSockJs = true;
-                sockJsManager->giveRequest(zhttpRequest, route.sockJsPath.length(),
-                                           route.sockJsAsPath, route);
-                zhttpRequest = 0;
-                deferCall.defer([=] { doFinished(); });
-                return;
-            }
+        // Before we do anything else, see if this is a sockjs request
+        if (!route.isNull() && !route.sockJsPath.isEmpty() &&
+            encPath.startsWith(route.sockJsPath)) {
+            isSockJs = true;
+            sockJsManager->giveRequest(zhttpRequest, route.sockJsPath.length(), route.sockJsAsPath,
+                                       route);
+            zhttpRequest = 0;
+            deferCall.defer([=] { doFinished(); });
+            return;
         }
 
         zhttpReqConnections.pausedConnection =
@@ -394,15 +381,6 @@ public:
         state = WaitingForResponse;
 
         bool isHttps = (requestData.uri.scheme() == "https");
-        QString host = requestData.uri.host();
-
-        QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
-
-        // Look up the route
-        if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-            route = domainMap->entry(routeId, encPath);
-        else
-            route = domainMap->entry(DomainMap::Http, isHttps, host, encPath);
 
         log_debug("requestsession: %p route has %d targets", q, route.targets.count());
 
@@ -1088,11 +1066,11 @@ public:
     void doFinished() { q->finished(); }
 };
 
-RequestSession::RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager,
+RequestSession::RequestSession(int workerId, SockJsManager *sockJsManager,
                                ZrpcManager *inspectManager, ZrpcChecker *inspectChecker,
                                ZrpcManager *acceptManager, StatsManager *stats) {
-    d = std::make_shared<Private>(this, workerId, domainMap, sockJsManager, inspectManager,
-                                  inspectChecker, acceptManager, stats);
+    d = std::make_shared<Private>(this, workerId, sockJsManager, inspectManager, inspectChecker,
+                                  acceptManager, stats);
 }
 
 RequestSession::~RequestSession() = default;
@@ -1140,8 +1118,6 @@ void RequestSession::setAutoCrossOrigin(bool enabled) { d->autoCrossOrigin = ena
 void RequestSession::setPrefetchSize(int size) { d->prefetchSize = size; }
 
 void RequestSession::setRoute(const DomainMap::Entry &route) { d->route = route; }
-
-void RequestSession::setRouteId(const QString &routeId) { d->routeId = routeId; }
 
 void RequestSession::setAutoShare(bool enabled) { d->autoShare = enabled; }
 

--- a/src/proxy/requestsession.h
+++ b/src/proxy/requestsession.h
@@ -52,9 +52,8 @@ class XffRule;
 /// response handling
 class RequestSession {
 public:
-    RequestSession(int workerId, DomainMap *domainMap, SockJsManager *sockJsManager,
-                   ZrpcManager *inspectManager, ZrpcChecker *inspectChecker, ZrpcManager *accept,
-                   StatsManager *stats);
+    RequestSession(int workerId, SockJsManager *sockJsManager, ZrpcManager *inspectManager,
+                   ZrpcChecker *inspectChecker, ZrpcManager *accept, StatsManager *stats);
     ~RequestSession();
 
     bool isRetry() const;
@@ -80,7 +79,6 @@ public:
     void setAutoCrossOrigin(bool enabled);
     void setPrefetchSize(int size);
     void setRoute(const DomainMap::Entry &route);
-    void setRouteId(const QString &routeId);
     void setAutoShare(bool enabled);
     void setAccepted(bool enabled);
     void setDefaultUpstreamKey(const Jwt::DecodingKey &key);


### PR DESCRIPTION
To implement external routing for handler-originated requests with mismatched paths (as mentioned in #48352), ideally we should do the route lookup in `Engine`. While investigating this, it occurred to me that the way we do route lookups is confusing because they can happen in two different modules: `Engine` or `RequestSession`. This PR attempts to simplify lookups a little bit by consolidating them in `Engine` and removing the ability to do them from `RequestSession`.

`RequestSession`'s API seemed especially confusing as you could configure it with an already looked-up route or with a route ID to look up, and this behavior was hard to reason about in conjunction with `Engine`'s own behavior. After these changes, only the former configuration is supported.

Note that route lookups still happen in multiple places within `Engine`, which could probably be improved, but at least they all happen in the same module rather than in potentially multiple modules.