### PR TITLE
write_vectored_offset: support writes of any size

### DIFF
--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -43,7 +43,7 @@ use crate::connmgr::track::{
 use crate::connmgr::websocket;
 use crate::connmgr::zhttppacket;
 use crate::core::buffer::{
-    Buffer, BufferBudget, ContiguousBuffer, LimitBufsMut, TmpBuffer, VecRingBuffer, VECTORED_MAX,
+    Buffer, BufferBudget, ContiguousBuffer, LimitBufsMut, TmpBuffer, VecRingBuffer, BUFFER_BUFS_MAX,
 };
 use crate::core::channel::{AsyncLocalReceiver, AsyncLocalSender};
 use crate::core::counter::Counter;
@@ -708,9 +708,8 @@ impl<W: AsyncWrite, M: AsRef<[u8]> + AsMut<[u8]>> Future
             return Poll::Pending;
         }
 
-        // protocol.send_message_content may add 1 element to vector
-        let mut buf_arr = mem::MaybeUninit::<[&mut [u8]; VECTORED_MAX - 1]>::uninit();
-        let mut bufs = w.buf.read_bufs_mut(&mut buf_arr).limit(f.avail);
+        let mut scratch = mem::MaybeUninit::<[&mut [u8]; BUFFER_BUFS_MAX]>::uninit();
+        let mut bufs = w.buf.read_bufs_mut(&mut scratch).limit(f.avail);
 
         match f.protocol.send_message_content(
             &mut StdWriteWrapper::new(Pin::new(&mut w.stream), cx),

--- a/src/connmgr/websocket.rs
+++ b/src/connmgr/websocket.rs
@@ -16,7 +16,8 @@
  */
 
 use crate::core::buffer::{
-    trim_for_display, write_vectored_offset, Buffer, LimitBufsMut, RingBuffer, VECTORED_MAX,
+    cap_bufs_mut, trim_for_display, write_vectored_offset, Buffer, LimitBufsMut, RingBuffer,
+    BUFFER_BUFS_MAX,
 };
 use crate::core::http1::HeaderParamsIterator;
 use arrayvec::ArrayVec;
@@ -51,6 +52,7 @@ pub const OPCODE_PING: u8 = 9;
 pub const OPCODE_PONG: u8 = 10;
 
 pub const CONTROL_FRAME_PAYLOAD_MAX: usize = 125;
+pub const SEND_FRAME_BUFS_MAX: usize = 8;
 
 const DEFAULT_MAX_WINDOW_BITS: u8 = 15;
 const SYNC_MARKER: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
@@ -861,8 +863,8 @@ where
         assert!(masked >= read);
         masked -= read;
 
-        let mut bufs_arr = MaybeUninit::<[&mut [u8]; VECTORED_MAX]>::uninit();
-        let mut bufs = src.read_bufs_mut(&mut bufs_arr).limit(masked);
+        let mut scratch = MaybeUninit::<[&mut [u8]; BUFFER_BUFS_MAX]>::uninit();
+        let mut bufs = src.read_bufs_mut(&mut scratch).limit(masked);
 
         apply_mask_vectored(bufs.as_slice(), mask, mask_offset + read);
     }
@@ -1024,6 +1026,10 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Protocol<T> {
 
         let sending_frame = &mut *self.sending.frame.borrow_mut();
 
+        // Cap to some reasonable number of bufs so we can use a fixed array for vectored I/O
+        let (src, capped) = cap_bufs_mut(src, SEND_FRAME_BUFS_MAX);
+        let fin = fin && !capped;
+
         let mut src_len = 0;
         for buf in src.iter() {
             src_len += buf.len();
@@ -1064,7 +1070,8 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Protocol<T> {
         // revert. In the worst case, nothing will be written and all
         // the bytes will be reverted
         let size = with_mask(src, mask, payload_sent, |src| {
-            let mut out = ArrayVec::<&[u8], VECTORED_MAX>::new();
+            // Add 1 for the potential header
+            let mut out = ArrayVec::<&[u8], { SEND_FRAME_BUFS_MAX + 1 }>::new();
 
             if header_remaining > 0 {
                 out.push(&header[frame.sent..]);
@@ -1285,9 +1292,8 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> Protocol<T> {
                 // (including WouldBlock) we can propagate the error without
                 // data loss
                 if read == 0 && (state.enc_buf.len() > 0 || msg.enc_output_end) {
-                    // send_frame adds 1 element to vector
-                    let mut bufs_arr = MaybeUninit::<[&mut [u8]; VECTORED_MAX - 1]>::uninit();
-                    let bufs = state.enc_buf.read_bufs_mut(&mut bufs_arr);
+                    let mut scratch = MaybeUninit::<[&mut [u8]; BUFFER_BUFS_MAX]>::uninit();
+                    let bufs = state.enc_buf.read_bufs_mut(&mut scratch);
 
                     // Set on first frame
                     let rsv1 = opcode != OPCODE_CONTINUATION;

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -181,9 +181,9 @@ fn write_vectored_offset_inner<'a, W: Write>(
 }
 
 /// Stack-allocates space for N IoSlices and calls `write_vectored_offset_inner`.
-fn write_vectored_offset_sized<'a, W: Write, const N: usize>(
+fn write_vectored_offset_sized<W: Write, const N: usize>(
     writer: &mut W,
-    bufs: &[&'a [u8]],
+    bufs: &[&[u8]],
     first_buf_offset: usize,
 ) -> Result<usize, io::Error> {
     // SAFETY: Creating an uninitialized array of MaybeUninit is always safe

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -1187,8 +1187,8 @@ mod tests {
         assert_eq!(r.remaining_capacity(), 3);
 
         r.write(b"678").unwrap();
-        let mut bufs_arr = [&b""[..]; 8];
-        let bufs = r.read_bufs(&mut bufs_arr);
+        let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+        let bufs = r.read_bufs(&mut scratch);
 
         assert_eq!(r.len(), 8);
         assert_eq!(r.remaining_capacity(), 0);
@@ -1222,8 +1222,8 @@ mod tests {
         r.write(b"12345").unwrap();
         r.read(&mut buf[..2]).unwrap();
 
-        let mut bufs_arr = [&b""[..]; 8];
-        let bufs = r.read_bufs(&mut bufs_arr);
+        let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+        let bufs = r.read_bufs(&mut scratch);
 
         assert_eq!(r.len(), 3);
         assert_eq!(r.read_buf(), b"345");
@@ -1242,8 +1242,8 @@ mod tests {
         r.write(b"6789a").unwrap();
         r.read(&mut buf[..2]).unwrap();
         r.write(b"bc").unwrap();
-        let mut bufs_arr = [&b""[..]; 8];
-        let bufs = r.read_bufs(&mut bufs_arr);
+        let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+        let bufs = r.read_bufs(&mut scratch);
 
         assert_eq!(r.len(), 8);
         assert_eq!(r.read_buf(), b"56789a");
@@ -1260,8 +1260,8 @@ mod tests {
 
         r.read(&mut buf[..6]).unwrap();
         r.write(b"def123").unwrap();
-        let mut bufs_arr = [&b""[..]; 8];
-        let bufs = r.read_bufs(&mut bufs_arr);
+        let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+        let bufs = r.read_bufs(&mut scratch);
 
         assert_eq!(r.len(), 8);
         assert_eq!(r.read_buf(), b"bc");
@@ -1271,8 +1271,8 @@ mod tests {
         assert_eq!(r.remaining_capacity(), 0);
 
         r.align();
-        let mut bufs_arr = [&b""[..]; 8];
-        let bufs = r.read_bufs(&mut bufs_arr);
+        let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+        let bufs = r.read_bufs(&mut scratch);
 
         assert_eq!(r.len(), 8);
         assert_eq!(r.read_buf(), b"bcdef123");

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -27,7 +27,9 @@ use std::slice;
 #[cfg(test)]
 use std::io::Read;
 
-pub const VECTORED_MAX: usize = 8;
+/// The maximum number of contiguous buffers that may be returned by Buffer trait methods.
+/// This is 2 in the case of RingBuffer due to its wraparound nature.
+pub const BUFFER_BUFS_MAX: usize = 2;
 
 pub fn trim_for_display(s: &str, max: usize) -> String {
     // NOTE: O(n)
@@ -150,6 +152,45 @@ impl Buffer for io::Cursor<&mut [u8]> {
     }
 }
 
+/// Converts a set of u8 slices to a set of IoSlices, skipping `first_buf_offset` bytes of the
+/// first slice, and writes them to `writer`. The caller must supply the memory to use for the
+/// IoSlices.
+fn write_vectored_offset_inner<'a, W: Write>(
+    writer: &mut W,
+    bufs: &[&'a [u8]],
+    first_buf_offset: usize,
+    scratch: &mut [MaybeUninit<io::IoSlice<'a>>],
+) -> Result<usize, io::Error> {
+    let mut count = 0;
+
+    for (i, (&buf, out)) in bufs.iter().zip(scratch.iter_mut()).enumerate() {
+        let buf = if i == 0 {
+            &buf[first_buf_offset..]
+        } else {
+            buf
+        };
+
+        out.write(io::IoSlice::new(buf));
+        count += 1;
+    }
+
+    // SAFETY: we just initialized count elements
+    let bufs = unsafe { slice::from_raw_parts(scratch.as_ptr() as *const io::IoSlice, count) };
+
+    writer.write_vectored(bufs)
+}
+
+/// Stack-allocates space for N IoSlices and calls `write_vectored_offset_inner`.
+fn write_vectored_offset_sized<'a, W: Write, const N: usize>(
+    writer: &mut W,
+    bufs: &[&'a [u8]],
+    first_buf_offset: usize,
+) -> Result<usize, io::Error> {
+    // SAFETY: Creating an uninitialized array of MaybeUninit is always safe
+    let mut scratch: [MaybeUninit<io::IoSlice>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+    write_vectored_offset_inner(writer, bufs, first_buf_offset, &mut scratch)
+}
+
 pub fn write_vectored_offset<W: Write>(
     writer: &mut W,
     bufs: &[&[u8]],
@@ -177,17 +218,45 @@ pub fn write_vectored_offset<W: Write>(
         start += 1;
     }
 
-    let mut arr = [io::IoSlice::new(&b""[..]); VECTORED_MAX];
-    let mut arr_len = 0;
+    let bufs = &bufs[start..];
 
-    for (index, &buf) in bufs.iter().enumerate().skip(start) {
-        let buf = if index == start { &buf[offset..] } else { buf };
-
-        arr[arr_len] = io::IoSlice::new(buf);
-        arr_len += 1;
+    // Dispatch to appropriately sized function
+    match bufs.len() {
+        0..=8 => write_vectored_offset_sized::<W, 8>(writer, bufs, offset),
+        9..=16 => write_vectored_offset_sized::<W, 16>(writer, bufs, offset),
+        17..=32 => write_vectored_offset_sized::<W, 32>(writer, bufs, offset),
+        33..=64 => write_vectored_offset_sized::<W, 64>(writer, bufs, offset),
+        65..=128 => write_vectored_offset_sized::<W, 128>(writer, bufs, offset),
+        129..=256 => write_vectored_offset_sized::<W, 256>(writer, bufs, offset),
+        257..=512 => write_vectored_offset_sized::<W, 512>(writer, bufs, offset),
+        513..=1024 => write_vectored_offset_sized::<W, 1024>(writer, bufs, offset),
+        _ => {
+            // Fall back to heap allocation for truly massive cases
+            let mut scratch = vec![MaybeUninit::uninit(); bufs.len()];
+            write_vectored_offset_inner(writer, bufs, offset, &mut scratch)
+        }
     }
+}
 
-    writer.write_vectored(&arr[..arr_len])
+/// Returns a potentially smaller slice and a flag set to true if the slice is smaller.
+pub fn cap_bufs<'a, 'b: 'a>(bufs: &'a [&'b [u8]], max: usize) -> (&'a [&'b [u8]], bool) {
+    if bufs.len() > max {
+        (&bufs[..max], true)
+    } else {
+        (bufs, false)
+    }
+}
+
+/// Returns a potentially smaller slice and a flag set to true if the slice is smaller.
+pub fn cap_bufs_mut<'a, 'b: 'a>(
+    bufs: &'a mut [&'b mut [u8]],
+    max: usize,
+) -> (&'a mut [&'b mut [u8]], bool) {
+    if bufs.len() > max {
+        (&mut bufs[..max], true)
+    } else {
+        (bufs, false)
+    }
 }
 
 struct LimitBufsRestore<T> {
@@ -1118,7 +1187,7 @@ mod tests {
         assert_eq!(r.remaining_capacity(), 3);
 
         r.write(b"678").unwrap();
-        let mut bufs_arr = [&b""[..]; VECTORED_MAX];
+        let mut bufs_arr = [&b""[..]; 8];
         let bufs = r.read_bufs(&mut bufs_arr);
 
         assert_eq!(r.len(), 8);
@@ -1153,7 +1222,7 @@ mod tests {
         r.write(b"12345").unwrap();
         r.read(&mut buf[..2]).unwrap();
 
-        let mut bufs_arr = [&b""[..]; VECTORED_MAX];
+        let mut bufs_arr = [&b""[..]; 8];
         let bufs = r.read_bufs(&mut bufs_arr);
 
         assert_eq!(r.len(), 3);
@@ -1173,7 +1242,7 @@ mod tests {
         r.write(b"6789a").unwrap();
         r.read(&mut buf[..2]).unwrap();
         r.write(b"bc").unwrap();
-        let mut bufs_arr = [&b""[..]; VECTORED_MAX];
+        let mut bufs_arr = [&b""[..]; 8];
         let bufs = r.read_bufs(&mut bufs_arr);
 
         assert_eq!(r.len(), 8);
@@ -1191,7 +1260,7 @@ mod tests {
 
         r.read(&mut buf[..6]).unwrap();
         r.write(b"def123").unwrap();
-        let mut bufs_arr = [&b""[..]; VECTORED_MAX];
+        let mut bufs_arr = [&b""[..]; 8];
         let bufs = r.read_bufs(&mut bufs_arr);
 
         assert_eq!(r.len(), 8);
@@ -1202,7 +1271,7 @@ mod tests {
         assert_eq!(r.remaining_capacity(), 0);
 
         r.align();
-        let mut bufs_arr = [&b""[..]; VECTORED_MAX];
+        let mut bufs_arr = [&b""[..]; 8];
         let bufs = r.read_bufs(&mut bufs_arr);
 
         assert_eq!(r.len(), 8);

--- a/src/core/http1/client.rs
+++ b/src/core/http1/client.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use crate::core::buffer::{Buffer, BufferBudget, VecRingBuffer, VECTORED_MAX};
+use crate::core::buffer::{Buffer, BufferBudget, VecRingBuffer, BUFFER_BUFS_MAX};
 use crate::core::http1::error::Error;
 use crate::core::http1::protocol::{self, BodySize, Header, ParseScratch, ParseStatus};
 use crate::core::http1::util::*;
@@ -306,11 +306,8 @@ impl<'a, R: AsyncRead, W: AsyncWrite> RequestBody<'a, R, W> {
 
                     let req_body = w.req_body.take().unwrap();
 
-                    // req_body.send() expects the input to leave room for at
-                    // least two more buffers in case chunked encoding is
-                    // used (for chunked header and footer)
-                    let mut buf_arr = [&b""[..]; VECTORED_MAX - 2];
-                    let bufs = w.buf.read_bufs(&mut buf_arr);
+                    let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+                    let bufs = w.buf.read_bufs(&mut scratch);
 
                     match req_body.send(
                         &mut StdWriteWrapper::new(Pin::new(&mut w.stream), cx),

--- a/src/core/http1/protocol.rs
+++ b/src/core/http1/protocol.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::collapsible_else_if)]
 
-use crate::core::buffer::{write_vectored_offset, FilledBuf, LimitBufs, VECTORED_MAX};
+use crate::core::buffer::{cap_bufs, write_vectored_offset, FilledBuf, LimitBufs};
 use arrayvec::ArrayVec;
 use std::cmp;
 use std::convert::TryFrom;
@@ -30,6 +30,8 @@ use std::str;
 const CHUNK_SIZE_MAX: usize = 0xffff;
 const CHUNK_HEADER_SIZE_MAX: usize = 6; // Ffff\r\n
 const CHUNK_FOOTER: &[u8] = b"\r\n";
+
+const SEND_BODY_BUFS_MAX: usize = 8;
 
 fn parse_as_int(src: &[u8]) -> Result<usize, io::Error> {
     let int_str = str::from_utf8(src);
@@ -293,6 +295,7 @@ fn write_chunk<W: Write>(
     chunk: &mut Option<Chunk>,
     max_size: usize,
 ) -> Result<usize, io::Error> {
+    assert!(content.len() <= SEND_BODY_BUFS_MAX);
     assert!(max_size <= CHUNK_SIZE_MAX);
 
     let mut content_len = 0;
@@ -327,11 +330,13 @@ fn write_chunk<W: Write>(
 
     let total = cheader.len() + data_size + footer.len();
 
-    let mut content = ArrayVec::<&[u8], { VECTORED_MAX - 2 }>::try_from(content).unwrap();
+    // Make the slice set mutable so we can limit it
+    let mut content = ArrayVec::<&[u8], { SEND_BODY_BUFS_MAX }>::try_from(content).unwrap();
     let content = content.as_mut_slice().limit(data_size);
 
     let size = {
-        let mut out = ArrayVec::<&[u8], VECTORED_MAX>::new();
+        // Add 2 for header and footer
+        let mut out = ArrayVec::<&[u8], { SEND_BODY_BUFS_MAX + 2 }>::new();
 
         out.push(cheader);
 
@@ -1043,6 +1048,10 @@ impl<'buf, 'headers> ServerProtocol {
     ) -> Result<usize, Error> {
         assert_eq!(self.state, ServerState::SendingBody);
 
+        // Cap to some reasonable number of bufs so we can use a fixed array for vectored I/O
+        let (src, capped) = cap_bufs(src, SEND_BODY_BUFS_MAX);
+        let end = end && !capped;
+
         let mut src_len = 0;
         for buf in src.iter() {
             src_len += buf.len();
@@ -1310,6 +1319,10 @@ impl ClientRequestBody {
         headers: Option<&[u8]>,
     ) -> SendStatus<ClientResponse, Self, Error> {
         let state = &mut self.state;
+
+        // Cap to some reasonable number of bufs so we can use a fixed array for vectored I/O
+        let (src, capped) = cap_bufs(src, SEND_BODY_BUFS_MAX);
+        let end = end && !capped;
 
         let mut src_len = 0;
         for buf in src.iter() {

--- a/src/core/http1/server.rs
+++ b/src/core/http1/server.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use crate::core::buffer::{Buffer, BufferBudget, ContiguousBuffer, VecRingBuffer, VECTORED_MAX};
+use crate::core::buffer::{Buffer, BufferBudget, ContiguousBuffer, VecRingBuffer, BUFFER_BUFS_MAX};
 use crate::core::http1::error::Error;
 use crate::core::http1::protocol::{self, BodySize, Header, ParseScratch, ParseStatus};
 use crate::core::http1::util::*;
@@ -767,11 +767,8 @@ impl<R: AsyncRead, W: AsyncWrite> ResponseBody<'_, R, W> {
                         return Some(Ok(0));
                     }
 
-                    // protocol.send_body() expects the input to leave room
-                    // for at least two more buffers in case chunked encoding
-                    // is used (for chunked header and footer)
-                    let mut buf_arr = [&b""[..]; VECTORED_MAX - 2];
-                    let bufs = w.buf.read_bufs(&mut buf_arr);
+                    let mut scratch = [&b""[..]; BUFFER_BUFS_MAX];
+                    let bufs = w.buf.read_bufs(&mut scratch);
 
                     match w.protocol.send_body(
                         &mut StdWriteWrapper::new(Pin::new(&mut w.stream), cx),


### PR DESCRIPTION
This PR makes `write_vectored_offset` support an unbounded number of input slices, making the API more ergonomic and enabling the possibility of writing outbound HTTP requests using sets of potentially hundreds of slices.

Background: `write_vectored_offset` is a convenience function that makes it easier to perform vectored I/O, by accepting a byte offset in addition to the slices to write. If a partial write occurs, the caller can simply write again with the same set of slices and an increased offset, without having to recalculate a new set of slices starting from some arbitrary position.

Currently, `write_vectored_offset` accepts no more than `VECTORED_MAX` input slices, set to a modest value of 8. This is mainly because vectored I/O operations take `IoSlice` instead of standard u8 slices, and having a fixed maximum allows the function to take u8 slices and convert them internally without heap allocations. Of course, this approach is restrictive: the number of input slices can't be large, and callers have to tiptoe around the limit.

This PR makes the function accept any number slices by having it delegate to a function with a const generic parameter `N` for the number of IoSlices to stack-allocate, based on the nearest power of 2, and if the number of slices is very large then it falls back to allocating the IoSlices on the heap.

A nice consequence of this is callers no longer have to worry about hitting a ceiling, so `VECTORED_MAX` is removed. Some other constants take its place:

* `BUFFER_BUFS_MAX`: The most number of slices that the `Buffer` trait methods might return. This is currently 2, in the case of `RingBuffer`. It can be used directly with such method calls, without needing to calculate relative sizes based on `VECTORED_MAX` which is now gone.
* `SEND_BODY_BUFS_MAX`, `SEND_FRAME_BUFS_MAX`: These are reasonable limits for when writing HTTP body or WebSocket message content. They are needed for certain stack allocated arrays that were previously leaning on `VECTORED_MAX` as a way to achieve reasonableness. We just use 8 again here. In practice, the number of input buffers will typically be no more than 2 (from ring buffers), but more is allowed in case that ever happens, and the behavior is graceful if the max is ever hit.