### PR TITLE
connmgr: remove unused overflow feature in server responses

### DIFF
--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -3657,13 +3657,9 @@ where
                 };
 
                 // First call can't fail
-                let (size, overflowed) = prepare_body
+                let size = prepare_body
                     .prepare(rdata.body, true)
                     .expect("infallible prepare call failed");
-
-                if overflowed > 0 {
-                    debug!("server-conn {}: overflowing {} bytes", id, overflowed);
-                }
 
                 // We confirmed above that the data will fit in the buffer
                 assert!(size == rdata.body.len());
@@ -3780,13 +3776,9 @@ where
     };
 
     // First call can't fail
-    let (size, overflowed) = prepare_body
+    let size = prepare_body
         .prepare(rdata.body, !rdata.more)
         .expect("infallible prepare call failed");
-
-    if overflowed > 0 {
-        debug!("server-conn {}: overflowing {} bytes", id, overflowed);
-    }
 
     // We confirmed above that the data will fit in the buffer
     assert!(size == rdata.body.len());
@@ -3930,12 +3922,7 @@ where
 
                     match &zresp.get().ptype {
                         zhttppacket::ResponsePacket::Data(rdata) => {
-                            let (size, overflowed) =
-                                prepare_body.prepare(rdata.body, !rdata.more)?;
-
-                            if overflowed > 0 {
-                                debug!("server-conn {}: overflowing {} bytes", id, overflowed);
-                            }
+                            let size = prepare_body.prepare(rdata.body, !rdata.more)?;
 
                             if size < rdata.body.len() {
                                 return Err(Error::BufferExceeded);

--- a/src/core/http1/server.rs
+++ b/src/core/http1/server.rs
@@ -564,7 +564,7 @@ pub struct ResponsePrepareBody<'a, 'b, R: AsyncRead, W: AsyncWrite> {
 
 impl<R: AsyncRead, W: AsyncWrite> ResponsePrepareBody<'_, '_, R, W> {
     // Only returns an error on invalid input
-    pub fn prepare(&mut self, src: &[u8], end: bool) -> Result<(usize, usize), Error> {
+    pub fn prepare(&mut self, src: &[u8], end: bool) -> Result<usize, Error> {
         let state = self.state.borrow();
         let state = state.as_ref().unwrap();
 
@@ -589,7 +589,7 @@ impl<R: AsyncRead, W: AsyncWrite> ResponsePrepareBody<'_, '_, R, W> {
             state.end.set(true);
         }
 
-        Ok((size, 0))
+        Ok(size)
     }
 }
 


### PR DESCRIPTION
In #48372, the need to handle so-called "overflow" body data was removed, and the method that reported the number of overflowed bytes was changed to always return zero. This PR removes the value entirely. It was only ever used to log a debug message if greater than zero, which can't happen now.