### PR TITLE
http1: return error if send_response returns incomplete

### DIFF
--- a/src/core/http1/server.rs
+++ b/src/core/http1/server.rs
@@ -436,15 +436,19 @@ impl<'a, R: AsyncRead, W: AsyncWrite> Response<'a, R, W> {
         let header_size = {
             let mut buf = io::Cursor::new(inner.wbuf.write_buf());
 
-            if inner
+            match inner
                 .protocol
                 .send_response(&mut buf, code, reason, headers, body_size, 0)
-                .is_err()
             {
-                // enable prepare_header to be called again
-                inner.wbuf.clear();
+                Ok(None) => {}
+                Ok(Some(_)) | Err(_) => {
+                    // Partial write, or error due to input being too large
 
-                return Err(Error::ResponseTooLarge(size_limit));
+                    // Enable prepare_header to be called again
+                    inner.wbuf.clear();
+
+                    return Err(Error::ResponseTooLarge(size_limit));
+                }
             }
 
             buf.position() as usize


### PR DESCRIPTION
A small fix before this code gets replaced. Currently, if `send_response` returns `Some` to indicate the write to the buffer was incomplete, we treat the call as successful. Instead, we should treat it as unsuccessful, same as `Err`.