### PR TITLE
connmgr: add ability to send large outbound request headers

### DIFF
--- a/src/connmgr/client.rs
+++ b/src/connmgr/client.rs
@@ -3214,9 +3214,9 @@ pub mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn test_task_sizes() {
-        // Sizes in debug mode at commit 6b636f8842149e351dd3c29a5d133737e2a8fdef
-        const REQ_TASK_SIZE_BASE: usize = 6888;
-        const STREAM_TASK_SIZE_BASE: usize = 13224;
+        // Sizes in debug mode at commit TBD
+        const REQ_TASK_SIZE_BASE: usize = 7064;
+        const STREAM_TASK_SIZE_BASE: usize = 15744;
 
         // Cause tests to fail if sizes grow too much
         const GROWTH_LIMIT: usize = 1000;

--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -4539,6 +4539,8 @@ where
     let stream = RefCell::new(stream);
     let req = client::Request::new(io_split(&stream), buf1, buf2);
 
+    let mut headers = ArrayVec::<http1::Header, HEADERS_MAX>::new();
+
     let req_header = {
         let rdata = match &zreq.ptype {
             zhttppacket::RequestPacket::Data(data) => data,
@@ -4546,8 +4548,6 @@ where
         };
 
         let host_port = &url[url::Position::BeforeHost..url::Position::AfterPort];
-
-        let mut headers = ArrayVec::<http1::Header, HEADERS_MAX>::new();
 
         headers.push(http1::Header {
             name: "Host",
@@ -5002,7 +5002,11 @@ where
 
     let req = client::Request::new(io_split(&stream), buf1, buf2);
 
-    let (req_header, ws_key, overflow) = {
+    let mut ws_key = None;
+    let mut ws_ext = ArrayVec::<u8, 512>::new();
+    let mut headers = ArrayVec::<http1::Header, HEADERS_MAX>::new();
+
+    let (req_header, overflow) = {
         let rdata = match &zreq.ptype {
             zhttppacket::RequestPacket::Data(data) => data,
             _ => return Err(Error::BadRequest),
@@ -5012,15 +5016,13 @@ where
 
         let host_port = &url[url::Position::BeforeHost..url::Position::AfterPort];
 
-        let ws_key = if websocket { Some(gen_ws_key()) } else { None };
+        if websocket {
+            ws_key = Some(gen_ws_key());
+        }
 
         if !websocket && rdata.more {
             follow_redirects = false;
         }
-
-        let mut ws_ext = ArrayVec::<u8, 512>::new();
-
-        let mut headers = ArrayVec::<http1::Header, HEADERS_MAX>::new();
 
         headers.push(http1::Header {
             name: "Host",
@@ -5152,7 +5154,7 @@ where
             req.prepare_header(method, path, &headers, body_size, false, initial_body, end)?
         };
 
-        (req_header, ws_key, overflow)
+        (req_header, overflow)
     };
 
     // Send request header

--- a/src/core/http1/client.rs
+++ b/src/core/http1/client.rs
@@ -19,7 +19,7 @@ use crate::core::buffer::{Buffer, BufferBudget, VecRingBuffer, BUFFER_BUFS_MAX};
 use crate::core::http1::error::Error;
 use crate::core::http1::protocol::{self, BodySize, Header, ParseScratch, ParseStatus};
 use crate::core::http1::util::*;
-use crate::core::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadHalf, StdWriteWrapper, WriteHalf};
+use crate::core::io::{AsyncRead, AsyncWrite, ReadHalf, StdWriteWrapper, WriteHalf};
 use crate::core::select::{select_2, Select2};
 use std::cell::RefCell;
 use std::io::{self, Write};
@@ -31,7 +31,7 @@ use std::str;
 pub struct Request<'a, R: AsyncRead, W: AsyncWrite> {
     r: ReadHalf<'a, R>,
     w: WriteHalf<'a, W>,
-    hbuf: &'a mut VecRingBuffer,
+    buf1: &'a mut VecRingBuffer,
     bbuf: &'a mut VecRingBuffer,
 }
 
@@ -44,79 +44,136 @@ impl<'a, R: AsyncRead, W: AsyncWrite> Request<'a, R, W> {
         Self {
             r: stream.0,
             w: stream.1,
-            hbuf: buf1,
+            buf1,
             bbuf: buf2,
         }
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn prepare_header(
+    pub fn prepare_header<'b>(
         self,
-        method: &str,
-        uri: &str,
-        headers: &[Header<'_>],
+        method: &'b str,
+        uri: &'b str,
+        headers: &'b [Header<'b>],
         body_size: BodySize,
         websocket: bool,
         initial_body: &[u8],
         end: bool,
-    ) -> Result<RequestHeader<'a, R, W>, Error> {
-        let req = protocol::ClientRequest::new();
-
-        let size_limit = self.hbuf.capacity();
-
-        let req_body = match req.send_header(self.hbuf, method, uri, headers, body_size, websocket)
-        {
-            protocol::SendHeaderStatus::Complete(req_body) => req_body,
-            protocol::SendHeaderStatus::Partial(_) | protocol::SendHeaderStatus::Error(_, _) => {
-                return Err(Error::RequestTooLarge(size_limit))
-            }
-        };
-
+    ) -> Result<RequestHeader<'a, 'b, R, W>, Error> {
         if self.bbuf.write_all(initial_body).is_err() {
             return Err(Error::BufferExceeded);
         }
 
         Ok(RequestHeader {
-            r: self.r,
-            w: self.w,
-            hbuf: self.hbuf,
+            buf1: self.buf1,
             bbuf: self.bbuf,
-            req_body,
             end,
+            r: self.r,
+            w: RefCell::new(RequestHeaderWrite {
+                stream: self.w,
+                method,
+                uri,
+                headers,
+                body_size,
+                websocket,
+                req: Some(protocol::ClientRequest::new()),
+            }),
         })
     }
 }
 
-pub struct RequestHeader<'a, R: AsyncRead, W: AsyncWrite> {
-    r: ReadHalf<'a, R>,
-    w: WriteHalf<'a, W>,
-    hbuf: &'a mut VecRingBuffer,
-    bbuf: &'a mut VecRingBuffer,
-    req_body: protocol::ClientRequestBody,
-    end: bool,
+struct RequestHeaderWrite<'a, 'b, W: AsyncWrite> {
+    stream: WriteHalf<'a, W>,
+    method: &'b str,
+    uri: &'b str,
+    headers: &'b [Header<'b>],
+    body_size: BodySize,
+    websocket: bool,
+    req: Option<protocol::ClientRequest>,
 }
 
-impl<'a, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, R, W> {
-    pub async fn send(mut self) -> Result<RequestBody<'a, R, W>, Error> {
-        while self.hbuf.len() > 0 {
-            let size = self.w.write(Buffer::read_buf(self.hbuf)).await?;
-            self.hbuf.read_commit(size);
-        }
+pub struct RequestHeader<'a, 'b, R: AsyncRead, W: AsyncWrite> {
+    buf1: &'a mut VecRingBuffer, // Unused at this step but passed along
+    bbuf: &'a mut VecRingBuffer,
+    end: bool,
+    r: ReadHalf<'a, R>,
+    w: RefCell<RequestHeaderWrite<'a, 'b, W>>,
+}
 
-        Ok(RequestBody {
-            inner: RefCell::new(Some(RequestBodyInner {
-                r: RefCell::new(RequestBodyRead {
-                    stream: self.r,
-                    buf: self.hbuf,
-                }),
-                w: RefCell::new(RequestBodyWrite {
-                    stream: self.w,
-                    buf: self.bbuf,
-                    req_body: Some(self.req_body),
-                    end: self.end,
-                }),
-            })),
-        })
+impl<'a, R: AsyncRead, W: AsyncWrite> RequestHeader<'a, '_, R, W> {
+    pub async fn send(self) -> Result<RequestBody<'a, R, W>, Error> {
+        // Use AsyncOperation pattern like RequestBody::send()
+        let result = AsyncOperation::new(
+            |cx| {
+                let w = &mut *self.w.borrow_mut();
+
+                // Keep trying to write until complete or would block
+                loop {
+                    if !w.stream.is_writable() {
+                        // Writer not ready, try again later
+                        return None;
+                    }
+
+                    let req = w.req.take().unwrap();
+
+                    match req.send_header(
+                        &mut StdWriteWrapper::new(Pin::new(&mut w.stream), cx),
+                        w.method,
+                        w.uri,
+                        w.headers,
+                        w.body_size,
+                        w.websocket,
+                    ) {
+                        protocol::SendHeaderStatus::Complete(req_body) => {
+                            // Headers sent successfully
+                            return Some(Ok(req_body));
+                        }
+                        protocol::SendHeaderStatus::Partial(req) => {
+                            // Partial write, try again immediately
+                            w.req = Some(req);
+                        }
+                        protocol::SendHeaderStatus::Error(req, e) => {
+                            match e {
+                                protocol::Error::Io(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                                    // Writer not ready, try again later
+                                    w.req = Some(req);
+                                    return None;
+                                }
+                                _ => {}
+                            }
+
+                            return Some(Err(e.into()));
+                        }
+                    }
+                }
+            },
+            || {
+                self.w.borrow_mut().stream.cancel();
+            },
+        )
+        .await;
+
+        match result {
+            Ok(req_body) => {
+                let w = self.w.into_inner();
+
+                Ok(RequestBody {
+                    inner: RefCell::new(Some(RequestBodyInner {
+                        r: RefCell::new(RequestBodyRead {
+                            stream: self.r,
+                            buf: self.buf1,
+                        }),
+                        w: RefCell::new(RequestBodyWrite {
+                            stream: w.stream,
+                            buf: self.bbuf,
+                            req_body: Some(req_body),
+                            end: self.end,
+                        }),
+                    })),
+                })
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -676,7 +733,7 @@ mod tests {
     use crate::core::io::{AsyncRead, AsyncWrite};
     use std::cell::RefCell;
     use std::future::Future;
-    use std::io::{self, Read, Write};
+    use std::io::{self, Read};
     use std::pin::Pin;
     use std::rc::Rc;
     use std::task::{Context, Poll};
@@ -690,6 +747,7 @@ mod tests {
     struct FakeStream {
         in_data: std::io::Cursor<Vec<u8>>,
         out_data: Vec<u8>,
+        write_limit: Option<(usize, usize)>,
     }
 
     impl FakeStream {
@@ -697,6 +755,15 @@ mod tests {
             Self {
                 in_data: std::io::Cursor::new(Vec::new()),
                 out_data: Vec::new(),
+                write_limit: None,
+            }
+        }
+
+        fn with_write_limit(size: usize) -> Self {
+            Self {
+                in_data: std::io::Cursor::new(Vec::new()),
+                out_data: Vec::new(),
+                write_limit: Some((size, size)),
             }
         }
     }
@@ -719,7 +786,24 @@ mod tests {
             _cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<Result<usize, io::Error>> {
-            Poll::Ready(self.out_data.write(buf))
+            let write_size = if let Some((left, max)) = self.write_limit.take() {
+                if left == 0 {
+                    // Replenish and yield
+                    self.write_limit = Some((max, max));
+                    return Poll::Pending;
+                }
+
+                let size = std::cmp::min(buf.len(), left);
+                self.write_limit = Some((left - size, max));
+
+                size
+            } else {
+                buf.len()
+            };
+
+            self.out_data.extend_from_slice(&buf[..write_size]);
+
+            Poll::Ready(Ok(write_size))
         }
 
         fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
@@ -927,5 +1011,99 @@ mod tests {
         let waker = std::sync::Arc::new(NoopWaker).into();
         let mut cx = Context::from_waker(&waker);
         assert!(fut.as_mut().poll(&mut cx).is_ready());
+    }
+
+    #[test]
+    fn test_request_partial_writes() {
+        let mut fut = pin!(async {
+            // Test that vectored sending handles partial writes correctly
+            let tmp = Rc::new(TmpBuffer::new(1024));
+            let mut buf1 = VecRingBuffer::new(256, &tmp);
+            let mut buf2 = VecRingBuffer::new(256, &tmp);
+
+            // Use a stream that only writes 20 bytes at a time to force partial writes
+            let mut stream = FakeStream::with_write_limit(20);
+
+            let stream_cell = RefCell::new(&mut stream);
+            let (r, w) = crate::core::io::io_split(&stream_cell);
+
+            let req = Request::new((r, w), &mut buf1, &mut buf2);
+
+            let headers = [
+                Header {
+                    name: "Host",
+                    value: b"example.com",
+                },
+                Header {
+                    name: "User-Agent",
+                    value: b"test-agent-with-a-very-long-name",
+                },
+                Header {
+                    name: "Content-Type",
+                    value: b"application/json",
+                },
+                Header {
+                    name: "Content-Length",
+                    value: b"0",
+                },
+            ];
+
+            let req_header = req
+                .prepare_header(
+                    "POST",
+                    "/api/v1/test",
+                    &headers,
+                    BodySize::Known(0),
+                    false,
+                    b"",
+                    true,
+                )
+                .unwrap();
+
+            // This should handle multiple partial writes and eventually succeed
+            let _req_body = req_header.send().await.unwrap();
+
+            // Verify that data was written (even with partial writes)
+            assert!(!stream.out_data.is_empty(), "No data was written");
+
+            let output = String::from_utf8_lossy(&stream.out_data);
+            assert!(
+                output.contains("POST /api/v1/test HTTP/1.1\r\n"),
+                "Missing request line"
+            );
+            assert!(
+                output.contains("Host: example.com\r\n"),
+                "Missing Host header"
+            );
+            assert!(output.ends_with("\r\n\r\n"), "Missing final CRLF");
+
+            println!(
+                "Partial write test output ({} bytes):\n{}",
+                stream.out_data.len(),
+                output
+            );
+        });
+
+        let waker = std::sync::Arc::new(NoopWaker).into();
+        let mut cx = Context::from_waker(&waker);
+
+        // Poll multiple times to handle partial writes
+        let mut poll_count = 0;
+        loop {
+            match fut.as_mut().poll(&mut cx) {
+                std::task::Poll::Ready(_) => break,
+                std::task::Poll::Pending => {
+                    poll_count += 1;
+                    if poll_count > 10 {
+                        panic!(
+                            "Too many polls ({}) - operation should have completed",
+                            poll_count
+                        );
+                    }
+                }
+            }
+        }
+
+        println!("Completed after {} polls", poll_count + 1);
     }
 }


### PR DESCRIPTION
Following #48365, this PR implements support for large outbound request headers.

Currently, `http1::client::Request::prepare_header` serializes its inputs (method, URI, headers) to a buffer and returns a `RequestHeader` instance. Then the async method `RequestHeader::send` writes the buffer to the socket. This PR reworks things such that `prepare_header` borrows its inputs without doing any serialization, keeping them in the `RequestHeader` instance, and then the `send` method writes the inputs directly to the socket, with resumption for partial writes.

The resulting API is essentially the same except callers have to ensure the inputs live until `send` completes, so some variables are moved around near call sites to achieve this.

Note: moving variables around in order to extend their lifetimes caused the async task sizes to increase beyond our latest thresholds. I'll see about optimizing the sizes afterwards, but if nothing can be done I think it's fine.

The underlying `http1::protocol::ClientRequest::send_header` function, like many of our low level I/O functions, is synchronous and operates on a `Write` implementation. In order to operate on an `AsyncWrite` implementation from within an async function, we use a pattern involving two convenience wrappers, `StdWriteWrapper` and `AsyncOperation`. `StdWriteWrapper` implements `Write` on anything that implements `AsyncWrite`. With it, an async socket object can be passed to `send_header`. `AsyncOperation` is then used to wrap the call and present it as a future that can be awaited.

Below is a manual test of ~20kb headers proxied from pushpin to nginx, using an 8kb block size in pushpin.

Before:

```
% curl -i -H "@largeheaders.txt" http://localhost:7999
HTTP/1.1 502 Bad Gateway
Content-Type: text/plain
Content-Length: 32

Error while proxying to origin.
```

Logs:

```
[DEBUG] 2026-06-16 10:44:11.549 [connmgr] [pushpin::connmgr::connection] client-conn 0-0-969f22eb-aa0c-41c7-ac78-17f58c90232c: process error: CoreHttp(RequestTooLarge(8192))
```

After:

```
% curl -i -H "@largeheaders.txt" http://localhost:7999
HTTP/1.1 200 OK
Server: nginx/1.29.8
Date: Tue, 16 Jun 2026 17:46:31 GMT
Content-Type: text/html
Last-Modified: Tue, 07 Apr 2026 11:41:31 GMT
ETag: "69d4ed6b-380"
Accept-Ranges: bytes
Content-Length: 896

<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
...
```