### PR TITLE
chore: Don't run full test suite for files that don't require it.

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -1,8 +1,12 @@
 name: CI
 on:
   pull_request:
-    branches: 
+    branches:
       - main
+    paths-ignore:
+      - 'docker/**'
+      - '**/*.md'
+      - '.github/workflows/docker-publish.yml'
 defaults:
   run:
      shell: bash -leo pipefail {0}


### PR DESCRIPTION
This is just a small quality of life change. No reason to run the full test suite for edits that don't benefit from it.

- `docker/**`:  the Dockerfile, entrypoint, compose, etc.
- `**/*.md`: any markdown file anywhere
- `.github/workflows/docker-publish.yml`: changes to the docker publish workflow alone won't trigger Rust CI, but other CI things should probably still trigger.