### PR TITLE
refactor: Consolidate docker into main pushpin repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,68 @@
+#
+# Pushpin Dockerfile
+#
+
+# Pull the base image
+FROM ubuntu:24.10 as build
+
+# Install deps
+RUN \
+  apt-get update && \
+  apt-get install -y bzip2 pkg-config make g++ rustc cargo libssl-dev qt6-base-dev libzmq3-dev libboost-dev
+
+WORKDIR /build
+
+ARG VERSION
+
+ADD https://github.com/fastly/pushpin/releases/download/v${VERSION}/pushpin-${VERSION}.tar.bz2 .
+
+RUN tar xf pushpin-${VERSION}.tar.bz2 && mv pushpin-${VERSION} pushpin
+
+WORKDIR /build/pushpin
+
+RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc
+RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc check
+RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc INSTALL_ROOT=/build/out install
+
+FROM ubuntu:24.10
+LABEL org.opencontainers.image.maintainer="Fastly OSS <oss@fastly.com>"
+
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends libqt6core6 libqt6network6 libzmq5 && \
+  apt-get -y autoremove && \
+  apt-get -y clean && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /build/out/ /
+
+# Add entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+
+# Create a non-root user, group, directories and switch to that user.
+RUN groupadd -r -g 1001 pushpin && \
+    useradd -r -u 1001 -g pushpin pushpin
+
+RUN mkdir -p /var/run/pushpin && \
+    chown -R pushpin:pushpin /etc/pushpin /var/run/pushpin
+
+# Using the user_id specifically here allows for less configuration in k8s
+USER 1001
+
+ENV LANG C.UTF-8
+
+# Define default entrypoint and command
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["pushpin", "--merge-output"]
+
+# Expose ports.
+# - 7999: HTTP port to forward on to the app
+# - 5560: ZMQ PULL for receiving messages
+# - 5561: HTTP port for receiving messages and commands
+# - 5562: ZMQ SUB for receiving messages
+# - 5563: ZMQ REP for receiving commands
+EXPOSE 7999
+EXPOSE 5560
+EXPOSE 5561
+EXPOSE 5562
+EXPOSE 5563

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,61 @@
+# Pushpin Dockerfile
+
+
+This repository contains **Dockerfile** of [Pushpin](http://pushpin.org/) for [Docker](https://www.docker.com/) published to the public [Docker Hub Registry](https://hub.docker.com/).
+
+## Base Docker Image
+
+* [ubuntu:24.10](https://hub.docker.com/_/ubuntu/)
+
+## Installation
+
+1. Install [Docker](https://www.docker.com/).
+
+2. Download [automated build](https://hub.docker.com/r/fanout/pushpin/) from public [Docker Hub Registry](https://hub.docker.com/): `docker pull fanout/pushpin`
+
+Alternatively, you can build an image from the `Dockerfile`. The easiest way to do this is with `docker-compose`, which picks up the source & image versions from `compose.yaml`:
+
+```sh
+docker-compose build
+```
+
+Or you can build with `docker` and manually specify the versions:
+
+```sh
+docker build --build-arg VERSION={SOURCE_VERSION} -t fanout/pushpin:{IMAGE_VERSION} .
+```
+
+## Usage
+
+```sh
+docker run \
+  -d \
+  -p 7999:7999 \
+  -p 5560-5563:5560-5563 \
+  --rm \
+  --name pushpin \
+  fanout/pushpin
+```
+
+By default, Pushpin routes traffic to a test handler.  See the [Getting Started Guide](https://pushpin.org/docs/getting-started/) for more information.
+
+Open `http://<host>:7999` to see the result.
+
+#### Configure Pushpin to route traffic
+
+To add custom Pushpin configuration to your Docker container, attach a configuration volume.
+
+```sh
+docker run \
+  -d \
+  -p 7999:7999 \
+  -p 5560-5563:5560-5563 \
+  -v $(pwd)/config:/etc/pushpin/ \
+  --rm \
+  --name pushpin \
+  fanout/pushpin
+```
+
+Note: The Docker entrypoint may make modifications to `pushpin.conf` so it runs properly in its container, exposing ports `7999`, `5560`, `5561`, `5562`, and `5563`.
+
+See project documentation for more on [configuring Pushpin](https://pushpin.org/docs/configuration/).

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  pushpin:
+    build:
+      context: .
+      args:
+        VERSION: 1.41.0
+    image: fanout/pushpin:1.41.0-1

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ -w /etc/pushpin/pushpin.conf ]; then
+	sed -i \
+		-e 's/services=.*/services=condure,pushpin-proxy,pushpin-handler/' \
+		-e 's/push_in_spec=.*/push_in_spec=tcp:\/\/\*:5560/' \
+		-e 's/push_in_http_addr=.*/push_in_http_addr=0.0.0.0/' \
+		-e 's/push_in_sub_specs=.*/push_in_sub_spec=tcp:\/\/\*:5562/' \
+		-e 's/command_spec=.*/command_spec=tcp:\/\/\*:5563/' \
+		-e 's/^http_port=.*/http_port=7999/' \
+		/etc/pushpin/pushpin.conf
+else
+	echo "docker-entrypoint.sh: unable to write to /etc/pushpin/pushpin.conf, readonly"
+fi
+
+# Set routes with ${target} for backwards-compatibility.
+if [ -v target ]; then
+	echo "* ${target},over_http" > /etc/pushpin/routes
+fi
+
+exec "$@"


### PR DESCRIPTION
In an effort to simplify the release processes we have I think it would be good to consolidate [the docker repo](https://github.com/fanout/docker-pushpin) into this main repo. To my knowledge, there is no real advantage to having a separate repo for this functionality (with the exception of maybe Github permissioning) so consolidating it here and running the CI as part of our normal release process should cut down on some steps.

The only change I've made from the repo is modifying the "MAINTAINER" label into `LABEL maintainer =` since the MAINTAINER label is deprecated. And I also added Fastly OSS as a maintainer.

The CI job will be in a follow up PR.