### PR TITLE
cowurl: switch from qurl impl to url crate impl via ffi

### DIFF
--- a/src/core/cowurl.cpp
+++ b/src/core/cowurl.cpp
@@ -15,41 +15,228 @@
  */
 
 #include "cowurl.h"
+
 #include "urlquery.h"
+#include <assert.h>
+
+static QString dataToString(ffi::CowUrlData data) {
+    assert(data.data);
+
+    QString s = QString::fromUtf8(data.data, data.len);
+    ffi::cow_url_data_delete(data);
+    return s;
+}
+
+static QByteArray dataToByteArray(ffi::CowUrlData data) {
+    assert(data.data);
+
+    QByteArray ba(data.data, data.len);
+    ffi::cow_url_data_delete(data);
+    return ba;
+}
+
+CowUrl::CowUrl() : inner_(nullptr) {}
+
+CowUrl::CowUrl(const QString &url) {
+    QByteArray utf8 = url.toUtf8();
+    inner_ = ffi::cow_url_from_string(utf8.constData());
+}
+
+CowUrl::CowUrl(const QString &url, [[maybe_unused]] ParsingMode mode) {
+    QByteArray utf8 = url.toUtf8();
+    inner_ = ffi::cow_url_from_string(utf8.constData());
+}
+
+CowUrl::CowUrl(const char *url) { inner_ = ffi::cow_url_from_string(url); }
+
+CowUrl::CowUrl(const CowUrl &other) {
+    inner_ = other.inner_ ? ffi::cow_url_clone(other.inner_) : nullptr;
+}
+
+CowUrl::~CowUrl() { ffi::cow_url_destroy(inner_); }
+
+CowUrl &CowUrl::operator=(const CowUrl &other) {
+    if (this != &other) {
+        ffi::cow_url_destroy(inner_);
+        inner_ = other.inner_ ? ffi::cow_url_clone(other.inner_) : nullptr;
+    }
+
+    return *this;
+}
 
 CowUrl CowUrl::fromEncoded(const QByteArray &input, [[maybe_unused]] ParsingMode mode) {
     CowUrl url;
-    url.inner_ = QUrl::fromEncoded(input);
+    url.inner_ = ffi::cow_url_from_string(input.constData());
     return url;
 }
 
 QString CowUrl::fromPercentEncoding(const QByteArray &input) {
-    return QUrl::fromPercentEncoding(input);
+    return QString::fromUtf8(QByteArray::fromPercentEncoding(input));
 }
 
 QByteArray CowUrl::toPercentEncoding(const QString &input) {
-    return QUrl::toPercentEncoding(input);
+    return input.toUtf8().toPercentEncoding();
 }
 
 bool CowUrl::isValidRelativeUrl(const QString &relativeUrl) {
     CowUrl dummyBase("http://example.com/");
-    return dummyBase.resolved(relativeUrl).isValid();
+    CowUrl resolved = dummyBase.resolved(relativeUrl);
+    return resolved.isValid();
+}
+
+bool CowUrl::isEmpty() const { return inner_ == nullptr; }
+
+bool CowUrl::isValid() const { return inner_ != nullptr; }
+
+void CowUrl::clear() {
+    ffi::cow_url_destroy(inner_);
+    inner_ = nullptr;
+}
+
+void CowUrl::setScheme(const QString &scheme) {
+    if (!inner_) {
+        return;
+    }
+
+    QByteArray schemeBytes = scheme.toUtf8();
+    ffi::cow_url_set_scheme(&inner_, schemeBytes.constData());
+}
+
+QString CowUrl::scheme() const {
+    if (!inner_) {
+        return QString();
+    }
+
+    return dataToString(ffi::cow_url_scheme(inner_));
+}
+
+QString CowUrl::path([[maybe_unused]] ComponentFormattingOptions options) const {
+    if (!inner_) {
+        return QString();
+    }
+
+    return dataToString(ffi::cow_url_path(inner_));
+}
+
+QString CowUrl::query([[maybe_unused]] ComponentFormattingOptions options) const {
+    if (!inner_) {
+        return QString();
+    }
+
+    ffi::CowUrlData data = ffi::cow_url_query(inner_);
+    if (data.data == nullptr) {
+        return QString();
+    }
+
+    return dataToString(data);
+}
+
+bool CowUrl::hasQuery() const { return inner_ && ffi::cow_url_has_query(inner_); }
+
+QString CowUrl::toString([[maybe_unused]] ComponentFormattingOptions options) const {
+    if (!inner_) {
+        return QString();
+    }
+
+    return dataToString(ffi::cow_url_to_string(inner_));
+}
+
+QByteArray CowUrl::toEncoded() const {
+    if (!inner_) {
+        return QByteArray();
+    }
+
+    return dataToByteArray(ffi::cow_url_to_string(inner_));
+}
+
+QString CowUrl::host() const {
+    if (!inner_) {
+        return QString();
+    }
+
+    ffi::CowUrlData data = ffi::cow_url_host(inner_);
+    if (data.data == nullptr) {
+        return QString();
+    }
+
+    return dataToString(data);
+}
+
+int CowUrl::port() const { return inner_ ? ffi::cow_url_port(inner_) : -1; }
+
+int CowUrl::port(int defaultPort) const {
+    int p = inner_ ? ffi::cow_url_port(inner_) : -1;
+    return (p < 0) ? defaultPort : p;
+}
+
+QString CowUrl::authority() const {
+    QString h = host();
+    if (h.isEmpty()) {
+        return QString();
+    }
+
+    int p = port();
+    if (p >= 0) {
+        return h + ':' + QString::number(p);
+    }
+
+    return h;
+}
+
+void CowUrl::setHost(const QString &host) {
+    if (!inner_) {
+        return;
+    }
+
+    QByteArray hostBytes = host.toUtf8();
+    ffi::cow_url_set_host(&inner_, hostBytes.constData());
+}
+
+void CowUrl::setPort(int port) {
+    if (!inner_) {
+        return;
+    }
+
+    ffi::cow_url_set_port(&inner_, port);
+}
+
+void CowUrl::setPath(const QString &path, [[maybe_unused]] ParsingMode mode) {
+    if (!inner_) {
+        return;
+    }
+
+    QByteArray pathBytes = path.toUtf8();
+    ffi::cow_url_set_path(&inner_, pathBytes.constData());
 }
 
 void CowUrl::setQuery(const QString &query) {
-    if (!query.isEmpty())
-        inner_.setQuery(query);
-    else
-        inner_.setQuery(QString());
+    if (!inner_) {
+        return;
+    }
+
+    if (!query.isEmpty()) {
+        QByteArray queryBytes = query.toUtf8();
+        ffi::cow_url_set_query(&inner_, queryBytes.constData());
+    } else {
+        ffi::cow_url_set_query(&inner_, nullptr);
+    }
 }
 
 void CowUrl::setQuery(const UrlQuery &query) { setQuery(query.toString()); }
 
-CowUrl CowUrl::resolved(const QString &relative) const {
-    if (!isValid() || relative.isEmpty())
-        return CowUrl();
+bool CowUrl::operator==(const CowUrl &other) const { return toString() == other.toString(); }
 
+bool CowUrl::operator!=(const CowUrl &other) const { return !(*this == other); }
+
+bool CowUrl::operator<(const CowUrl &other) const { return toString() < other.toString(); }
+
+CowUrl CowUrl::resolved(const QString &relative) const {
+    if (!isValid() || relative.isEmpty()) {
+        return CowUrl();
+    }
+
+    QByteArray relativeBytes = relative.toUtf8();
     CowUrl result;
-    result.inner_ = inner_.resolved(QUrl(relative));
+    result.inner_ = ffi::cow_url_join(inner_, relativeBytes.constData());
     return result;
 }

--- a/src/core/cowurl.h
+++ b/src/core/cowurl.h
@@ -17,6 +17,7 @@
 #ifndef COWURL_H
 #define COWURL_H
 
+#include "rust/bindings.h"
 #include <QByteArray>
 #include <QHash>
 #include <QString>
@@ -24,8 +25,6 @@
 
 class UrlQuery;
 
-// QUrl-like class that currently forwards to an inner QUrl, to assist with reducing direct
-// dependency on Qt. The API is designed to allow cheap conversion to/from QUrl.
 class CowUrl {
 public:
     enum ParsingMode { StrictMode = 0 };
@@ -36,69 +35,57 @@ public:
         FullyDecoded = QUrl::FullyDecoded
     };
 
-    CowUrl() = default;
-    CowUrl(const QString &url, [[maybe_unused]] ParsingMode mode = StrictMode) : inner_(url) {}
-    CowUrl(const char *url) : inner_(url) {}
-    CowUrl(const CowUrl &other) = default;
-    CowUrl &operator=(const CowUrl &other) = default;
+    CowUrl();
+    CowUrl(const QString &url);
+    CowUrl(const QString &url, ParsingMode mode);
+    CowUrl(const char *url);
+    CowUrl(const CowUrl &other);
+    ~CowUrl();
 
-    bool operator==(const CowUrl &other) const { return inner_ == other.inner_; }
-    bool operator!=(const CowUrl &other) const { return inner_ != other.inner_; }
-    bool operator<(const CowUrl &other) const {
-        return inner_.toString() < other.inner_.toString();
-    }
+    CowUrl &operator=(const CowUrl &other);
+
+    bool operator==(const CowUrl &other) const;
+    bool operator!=(const CowUrl &other) const;
+    bool operator<(const CowUrl &other) const;
 
     static CowUrl fromEncoded(const QByteArray &input, ParsingMode mode = StrictMode);
     static QString fromPercentEncoding(const QByteArray &input);
     static QByteArray toPercentEncoding(const QString &input);
+
+    // Validates that a potentially relative URL string is syntactically valid
+    // by attempting to resolve it against a dummy base URL
     static bool isValidRelativeUrl(const QString &relativeUrl);
 
-    bool isValid() const { return inner_.isValid() && !inner_.scheme().isEmpty(); }
-    bool isEmpty() const { return !isValid(); }
-    void clear() { inner_.clear(); }
+    bool isEmpty() const;
+    bool isValid() const;
+    void clear();
 
-    void setScheme(const QString &scheme) { inner_.setScheme(scheme); }
-    QString scheme() const { return inner_.scheme(); }
+    void setScheme(const QString &scheme);
+    QString scheme() const;
+    QString path(ComponentFormattingOptions options = FullyEncoded) const;
+    QString query(ComponentFormattingOptions options = FullyEncoded) const;
+    bool hasQuery() const;
 
-    QString path(ComponentFormattingOptions options = FullyEncoded) const {
-        return inner_.path(static_cast<QUrl::ComponentFormattingOptions>(options));
-    }
-    void setPath(const QString &path, [[maybe_unused]] ParsingMode mode = StrictMode) {
-        inner_.setPath(path);
-    }
-
-    QString query(ComponentFormattingOptions options = FullyEncoded) const {
-        if (!inner_.hasQuery())
-            return QString();
-        return inner_.query(static_cast<QUrl::ComponentFormattingOptions>(options));
-    }
-    bool hasQuery() const { return inner_.hasQuery(); }
+    QString host() const;
+    int port() const;
+    int port(int defaultPort) const;
+    QString authority() const;
+    void setHost(const QString &host);
+    void setPort(int port);
+    void setPath(const QString &path, ParsingMode mode = StrictMode);
     void setQuery(const QString &query);
     void setQuery(const UrlQuery &query);
 
-    QString host() const { return inner_.host(); }
-    void setHost(const QString &host) { inner_.setHost(host); }
+    CowUrl resolved(const QString &relativeString) const;
 
-    int port() const { return inner_.port(); }
-    int port(int defaultPort) const { return inner_.port(defaultPort); }
-    void setPort(int port) { inner_.setPort(port); }
-
-    QString authority() const { return inner_.authority(); }
-
-    CowUrl resolved(const QString &relative) const;
-
-    QString toString(ComponentFormattingOptions options = FullyEncoded) const {
-        return inner_.toString(static_cast<QUrl::ComponentFormattingOptions>(options));
-    }
-    QByteArray toEncoded() const { return inner_.toEncoded(); }
+    QString toString(ComponentFormattingOptions options = FullyEncoded) const;
+    QByteArray toEncoded() const;
 
 private:
-    friend uint qHash(const CowUrl &url, uint seed);
-
-    QUrl inner_;
+    ffi::Url *inner_;
 };
 
 // Hash function for CowUrl so it can be used in QHash
-inline uint qHash(const CowUrl &url, uint seed = 0) { return qHash(url.inner_, seed); }
+inline size_t qHash(const CowUrl &url, size_t seed = 0) { return qHash(url.toString(), seed); }
 
 #endif // COWURL_H


### PR DESCRIPTION
Notably, various FFI functions take a pointer to a pointer in order to allow updating the pointer's location. For example, when calling something like `ffi::cow_url_set_host(&inner_, hostBytes.constData())`, if the inner arc'd object had more than one ref then it will be deep copied and `inner_` will now point to the copy.

After preparing this I realized the comparison operators are pretty inefficient (converting to strings and comparing them). I'll address that afterwards with FFI functions that call the underlying Rust comparison methods.