### PR TITLE
http1: ability to dynamically resize header read buffers

### DIFF
--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -1429,7 +1429,7 @@ async fn send_error_response<R: AsyncRead, W: AsyncWrite>(
 async fn server_req_read_body<R: AsyncRead, W: AsyncWrite>(
     id: &str,
     req: &http1::Request<'_, '_>,
-    req_body: &mut server::RequestBodyKeepHeader<'_, '_, R, W>,
+    req_body: &mut server::RequestBodyKeepHeader<'_, '_, '_, '_, R, W>,
     peer_addr: Option<&SocketAddr>,
     secure: bool,
     body_buf: &mut ContiguousBuffer,
@@ -1528,7 +1528,7 @@ async fn server_req_read_header_and_body<R: AsyncRead, W: AsyncWrite>(
     // this function and do not use the ?-operator
     let (req_header, mut req_body) = {
         // ABR: discard_while
-        match discard_while(zreceiver, pin!(req_header.recv(&mut scratch))).await {
+        match discard_while(zreceiver, pin!(req_header.recv(&mut scratch, None))).await {
             Ok(ret) => ret,
             Err(e) if e.is_eof() => return Ok(None),
             Err(e) => return Err(e),
@@ -3387,7 +3387,7 @@ async fn server_stream_read_header<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite>(
     // this function and do not use the ?-operator
     let (req_header, req_body) = {
         // ABR: discard_while
-        match discard_while(zreceiver, pin!(req_header.recv(&mut scratch))).await {
+        match discard_while(zreceiver, pin!(req_header.recv(&mut scratch, None))).await {
             Ok(ret) => ret,
             Err(e) if e.is_eof() => return Ok(None),
             Err(e) => return Err(e),
@@ -4611,7 +4611,7 @@ where
 
     let mut scratch = http1::ParseScratch::<HEADERS_MAX>::new();
 
-    let (resp, resp_body) = resp.recv_header(&mut scratch).await?;
+    let (resp, resp_body) = resp.recv_header(&mut scratch, None).await?;
 
     let (zresp, finished) = {
         let resp_ref = resp.get();
@@ -5193,7 +5193,7 @@ where
 
     let (resp_body, ws_config) = {
         let mut scratch = http1::ParseScratch::<HEADERS_MAX>::new();
-        let mut recv_header = pin!(resp.recv_header(&mut scratch));
+        let mut recv_header = pin!(resp.recv_header(&mut scratch, None));
 
         let (resp, resp_body) = loop {
             // ABR: select contains read

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -950,6 +950,28 @@ impl<'a> BufferBudget<'a> {
 
         count
     }
+
+    /// Shrink buffer to target capacity
+    ///
+    /// If the buffer was expanded beyond target_capacity, it will be resized back
+    /// to the target size and the corresponding blocks will be released.
+    pub fn shrink_buffer(&mut self, buf: &mut VecRingBuffer, target_capacity: usize) {
+        let capacity = buf.capacity();
+
+        if capacity > target_capacity {
+            // Expansion should be in whole blocks
+            assert_eq!(
+                (capacity - target_capacity) % self.block_size,
+                0,
+                "expansion size must be multiple of block size"
+            );
+
+            buf.resize(target_capacity);
+
+            let blocks_freed = (capacity - target_capacity) / self.block_size;
+            self.release_blocks(blocks_freed);
+        }
+    }
 }
 
 impl Drop for BufferBudget<'_> {
@@ -1304,6 +1326,64 @@ mod tests {
         let size = r.read(&mut buf).unwrap();
         assert_eq!(size, 8);
         assert_eq!(&buf[..size], b"12345678");
+    }
+
+    #[test]
+    fn test_buffer_budget_shrink() {
+        let counter = Counter::new(10);
+        let mut budget = BufferBudget::new(&counter)
+            .with_block_size(64)
+            .with_blocks_max(5);
+
+        let tmp = std::rc::Rc::new(TmpBuffer::new(512));
+        let mut buf = VecRingBuffer::new(128, &tmp);
+        let original_capacity = buf.capacity();
+
+        // Fill buffer so remaining_capacity() == 0
+        buf.write_all(&vec![0u8; 128]).unwrap();
+        assert_eq!(buf.remaining_capacity(), 0);
+
+        // Expand the buffer
+        budget.expand_buffer_if_needed(&mut buf);
+        assert_eq!(buf.capacity(), original_capacity + 64);
+        assert_eq!(budget.blocks_used(), 1);
+
+        // Fill again to trigger another expansion
+        buf.write_all(&vec![0u8; 64]).unwrap();
+        assert_eq!(buf.remaining_capacity(), 0);
+
+        // Expand again
+        budget.expand_buffer_if_needed(&mut buf);
+        assert_eq!(buf.capacity(), original_capacity + 128);
+        assert_eq!(budget.blocks_used(), 2);
+
+        // Shrink back to original
+        budget.shrink_buffer(&mut buf, original_capacity);
+        assert_eq!(buf.capacity(), original_capacity);
+        assert_eq!(budget.blocks_used(), 0);
+
+        // Verify shrinking a non-expanded buffer is safe (no-op)
+        budget.shrink_buffer(&mut buf, original_capacity);
+        assert_eq!(buf.capacity(), original_capacity);
+        assert_eq!(budget.blocks_used(), 0);
+
+        // Test shrinking to a different target size
+        buf.clear(); // Clear buffer after previous shrinking
+        buf.write_all(&vec![0u8; 128]).unwrap();
+        assert_eq!(buf.remaining_capacity(), 0);
+
+        budget.expand_buffer_if_needed(&mut buf);
+        buf.write_all(&vec![0u8; 64]).unwrap(); // Fill the expansion space
+        assert_eq!(buf.remaining_capacity(), 0);
+
+        budget.expand_buffer_if_needed(&mut buf);
+        assert_eq!(buf.capacity(), original_capacity + 128);
+        assert_eq!(budget.blocks_used(), 2);
+
+        // Shrink to intermediate size
+        budget.shrink_buffer(&mut buf, original_capacity + 64);
+        assert_eq!(buf.capacity(), original_capacity + 64);
+        assert_eq!(budget.blocks_used(), 1);
     }
 
     #[test]

--- a/src/core/http1/client.rs
+++ b/src/core/http1/client.rs
@@ -402,17 +402,20 @@ pub struct Response<'a, R: AsyncRead> {
 }
 
 impl<'a, R: AsyncRead> Response<'a, R> {
-    pub async fn recv_header<'b, const N: usize>(
+    pub async fn recv_header<'b, 'budget, 'counter, const N: usize>(
         mut self,
         mut scratch: &'b mut ParseScratch<N>,
+        mut budget: Option<&'budget mut BufferBudget<'counter>>,
     ) -> Result<
         (
             protocol::OwnedResponse<'b, N>,
-            ResponseBodyKeepHeader<'a, R>,
+            ResponseBodyKeepHeader<'a, 'budget, 'counter, R>,
         ),
         Error,
     > {
         let mut resp = self.inner;
+
+        let original_rbuf_capacity = self.rbuf.capacity();
 
         let (resp, resp_body) = loop {
             {
@@ -442,6 +445,13 @@ impl<'a, R: AsyncRead> Response<'a, R> {
 
             if let Err(e) = recv_nonzero(&mut self.r, self.rbuf).await {
                 if e.kind() == io::ErrorKind::WriteZero {
+                    // Try to expand the buffer before failing
+                    if let Some(budget) = budget.as_mut() {
+                        let expanded = budget.expand_buffer_if_needed(self.rbuf);
+                        if expanded > 0 {
+                            continue; // Retry reading with the expanded buffer
+                        }
+                    }
                     return Err(Error::BufferExceeded);
                 }
 
@@ -452,7 +462,7 @@ impl<'a, R: AsyncRead> Response<'a, R> {
         // At this point, resp has taken rbuf's inner buffer, such that
         // rbuf has no inner buffer
 
-        // Put remaining readable bytes in wbuf
+        // Put remaining readable bytes in wbuf, which should always fit
         self.wbuf.write_all(resp.remaining_bytes())?;
 
         // Swap inner buffers, such that rbuf now contains the remaining
@@ -471,6 +481,8 @@ impl<'a, R: AsyncRead> Response<'a, R> {
                     })),
                 },
                 wbuf: RefCell::new(Some(self.wbuf)),
+                original_rbuf_capacity,
+                budget,
             },
         ))
     }
@@ -574,19 +586,27 @@ impl<R: AsyncRead> ResponseBody<'_, R> {
     }
 }
 
-pub struct ResponseBodyKeepHeader<'a, R: AsyncRead> {
+pub struct ResponseBodyKeepHeader<'a, 'budget, 'counter, R: AsyncRead> {
     inner: ResponseBody<'a, R>,
     wbuf: RefCell<Option<&'a mut VecRingBuffer>>,
+    // Track original capacity for shrinking back after header discard
+    original_rbuf_capacity: usize,
+    budget: Option<&'budget mut BufferBudget<'counter>>,
 }
 
-impl<'a, R: AsyncRead> ResponseBodyKeepHeader<'a, R> {
+impl<'a, R: AsyncRead> ResponseBodyKeepHeader<'a, '_, '_, R> {
     pub fn discard_header<const N: usize>(
-        self,
+        mut self,
         resp: protocol::OwnedResponse<N>,
     ) -> Result<ResponseBody<'a, R>, Error> {
         if let Some(wbuf) = self.wbuf.borrow_mut().take() {
             wbuf.set_inner(resp.into_buf());
             wbuf.clear();
+
+            // Shrink buffer back to original size if expansion occurred
+            if let Some(budget) = self.budget.as_mut() {
+                budget.shrink_buffer(wbuf, self.original_rbuf_capacity);
+            }
 
             Ok(self.inner)
         } else {
@@ -645,5 +665,268 @@ impl FinishedKeepHeader<'_> {
 
     pub fn is_persistent(&self) -> bool {
         self.inner.is_persistent()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::buffer::TmpBuffer;
+    use crate::core::counter::Counter;
+    use crate::core::http1::protocol::ParseScratch;
+    use crate::core::io::{AsyncRead, AsyncWrite};
+    use std::cell::RefCell;
+    use std::future::Future;
+    use std::io::{self, Read, Write};
+    use std::pin::Pin;
+    use std::rc::Rc;
+    use std::task::{Context, Poll};
+
+    struct NoopWaker;
+
+    impl std::task::Wake for NoopWaker {
+        fn wake(self: std::sync::Arc<Self>) {}
+    }
+
+    struct FakeStream {
+        in_data: std::io::Cursor<Vec<u8>>,
+        out_data: Vec<u8>,
+    }
+
+    impl FakeStream {
+        fn new() -> Self {
+            Self {
+                in_data: std::io::Cursor::new(Vec::new()),
+                out_data: Vec::new(),
+            }
+        }
+    }
+
+    impl AsyncRead for FakeStream {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            Poll::Ready(self.in_data.read(buf))
+        }
+
+        fn cancel(&mut self) {}
+    }
+
+    impl AsyncWrite for FakeStream {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            Poll::Ready(self.out_data.write(buf))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn is_writable(&self) -> bool {
+            true
+        }
+
+        fn cancel(&mut self) {}
+    }
+
+    const HEADERS_MAX: usize = 32;
+
+    #[test]
+    fn response_header_expansion_enabled() {
+        let mut fut = std::pin::pin!(async {
+            let mut stream = FakeStream::new();
+
+            // Create a response with headers larger than the initial buffer
+            let mut large_headers = String::from("HTTP/1.1 200 OK\r\n");
+            // Add many headers to exceed the small buffer size
+            for i in 0..15 {
+                large_headers.push_str(&format!("X-Custom-Header-{}: value-{}\r\n", i, i));
+            }
+            large_headers.push_str("Content-Length: 6\r\n\r\nhello\n");
+
+            stream
+                .in_data
+                .get_mut()
+                .extend_from_slice(large_headers.as_bytes());
+
+            {
+                let stream = RefCell::new(&mut stream);
+                let (r, _w) = crate::core::io::io_split(&stream);
+
+                let tmp = Rc::new(TmpBuffer::new(1024));
+                let mut buf1 = VecRingBuffer::new(32, &tmp); // Small buffer to force expansion
+                let mut buf2 = VecRingBuffer::new(32, &tmp);
+
+                // Set up budget for expansion
+                let counter = Counter::new(1000);
+                let mut budget = BufferBudget::new(&counter).with_block_size(64);
+
+                let resp = Response {
+                    r,
+                    rbuf: &mut buf1,
+                    wbuf: &mut buf2,
+                    inner: protocol::ClientResponse::new(),
+                };
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+                let (resp_header, resp_body) = resp
+                    .recv_header(&mut scratch, Some(&mut budget))
+                    .await
+                    .unwrap();
+
+                let resp_ref = resp_header.get();
+                assert_eq!(resp_ref.code, 200);
+                assert_eq!(resp_ref.reason, "OK");
+
+                // Verify that expansion was used (original rbuf was small)
+                assert_eq!(resp_body.original_rbuf_capacity, 32);
+
+                // The fact that parsing succeeded with large headers and small initial buffer
+                // proves that buffer expansion worked (would have failed without expansion)
+
+                let resp_body_final = resp_body.discard_header(resp_header).unwrap();
+
+                // After discard_header, verify buffer was shrunk back to original size
+                let final_capacity = {
+                    let inner = resp_body_final.inner.borrow();
+                    let inner = inner.as_ref().unwrap();
+                    inner.rbuf.capacity()
+                };
+                assert_eq!(
+                    final_capacity, 32,
+                    "Buffer should be shrunk back to original size (32), got {}",
+                    final_capacity
+                );
+            }
+        });
+
+        let waker = std::sync::Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn response_header_expansion_disabled() {
+        let mut fut = std::pin::pin!(async {
+            let mut stream = FakeStream::new();
+
+            // Create a response with headers larger than the buffer
+            let mut large_headers = String::from("HTTP/1.1 200 OK\r\n");
+            // Add many headers to exceed buffer size
+            for i in 0..15 {
+                large_headers.push_str(&format!("X-Custom-Header-{}: value-{}\r\n", i, i));
+            }
+            large_headers.push_str("Content-Length: 6\r\n\r\nhello\n");
+
+            stream
+                .in_data
+                .get_mut()
+                .extend_from_slice(large_headers.as_bytes());
+
+            {
+                let stream = RefCell::new(&mut stream);
+                let (r, _w) = crate::core::io::io_split(&stream);
+
+                let tmp = Rc::new(TmpBuffer::new(1024));
+                let mut buf1 = VecRingBuffer::new(32, &tmp); // Small buffer
+                let mut buf2 = VecRingBuffer::new(32, &tmp);
+
+                // No budget provided - expansion disabled
+                let resp = Response {
+                    r,
+                    rbuf: &mut buf1,
+                    wbuf: &mut buf2,
+                    inner: protocol::ClientResponse::new(),
+                };
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+                let result = resp.recv_header(&mut scratch, None).await;
+
+                // Should fail due to buffer being too small and no expansion available
+                assert!(result.is_err());
+
+                // Verify buffer capacity remained unchanged (no expansion occurred)
+                assert_eq!(
+                    buf1.capacity(),
+                    32,
+                    "Buffer capacity should remain 32 when expansion is disabled, got {}",
+                    buf1.capacity()
+                );
+            }
+        });
+
+        let waker = std::sync::Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn response_header_basic() {
+        let mut fut = std::pin::pin!(async {
+            let mut stream = FakeStream::new();
+
+            // Simple response that fits in buffer
+            stream.in_data.get_mut().extend_from_slice(
+                "HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nhello\n".as_bytes(),
+            );
+
+            {
+                let stream = RefCell::new(&mut stream);
+                let (r, _w) = crate::core::io::io_split(&stream);
+
+                let tmp = Rc::new(TmpBuffer::new(64));
+                let mut buf1 = VecRingBuffer::new(64, &tmp);
+                let mut buf2 = VecRingBuffer::new(64, &tmp);
+
+                let resp = Response {
+                    r,
+                    rbuf: &mut buf1,
+                    wbuf: &mut buf2,
+                    inner: protocol::ClientResponse::new(),
+                };
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+                let (resp_header, resp_body) = resp.recv_header(&mut scratch, None).await.unwrap();
+
+                let resp_ref = resp_header.get();
+                assert_eq!(resp_ref.code, 200);
+                assert_eq!(resp_ref.reason, "OK");
+
+                // Verify no expansion occurred - buffer should still be original size
+                let current_rbuf_capacity = {
+                    let inner = resp_body.inner.inner.borrow();
+                    let inner = inner.as_ref().unwrap();
+                    inner.rbuf.capacity()
+                };
+                assert_eq!(
+                    current_rbuf_capacity, 64,
+                    "Expected no expansion, rbuf capacity should remain 64, got {}",
+                    current_rbuf_capacity
+                );
+
+                let resp_body_final = resp_body.discard_header(resp_header).unwrap();
+
+                // After discard_header, verify buffer capacity is still unchanged
+                let final_capacity = {
+                    let inner = resp_body_final.inner.borrow();
+                    let inner = inner.as_ref().unwrap();
+                    inner.rbuf.capacity()
+                };
+                assert_eq!(
+                    final_capacity, 64,
+                    "Buffer capacity should remain 64 after discard_header, got {}",
+                    final_capacity
+                );
+            }
+        });
+
+        let waker = std::sync::Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
     }
 }

--- a/src/core/http1/protocol.rs
+++ b/src/core/http1/protocol.rs
@@ -1393,6 +1393,13 @@ pub struct ClientResponse {
 }
 
 impl ClientResponse {
+    #[cfg(test)]
+    pub fn new() -> Self {
+        Self {
+            state: ClientState::new(),
+        }
+    }
+
     pub fn recv_header<const N: usize>(
         mut self,
         rbuf: FilledBuf,

--- a/src/core/http1/server.rs
+++ b/src/core/http1/server.rs
@@ -75,13 +75,14 @@ pub struct RequestHeader<'a, 'b, R: AsyncRead, W: AsyncWrite> {
 
 impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, 'b, R, W> {
     // Read from stream into buf, and parse buf as a request header
-    pub async fn recv<'c, const N: usize>(
+    pub async fn recv<'c, 'budget, 'counter, const N: usize>(
         self,
         mut scratch: &'c mut ParseScratch<N>,
+        mut budget: Option<&'budget mut BufferBudget<'counter>>,
     ) -> Result<
         (
             protocol::OwnedRequest<'c, N>,
-            RequestBodyKeepHeader<'a, 'b, R, W>,
+            RequestBodyKeepHeader<'a, 'b, 'budget, 'counter, R, W>,
         ),
         Error,
     > {
@@ -90,7 +91,7 @@ impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, 'b, R, W> {
             protocol::ServerState::ReceivingRequest
         );
 
-        let size_limit = self.inner.rbuf.remaining_capacity();
+        let original_rbuf_capacity = self.inner.rbuf.capacity();
 
         let req = loop {
             {
@@ -117,7 +118,14 @@ impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, 'b, R, W> {
 
             if let Err(e) = recv_nonzero(&mut self.inner.r, self.inner.rbuf).await {
                 if e.kind() == io::ErrorKind::WriteZero {
-                    return Err(Error::RequestTooLarge(size_limit));
+                    // Try to expand the buffer before failing
+                    if let Some(budget) = &mut budget {
+                        let expanded = budget.expand_buffer_if_needed(self.inner.rbuf);
+                        if expanded > 0 {
+                            continue; // Retry reading with the expanded buffer
+                        }
+                    }
+                    return Err(Error::RequestTooLarge(self.inner.rbuf.capacity()));
                 }
 
                 return Err(e.into());
@@ -133,7 +141,7 @@ impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, 'b, R, W> {
         // At this point, req has taken rbuf's inner buffer, such that
         // rbuf has no inner buffer
 
-        // Put remaining readable bytes in wbuf
+        // Put remaining readable bytes in wbuf, which should always fit
         self.inner.wbuf.write_all(req.remaining_bytes())?;
 
         // Swap inner buffers, such that rbuf now contains the remaining
@@ -157,6 +165,8 @@ impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, 'b, R, W> {
                         })),
                     },
                     wbuf: self.inner.wbuf,
+                    original_rbuf_capacity,
+                    budget,
                 }),
             },
         ))
@@ -319,24 +329,32 @@ impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestBody<'a, 'b, R, W> {
     }
 }
 
-struct RequestBodyKeepHeaderInner<'a, 'b, R: AsyncRead, W: AsyncWrite> {
+struct RequestBodyKeepHeaderInner<'a, 'b, 'budget, 'counter, R: AsyncRead, W: AsyncWrite> {
     inner: RequestBody<'a, 'b, R, W>,
     wbuf: &'b mut VecRingBuffer,
+    // Track original capacity for shrinking back after header discard
+    original_rbuf_capacity: usize,
+    budget: Option<&'budget mut BufferBudget<'counter>>,
 }
 
-pub struct RequestBodyKeepHeader<'a, 'b, R: AsyncRead, W: AsyncWrite> {
-    inner: Option<RequestBodyKeepHeaderInner<'a, 'b, R, W>>,
+pub struct RequestBodyKeepHeader<'a, 'b, 'budget, 'counter, R: AsyncRead, W: AsyncWrite> {
+    inner: Option<RequestBodyKeepHeaderInner<'a, 'b, 'budget, 'counter, R, W>>,
 }
 
-impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestBodyKeepHeader<'a, 'b, R, W> {
+impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestBodyKeepHeader<'a, 'b, '_, '_, R, W> {
     pub fn discard_header<const N: usize>(
         mut self,
         req: protocol::OwnedRequest<N>,
     ) -> RequestBody<'a, 'b, R, W> {
-        let inner = self.inner.take().unwrap();
+        let mut inner = self.inner.take().unwrap();
 
         inner.wbuf.set_inner(req.into_buf());
         inner.wbuf.clear();
+
+        // Shrink buffer back to original size if expansion occurred
+        if let Some(budget) = &mut inner.budget {
+            budget.shrink_buffer(inner.wbuf, inner.original_rbuf_capacity);
+        }
 
         inner.inner
     }
@@ -358,7 +376,7 @@ impl<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite> RequestBodyKeepHeader<'a, 'b, R, W
     }
 }
 
-impl<R: AsyncRead, W: AsyncWrite> Drop for RequestBodyKeepHeader<'_, '_, R, W> {
+impl<R: AsyncRead, W: AsyncWrite> Drop for RequestBodyKeepHeader<'_, '_, '_, '_, R, W> {
     fn drop(&mut self) {
         if self.inner.is_some() {
             panic!("RequestBodyKeepHeader must be consumed by discard_header() instead of dropped");
@@ -811,6 +829,7 @@ impl Finished {
 mod tests {
     use super::*;
     use crate::core::buffer::TmpBuffer;
+    use crate::core::counter::Counter;
     use crate::core::io::io_split;
     use std::cmp;
     use std::future::Future;
@@ -907,7 +926,7 @@ mod tests {
                 let header = req.recv_header(&mut resp);
 
                 let mut scratch = ParseScratch::<HEADERS_MAX>::new();
-                let (req_header, req_body) = header.recv(&mut scratch).await.unwrap();
+                let (req_header, req_body) = header.recv(&mut scratch, None).await.unwrap();
 
                 // catch to avoid running req_body destructor
                 let result = panic::catch_unwind(|| {
@@ -989,7 +1008,7 @@ mod tests {
                 let header = req.recv_header(&mut resp);
 
                 let mut scratch = ParseScratch::<HEADERS_MAX>::new();
-                let (req_header, req_body) = header.recv(&mut scratch).await.unwrap();
+                let (req_header, req_body) = header.recv(&mut scratch, None).await.unwrap();
 
                 // catch to avoid running req_body destructor
                 let result = panic::catch_unwind(|| {
@@ -1079,7 +1098,7 @@ mod tests {
                 let header = req.recv_header(&mut resp);
 
                 let mut scratch = ParseScratch::<HEADERS_MAX>::new();
-                let (req_header, req_body) = header.recv(&mut scratch).await.unwrap();
+                let (req_header, req_body) = header.recv(&mut scratch, None).await.unwrap();
 
                 // catch to avoid running req_body destructor
                 let result = panic::catch_unwind(|| {
@@ -1154,7 +1173,7 @@ mod tests {
                 let header = req.recv_header(&mut resp);
 
                 let mut scratch = ParseScratch::<HEADERS_MAX>::new();
-                let (req_header, req_body) = header.recv(&mut scratch).await.unwrap();
+                let (req_header, req_body) = header.recv(&mut scratch, None).await.unwrap();
                 let req_body = req_body.discard_header(req_header);
                 drop(req_body);
 
@@ -1200,6 +1219,193 @@ mod tests {
                 "HTTP/1.1 200 OK\r\nContent-Length: 64\r\n\r\n".to_string() + expected_body;
 
             assert_eq!(str::from_utf8(&stream.out_data).unwrap(), expected);
+        });
+
+        let waker = Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn dynamic_header_expansion_enabled() {
+        let mut fut = pin!(async {
+            let mut stream = FakeStream::new();
+
+            // Create a request with headers larger than the initial buffer
+            let mut large_headers = String::from("POST /path HTTP/1.1\r\n");
+            // Add many headers to exceed initial buffer size
+            for i in 0..20 {
+                large_headers.push_str(&format!("X-Custom-Header-{}: value-{}\r\n", i, i));
+            }
+            large_headers.push_str("Content-Length: 6\r\n\r\nhello\n");
+
+            stream.in_data.write_all(large_headers.as_bytes()).unwrap();
+
+            {
+                let stream = RefCell::new(&mut stream);
+
+                // Use larger TmpBuffer to allow expansion
+                let tmp = Rc::new(TmpBuffer::new(2048));
+                let mut buf1 = VecRingBuffer::new(64, &tmp); // Small initial buffer
+                let mut buf2 = VecRingBuffer::new(1024, &tmp);
+
+                let (req, mut resp) = Request::new(io_split(&stream), &mut buf1, &mut buf2);
+                let header = req.recv_header(&mut resp);
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+
+                // Block-based expansion function similar to connmgr
+                let counter = Counter::new(100); // Shared counter with plenty of blocks
+                let mut budget = BufferBudget::new(&counter)
+                    .with_blocks_max(20) // Local limit of 20 blocks
+                    .with_block_size(64); // Block-based expansion
+                let result = header.recv(&mut scratch, Some(&mut budget)).await;
+
+                // Should succeed with expansion enabled
+                assert!(result.is_ok());
+                let (req_header, req_body) = result.unwrap();
+
+                let req_ref = req_header.get();
+                assert_eq!(req_ref.method, "POST");
+                assert_eq!(req_ref.uri, "/path");
+                assert_eq!(req_ref.body_size, BodySize::Known(6));
+
+                req_body.discard_header(req_header);
+            }
+        });
+
+        let waker = Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn dynamic_header_expansion_disabled() {
+        let mut fut = pin!(async {
+            let mut stream = FakeStream::new();
+
+            // Create a request with headers larger than the buffer
+            let mut large_headers = String::from("POST /path HTTP/1.1\r\n");
+            // Add many headers to exceed buffer size
+            for i in 0..20 {
+                large_headers.push_str(&format!("X-Custom-Header-{}: value-{}\r\n", i, i));
+            }
+            large_headers.push_str("Content-Length: 6\r\n\r\nhello\n");
+
+            stream.in_data.write_all(large_headers.as_bytes()).unwrap();
+
+            {
+                let stream = RefCell::new(&mut stream);
+
+                let tmp = Rc::new(TmpBuffer::new(128)); // Small buffer
+                let mut buf1 = VecRingBuffer::new(32, &tmp); // Very small initial buffer
+                let mut buf2 = VecRingBuffer::new(128, &tmp);
+
+                let (req, mut resp) = Request::new(io_split(&stream), &mut buf1, &mut buf2);
+                let header = req.recv_header(&mut resp);
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+
+                // No expansion function provided - should fail
+                let result = header.recv(&mut scratch, None).await;
+
+                // Should fail due to insufficient buffer space
+                assert!(result.is_err());
+            }
+        });
+
+        let waker = Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn dynamic_header_with_pipelined_data() {
+        let mut fut = pin!(async {
+            let mut stream = FakeStream::new();
+
+            // Create a request with large headers and pipelined data (remaining bytes)
+            let mut large_headers = String::from("POST /path HTTP/1.1\r\n");
+            // Add headers to exceed initial buffer size but stay reasonable
+            for i in 0..8 {
+                large_headers.push_str(&format!("X-Custom-Header-{}: value-{}\r\n", i, i));
+            }
+            large_headers.push_str("Content-Length: 6\r\n\r\nhello\n");
+            // Add small pipelined request data (tests concern #1)
+            large_headers.push_str("GET /next HTTP/1.1\r\n\r\n");
+
+            stream.in_data.write_all(large_headers.as_bytes()).unwrap();
+
+            {
+                let stream = RefCell::new(&mut stream);
+
+                let tmp = Rc::new(TmpBuffer::new(1024));
+                let mut buf1 = VecRingBuffer::new(32, &tmp); // Very small initial buffer
+                let mut buf2 = VecRingBuffer::new(64, &tmp); // Small second buffer
+
+                let (req, mut resp) = Request::new(io_split(&stream), &mut buf1, &mut buf2);
+                let header = req.recv_header(&mut resp);
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+
+                // Test shows the limitation: block budget doesn't carry over after buffer swap
+                // Use BufferBudget for expansion to handle large headers
+                let counter = Counter::new(100);
+                let mut budget = BufferBudget::new(&counter)
+                    .with_blocks_max(10)
+                    .with_block_size(64);
+
+                let result = header.recv(&mut scratch, Some(&mut budget)).await;
+                assert!(result.is_ok());
+                let (req_header, req_body) = result.unwrap();
+
+                // Verify the request was parsed correctly despite expansion
+                let req_ref = req_header.get();
+                assert_eq!(req_ref.method, "POST");
+                assert_eq!(req_ref.uri, "/path");
+
+                let req_body = req_body.discard_header(req_header);
+
+                // The fact that parsing succeeded with a 32-byte buffer and large headers
+                // is sufficient evidence that buffer expansion occurred
+                // (without expansion, parsing would have failed due to insufficient space)
+
+                drop(req_body);
+            }
+        });
+
+        let waker = Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn blocks_max_carryover() {
+        let mut fut = pin!(async {
+            let mut stream = FakeStream::new();
+
+            let request = "POST /path HTTP/1.1\r\nContent-Length: 6\r\n\r\nhello\n";
+            stream.in_data.write_all(request.as_bytes()).unwrap();
+
+            {
+                let stream = RefCell::new(&mut stream);
+
+                let tmp = Rc::new(TmpBuffer::new(1024));
+                let mut buf1 = VecRingBuffer::new(64, &tmp);
+                let mut buf2 = VecRingBuffer::new(64, &tmp);
+
+                let (req, mut resp) = Request::new(io_split(&stream), &mut buf1, &mut buf2);
+                let header = req.recv_header(&mut resp);
+
+                let mut scratch = ParseScratch::<HEADERS_MAX>::new();
+
+                let result = header.recv(&mut scratch, None).await; // No expansion needed
+                assert!(result.is_ok());
+                let (req_header, req_body) = result.unwrap();
+
+                let req_body = req_body.discard_header(req_header);
+                drop(req_body);
+            }
         });
 
         let waker = Arc::new(NoopWaker).into();


### PR DESCRIPTION
This adds an `Option<&mut BufferBudget>` argument when reading request headers or response headers. If `Some`, the read buffer will be expanded as necessary, pulling from the budget. When the parsed headers are no longer needed and `discard_header` is called as part of the normal flow, the buffer is shrunk back down and the blocks are returned to the budget. The feature is not actually used anywhere yet, with all call sites updated to pass `None` for now.

Two additional lifetimes needed to be added for this to work, since the argument reference is mutable and `BufferBudget` itself has a lifetime, and mutable references have strict variance rules. It's a bit gross, but sometimes this happens when we have a lot of borrowing going on.