### PR TITLE
rename url to cowurl, for consistency with other cow types

### DIFF
--- a/src/core/cowurl.h
+++ b/src/core/cowurl.h
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#ifndef URL_H
-#define URL_H
+#ifndef COWURL_H
+#define COWURL_H
 
 #include <QUrl>
 
-// Type alias for URL handling - this will be replaced with a custom implementation later
-using Url = QUrl;
+// Type alias for copy-on-write URL handling - this will be replaced with a custom implementation
+// later
+using CowUrl = QUrl;
 
-#endif // URL_H
+#endif // COWURL_H

--- a/src/core/httprequest.h
+++ b/src/core/httprequest.h
@@ -24,8 +24,8 @@
 #ifndef HTTPREQUEST_H
 #define HTTPREQUEST_H
 
+#include "cowurl.h"
 #include "httpheaders.h"
-#include "url.h"
 #include <QHostAddress>
 #include <boost/signals2.hpp>
 
@@ -59,7 +59,7 @@ public:
     virtual void setTimeout(int msecs) = 0;
     virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
-    virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers) = 0;
+    virtual void start(const QString &method, const CowUrl &uri, const HttpHeaders &headers) = 0;
     virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers) = 0;
 
     // May call this multiple times
@@ -76,7 +76,7 @@ public:
     virtual ErrorCondition errorCondition() const = 0;
 
     virtual QString requestMethod() const = 0;
-    virtual Url requestUri() const = 0;
+    virtual CowUrl requestUri() const = 0;
     virtual HttpHeaders requestHeaders() const = 0;
 
     virtual int responseCode() const = 0;

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -142,7 +142,7 @@ void logVariantWithContent(int level, const Variant &data, const QString &conten
 
 void logRequest(int level, const RequestData &data, const Config &config) {
     QString msg = QString("%1 %2").arg(data.requestData.method,
-                                       data.requestData.uri.toString(Url::FullyEncoded));
+                                       data.requestData.uri.toString(CowUrl::FullyEncoded));
 
     if (!data.targetStr.isEmpty())
         msg += QString(" -> %1").arg(data.targetStr);
@@ -154,9 +154,9 @@ void logRequest(int level, const RequestData &data, const Config &config) {
     if (config.fromAddress && !data.fromAddress.isNull())
         msg += QString(" from=%1").arg(data.fromAddress.toString());
 
-    Url ref = Url(QString::fromUtf8(data.requestData.headers.get("Referer").asQByteArray()));
+    CowUrl ref = CowUrl(QString::fromUtf8(data.requestData.headers.get("Referer").asQByteArray()));
     if (!ref.isEmpty())
-        msg += QString(" ref=%1").arg(ref.toString(Url::FullyEncoded));
+        msg += QString(" ref=%1").arg(ref.toString(CowUrl::FullyEncoded));
 
     if (!data.routeId.isEmpty())
         msg += QString(" route=%1").arg(data.routeId);

--- a/src/core/packet/httprequestdata.h
+++ b/src/core/packet/httprequestdata.h
@@ -24,12 +24,12 @@
 #define HTTPREQUESTDATA_H
 
 #include "../httpheaders.h"
-#include "url.h"
+#include "cowurl.h"
 
 class HttpRequestData {
 public:
     QString method;
-    Url uri;
+    CowUrl uri;
     HttpHeaders headers;
     QByteArray body;
 };

--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -257,7 +257,7 @@ bool RetryRequestPacket::fromVariant(const Variant &in) {
 
     if (!vrequestData.contains("uri") || typeId(vrequestData["uri"]) != VariantType::ByteArray)
         return false;
-    requestData.uri = Url::fromEncoded(vrequestData["uri"].toByteArray(), Url::StrictMode);
+    requestData.uri = CowUrl::fromEncoded(vrequestData["uri"].toByteArray(), CowUrl::StrictMode);
 
     requestData.headers.clear();
     if (vrequestData.contains("headers")) {

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -111,8 +111,8 @@ errorMessage); if(!ok_)
                                 return WsControlPacket();
                         }
 
-                        msg.uri = Url::fromEncoded(getString(vitem, pn, "uri",
-false, &ok_, errorMessage).toUtf8(), Url::StrictMode); if(!ok_)
+                        msg.uri = CowUrl::fromEncoded(getString(vitem, pn, "uri",
+false, &ok_, errorMessage).toUtf8(), CowUrl::StrictMode); if(!ok_)
                         {
                                 if(ok)
                                         *ok = false;
@@ -341,7 +341,7 @@ bool WsControlPacket::fromVariant(const Variant &in) {
             if (typeId(vitem["uri"]) != VariantType::ByteArray)
                 return false;
 
-            item.uri = Url::fromEncoded(vitem["uri"].toByteArray(), Url::StrictMode);
+            item.uri = CowUrl::fromEncoded(vitem["uri"].toByteArray(), CowUrl::StrictMode);
         }
 
         if (vitem.contains("content-type")) {

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -24,7 +24,7 @@
 #ifndef WSCONTROLPACKET_H
 #define WSCONTROLPACKET_H
 
-#include "url.h"
+#include "cowurl.h"
 #include "variant.h"
 #include <QByteArray>
 #include <QList>
@@ -52,7 +52,7 @@ public:
         QByteArray cid;
         Type type;
         QByteArray requestId;
-        Url uri;
+        CowUrl uri;
         QByteArray contentType;
         QByteArray message;
         bool queue;

--- a/src/core/urlquery.h
+++ b/src/core/urlquery.h
@@ -17,7 +17,7 @@
 #ifndef URLQUERY_H
 #define URLQUERY_H
 
-#include "url.h"
+#include "cowurl.h"
 #include <QString>
 #include <QStringList>
 #include <QUrlQuery>
@@ -26,7 +26,7 @@ class UrlQuery {
 public:
     // Constructors
     UrlQuery() = default;
-    explicit UrlQuery(const Url &url) : inner_(url) {}
+    explicit UrlQuery(const CowUrl &url) : inner_(url) {}
     explicit UrlQuery(const QString &queryString) : inner_(queryString) {}
     UrlQuery(const UrlQuery &other) : inner_(other.inner_) {}
     UrlQuery(UrlQuery &&other) noexcept : inner_(std::move(other.inner_)) {}
@@ -60,22 +60,23 @@ public:
 
     // Item access
     bool hasQueryItem(const QString &key) const { return inner_.hasQueryItem(key); }
-    QString queryItemValue(const QString &key,
-                           Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+    QString
+    queryItemValue(const QString &key,
+                   CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
         return inner_.queryItemValue(key, encoding);
     }
     QStringList
     allQueryItemValues(const QString &key,
-                       Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+                       CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
         return inner_.allQueryItemValues(key, encoding);
     }
     QList<QPair<QString, QString>>
-    queryItems(Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+    queryItems(CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
         return inner_.queryItems(encoding);
     }
 
     // String conversion
-    QString toString(Url::ComponentFormattingOptions encoding = Url::PrettyDecoded) const {
+    QString toString(CowUrl::ComponentFormattingOptions encoding = CowUrl::PrettyDecoded) const {
         return inner_.toString(encoding);
     }
 

--- a/src/core/websocket.h
+++ b/src/core/websocket.h
@@ -24,8 +24,8 @@
 #ifndef WEBSOCKET_H
 #define WEBSOCKET_H
 
+#include "cowurl.h"
 #include "httpheaders.h"
-#include "url.h"
 #include <QHostAddress>
 #include <boost/signals2.hpp>
 
@@ -69,14 +69,14 @@ public:
     virtual void setIgnoreTlsErrors(bool on) = 0;
     virtual void setClientCert(const QString &cert, const QString &key) = 0;
 
-    virtual void start(const Url &uri, const HttpHeaders &headers) = 0;
+    virtual void start(const CowUrl &uri, const HttpHeaders &headers) = 0;
 
     virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers) = 0;
     virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
                               const QByteArray &body) = 0;
 
     virtual State state() const = 0;
-    virtual Url requestUri() const = 0;
+    virtual CowUrl requestUri() const = 0;
     virtual HttpHeaders requestHeaders() const = 0;
     virtual int responseCode() const = 0;
     virtual QByteArray responseReason() const = 0;

--- a/src/core/zhttpmanager.cpp
+++ b/src/core/zhttpmanager.cpp
@@ -1178,14 +1178,14 @@ void ZhttpManager::registerKeepAlive(ZWebSocket *sock) {
 
 void ZhttpManager::unregisterKeepAlive(ZWebSocket *sock) { d->unregisterKeepAlive(sock); }
 
-int ZhttpManager::estimateRequestHeaderBytes(const QString &method, const Url &uri,
+int ZhttpManager::estimateRequestHeaderBytes(const QString &method, const CowUrl &uri,
                                              const HttpHeaders &headers) {
     int total = method.toUtf8().length();
 
-    total += uri.path(Url::FullyEncoded).length();
+    total += uri.path(CowUrl::FullyEncoded).length();
 
     if (uri.hasQuery())
-        total += uri.query(Url::FullyEncoded).length() + 1; // +1 for question mark
+        total += uri.query(CowUrl::FullyEncoded).length() + 1; // +1 for question mark
 
     foreach (const HttpHeader &h, headers) {
         total += h.first.length();

--- a/src/core/zhttpmanager.h
+++ b/src/core/zhttpmanager.h
@@ -24,7 +24,7 @@
 #ifndef ZHTTPMANAGER_H
 #define ZHTTPMANAGER_H
 
-#include "url.h"
+#include "cowurl.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include <boost/signals2.hpp>
@@ -69,7 +69,7 @@ public:
     // For server mode, jump directly to responding state
     ZhttpRequest *createRequestFromState(const ZhttpRequest::ServerState &state);
 
-    static int estimateRequestHeaderBytes(const QString &method, const Url &uri,
+    static int estimateRequestHeaderBytes(const QString &method, const CowUrl &uri,
                                           const HttpHeaders &headers);
     static int estimateResponseHeaderBytes(int code, const QByteArray &reason,
                                            const HttpHeaders &headers);

--- a/src/core/zhttprequest.cpp
+++ b/src/core/zhttprequest.cpp
@@ -77,7 +77,7 @@ public:
     bool sendBodyAfterAck;
     Variant passthrough;
     QString requestMethod;
-    Url requestUri;
+    CowUrl requestUri;
     HttpHeaders requestHeaders;
     BufferList requestBodyBuf;
     int inSeq;
@@ -1076,7 +1076,7 @@ void ZhttpRequest::setPassthroughData(const Variant &data) { d->passthrough = da
 
 void ZhttpRequest::setQuiet(bool on) { d->quiet = on; }
 
-void ZhttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers) {
+void ZhttpRequest::start(const QString &method, const CowUrl &uri, const HttpHeaders &headers) {
     assert(!d->server);
 
     d->requestMethod = method;
@@ -1166,7 +1166,7 @@ HttpRequest::ErrorCondition ZhttpRequest::errorCondition() const { return d->err
 
 QString ZhttpRequest::requestMethod() const { return d->requestMethod; }
 
-Url ZhttpRequest::requestUri() const { return d->requestUri; }
+CowUrl ZhttpRequest::requestUri() const { return d->requestUri; }
 
 HttpHeaders ZhttpRequest::requestHeaders() const { return d->requestHeaders; }
 

--- a/src/core/zhttprequest.h
+++ b/src/core/zhttprequest.h
@@ -24,8 +24,8 @@
 #ifndef ZHTTPREQUEST_H
 #define ZHTTPREQUEST_H
 
+#include "cowurl.h"
 #include "httprequest.h"
-#include "url.h"
 #include "variant.h"
 #include <boost/signals2.hpp>
 
@@ -47,7 +47,7 @@ public:
         Rid rid;
         QHostAddress peerAddress;
         QString requestMethod;
-        Url requestUri;
+        CowUrl requestUri;
         HttpHeaders requestHeaders;
         QByteArray requestBody;
         int responseCode;
@@ -87,7 +87,7 @@ public:
     virtual void setTimeout(int msecs);
     virtual void setClientCert(const QString &cert, const QString &key);
 
-    virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
+    virtual void start(const QString &method, const CowUrl &uri, const HttpHeaders &headers);
     virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
 
     virtual void writeBody(const QByteArray &body);
@@ -103,7 +103,7 @@ public:
     virtual ErrorCondition errorCondition() const;
 
     virtual QString requestMethod() const;
-    virtual Url requestUri() const;
+    virtual CowUrl requestUri() const;
     virtual HttpHeaders requestHeaders() const;
 
     virtual int responseCode() const;

--- a/src/core/zhttprequestpacket.cpp
+++ b/src/core/zhttprequestpacket.cpp
@@ -348,7 +348,7 @@ bool ZhttpRequestPacket::fromVariant(const Variant &in) {
         if (typeId(obj["uri"]) != VariantType::ByteArray)
             return false;
 
-        uri = Url::fromEncoded(obj["uri"].toByteArray(), Url::StrictMode);
+        uri = CowUrl::fromEncoded(obj["uri"].toByteArray(), CowUrl::StrictMode);
     }
 
     headers.clear();

--- a/src/core/zhttprequestpacket.h
+++ b/src/core/zhttprequestpacket.h
@@ -24,8 +24,8 @@
 
 #include "cowbytearray.h"
 #include "cowstring.h"
+#include "cowurl.h"
 #include "httpheaders.h"
-#include "url.h"
 #include "variant.h"
 #include <QHostAddress>
 
@@ -68,7 +68,7 @@ public:
     int timeout;
 
     CowString method;
-    Url uri;
+    CowUrl uri;
     HttpHeaders headers;
     CowByteArray body;
 

--- a/src/core/zwebsocket.cpp
+++ b/src/core/zwebsocket.cpp
@@ -62,7 +62,7 @@ public:
     bool ignoreTlsErrors;
     QString clientCert;
     QString clientKey;
-    Url requestUri;
+    CowUrl requestUri;
     HttpHeaders requestHeaders;
     int inSeq;
     int outSeq;
@@ -950,7 +950,7 @@ void ZWebSocket::setClientCert(const QString &cert, const QString &key) {
     d->clientKey = key;
 }
 
-void ZWebSocket::start(const Url &uri, const HttpHeaders &headers) {
+void ZWebSocket::start(const CowUrl &uri, const HttpHeaders &headers) {
     assert(!d->server);
 
     d->requestUri = uri;
@@ -1001,7 +1001,7 @@ WebSocket::State ZWebSocket::state() const {
     }
 }
 
-Url ZWebSocket::requestUri() const { return d->requestUri; }
+CowUrl ZWebSocket::requestUri() const { return d->requestUri; }
 
 HttpHeaders ZWebSocket::requestHeaders() const { return d->requestHeaders; }
 

--- a/src/core/zwebsocket.h
+++ b/src/core/zwebsocket.h
@@ -24,7 +24,7 @@
 #ifndef ZWEBSOCKET_H
 #define ZWEBSOCKET_H
 
-#include "url.h"
+#include "cowurl.h"
 #include "websocket.h"
 #include <boost/signals2.hpp>
 
@@ -55,14 +55,14 @@ public:
     virtual void setIgnoreTlsErrors(bool on);
     virtual void setClientCert(const QString &cert, const QString &key);
 
-    virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const CowUrl &uri, const HttpHeaders &headers);
 
     virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
     virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
                               const QByteArray &body);
 
     virtual State state() const;
-    virtual Url requestUri() const;
+    virtual CowUrl requestUri() const;
     virtual HttpHeaders requestHeaders() const;
     virtual int responseCode() const;
     virtual QByteArray responseReason() const;

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -283,7 +283,7 @@ class HttpFilterInner {
 public:
     HttpFilter::Mode mode;
     std::unique_ptr<ZhttpRequest> req;
-    Url uri;
+    CowUrl uri;
     HttpHeaders headers;
     QByteArray origContent;
     bool haveResponseHeader;
@@ -295,7 +295,7 @@ public:
     HttpFilterInner(HttpFilter::Mode _mode)
         : mode(_mode), haveResponseHeader(false), responseSizeMax(-1) {}
 
-    void setup(ZhttpManager *zhttpOut, const Url &_uri, const HttpHeaders &_headers,
+    void setup(ZhttpManager *zhttpOut, const CowUrl &_uri, const HttpHeaders &_headers,
                const Variant &passthroughData, const QByteArray &content, int _responseSizeMax) {
         uri = _uri;
         headers = _headers;
@@ -441,7 +441,7 @@ HttpFilter::HttpFilter(Mode mode) {
 }
 
 void HttpFilter::start(const Filter::Context &context, const QByteArray &content) {
-    Url url = Url(context.subscriptionMeta.value("url"), Url::StrictMode);
+    CowUrl url = CowUrl(context.subscriptionMeta.value("url"), CowUrl::StrictMode);
     if (!url.isValid()) {
         Result r;
         r.errorMessage = "invalid or missing url value";
@@ -449,15 +449,15 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
         return;
     }
 
-    Url currentUri = context.currentUri;
+    CowUrl currentUri = context.currentUri;
     if (currentUri.scheme() == "wss")
         currentUri.setScheme("https");
     else if (currentUri.scheme() == "ws")
         currentUri.setScheme("http");
 
-    Url destUri = currentUri.resolved(url);
+    CowUrl destUri = currentUri.resolved(url);
 
-    Url requestUri = context.requestUri;
+    CowUrl requestUri = context.requestUri;
     int requestPort = requestUri.port(requestUri.scheme() == "https" ? 443 : 80);
     int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 

--- a/src/handler/filter.h
+++ b/src/handler/filter.h
@@ -24,8 +24,8 @@
 #ifndef FILTER_H
 #define FILTER_H
 
+#include "cowurl.h"
 #include "ratelimiter.h"
-#include "url.h"
 #include "zhttprequest.h"
 #include <QHash>
 #include <QString>
@@ -58,8 +58,8 @@ public:
 
         // For network access
         ZhttpManager *zhttpOut;
-        Url requestUri; // What was fetched at session start
-        Url currentUri; // Where we are now, potentially after following next links
+        CowUrl requestUri; // What was fetched at session start
+        CowUrl currentUri; // Where we are now, potentially after following next links
         QString route;
         bool trusted;
         std::shared_ptr<RateLimiter> limiter;

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -105,7 +105,7 @@ public:
             return;
         }
 
-        Url uri = req->requestUri();
+        CowUrl uri = req->requestUri();
         QByteArray body = req->readBody();
         bool preferInternal = req->passthroughData().toMap().value("prefer-internal").toBool();
 

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -143,7 +143,7 @@ public:
                 return;
             }
 
-            requestData.uri = Url(args["uri"].toString(), Url::StrictMode);
+            requestData.uri = CowUrl(args["uri"].toString(), CowUrl::StrictMode);
             if (!requestData.uri.isValid()) {
                 respondError("bad-request");
                 return;
@@ -212,7 +212,7 @@ public:
 
                 auto d = std::unique_ptr<Deferred>(SessionRequest::detectRulesGet(
                     stateClient, requestData.uri.host().toUtf8(),
-                    requestData.uri.path(Url::FullyEncoded).toUtf8()));
+                    requestData.uri.path(CowUrl::FullyEncoded).toUtf8()));
 
                 // Safe to not track, since d can't outlive this
                 d->finished.connect(boost::bind(&InspectWorker::sessionDetectRulesGet_finished,
@@ -243,7 +243,7 @@ private:
             // reason the query part is not considered is because it may vary per client and
             // Grip-Last supersedes whatever is in the query
 
-            Url uri = requestData.uri;
+            CowUrl uri = requestData.uri;
             uri.setQuery(QString()); // Remove the query part
 
             QList<QByteArray> gripLastHeaders =
@@ -291,7 +291,7 @@ private:
 
                 if (!rule.jsonParam.isEmpty()) {
                     UrlQuery tmp(QString::fromUtf8(requestData.body));
-                    jsonData = tmp.queryItemValue(rule.jsonParam, Url::FullyDecoded).toUtf8();
+                    jsonData = tmp.queryItemValue(rule.jsonParam, CowUrl::FullyDecoded).toUtf8();
                 } else {
                     jsonData = requestData.body;
                 }
@@ -762,7 +762,7 @@ private:
         if (!rd.contains("uri") || typeId(rd["uri"]) != VariantType::ByteArray)
             return HttpRequestData();
 
-        out.uri = Url(rd["uri"].toString(), Url::StrictMode);
+        out.uri = CowUrl(rd["uri"].toString(), CowUrl::StrictMode);
         if (!out.uri.isValid())
             return HttpRequestData();
 
@@ -2437,7 +2437,7 @@ private:
                         addSub(channel);
 
                         log_info("subscribe %s channel=%s",
-                                 qPrintable(s->requestData.uri.toString(Url::FullyEncoded)),
+                                 qPrintable(s->requestData.uri.toString(CowUrl::FullyEncoded)),
                                  qPrintable(channel));
                     } else {
                         auto routeInfo = LogUtil::RouteInfo(s->route, s->logLevel);
@@ -2567,7 +2567,7 @@ private:
                 addSub(channel);
 
                 log_info("subscribe %s channel=%s",
-                         qPrintable(s->requestData.uri.toString(Url::FullyEncoded)),
+                         qPrintable(s->requestData.uri.toString(CowUrl::FullyEncoded)),
                          qPrintable(channel));
             } else if (item.type == WsControlPacket::Item::Ack) {
                 int reqId = item.requestId.toInt();
@@ -2827,7 +2827,7 @@ private:
         addSub(channel);
 
         QString msg = QString("subscribe %1 channel=%2")
-                          .arg(hs->requestUri().toString(Url::FullyEncoded), channel);
+                          .arg(hs->requestUri().toString(CowUrl::FullyEncoded), channel);
         if (hs->isRetry())
             msg += " retry";
 

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -248,7 +248,7 @@ public:
         zresp.code = 200;
         zresp.reason = "OK";
 
-        QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = zreq.uri.path(CowUrl::FullyEncoded).toUtf8();
 
         zresp.headers += HttpHeader("Content-Type", "text/plain");
 

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -160,9 +160,9 @@ public:
     int sentOutReqData;
     int retries;
     QString errorMessage;
-    Url currentUri;
-    Url nextUri;
-    Url goneUri;
+    CowUrl currentUri;
+    CowUrl nextUri;
+    CowUrl goneUri;
     bool needUpdate;
     Priority needUpdatePriority;
     UpdateAction *pendingAction;
@@ -1017,7 +1017,7 @@ private:
         finishedCallback.call({q});
     }
 
-    void prepareOutReq(const Url &destUri, bool autoShare = false) {
+    void prepareOutReq(const CowUrl &destUri, bool autoShare = false) {
         haveOutReqHeaders = false;
         sentOutReqData = 0;
 
@@ -1026,7 +1026,7 @@ private:
             outReq->readyRead.connect(boost::bind(&Private::outReq_readyRead, this));
         errorOutConnection = outReq->error.connect(boost::bind(&Private::outReq_error, this));
 
-        Url requestUri = req->requestUri();
+        CowUrl requestUri = req->requestUri();
         int requestPort = requestUri.port(requestUri.scheme() == "https" ? 443 : 80);
         int destPort = destUri.port(destUri.scheme() == "https" ? 443 : 80);
 
@@ -1209,7 +1209,7 @@ private:
         }
     }
 
-    void logRequest(const QString &method, const Url &uri, const HttpHeaders &headers, int code,
+    void logRequest(const QString &method, const CowUrl &uri, const HttpHeaders &headers, int code,
                     int bodySize) {
         LogUtil::RequestData rd;
 
@@ -1230,7 +1230,7 @@ private:
         LogUtil::logRequest(LOG_LEVEL_INFO, rd, logConfig);
     }
 
-    void logRequestError(const QString &method, const Url &uri, const HttpHeaders &headers) {
+    void logRequestError(const QString &method, const CowUrl &uri, const HttpHeaders &headers) {
         LogUtil::RequestData rd;
 
         // Only log route id if explicitly set
@@ -1505,7 +1505,7 @@ Instruct::HoldMode HttpSession::holdMode() const {
 
 ZhttpRequest::Rid HttpSession::rid() const { return d->req->rid(); }
 
-Url HttpSession::requestUri() const { return d->req->requestUri(); }
+CowUrl HttpSession::requestUri() const { return d->req->requestUri(); }
 
 bool HttpSession::isRetry() const { return d->adata.isRetry; }
 

--- a/src/handler/httpsession.h
+++ b/src/handler/httpsession.h
@@ -26,12 +26,12 @@
 
 #include "callback.h"
 #include "clientsession.h"
+#include "cowurl.h"
 #include "filter.h"
 #include "inspectdata.h"
 #include "instruct.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
-#include "url.h"
 #include "zhttprequest.h"
 #include <boost/signals2.hpp>
 
@@ -99,7 +99,7 @@ public:
 
     Instruct::HoldMode holdMode() const;
     ZhttpRequest::Rid rid() const;
-    Url requestUri() const;
+    CowUrl requestUri() const;
     bool isRetry() const;
     QString statsRoute() const;
     QString sid() const;

--- a/src/handler/httpsessionupdatemanager.cpp
+++ b/src/handler/httpsessionupdatemanager.cpp
@@ -23,23 +23,23 @@
 
 #include "httpsessionupdatemanager.h"
 
+#include "cowurl.h"
 #include "defercall.h"
 #include "httpsession.h"
 #include "timer.h"
-#include "url.h"
 
 class HttpSessionUpdateManager::Private {
 public:
     class Bucket {
     public:
-        QPair<int, Url> key;
+        QPair<int, CowUrl> key;
         QSet<HttpSession *> sessions;
         QSet<HttpSession *> deferredSessions;
         std::unique_ptr<Timer> timer;
     };
 
     HttpSessionUpdateManager *q;
-    QHash<QPair<int, Url>, Bucket *> buckets;
+    QHash<QPair<int, CowUrl>, Bucket *> buckets;
     QHash<Timer *, Bucket *> bucketsByTimer;
     QHash<HttpSession *, Bucket *> bucketsBySession;
 
@@ -56,10 +56,10 @@ public:
         delete bucket;
     }
 
-    void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout) {
-        Url tmp = uri;
+    void registerSession(HttpSession *hs, int timeout, const CowUrl &uri, bool resetTimeout) {
+        CowUrl tmp = uri;
         tmp.setQuery(QString()); // Remove the query part
-        QPair<int, Url> key(timeout, tmp);
+        QPair<int, CowUrl> key(timeout, tmp);
 
         Bucket *bucket = buckets.value(key);
         if (bucket) {
@@ -140,7 +140,7 @@ HttpSessionUpdateManager::HttpSessionUpdateManager() { d = new Private(this); }
 
 HttpSessionUpdateManager::~HttpSessionUpdateManager() { delete d; }
 
-void HttpSessionUpdateManager::registerSession(HttpSession *hs, int timeout, const Url &uri,
+void HttpSessionUpdateManager::registerSession(HttpSession *hs, int timeout, const CowUrl &uri,
                                                bool resetTimeout) {
     d->registerSession(hs, timeout, uri, resetTimeout);
 }

--- a/src/handler/httpsessionupdatemanager.h
+++ b/src/handler/httpsessionupdatemanager.h
@@ -24,7 +24,7 @@
 #ifndef HTTPSESSIONUPDATEMANAGER_H
 #define HTTPSESSIONUPDATEMANAGER_H
 
-#include "url.h"
+#include "cowurl.h"
 
 #define TIMERS_PER_UNIQUE_UPDATE_REGISTRATION 1
 class HttpSession;
@@ -35,7 +35,8 @@ public:
     ~HttpSessionUpdateManager();
 
     // No-op if session already registered and resetTimeout=false
-    void registerSession(HttpSession *hs, int timeout, const Url &uri, bool resetTimeout = false);
+    void registerSession(HttpSession *hs, int timeout, const CowUrl &uri,
+                         bool resetTimeout = false);
 
     void unregisterSession(HttpSession *hs);
 

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -242,9 +242,9 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
         newResponse.reason = reason;
     }
 
-    Url nextLink;
+    CowUrl nextLink;
     int nextLinkTimeout = -1;
-    Url goneLink;
+    CowUrl goneLink;
     foreach (const HttpHeaderParameters &params, response.headers.getAllAsParameters("Grip-Link")) {
         if (params.count() < 2)
             continue;
@@ -256,7 +256,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
             return Instruct();
         }
 
-        Url link = Url::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
+        CowUrl link = CowUrl::fromEncoded(linkParam.mid(1, linkParam.length() - 2));
         if (!link.isValid()) {
             setError(ok, errorMessage, "Grip-Link contains invalid link");
             return Instruct();

--- a/src/handler/instruct.h
+++ b/src/handler/instruct.h
@@ -23,8 +23,8 @@
 #ifndef INSTRUCT_H
 #define INSTRUCT_H
 
+#include "cowurl.h"
 #include "packet/httpresponsedata.h"
-#include "url.h"
 #include <QByteArray>
 #include <QHash>
 #include <QList>
@@ -53,9 +53,9 @@ public:
     int keepAliveTimeout;
     QHash<QString, QString> meta;
     HttpResponseData response;
-    Url nextLink;
+    CowUrl nextLink;
     int nextLinkTimeout;
-    Url goneLink;
+    CowUrl goneLink;
 
     Instruct()
         : holdMode(NoHold),

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -2246,7 +2246,7 @@ public:
             }
 
             QByteArray uriRaw = scheme + "://" + host + mreq.uri;
-            Url uri = Url::fromEncoded(uriRaw, Url::TolerantMode);
+            CowUrl uri = CowUrl::fromEncoded(uriRaw, CowUrl::TolerantMode);
             if (!uri.isValid()) {
                 log_warning("m2: invalid constructed uri: [%s]", uriRaw.data());
                 m2_writeErrorClose(conn);

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -503,10 +503,10 @@ public:
                     QString::fromUtf8(req->requestHeaders().get("Pushpin-Route").asQByteArray());
         }
 
-        Url uri = req->requestUri();
+        CowUrl uri = req->requestUri();
         bool isSecure = (uri.scheme() == "https");
         QString host = uri.host();
-        QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = uri.path(CowUrl::FullyEncoded).toUtf8();
 
         DomainMap::Entry route;
 
@@ -598,14 +598,14 @@ public:
         if (config.acceptXForwardedProto && isXForwardedProtocolTls(sock->requestHeaders()))
             sock->setIsTls(true);
 
-        Url requestUri = sock->requestUri();
+        CowUrl requestUri = sock->requestUri();
 
         log_debug("worker %d: IN ws id=%s, %s", config.id, sock->rid().second.data(),
                   requestUri.toEncoded().data());
 
         bool isSecure = (requestUri.scheme() == "wss");
         QString host = requestUri.host();
-        QByteArray encPath = requestUri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = requestUri.path(CowUrl::FullyEncoded).toUtf8();
 
         QString routeId;
 
@@ -847,7 +847,7 @@ private:
 
             bool isSecure = req.https;
             QString host = p.requestData.uri.host();
-            QByteArray encPath = p.requestData.uri.path(Url::FullyEncoded).toUtf8();
+            QByteArray encPath = p.requestData.uri.path(CowUrl::FullyEncoded).toUtf8();
 
             QString routeId = QString::fromUtf8(p.route);
 

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -351,7 +351,7 @@ private:
         zresp.code = 200;
         zresp.reason = "OK";
 
-        QByteArray encPath = zreq.uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = zreq.uri.path(CowUrl::FullyEncoded).toUtf8();
 
         UrlQuery query(zreq.uri.query());
         QString hold = query.queryItemValue("hold");

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -26,6 +26,7 @@
 #include "acceptdata.h"
 #include "acceptrequest.h"
 #include "bufferlist.h"
+#include "cowurl.h"
 #include "inspectdata.h"
 #include "jwt.h"
 #include "log.h"
@@ -38,7 +39,6 @@
 #include "statsmanager.h"
 #include "statusreasons.h"
 #include "testhttprequest.h"
-#include "url.h"
 #include "variant.h"
 #include "xffrule.h"
 #include "zhttpmanager.h"
@@ -255,7 +255,7 @@ public:
             if (!route.asHost.isEmpty())
                 ProxyUtil::applyHost(&requestData.uri, route.asHost);
 
-            QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
+            QByteArray path = requestData.uri.path(CowUrl::FullyEncoded).toUtf8();
 
             if (route.pathRemove > 0)
                 path = path.mid(route.pathRemove);
@@ -263,7 +263,7 @@ public:
             if (!route.pathPrepend.isEmpty())
                 path = route.pathPrepend + path;
 
-            requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
+            requestData.uri.setPath(QString::fromUtf8(path), CowUrl::StrictMode);
 
             QByteArray sigIss = defaultSigIss;
             Jwt::EncodingKey sigKey = defaultSigKey;
@@ -376,7 +376,7 @@ public:
             }
         }
 
-        Url uri = requestData.uri;
+        CowUrl uri = requestData.uri;
         if (target.ssl)
             uri.setScheme("https");
         else
@@ -398,7 +398,7 @@ public:
                     --pathRemove;
 
                 if (pathRemove > 0)
-                    uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
+                    uri.setPath(uri.path(CowUrl::FullyEncoded).mid(pathRemove));
             }
 
             zhttpRequest = std::make_unique<TestHttpRequest>();

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -220,7 +220,7 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
         requestData->headers += HttpHeader("X-Forwarded-For", HttpHeaders::join(xffValues));
 }
 
-void applyHost(Url *url, const QString &host) {
+void applyHost(CowUrl *url, const QString &host) {
     int at = host.indexOf(':');
     if (at != -1) {
         url->setHost(host.mid(0, at));
@@ -231,7 +231,7 @@ void applyHost(Url *url, const QString &host) {
     }
 }
 
-void applyHostHeader(HttpHeaders *headers, const Url &uri) {
+void applyHostHeader(HttpHeaders *headers, const CowUrl &uri) {
     QByteArray hostHeader = uri.host().toUtf8();
     if (uri.port() != -1)
         hostHeader += ':' + QByteArray::number(uri.port());

--- a/src/proxy/proxyutil.h
+++ b/src/proxy/proxyutil.h
@@ -23,9 +23,9 @@
 #ifndef PROXYUTIL_H
 #define PROXYUTIL_H
 
+#include "cowurl.h"
 #include "domainmap.h"
 #include "packet/httprequestdata.h"
-#include "url.h"
 #include "xffrule.h"
 #include <QByteArray>
 #include <QHostAddress>
@@ -53,9 +53,9 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
                               const QHostAddress &peerAddress, const InspectData &idata,
                               bool gripEnabled, bool intReq);
 
-void applyHost(Url *url, const QString &host);
+void applyHost(CowUrl *url, const QString &host);
 
-void applyHostHeader(HttpHeaders *headers, const Url &uri);
+void applyHostHeader(HttpHeaders *headers, const CowUrl &uri);
 void applyGripSig(const char *logprefix, void *object, HttpHeaders *headers,
                   const QByteArray &sigIss, const Jwt::EncodingKey &sigKey);
 

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -27,6 +27,7 @@
 #include "acceptrequest.h"
 #include "bufferlist.h"
 #include "cors.h"
+#include "cowurl.h"
 #include "defercall.h"
 #include "inspectdata.h"
 #include "inspectrequest.h"
@@ -38,7 +39,6 @@
 #include "qtcompat.h"
 #include "sockjsmanager.h"
 #include "statsmanager.h"
-#include "url.h"
 #include "urlquery.h"
 #include "variant.h"
 #include "xffrule.h"
@@ -271,7 +271,7 @@ public:
 
         bool isHttps = (requestData.uri.scheme() == "https");
         QString host = requestData.uri.host();
-        QByteArray encPath = requestData.uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = requestData.uri.path(CowUrl::FullyEncoded).toUtf8();
 
         // Before we do anything else, see if this is a sockjs request
         if (!route.isNull() && !route.sockJsPath.isEmpty() &&
@@ -576,7 +576,7 @@ public:
         if (!config.bodyParam.isEmpty())
             bodyParam = QString::fromUtf8(config.bodyParam);
 
-        Url uri = requestData.uri;
+        CowUrl uri = requestData.uri;
         UrlQuery query(uri);
 
         // Two ways to activate JSON-P:
@@ -591,7 +591,7 @@ public:
         QByteArray callback;
         if (query.hasQueryItem(callbackParam)) {
             callback = parsePercentEncoding(
-                query.queryItemValue(callbackParam, Url::FullyEncoded).toUtf8());
+                query.queryItemValue(callbackParam, CowUrl::FullyEncoded).toUtf8());
             if (callback.isEmpty()) {
                 log_debug("requestsession: id=%s invalid callback parameter, rejecting",
                           rid.second.data());
@@ -606,8 +606,8 @@ public:
 
         QString method;
         if (query.hasQueryItem("_method")) {
-            method = QString::fromLatin1(
-                parsePercentEncoding(query.queryItemValue("_method", Url::FullyEncoded).toUtf8()));
+            method = QString::fromLatin1(parsePercentEncoding(
+                query.queryItemValue("_method", CowUrl::FullyEncoded).toUtf8()));
             if (!validMethod(method)) {
                 log_debug("requestsession: id=%s invalid _method parameter, rejecting",
                           rid.second.data());
@@ -623,7 +623,8 @@ public:
         if (query.hasQueryItem("_headers")) {
             QJsonParseError e;
             QJsonDocument doc = QJsonDocument::fromJson(
-                parsePercentEncoding(query.queryItemValue("_headers", Url::FullyEncoded).toUtf8()),
+                parsePercentEncoding(
+                    query.queryItemValue("_headers", CowUrl::FullyEncoded).toUtf8()),
                 &e);
             if (e.error != QJsonParseError::NoError || !doc.isObject()) {
                 log_debug("requestsession: id=%s invalid _headers parameter, rejecting",
@@ -662,7 +663,7 @@ public:
         if (!bodyParam.isEmpty()) {
             if (query.hasQueryItem(bodyParam)) {
                 body = parsePercentEncoding(
-                    query.queryItemValue(bodyParam, Url::FullyEncoded).toUtf8());
+                    query.queryItemValue(bodyParam, CowUrl::FullyEncoded).toUtf8());
                 if (body.isNull()) {
                     log_debug("requestsession: id=%s invalid body parameter, rejecting",
                               rid.second.data());
@@ -698,7 +699,7 @@ public:
             QByteArray tmp = uri.toEncoded();
             if (tmp.length() > 0 && tmp[tmp.length() - 1] == '?') {
                 tmp.truncate(tmp.length() - 1);
-                uri = Url::fromEncoded(tmp, Url::StrictMode);
+                uri = CowUrl::fromEncoded(tmp, CowUrl::StrictMode);
             }
         }
 

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -88,7 +88,7 @@ public:
         BufferList reqBody;
         QByteArray path;
         QByteArray jsonpCallback;
-        Url asUri;
+        CowUrl asUri;
         DomainMap::Entry route;
         QByteArray sid;
         QByteArray lastPart;
@@ -201,9 +201,9 @@ public:
         Session *s = new Session(this);
         s->req = req;
 
-        Url uri = req->requestUri();
+        CowUrl uri = req->requestUri();
 
-        QByteArray encPath = uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = uri.path(CowUrl::FullyEncoded).toUtf8();
         s->path = encPath.mid(basePathStart);
 
         UrlQuery query(uri);
@@ -222,9 +222,9 @@ public:
         s->asUri = uri;
         s->asUri.setScheme((s->asUri.scheme() == "https") ? "wss" : "ws");
         if (!asPath.isEmpty())
-            s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
+            s->asUri.setPath(QString::fromUtf8(asPath), CowUrl::StrictMode);
         else
-            s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart)), Url::StrictMode);
+            s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart)), CowUrl::StrictMode);
 
         s->route = route;
 
@@ -245,14 +245,14 @@ public:
         Session *s = new Session(this);
         s->sock = sock;
 
-        QByteArray encPath = sock->requestUri().path(Url::FullyEncoded).toUtf8();
+        QByteArray encPath = sock->requestUri().path(CowUrl::FullyEncoded).toUtf8();
         s->path = encPath.mid(basePathStart);
         s->asUri = sock->requestUri();
         if (!asPath.isEmpty())
-            s->asUri.setPath(QString::fromUtf8(asPath), Url::StrictMode);
+            s->asUri.setPath(QString::fromUtf8(asPath), CowUrl::StrictMode);
         else
             s->asUri.setPath(QString::fromUtf8(encPath.mid(0, basePathStart) + "/websocket"),
-                             Url::StrictMode);
+                             CowUrl::StrictMode);
         s->route = route;
 
         wsConnectionMap[sock] = {

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -337,8 +337,8 @@ public:
                         if (at == -1)
                             continue;
 
-                        if (Url::fromPercentEncoding(kv.mid(0, at)) == "d") {
-                            param = Url::fromPercentEncoding(kv.mid(at + 1)).toUtf8();
+                        if (CowUrl::fromPercentEncoding(kv.mid(0, at)) == "d") {
+                            param = CowUrl::fromPercentEncoding(kv.mid(at + 1)).toUtf8();
                             break;
                         }
                     }
@@ -999,7 +999,7 @@ void SockJsSession::setClientCert([[maybe_unused]] const QString &cert,
     assert(0);
 }
 
-void SockJsSession::start([[maybe_unused]] const Url &uri,
+void SockJsSession::start([[maybe_unused]] const CowUrl &uri,
                           [[maybe_unused]] const HttpHeaders &headers) {
     // This class is server only
     assert(0);
@@ -1016,7 +1016,7 @@ void SockJsSession::respondError(int code, const QByteArray &reason, const HttpH
 
 WebSocket::State SockJsSession::state() const { return d->state; }
 
-Url SockJsSession::requestUri() const { return d->requestData.uri; }
+CowUrl SockJsSession::requestUri() const { return d->requestData.uri; }
 
 HttpHeaders SockJsSession::requestHeaders() const { return d->requestData.headers; }
 
@@ -1080,7 +1080,7 @@ WebSocket::Frame SockJsSession::readFrame() { return d->readFrame(); }
 void SockJsSession::close(int code, const QString &reason) { d->close(code, reason); }
 
 void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req,
-                                const QByteArray &jsonpCallback, const Url &asUri,
+                                const QByteArray &jsonpCallback, const CowUrl &asUri,
                                 const QByteArray &sid, const QByteArray &lastPart,
                                 const QByteArray &body, const DomainMap::Entry &route) {
     d->manager = manager;
@@ -1102,7 +1102,7 @@ void SockJsSession::setupServer(SockJsManager *manager, ZhttpRequest *req,
     d->setup();
 }
 
-void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const CowUrl &asUri,
                                 const DomainMap::Entry &route) {
     d->manager = manager;
     d->mode = Private::WebSocketPassthrough;
@@ -1115,7 +1115,7 @@ void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const 
     d->setup();
 }
 
-void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+void SockJsSession::setupServer(SockJsManager *manager, ZWebSocket *sock, const CowUrl &asUri,
                                 const QByteArray &sid, [[maybe_unused]] const QByteArray &lastPart,
                                 const DomainMap::Entry &route) {
     d->manager = manager;

--- a/src/proxy/sockjssession.h
+++ b/src/proxy/sockjssession.h
@@ -24,9 +24,9 @@
 #ifndef SOCKJSSESSION_H
 #define SOCKJSSESSION_H
 
+#include "cowurl.h"
 #include "domainmap.h"
 #include "httpheaders.h"
-#include "url.h"
 #include "websocket.h"
 #include <QHostAddress>
 #include <boost/signals2.hpp>
@@ -58,14 +58,14 @@ public:
     virtual void setIgnoreTlsErrors(bool on);
     virtual void setClientCert(const QString &cert, const QString &key);
 
-    virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const CowUrl &uri, const HttpHeaders &headers);
 
     virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
     virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
                               const QByteArray &body);
 
     virtual State state() const;
-    virtual Url requestUri() const;
+    virtual CowUrl requestUri() const;
     virtual HttpHeaders requestHeaders() const;
     virtual int responseCode() const;
     virtual QByteArray responseReason() const;
@@ -89,11 +89,11 @@ private:
     friend class SockJsManager;
     SockJsSession();
     void setupServer(SockJsManager *manager, ZhttpRequest *req, const QByteArray &jsonpCallback,
-                     const Url &asUri, const QByteArray &sid, const QByteArray &lastPart,
+                     const CowUrl &asUri, const QByteArray &sid, const QByteArray &lastPart,
                      const QByteArray &body, const DomainMap::Entry &route);
-    void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+    void setupServer(SockJsManager *manager, ZWebSocket *sock, const CowUrl &asUri,
                      const DomainMap::Entry &route);
-    void setupServer(SockJsManager *manager, ZWebSocket *sock, const Url &asUri,
+    void setupServer(SockJsManager *manager, ZWebSocket *sock, const CowUrl &asUri,
                      const QByteArray &sid, const QByteArray &lastPart,
                      const DomainMap::Entry &route);
 

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -141,7 +141,7 @@ void TestHttpRequest::setTimeout([[maybe_unused]] int msecs) {}
 void TestHttpRequest::setClientCert([[maybe_unused]] const QString &cert,
                                     [[maybe_unused]] const QString &key) {}
 
-void TestHttpRequest::start(const QString &method, const Url &uri, const HttpHeaders &headers) {
+void TestHttpRequest::start(const QString &method, const CowUrl &uri, const HttpHeaders &headers) {
     assert(d->state == Private::Idle);
 
     d->state = Private::ReceivingRequest;
@@ -207,7 +207,7 @@ HttpRequest::ErrorCondition TestHttpRequest::errorCondition() const { return d->
 
 QString TestHttpRequest::requestMethod() const { return d->request.method; }
 
-Url TestHttpRequest::requestUri() const { return d->request.uri; }
+CowUrl TestHttpRequest::requestUri() const { return d->request.uri; }
 
 HttpHeaders TestHttpRequest::requestHeaders() const { return d->request.headers; }
 

--- a/src/proxy/testhttprequest.h
+++ b/src/proxy/testhttprequest.h
@@ -23,8 +23,8 @@
 #ifndef TESTHTTPREQUEST_H
 #define TESTHTTPREQUEST_H
 
+#include "cowurl.h"
 #include "httprequest.h"
-#include "url.h"
 
 /// HTTP request instance for testing that simulates HTTP behavior
 class TestHttpRequest : public HttpRequest {
@@ -47,7 +47,7 @@ public:
     virtual void setTimeout(int msecs);
     virtual void setClientCert(const QString &cert, const QString &key);
 
-    virtual void start(const QString &method, const Url &uri, const HttpHeaders &headers);
+    virtual void start(const QString &method, const CowUrl &uri, const HttpHeaders &headers);
     virtual void beginResponse(int code, const QByteArray &reason, const HttpHeaders &headers);
 
     virtual void writeBody(const QByteArray &body);
@@ -63,7 +63,7 @@ public:
     virtual ErrorCondition errorCondition() const;
 
     virtual QString requestMethod() const;
-    virtual Url requestUri() const;
+    virtual CowUrl requestUri() const;
     virtual HttpHeaders requestHeaders() const;
 
     virtual int responseCode() const;

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -144,7 +144,7 @@ void TestWebSocket::setIgnoreTlsErrors([[maybe_unused]] bool on) {}
 void TestWebSocket::setClientCert([[maybe_unused]] const QString &cert,
                                   [[maybe_unused]] const QString &key) {}
 
-void TestWebSocket::start(const Url &uri, const HttpHeaders &headers) {
+void TestWebSocket::start(const CowUrl &uri, const HttpHeaders &headers) {
     d->request.uri = uri;
     d->request.headers = headers;
 
@@ -178,7 +178,7 @@ WebSocket::State TestWebSocket::state() const {
         return Closing;
 }
 
-Url TestWebSocket::requestUri() const { return d->request.uri; }
+CowUrl TestWebSocket::requestUri() const { return d->request.uri; }
 
 HttpHeaders TestWebSocket::requestHeaders() const { return d->request.headers; }
 

--- a/src/proxy/testwebsocket.h
+++ b/src/proxy/testwebsocket.h
@@ -24,7 +24,7 @@
 #ifndef TESTWEBSOCKET_H
 #define TESTWEBSOCKET_H
 
-#include "url.h"
+#include "cowurl.h"
 #include "websocket.h"
 
 class ZhttpManager;
@@ -46,14 +46,14 @@ public:
     virtual void setIgnoreTlsErrors(bool on);
     virtual void setClientCert(const QString &cert, const QString &key);
 
-    virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const CowUrl &uri, const HttpHeaders &headers);
 
     virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
     virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
                               const QByteArray &body);
 
     virtual State state() const;
-    virtual Url requestUri() const;
+    virtual CowUrl requestUri() const;
     virtual HttpHeaders requestHeaders() const;
     virtual int responseCode() const;
     virtual QByteArray responseReason() const;

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -954,7 +954,7 @@ void WebSocketOverHttp::setClientCert(const QString &cert, const QString &key) {
     d->clientKey = key;
 }
 
-void WebSocketOverHttp::start(const Url &uri, const HttpHeaders &headers) {
+void WebSocketOverHttp::start(const CowUrl &uri, const HttpHeaders &headers) {
     assert(d->state == Idle);
 
     d->requestData.uri = uri;
@@ -981,7 +981,7 @@ void WebSocketOverHttp::respondError([[maybe_unused]] int code,
 
 WebSocket::State WebSocketOverHttp::state() const { return d->state; }
 
-Url WebSocketOverHttp::requestUri() const { return d->requestData.uri; }
+CowUrl WebSocketOverHttp::requestUri() const { return d->requestData.uri; }
 
 HttpHeaders WebSocketOverHttp::requestHeaders() const { return d->requestData.headers; }
 

--- a/src/proxy/websocketoverhttp.h
+++ b/src/proxy/websocketoverhttp.h
@@ -24,7 +24,7 @@
 #ifndef WEBSOCKETOVERHTTP_H
 #define WEBSOCKETOVERHTTP_H
 
-#include "url.h"
+#include "cowurl.h"
 #include "websocket.h"
 #include <boost/signals2.hpp>
 #include <map>
@@ -71,14 +71,14 @@ public:
     virtual void setIgnoreTlsErrors(bool on);
     virtual void setClientCert(const QString &cert, const QString &key);
 
-    virtual void start(const Url &uri, const HttpHeaders &headers);
+    virtual void start(const CowUrl &uri, const HttpHeaders &headers);
 
     virtual void respondSuccess(const QByteArray &reason, const HttpHeaders &headers);
     virtual void respondError(int code, const QByteArray &reason, const HttpHeaders &headers,
                               const QByteArray &body);
 
     virtual State state() const;
-    virtual Url requestUri() const;
+    virtual CowUrl requestUri() const;
     virtual HttpHeaders requestHeaders() const;
     virtual int responseCode() const;
     virtual QByteArray responseReason() const;

--- a/src/proxy/websocketoverhttptest.cpp
+++ b/src/proxy/websocketoverhttptest.cpp
@@ -103,7 +103,7 @@ public:
             return;
         }
 
-        Url uri = req->requestUri();
+        CowUrl uri = req->requestUri();
         HttpHeaders headers = req->requestHeaders();
         QByteArray body = req->readBody();
 
@@ -255,7 +255,7 @@ static void io(std::function<void(int)> loop_wait) {
     bool clientError = false;
     client.error.connect([&] { clientError = true; });
 
-    client.start(Url("ws://localhost/ws"), HttpHeaders());
+    client.start(CowUrl("ws://localhost/ws"), HttpHeaders());
 
     while (!clientConnected && !clientError)
         loop_wait(10);
@@ -314,7 +314,7 @@ static void replay(std::function<void(int)> loop_wait) {
     bool clientError = false;
     client.error.connect([&] { clientError = true; });
 
-    client.start(Url("ws://localhost/ws"), HttpHeaders());
+    client.start(CowUrl("ws://localhost/ws"), HttpHeaders());
 
     while (!clientConnected && !clientError)
         loop_wait(10);

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -23,8 +23,8 @@
 
 #include "wscontrolsession.h"
 
+#include "cowurl.h"
 #include "timer.h"
-#include "url.h"
 #include "wscontrolmanager.h"
 #include <QDateTime>
 #include <assert.h>
@@ -51,7 +51,7 @@ public:
     bool separateStats;
     QByteArray channelPrefix;
     int logLevel;
-    Url uri;
+    CowUrl uri;
     bool targetTrusted;
     Connection requestTimerConnection;
 
@@ -275,7 +275,7 @@ QByteArray WsControlSession::peer() const { return d->peer; }
 QByteArray WsControlSession::cid() const { return d->cid; }
 
 void WsControlSession::start(bool debug, const QByteArray &routeId, bool separateStats,
-                             const QByteArray &channelPrefix, int logLevel, const Url &uri,
+                             const QByteArray &channelPrefix, int logLevel, const CowUrl &uri,
                              bool targetTrusted) {
     d->debug = debug;
     d->route = routeId;

--- a/src/proxy/wscontrolsession.h
+++ b/src/proxy/wscontrolsession.h
@@ -24,8 +24,8 @@
 #ifndef WSCONTROLSESSION_H
 #define WSCONTROLSESSION_H
 
+#include "cowurl.h"
 #include "packet/wscontrolpacket.h"
-#include "url.h"
 #include "websocket.h"
 #include "wscontrol.h"
 #include <QByteArray>
@@ -46,7 +46,8 @@ public:
     QByteArray cid() const;
 
     void start(bool debug, const QByteArray &routeId, bool separateStats,
-               const QByteArray &channelPrefix, int logLevel, const Url &uri, bool targetTrusted);
+               const QByteArray &channelPrefix, int logLevel, const CowUrl &uri,
+               bool targetTrusted);
     void sendGripMessage(const QByteArray &message);
     void sendNeedKeepAlive();
     void sendSubscribe(const QByteArray &channel);

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -24,6 +24,7 @@
 #include "wsproxysession.h"
 
 #include "connectionmanager.h"
+#include "cowurl.h"
 #include "defercall.h"
 #include "inspectdata.h"
 #include "jwt.h"
@@ -33,7 +34,6 @@
 #include "statsmanager.h"
 #include "testwebsocket.h"
 #include "timer.h"
-#include "url.h"
 #include "websocketoverhttp.h"
 #include "wscontrol.h"
 #include "wscontrolmanager.h"
@@ -385,7 +385,7 @@ public:
         if (!route.asHost.isEmpty())
             ProxyUtil::applyHost(&requestData.uri, route.asHost);
 
-        QByteArray path = requestData.uri.path(Url::FullyEncoded).toUtf8();
+        QByteArray path = requestData.uri.path(CowUrl::FullyEncoded).toUtf8();
 
         if (route.pathRemove > 0)
             path = path.mid(route.pathRemove);
@@ -393,7 +393,7 @@ public:
         if (!route.pathPrepend.isEmpty())
             path = route.pathPrepend + path;
 
-        requestData.uri.setPath(QString::fromUtf8(path), Url::StrictMode);
+        requestData.uri.setPath(QString::fromUtf8(path), CowUrl::StrictMode);
 
         sigIss = defaultSigIss;
         sigKey = defaultSigKey;
@@ -462,7 +462,7 @@ public:
 
         target = targets.takeFirst();
 
-        Url uri = requestData.uri;
+        CowUrl uri = requestData.uri;
         if (target.ssl)
             uri.setScheme("wss");
         else
@@ -484,7 +484,7 @@ public:
                     --pathRemove;
 
                 if (pathRemove > 0)
-                    uri.setPath(uri.path(Url::FullyEncoded).mid(pathRemove));
+                    uri.setPath(uri.path(CowUrl::FullyEncoded).mid(pathRemove));
             }
 
             outSock = std::make_unique<TestWebSocket>();

--- a/src/runner/connmgrservice.cpp
+++ b/src/runner/connmgrservice.cpp
@@ -22,9 +22,9 @@
 
 #include "connmgrservice.h"
 
+#include "cowurl.h"
 #include "log.h"
 #include "template.h"
-#include "url.h"
 #include <QDir>
 #include <QProcess>
 
@@ -69,7 +69,7 @@ ConnmgrService::ConnmgrService(const QString &name, const QString &binFile, cons
 
                 args_ += arg;
             } else {
-                Url url;
+                CowUrl url;
                 url.setHost(!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
                 url.setPort(p.port);
 

--- a/src/runner/runnerapp.cpp
+++ b/src/runner/runnerapp.cpp
@@ -24,6 +24,7 @@
 
 #include "config.h"
 #include "connmgrservice.h"
+#include "cowurl.h"
 #include "listenport.h"
 #include "log.h"
 #include "m2adapterservice.h"
@@ -33,7 +34,6 @@
 #include "pushpinproxyservice.h"
 #include "rust/bindings.h"
 #include "settings.h"
-#include "url.h"
 #include "urlquery.h"
 #include "zurlservice.h"
 #include <QCommandLineParser>
@@ -74,8 +74,8 @@ static QPair<QHostAddress, int> parsePort(const QString &s) {
 
     // Otherwise, assume it's an address:port combination
 
-    // Parse with Url in order to support bracketed IPv6 notation
-    Url url{Url::fromUserInput(s)};
+    // Parse with CowUrl in order to support bracketed IPv6 notation
+    CowUrl url{CowUrl::fromUserInput(s)};
 
     return QPair<QHostAddress, int>(QHostAddress(url.host()), url.port());
 }
@@ -476,7 +476,7 @@ public:
             }
 
             foreach (const QString &localPortStr, localPortStrs) {
-                Url path = Url::fromEncoded(localPortStr.toUtf8());
+                CowUrl path = CowUrl::fromEncoded(localPortStr.toUtf8());
                 if (!path.isValid()) {
                     log_error("invalid local port: %s", qPrintable(localPortStr));
                     q->quit(1);


### PR DESCRIPTION
This renames the `Url` alias to `CowUrl` and updates all the call sites. No other changes. It is still an alias to `QUrl`.