### PR TITLE
treat route log_level as the max level rather than the logging level

### DIFF
--- a/src/core/log.rs
+++ b/src/core/log.rs
@@ -585,7 +585,7 @@ impl Log for DebugLogger {
     fn flush(&self) {}
 }
 
-mod ffi {
+pub mod ffi {
     use super::*;
     use std::ffi::{c_char, c_int, CStr};
     use std::fs::OpenOptions;
@@ -606,7 +606,7 @@ mod ffi {
         }
     }
 
-    fn int_to_optional_level_filter(level: c_int) -> Option<LevelFilter> {
+    pub fn int_to_optional_level_filter(level: c_int) -> Option<LevelFilter> {
         match level {
             c_int::MIN..=-1 => None,
             0 => Some(log::LevelFilter::Error),

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -64,9 +64,10 @@ static QString makeLastIdsStr(const HttpHeaders &headers) {
     return out;
 }
 
-static void logPacket(int level, const QString &message, const Variant &data = Variant(),
-                      int dataMax = -1, const QByteArray &content = QByteArray(),
-                      int contentMax = -1) {
+static void logPacketWithOutputLevel(int outputLevel, int level, const QString &message,
+                                     const Variant &data = Variant(), int dataMax = -1,
+                                     const QByteArray &content = QByteArray(),
+                                     int contentMax = -1) {
     QString out = message;
 
     if (data.isValid()) {
@@ -79,7 +80,13 @@ static void logPacket(int level, const QString &message, const Variant &data = V
         out += TnetString::variantToString(Variant(buf), -1);
     }
 
-    log(level, "%s", qPrintable(out));
+    logWithOutputLevel(outputLevel, level, "%s", qPrintable(out));
+}
+
+static void logPacket(int level, const QString &message, const Variant &data = Variant(),
+                      int dataMax = -1, const QByteArray &content = QByteArray(),
+                      int contentMax = -1) {
+    logPacketWithOutputLevel(-1, level, message, data, dataMax, content, contentMax);
 }
 
 static void logPacket(int level, const Variant &data, const char *fmt, va_list ap) {
@@ -102,8 +109,8 @@ static void logPacket(int level, const Variant &data, const QString &contentFiel
         hdata.remove(contentField);
         meta = hdata;
     } else {
-        // If data isn't a hash, then we can't extract content, so the meta part will be the entire
-        // data
+        // If data isn't a hash, then we can't extract content, so the meta part will be the
+        // entire data
         meta = data;
     }
 
@@ -180,16 +187,16 @@ void logRequest(int level, const RequestData &data, const Config &config) {
     if (!lastIdsStr.isEmpty())
         msg += ' ' + lastIdsStr;
 
-    log(level, "%s", qPrintable(msg));
+    logWithOutputLevel(data.logLevel, level, "%s", qPrintable(msg));
 }
 
-void logForRoute(const RouteInfo &routeInfo, const char *fmt, ...) {
+void logForRoute(int level, const RouteInfo &routeInfo, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     QString msg = QString::vasprintf(fmt, ap);
     if (!routeInfo.id.isEmpty())
         msg += QString(" route=%1").arg(routeInfo.id);
-    logPacket(routeInfo.logLevel, msg);
+    logPacketWithOutputLevel(routeInfo.logLevel, level, msg);
     va_end(ap);
 }
 

--- a/src/core/logutil.h
+++ b/src/core/logutil.h
@@ -37,6 +37,7 @@ enum RequestStatus { Response, Accept, Error };
 class RequestData {
 public:
     QString routeId;
+    int logLevel;
     RequestStatus status;
     HttpRequestData requestData;
     HttpResponseData responseData;
@@ -48,7 +49,8 @@ public:
     QHostAddress fromAddress;
 
     RequestData()
-        : status(Response),
+        : logLevel(-1),
+          status(Response),
           responseBodySize(-1),
           targetOverHttp(false),
           retry(false),
@@ -77,7 +79,7 @@ void logByteArray(int level, const QByteArray &content, const char *fmt, ...);
 void logVariantWithContent(int level, const Variant &data, const QString &contentField,
                            const char *fmt, ...);
 void logRequest(int level, const RequestData &data, const Config &config = Config());
-void logForRoute(const RouteInfo &routeInfo, const char *fmt, ...);
+void logForRoute(int level, const RouteInfo &routeInfo, const char *fmt, ...);
 
 } // namespace LogUtil
 

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -2441,7 +2441,8 @@ private:
                                  qPrintable(channel));
                     } else {
                         auto routeInfo = LogUtil::RouteInfo(s->route, s->logLevel);
-                        LogUtil::logForRoute(routeInfo, "wssession: too many subscriptions");
+                        LogUtil::logForRoute(LOG_LEVEL_DEBUG, routeInfo,
+                                             "wssession: too many subscriptions");
                     }
                 } else if (cm.type == WsControlMessage::Unsubscribe) {
                     QString channel = s->channelPrefix + cm.channel;

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -198,7 +198,7 @@ public:
             int _connectionSubscriptionMax)
         : q(_q),
           req(_req),
-          logLevel(LOG_LEVEL_DEBUG),
+          logLevel(-1),
           stats(_stats),
           outZhttp(_outZhttp),
           updateLimiter(_updateLimiter),
@@ -271,7 +271,7 @@ public:
             instruct.channels = instruct.channels.mid(0, connectionSubscriptionMax);
 
             auto routeInfo = LogUtil::RouteInfo(adata.route, logLevel);
-            LogUtil::logForRoute(routeInfo, "httpsession: too many subscriptions");
+            LogUtil::logForRoute(LOG_LEVEL_DEBUG, routeInfo, "httpsession: too many subscriptions");
         }
 
         // Need to send initial content?
@@ -1164,7 +1164,8 @@ private:
                         instruct.channels = instruct.channels.mid(0, connectionSubscriptionMax);
 
                         auto routeInfo = LogUtil::RouteInfo(adata.route, logLevel);
-                        LogUtil::logForRoute(routeInfo, "httpsession: too many subscriptions");
+                        LogUtil::logForRoute(LOG_LEVEL_DEBUG, routeInfo,
+                                             "httpsession: too many subscriptions");
                     }
 
                     if (instruct.holdMode == Instruct::StreamHold) {
@@ -1216,6 +1217,7 @@ private:
         if (!adata.statsRoute.isEmpty())
             rd.routeId = adata.route;
 
+        rd.logLevel = logLevel;
         rd.status = LogUtil::Response;
 
         rd.requestData.method = method;
@@ -1235,6 +1237,7 @@ private:
         if (!adata.statsRoute.isEmpty())
             rd.routeId = adata.route;
 
+        rd.logLevel = logLevel;
         rd.status = LogUtil::Error;
 
         rd.requestData.method = method;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -36,7 +36,7 @@
 WsSession::WsSession()
     : nextReqId(0),
       debug(false),
-      logLevel(LOG_LEVEL_DEBUG),
+      logLevel(-1),
       targetTrusted(false),
       ttl(0),
       inProcessPublishQueue(false),

--- a/src/proxy/domainmap.cpp
+++ b/src/proxy/domainmap.cpp
@@ -106,7 +106,7 @@ public:
               autoCrossOrigin(false),
               session(false),
               grip(true),
-              logLevel(LOG_LEVEL_DEBUG) {}
+              logLevel(-1) {}
 
         // Checks only the condition, not sig/targets
         bool compare(const Rule &other) const {

--- a/src/proxy/domainmap.h
+++ b/src/proxy/domainmap.h
@@ -142,7 +142,7 @@ public:
               session(false),
               separateStats(false),
               grip(true),
-              logLevel(LOG_LEVEL_DEBUG) {}
+              logLevel(-1) {}
     };
 
     DomainMap();

--- a/src/proxy/domainmap.rs
+++ b/src/proxy/domainmap.rs
@@ -16,15 +16,14 @@
  * limitations under the License.
  */
 
+use crate::core::log::ffi::int_to_optional_level_filter;
 use std::ffi::CString;
-use std::os::raw::c_int;
 use std::ptr;
 
 /// Route parameters returned by DomainMap lookups
-#[repr(C)]
 #[derive(Debug, Clone)]
 pub struct RouteParams {
-    pub log_level: c_int,
+    pub log_level: Option<log::LevelFilter>,
 }
 
 /// Rust wrapper for DomainMap FFI
@@ -68,7 +67,7 @@ impl DomainMap {
             None => ptr::null(),
         };
 
-        let mut ffi_params = crate::ffi::DomainMapRouteParams { log_level: 0 };
+        let mut ffi_params = crate::ffi::DomainMapRouteParams { log_level: -1 };
 
         let result = unsafe {
             crate::ffi::domainmap_entry_params(
@@ -79,13 +78,13 @@ impl DomainMap {
             )
         };
 
-        if result == 0 {
-            Some(RouteParams {
-                log_level: ffi_params.log_level,
-            })
-        } else {
-            None
+        if result != 0 {
+            return None;
         }
+
+        let log_level = int_to_optional_level_filter(ffi_params.log_level);
+
+        Some(RouteParams { log_level })
     }
 }
 

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -661,6 +661,8 @@ public:
         if (route.separateStats)
             rd.routeId = route.id;
 
+        rd.logLevel = route.logLevel;
+
         if (accepted) {
             rd.status = LogUtil::Accept;
         } else if (resp.code != -1) {

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -908,6 +908,8 @@ public:
         if (route.separateStats)
             rd.routeId = route.id;
 
+        rd.logLevel = route.logLevel;
+
         if (accepted) {
             rd.status = LogUtil::Accept;
         } else if (resp.code != -1 && !si->unclean) {

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -698,6 +698,8 @@ public:
         if (route.separateStats)
             rd.routeId = route.id;
 
+        rd.logLevel = route.logLevel;
+
         if (responseCode != -1) {
             rd.status = LogUtil::Response;
             rd.responseData.code = responseCode;


### PR DESCRIPTION
Currently, the `log_level` route parameter controls the log level used by some route-specific log messages. This is mainly useful for enabling logs for certain routes without having to increase the application-wide max log level. However, this approach of changing the levels of log messages has some problems/limitations:

* The original levels are lost. For example, if the param is set to 1 to cause a route's info/debug/trace log calls to log at warning level, well, they all get logged as warnings making their individual severities unclear.
* It adds noise to the more critical levels. For example, causing a route's info/debug/trace log calls to log at warning level means that some warnings are real warnings and others might just be hoisted info/debug/trace messages.
* It's not possible to granularly control which route-specific log messages are targeted. For example, it could be nice to be able to enable info-level logs for a route without also enabling debug/trace levels.

This PR attempts to make things better by changing the behavior of `log_level` from controlling the levels of the messages themselves to controlling the max level allowed for such messages. For example, if the param is set to 2, then the route's info level logs will be logged regardless of the application-wide max level, and they will be logged as info level. Setting to 3 would then get the debug level logs too, and so on. If unspecified, the application-wide max level applies.

Below is an example of Pushpin running with a default max level of 1 and configured with two routes, with requests for the second route using a max level of 3:

```
% ./pushpin-legacy -m --route "* test" --route "example.com,log_level=3 test" --loglevel 1   
```

Requests to both routes work as expected:

```
% curl http://localhost:7999                           
Hello from the Pushpin test handler!
% curl --connect-to ::localhost:7999 http://example.com
Hello from the Pushpin test handler!
```

But only requests to the second one are logged:

```
[INFO] 2026-07-16 11:22:06.050 [proxy] GET http://example.com/ -> test code=200 37
```

The one caveat of this approach is it may be confusing to see higher level logs being outputted when the application-wide max level is set to a lower level. However, I think this should be less confusing the current behavior. The way to reason about it: the max level is not a fixed effect controlled by a single configuration option but a dynamic effect controlled by multiple configuration options. The application-wide max level is a default/fallback that may be superseded by context-specific max levels.

Compatibility note: in general we shouldn't change the behavior of existing options so as to not break Pushpin's semver guarantees, however I think we can get away with changing the behavior of the `log_level` route param because log output is not part of the guarantee. The worst that happens to existing users of the param is route-specific logs stop appearing until they update their configuration, but we are not obligated to retain such logs and could remove them too.