### PR TITLE
externally route subrequests that don't match the original route

### DIFF
--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -506,45 +506,56 @@ public:
         Url uri = req->requestUri();
         bool isSecure = (uri.scheme() == "https");
         QString host = uri.host();
+        QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
 
         DomainMap::Entry route;
 
-        if (passthroughData.isValid() && !preferInternal) {
-            // Passthrough request with preferInternal=false. In this case, set up a direct route,
-            // using some settings from the original route
+        // Look up the route by ID?
+        if (!routeId.isEmpty() && !domainMap->isIdShared(routeId)) {
+            // NOTE: This lookup is not constrained by request path. Must check
+            // route.matchesPath() before actually routing the current request to it.
+            route = domainMap->entry(routeId);
+        }
 
-            DomainMap::Entry originalRoute;
-            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-                originalRoute = domainMap->entry(routeId);
+        if (passthroughData.isValid()) {
+            // Passthrough request (always with a route ID)
 
-            const VariantHash data = passthroughData.toHash();
+            // If a route is found by ID, but the request is not meant for internal routing or
+            // it doesn't match the route, then route externally.
+            if (!route.isNull() && (!preferInternal || !route.matchesPath(encPath))) {
+                DomainMap::Entry externalRoute;
 
-            // Use sig settings from the original route, if available
-            if (!originalRoute.isNull()) {
-                route.sigIss = originalRoute.sigIss;
-                route.sigKey = originalRoute.sigKey;
+                const VariantHash data = passthroughData.toHash();
+
+                // Use sig settings from the original route
+                externalRoute.sigIss = route.sigIss;
+                externalRoute.sigKey = route.sigKey;
+
+                DomainMap::Target target;
+                target.connectHost = host;
+                target.connectPort = uri.port(isSecure ? 443 : 80);
+                target.ssl = isSecure;
+                target.trusted = data["trusted"].toBool();
+
+                externalRoute.targets += target;
+
+                // Replace with the external route
+                route = externalRoute;
             }
-
-            DomainMap::Target target;
-            target.connectHost = host;
-            target.connectPort = uri.port(isSecure ? 443 : 80);
-            target.ssl = isSecure;
-            target.trusted = data["trusted"].toBool();
-
-            route.targets += target;
         } else {
-            // Regular request (with or without a route ID), or a passthrough request with
-            // preferInternal=true. In that case, use domainmap for lookup, with route ID if
-            // available
+            // Regular request (with or without a route ID)
 
-            QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
+            // Invalidate route if path doesn't match
+            if (!route.isNull() && !route.matchesPath(encPath))
+                route = DomainMap::Entry();
 
-            // Look up the route
-            if (!routeId.isEmpty() && !domainMap->isIdShared(routeId))
-                route = domainMap->entry(routeId, encPath);
-            else
+            // Perform a regular lookup if there wasn't a route ID
+            if (route.isNull() && routeId.isEmpty())
                 route = domainMap->entry(DomainMap::Http, isSecure, host, encPath);
         }
+
+        // At this point, `route` may be null if a passthrough request's route no longer
+        // exists, or if a regular request's route was not found.
 
         RequestSession *rs = new RequestSession(config.id, sockJsManager.get(), inspect.get(),
                                                 inspectChecker.get(), accept.get(), stats.get());


### PR DESCRIPTION
Currently, if a subrequest (handler-originated request) has the same authority as the original request of the session that it is acting for, but it doesn't match the path of the original request's route, it is rejected. This is because the original request's route might have path-rewriting rules that don't make sense for an unexpected path. A better behavior would be to allow the request to match on a different route. There are a couple of ways we could go about this:

* Re-match internally. This would let us forward the request directly to another route's target.
* Forward the request externally, causing it to potentially do a full loopback to Pushpin in order to match on a different route and then be forwarded on to its target.

My sense is the latter is safer. It's what we already do for subrequests that have a different authority than the original request of the session. I think we need to be careful about being too clever when we do internal routing, since whatever we do bypasses any logic that might exist in the network path before Pushpin, e.g. load balancer rules.

The downside to external routing is if requests end up looping to Pushpin again, it's harder to receive GRIP instructions since the second Pushpin invocation will handle the instructions instead of passing them through. However, this is already the case when using links with different authorities. In general, it's best to avoid loopbacks, by providing absolute links that reference targets directly.

Fixes #48292.