### PR TITLE
add urlquery as a wrapper around qurlquery

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -2,6 +2,7 @@ HEADERS += \
 	$$PWD/cowbytearray.h \
 	$$PWD/cowstring.h \
 	$$PWD/url.h \
+	$$PWD/urlquery.h \
 	$$PWD/variant.h
 
 HEADERS += \

--- a/src/core/urlquery.h
+++ b/src/core/urlquery.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef URLQUERY_H
+#define URLQUERY_H
+
+#include "url.h"
+#include <QString>
+#include <QStringList>
+#include <QUrlQuery>
+
+class UrlQuery {
+public:
+    // Constructors
+    UrlQuery() = default;
+    explicit UrlQuery(const Url &url) : inner_(url) {}
+    explicit UrlQuery(const QString &queryString) : inner_(queryString) {}
+    UrlQuery(const UrlQuery &other) : inner_(other.inner_) {}
+    UrlQuery(UrlQuery &&other) noexcept : inner_(std::move(other.inner_)) {}
+
+    // Assignment operators
+    UrlQuery &operator=(const UrlQuery &other) {
+        if (this != &other) {
+            inner_ = other.inner_;
+        }
+        return *this;
+    }
+    UrlQuery &operator=(UrlQuery &&other) noexcept {
+        if (this != &other) {
+            inner_ = std::move(other.inner_);
+        }
+        return *this;
+    }
+
+    // Comparison operators
+    bool operator==(const UrlQuery &other) const { return inner_ == other.inner_; }
+    bool operator!=(const UrlQuery &other) const { return inner_ != other.inner_; }
+
+    // Query manipulation
+    void clear() { inner_.clear(); }
+    bool isEmpty() const { return inner_.isEmpty(); }
+
+    // Item management
+    void addQueryItem(const QString &key, const QString &value) { inner_.addQueryItem(key, value); }
+    void removeQueryItem(const QString &key) { inner_.removeQueryItem(key); }
+    void removeAllQueryItems(const QString &key) { inner_.removeAllQueryItems(key); }
+
+    // Item access
+    bool hasQueryItem(const QString &key) const { return inner_.hasQueryItem(key); }
+    QString queryItemValue(const QString &key,
+                           Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+        return inner_.queryItemValue(key, encoding);
+    }
+    QStringList
+    allQueryItemValues(const QString &key,
+                       Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+        return inner_.allQueryItemValues(key, encoding);
+    }
+    QList<QPair<QString, QString>>
+    queryItems(Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+        return inner_.queryItems(encoding);
+    }
+
+    // String conversion
+    QString toString(Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+        return inner_.toString(encoding);
+    }
+
+    // Access to underlying QUrlQuery for compatibility
+    const QUrlQuery &asQUrlQuery() const { return inner_; }
+    QUrlQuery &asQUrlQuery() { return inner_; }
+
+private:
+    QUrlQuery inner_;
+};
+
+#endif // URLQUERY_H

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -56,6 +56,7 @@
 #include "statsmanager.h"
 #include "timer.h"
 #include "tnetstring.h"
+#include "urlquery.h"
 #include "variant.h"
 #include "variantutil.h"
 #include "wscontrolmessage.h"
@@ -71,7 +72,6 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QUrlQuery>
 #include <algorithm>
 #include <assert.h>
 
@@ -290,7 +290,7 @@ private:
                 QByteArray jsonData;
 
                 if (!rule.jsonParam.isEmpty()) {
-                    QUrlQuery tmp(QString::fromUtf8(requestData.body));
+                    UrlQuery tmp(QString::fromUtf8(requestData.body));
                     jsonData = tmp.queryItemValue(rule.jsonParam, Url::FullyDecoded).toUtf8();
                 } else {
                     jsonData = requestData.body;

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -32,6 +32,7 @@
 #include "statsmanager.h"
 #include "test.h"
 #include "tnetstring.h"
+#include "urlquery.h"
 #include "variant.h"
 #include "zhttpmanager.h"
 #include "zhttprequestpacket.h"
@@ -352,7 +353,7 @@ private:
 
         QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
 
-        QUrlQuery query(zreq.uri.query());
+        UrlQuery query(zreq.uri.query());
         QString hold = query.queryItemValue("hold");
         bool bodyInstruct = (query.queryItemValue("body-instruct") == "true");
         bool large = (query.queryItemValue("large") == "true");

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -39,6 +39,7 @@
 #include "sockjsmanager.h"
 #include "statsmanager.h"
 #include "url.h"
+#include "urlquery.h"
 #include "variant.h"
 #include "xffrule.h"
 #include "zhttpmanager.h"
@@ -48,7 +49,6 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QUrlQuery>
 #include <assert.h>
 
 #define MAX_SHARED_REQUEST_BODY 100000
@@ -577,7 +577,7 @@ public:
             bodyParam = QString::fromUtf8(config.bodyParam);
 
         Url uri = requestData.uri;
-        QUrlQuery query(uri);
+        UrlQuery query(uri);
 
         // Two ways to activate JSON-P:
         // 1) callback param present
@@ -691,7 +691,7 @@ public:
             }
         }
 
-        uri.setQuery(query);
+        uri.setQuery(query.asQUrlQuery());
 
         // If we have no query items anymore, strip the '?'
         if (query.isEmpty()) {

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -28,6 +28,7 @@
 #include "qtcompat.h"
 #include "sockjssession.h"
 #include "timer.h"
+#include "urlquery.h"
 #include "variant.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
@@ -36,7 +37,6 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
-#include <QUrlQuery>
 #include <QtGlobal>
 #include <assert.h>
 
@@ -206,7 +206,7 @@ public:
         QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
         s->path = encPath.mid(basePathStart);
 
-        QUrlQuery query(uri);
+        UrlQuery query(uri);
 
         QList<QByteArray> parts = s->path.split('/');
         if (!parts.isEmpty() && parts.last().startsWith("jsonp")) {

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -30,13 +30,13 @@
 #include "qtcompat.h"
 #include "sockjsmanager.h"
 #include "timer.h"
+#include "urlquery.h"
 #include "variant.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QUrlQuery>
 #include <assert.h>
 
 using std::map;
@@ -345,7 +345,7 @@ public:
                 }
             } else // GET
             {
-                QUrlQuery query(_req->requestUri());
+                UrlQuery query(_req->requestUri());
                 param = query.queryItemValue("d").toUtf8();
             }
 

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -29,8 +29,8 @@
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "statusreasons.h"
+#include "urlquery.h"
 #include <QSet>
-#include <QUrlQuery>
 #include <assert.h>
 
 #define MAX_REQUEST_SIZE 100000
@@ -74,7 +74,7 @@ public:
 
         QSet<QString> channels;
 
-        QUrlQuery query(request.uri);
+        UrlQuery query(request.uri);
         QList<QPair<QString, QString>> queryItems = query.queryItems();
         for (int n = 0; n < queryItems.count(); ++n) {
             if (queryItems[n].first == "channel")

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -27,9 +27,9 @@
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "statusreasons.h"
+#include "urlquery.h"
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QUrlQuery>
 #include <assert.h>
 
 #define BUFFER_SIZE 200000
@@ -59,7 +59,7 @@ public:
 
         QSet<QString> channels;
 
-        QUrlQuery query(request.uri);
+        UrlQuery query(request.uri);
         QList<QPair<QString, QString>> queryItems = query.queryItems();
         for (int n = 0; n < queryItems.count(); ++n) {
             if (queryItems[n].first == "channel")

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -34,6 +34,7 @@
 #include "rust/bindings.h"
 #include "settings.h"
 #include "url.h"
+#include "urlquery.h"
 #include "zurlservice.h"
 #include <QCommandLineParser>
 #include <QCoreApplication>
@@ -41,7 +42,6 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QStringList>
-#include <QUrlQuery>
 
 struct ServiceConnections {
     Connection startedConnection;
@@ -483,7 +483,7 @@ public:
                     return;
                 }
 
-                QUrlQuery query(path.query());
+                UrlQuery query(path.query());
 
                 int mode = -1;
                 if (query.hasQueryItem("mode")) {


### PR DESCRIPTION
As part of migrating away from `QUrl`, this PR adds a wrapper to help with migrating away from a companion type, `QUrlQuery`.

Unlike `Url` which is currently an alias for `QUrl` until it is replaced with a substitute implementation, for `UrlQuery` I've gone straight to a wrapper. This way we have more control over it at the time the `Url` implementation is substituted. Notably, we'll be able to maintain a `UrlQuery(const Url &)` constructor through that transition, which would not be possible if `UrlQuery` were simply an alias for `QUrlQuery`.

After this lands, the plan is to replace the implementation of `Url` with one based on the Rust `url` crate. The `UrlQuery` type can remain Qt-backed through that transition, and later we can figure out how to substitute its implementation as well.