### PR TITLE
add c++ cowurl type, initially as a wrapper around qurl

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,9 +1,12 @@
 HEADERS += \
 	$$PWD/cowbytearray.h \
 	$$PWD/cowstring.h \
-	$$PWD/url.h \
+	$$PWD/cowurl.h \
 	$$PWD/urlquery.h \
 	$$PWD/variant.h
+
+SOURCES += \
+	$$PWD/cowurl.cpp
 
 HEADERS += \
 	$$PWD/zmqcontext.h \

--- a/src/core/cowurl.cpp
+++ b/src/core/cowurl.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cowurl.h"
+#include "urlquery.h"
+
+CowUrl CowUrl::fromEncoded(const QByteArray &input, [[maybe_unused]] ParsingMode mode) {
+    CowUrl url;
+    url.inner_ = QUrl::fromEncoded(input);
+    return url;
+}
+
+QString CowUrl::fromPercentEncoding(const QByteArray &input) {
+    return QUrl::fromPercentEncoding(input);
+}
+
+QByteArray CowUrl::toPercentEncoding(const QString &input) {
+    return QUrl::toPercentEncoding(input);
+}
+
+bool CowUrl::isValidRelativeUrl(const QString &relativeUrl) {
+    CowUrl dummyBase("http://example.com/");
+    return dummyBase.resolved(relativeUrl).isValid();
+}
+
+void CowUrl::setQuery(const QString &query) {
+    if (!query.isEmpty())
+        inner_.setQuery(query);
+    else
+        inner_.setQuery(QString());
+}
+
+void CowUrl::setQuery(const UrlQuery &query) { setQuery(query.toString()); }
+
+CowUrl CowUrl::resolved(const QString &relative) const {
+    if (!isValid() || relative.isEmpty())
+        return CowUrl();
+
+    CowUrl result;
+    result.inner_ = inner_.resolved(QUrl(relative));
+    return result;
+}

--- a/src/core/cowurl.h
+++ b/src/core/cowurl.h
@@ -17,10 +17,88 @@
 #ifndef COWURL_H
 #define COWURL_H
 
+#include <QByteArray>
+#include <QHash>
+#include <QString>
 #include <QUrl>
 
-// Type alias for copy-on-write URL handling - this will be replaced with a custom implementation
-// later
-using CowUrl = QUrl;
+class UrlQuery;
+
+// QUrl-like class that currently forwards to an inner QUrl, to assist with reducing direct
+// dependency on Qt. The API is designed to allow cheap conversion to/from QUrl.
+class CowUrl {
+public:
+    enum ParsingMode { StrictMode = 0 };
+
+    enum ComponentFormattingOptions : unsigned int {
+        PrettyDecoded = QUrl::PrettyDecoded,
+        FullyEncoded = QUrl::FullyEncoded,
+        FullyDecoded = QUrl::FullyDecoded
+    };
+
+    CowUrl() = default;
+    CowUrl(const QString &url, [[maybe_unused]] ParsingMode mode = StrictMode) : inner_(url) {}
+    CowUrl(const char *url) : inner_(url) {}
+    CowUrl(const CowUrl &other) = default;
+    CowUrl &operator=(const CowUrl &other) = default;
+
+    bool operator==(const CowUrl &other) const { return inner_ == other.inner_; }
+    bool operator!=(const CowUrl &other) const { return inner_ != other.inner_; }
+    bool operator<(const CowUrl &other) const {
+        return inner_.toString() < other.inner_.toString();
+    }
+
+    static CowUrl fromEncoded(const QByteArray &input, ParsingMode mode = StrictMode);
+    static QString fromPercentEncoding(const QByteArray &input);
+    static QByteArray toPercentEncoding(const QString &input);
+    static bool isValidRelativeUrl(const QString &relativeUrl);
+
+    bool isValid() const { return inner_.isValid() && !inner_.scheme().isEmpty(); }
+    bool isEmpty() const { return !isValid(); }
+    void clear() { inner_.clear(); }
+
+    void setScheme(const QString &scheme) { inner_.setScheme(scheme); }
+    QString scheme() const { return inner_.scheme(); }
+
+    QString path(ComponentFormattingOptions options = FullyEncoded) const {
+        return inner_.path(static_cast<QUrl::ComponentFormattingOptions>(options));
+    }
+    void setPath(const QString &path, [[maybe_unused]] ParsingMode mode = StrictMode) {
+        inner_.setPath(path);
+    }
+
+    QString query(ComponentFormattingOptions options = FullyEncoded) const {
+        if (!inner_.hasQuery())
+            return QString();
+        return inner_.query(static_cast<QUrl::ComponentFormattingOptions>(options));
+    }
+    bool hasQuery() const { return inner_.hasQuery(); }
+    void setQuery(const QString &query);
+    void setQuery(const UrlQuery &query);
+
+    QString host() const { return inner_.host(); }
+    void setHost(const QString &host) { inner_.setHost(host); }
+
+    int port() const { return inner_.port(); }
+    int port(int defaultPort) const { return inner_.port(defaultPort); }
+    void setPort(int port) { inner_.setPort(port); }
+
+    QString authority() const { return inner_.authority(); }
+
+    CowUrl resolved(const QString &relative) const;
+
+    QString toString(ComponentFormattingOptions options = FullyEncoded) const {
+        return inner_.toString(static_cast<QUrl::ComponentFormattingOptions>(options));
+    }
+    QByteArray toEncoded() const { return inner_.toEncoded(); }
+
+private:
+    friend uint qHash(const CowUrl &url, uint seed);
+
+    QUrl inner_;
+};
+
+// Hash function for CowUrl so it can be used in QHash
+inline uint qHash(const CowUrl &url, uint seed = 0) { return qHash(url.inner_, seed); }
 
 #endif // COWURL_H

--- a/src/core/cowurltest.cpp
+++ b/src/core/cowurltest.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2025 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cowurl.h"
+#include "test.h"
+
+static void basicUrlOperations() {
+    // Test construction and basic operations
+    CowUrl url("https://example.com/path?query=value");
+    TEST_ASSERT(url.isValid());
+    TEST_ASSERT(!url.isEmpty());
+    TEST_ASSERT_EQ(url.scheme(), QString("https"));
+    TEST_ASSERT_EQ(url.path(), QString("/path"));
+    TEST_ASSERT_EQ(url.query(), QString("query=value"));
+    TEST_ASSERT(url.hasQuery());
+
+    // Test toString
+    QString urlString = url.toString();
+    TEST_ASSERT(urlString.startsWith("https://example.com"));
+
+    // Test toEncoded
+    QByteArray encoded = url.toEncoded();
+    TEST_ASSERT(!encoded.isEmpty());
+}
+
+static void invalidUrl() {
+    CowUrl url("not a url");
+    TEST_ASSERT(!url.isValid());
+    TEST_ASSERT(url.isEmpty());
+    TEST_ASSERT_EQ(url.scheme(), QString());
+}
+
+static void emptyUrl() {
+    CowUrl url;
+    TEST_ASSERT(!url.isValid());
+    TEST_ASSERT(url.isEmpty());
+    TEST_ASSERT_EQ(url.scheme(), QString());
+}
+
+static void fromEncoded() {
+    // Valid URL with percent-encoded characters in the path
+    CowUrl url = CowUrl::fromEncoded("https://example.com/path%20with%20spaces?q=1");
+    TEST_ASSERT(url.isValid());
+    TEST_ASSERT_EQ(url.scheme(), QString("https"));
+    TEST_ASSERT_EQ(url.host(), QString("example.com"));
+
+    // Invalid input
+    CowUrl invalid = CowUrl::fromEncoded("not a url");
+    TEST_ASSERT(!invalid.isValid());
+    TEST_ASSERT(invalid.isEmpty());
+}
+
+static void schemeOperations() {
+    CowUrl url("http://example.com/path");
+    TEST_ASSERT_EQ(url.scheme(), QString("http"));
+
+    url.setScheme("https");
+    TEST_ASSERT_EQ(url.scheme(), QString("https"));
+}
+
+static void clearUrl() {
+    CowUrl url("https://example.com");
+    TEST_ASSERT(url.isValid());
+
+    url.clear();
+    TEST_ASSERT(!url.isValid());
+    TEST_ASSERT(url.isEmpty());
+}
+
+static void copyAndAssign() {
+    CowUrl url1("https://example.com");
+    CowUrl url2(url1); // Copy constructor
+
+    TEST_ASSERT_EQ(url1.scheme(), url2.scheme());
+
+    CowUrl url3;
+    url3 = url1; // Assignment operator
+    TEST_ASSERT_EQ(url1.scheme(), url3.scheme());
+}
+
+static void relativeUrlValidation() {
+    // Test valid relative URLs
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("/next"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("/path/to/resource"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("relative/path"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("?query=value"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("../parent"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("file.html"));
+
+    // Test valid absolute URLs (should also work)
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("http://example.com/path"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("https://example.com/"));
+
+    // Test invalid URLs
+    TEST_ASSERT(!CowUrl::isValidRelativeUrl("")); // Empty string
+    // Note: URL resolution is quite permissive, so truly invalid URLs are rare
+    // Most strings that look like paths are valid relative URLs
+}
+
+static void urlResolution() {
+    CowUrl base("http://example.com/path/current");
+
+    // Test that absolute URLs are returned as-is (not modified by base)
+    CowUrl absoluteResult1 = base.resolved(QString("http://other.com/different"));
+    TEST_ASSERT_EQ(absoluteResult1.toString(), QString("http://other.com/different"));
+
+    CowUrl absoluteResult2 = base.resolved(QString("https://secure.com/path"));
+    TEST_ASSERT_EQ(absoluteResult2.toString(), QString("https://secure.com/path"));
+
+    // Test relative URLs are properly resolved
+    CowUrl relativeResult1 = base.resolved(QString("/absolute-path"));
+    TEST_ASSERT_EQ(relativeResult1.host(), QString("example.com"));
+    TEST_ASSERT(relativeResult1.path().startsWith("/absolute-path"));
+
+    CowUrl relativeResult2 = base.resolved(QString("relative-file"));
+    TEST_ASSERT_EQ(relativeResult2.host(), QString("example.com"));
+    TEST_ASSERT(relativeResult2.toString().contains("relative-file"));
+
+    // Test query-only relative URLs
+    CowUrl queryResult = base.resolved(QString("?newquery=value"));
+    TEST_ASSERT_EQ(queryResult.host(), QString("example.com"));
+    TEST_ASSERT(queryResult.hasQuery());
+
+    // Test that our validation method works correctly for both cases
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("http://absolute.com/path")); // Absolute
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("/relative/path"));           // Relative
+
+    // Test other schemes (now supported via url crate's join method)
+    CowUrl ftpResult = base.resolved(QString("ftp://ftp.example.com/file"));
+    TEST_ASSERT_EQ(ftpResult.toString(), QString("ftp://ftp.example.com/file"));
+
+    // Test WebSocket URLs
+    CowUrl wsResult = base.resolved(QString("ws://websocket.example.com/socket"));
+    TEST_ASSERT_EQ(wsResult.toString(), QString("ws://websocket.example.com/socket"));
+
+    CowUrl wssResult = base.resolved(QString("wss://secure-websocket.example.com/socket"));
+    TEST_ASSERT_EQ(wssResult.toString(), QString("wss://secure-websocket.example.com/socket"));
+
+    // Test empty relative URL
+    CowUrl emptyResult = base.resolved(QString(""));
+    TEST_ASSERT(!emptyResult.isValid()); // Should return invalid URL
+
+    // Verify that absolute URLs resolve to themselves (unchanged)
+    QString absoluteUrl1 = "http://different.com/path";
+    QString absoluteUrl2 = "https://secure.example.org/api";
+
+    TEST_ASSERT_EQ(base.resolved(absoluteUrl1).toString(), absoluteUrl1);
+    TEST_ASSERT_EQ(base.resolved(absoluteUrl2).toString(), absoluteUrl2);
+
+    // Verify these absolute URLs are considered "valid relative URLs" by our validation method
+    TEST_ASSERT(CowUrl::isValidRelativeUrl(absoluteUrl1));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl(absoluteUrl2));
+
+    // Test that our validation method now supports more schemes too
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("ftp://ftp.example.com/file"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("ws://websocket.example.com/socket"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("wss://secure-websocket.example.com/socket"));
+    TEST_ASSERT(CowUrl::isValidRelativeUrl("file:///local/file.txt"));
+}
+
+extern "C" int cowurl_test(ffi::TestException *out_ex) {
+    TEST_CATCH(basicUrlOperations());
+    TEST_CATCH(invalidUrl());
+    TEST_CATCH(emptyUrl());
+    TEST_CATCH(fromEncoded());
+    TEST_CATCH(schemeOperations());
+    TEST_CATCH(clearUrl());
+    TEST_CATCH(copyAndAssign());
+    TEST_CATCH(relativeUrlValidation());
+    TEST_CATCH(urlResolution());
+
+    return 0;
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -133,6 +133,11 @@ mod tests {
         unsafe { ffi::cowstring_test(out_ex) == 0 }
     }
 
+    fn cowurl_test(out_ex: &mut TestException) -> bool {
+        // SAFETY: safe to call
+        unsafe { ffi::cowurl_test(out_ex) == 0 }
+    }
+
     fn httpheaders_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
         unsafe { ffi::httpheaders_test(out_ex) == 0 }
@@ -176,6 +181,11 @@ mod tests {
     #[test]
     fn cowstring() {
         run_cpp(cowstring_test);
+    }
+
+    #[test]
+    fn cowurl() {
+        run_cpp(cowurl_test);
     }
 
     #[test]

--- a/src/core/tests.pri
+++ b/src/core/tests.pri
@@ -1,6 +1,7 @@
 SOURCES += \
 	$$PWD/cowbytearraytest.cpp \
 	$$PWD/cowstringtest.cpp \
+	$$PWD/cowurltest.cpp \
 	$$PWD/httpheaderstest.cpp \
 	$$PWD/jwttest.cpp \
 	$$PWD/timertest.cpp \

--- a/src/core/urlquery.h
+++ b/src/core/urlquery.h
@@ -20,13 +20,14 @@
 #include "cowurl.h"
 #include <QString>
 #include <QStringList>
+#include <QUrl>
 #include <QUrlQuery>
 
 class UrlQuery {
 public:
     // Constructors
     UrlQuery() = default;
-    explicit UrlQuery(const CowUrl &url) : inner_(url) {}
+    explicit UrlQuery(const CowUrl &url) : inner_(url.query()) {}
     explicit UrlQuery(const QString &queryString) : inner_(queryString) {}
     UrlQuery(const UrlQuery &other) : inner_(other.inner_) {}
     UrlQuery(UrlQuery &&other) noexcept : inner_(std::move(other.inner_)) {}
@@ -63,21 +64,22 @@ public:
     QString
     queryItemValue(const QString &key,
                    CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
-        return inner_.queryItemValue(key, encoding);
+        return inner_.queryItemValue(key, static_cast<QUrl::ComponentFormattingOptions>(encoding));
     }
     QStringList
     allQueryItemValues(const QString &key,
                        CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
-        return inner_.allQueryItemValues(key, encoding);
+        return inner_.allQueryItemValues(key,
+                                         static_cast<QUrl::ComponentFormattingOptions>(encoding));
     }
     QList<QPair<QString, QString>>
     queryItems(CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
-        return inner_.queryItems(encoding);
+        return inner_.queryItems(static_cast<QUrl::ComponentFormattingOptions>(encoding));
     }
 
     // String conversion
     QString toString(CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
-        return inner_.toString(encoding);
+        return inner_.toString(static_cast<QUrl::ComponentFormattingOptions>(encoding));
     }
 
     // Access to underlying QUrlQuery for compatibility

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -441,10 +441,10 @@ HttpFilter::HttpFilter(Mode mode) {
 }
 
 void HttpFilter::start(const Filter::Context &context, const QByteArray &content) {
-    CowUrl url = CowUrl(context.subscriptionMeta.value("url"), CowUrl::StrictMode);
-    if (!url.isValid()) {
+    QString urlString = context.subscriptionMeta.value("url");
+    if (urlString.isEmpty()) {
         Result r;
-        r.errorMessage = "invalid or missing url value";
+        r.errorMessage = "missing url value";
         finished(r);
         return;
     }
@@ -455,7 +455,14 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
     else if (currentUri.scheme() == "ws")
         currentUri.setScheme("http");
 
-    CowUrl destUri = currentUri.resolved(url);
+    // Handle relative URLs by resolving against currentUri
+    CowUrl destUri = currentUri.resolved(urlString);
+    if (!destUri.isValid()) {
+        Result r;
+        r.errorMessage = "invalid url value";
+        finished(r);
+        return;
+    }
 
     CowUrl requestUri = context.requestUri;
     int requestPort = requestUri.port(requestUri.scheme() == "https" ? 443 : 80);

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -242,9 +242,9 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
         newResponse.reason = reason;
     }
 
-    CowUrl nextLink;
+    QString nextLink;
     int nextLinkTimeout = -1;
-    CowUrl goneLink;
+    QString goneLink;
     foreach (const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link")) {
         if (params.count() < 2)
             continue;
@@ -256,15 +256,22 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
             return Instruct();
         }
 
-        CowUrl link = CowUrl::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
-        if (!link.isValid()) {
-            setError(ok, errorMessage, "Grip-Link contains invalid link");
-            return Instruct();
+        QByteArray linkBytes = linkParam.mid(1, linkParam.length() - 2);
+        QString linkString = QString::fromUtf8(linkBytes);
+
+        // Validate the URL - try to create a Url first, if that fails, validate as relative URL
+        CowUrl tempLink(linkString);
+        if (!tempLink.isValid()) {
+            // Try validating as a relative URL
+            if (!CowUrl::isValidRelativeUrl(linkString)) {
+                setError(ok, errorMessage, "Grip-Link contains invalid link");
+                return Instruct();
+            }
         }
 
         QByteArray rel = params.get("rel").asQByteArray();
         if (rel == "next") {
-            nextLink = link;
+            nextLink = linkString;
 
             if (params.contains("timeout")) {
                 bool x;
@@ -282,7 +289,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
                 nextLinkTimeout = DEFAULT_NEXTLINK_TIMEOUT;
             }
         } else if (rel == "gone") {
-            goneLink = link;
+            goneLink = linkString;
         }
     }
 

--- a/src/handler/instruct.h
+++ b/src/handler/instruct.h
@@ -53,9 +53,9 @@ public:
     int keepAliveTimeout;
     QHash<QString, QString> meta;
     HttpResponseData response;
-    CowUrl nextLink;
+    QString nextLink;
     int nextLinkTimeout;
-    CowUrl goneLink;
+    QString goneLink;
 
     Instruct()
         : holdMode(NoHold),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ pub mod ffi {
     import_cpptest! {
         pub fn cowbytearray_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn cowstring_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn cowurl_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn httpheaders_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn jwt_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn timer_test(out_ex: *mut TestException) -> libc::c_int;

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -2246,7 +2246,7 @@ public:
             }
 
             QByteArray uriRaw = scheme + "://" + host + mreq.uri;
-            CowUrl uri = CowUrl::fromEncoded(uriRaw, CowUrl::TolerantMode);
+            CowUrl uri = CowUrl::fromEncoded(uriRaw, CowUrl::StrictMode);
             if (!uri.isValid()) {
                 log_warning("m2: invalid constructed uri: [%s]", uriRaw.data());
                 m2_writeErrorClose(conn);

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -692,7 +692,7 @@ public:
             }
         }
 
-        uri.setQuery(query.asQUrlQuery());
+        uri.setQuery(query);
 
         // If we have no query items anymore, strip the '?'
         if (query.isEmpty()) {

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -75,7 +75,7 @@ static QPair<QHostAddress, int> parsePort(const QString &s) {
     // Otherwise, assume it's an address:port combination
 
     // Parse with CowUrl in order to support bracketed IPv6 notation
-    CowUrl url{CowUrl::fromUserInput(s)};
+    CowUrl url("http://" + s);
 
     return QPair<QHostAddress, int>(QHostAddress(url.host()), url.port());
 }


### PR DESCRIPTION
This replaces the `CowUrl` alias with a class that wraps `QUrl`. The API is nearly identical to `QUrl`, incorporating the limitations we expect to have for when we start using the `cow_url_*` FFI, even though the FFI is not being used here yet. I'm thinking the changes will be easier to reason about if we do them in multiple steps like this. As a first step, this PR introduces the slightly limited `CowUrl` API along with tests, and updates call sites accordingly.

The main limitations of the new `CowUrl` API vs `QUrl` are:

* No support for non-strict parsing. There are two places where such parsing is performed, in m2adapter (via the `TolerantMode` flag), and in the runner (via the `fromUserInput` method). Neither of these cases actually require non-strict parsing so they are updated.
* No support for prettified output. `QUrl::toString` defaults to `PrettyDecoded`, but `CowUrl::toString` defaults to `FullyEncoded`. None of the existing `toString` calls specify a style, and I believe it should be fine to produce non-prettified output anywhere prettified output would have been acceptable.
* No support for relative URLs. These will be kept in strings instead, and can be validated with `CowUrl::isValidRelativeUrl`.

After this change lands, we can swap out the implementation to one that is FFI-based, without needing to update call sites or the tests, and the tests will continue to pass with the new implementation.