### PR TITLE
consolidate tcp/unix socket listening configuration

### DIFF
--- a/src/bin/pushpin-connmgr.rs
+++ b/src/bin/pushpin-connmgr.rs
@@ -17,7 +17,8 @@
 
 use clap::{Arg, ArgAction, Command};
 use log::{error, LevelFilter};
-use pushpin::connmgr::{run, App, Config, DebugSocketConfig, ListenConfig, ListenSpec};
+use pushpin::connmgr::{run, App, Config, ListenConfig, ListenSpec};
+use pushpin::core::config::{NetListenConfig, UnixListenConfig};
 use pushpin::core::log::{get_simple_logger, local_offset_check};
 use pushpin::core::version;
 use std::error::Error;
@@ -114,76 +115,47 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
     };
 
     for v in args.listen.iter() {
-        let mut parts = v.split(',');
+        let net: NetListenConfig = v
+            .parse()
+            .map_err(|e| format!("failed to parse listen: {}", e))?;
 
-        // There's always a first part
-        let part1 = parts.next().unwrap();
+        let (spec, stream) = match net {
+            NetListenConfig::Tcp(mut c) => {
+                let stream =
+                    c.params.remove("req").is_none() || c.params.remove("stream").is_some();
+                let tls = c.params.remove("tls").is_some();
+                let default_cert = c.params.remove("default-cert");
 
-        let mut stream = true;
-        let mut tls = false;
-        let mut default_cert = None;
-        let mut local = false;
-        let mut mode = None;
-        let mut user = None;
-        let mut group = None;
-
-        for part in parts {
-            let (k, v) = match part.find('=') {
-                Some(pos) => (&part[..pos], &part[(pos + 1)..]),
-                None => (part, ""),
-            };
-
-            match k {
-                "req" => stream = false,
-                "stream" => stream = true,
-                "tls" => tls = true,
-                "default-cert" => default_cert = Some(String::from(v)),
-                "local" => local = true,
-                "mode" => match u32::from_str_radix(v, 8) {
-                    Ok(x) => mode = Some(x),
-                    Err(e) => return Err(format!("failed to parse mode: {}", e).into()),
-                },
-                "user" => user = Some(String::from(v)),
-                "group" => group = Some(String::from(v)),
-                _ => return Err(format!("failed to parse listen: invalid param: {}", part).into()),
-            }
-        }
-
-        let spec = if local {
-            ListenSpec::Local {
-                path: PathBuf::from(part1),
-                mode,
-                user,
-                group,
-            }
-        } else {
-            let port_pos = match part1.rfind(':') {
-                Some(pos) => pos + 1,
-                None => 0,
-            };
-
-            let port = &part1[port_pos..];
-            if port.parse::<u16>().is_err() {
-                return Err(format!("failed to parse listen: invalid port {}", port).into());
-            }
-
-            let addr = if port_pos > 0 {
-                String::from(part1)
-            } else {
-                format!("0.0.0.0:{}", part1)
-            };
-
-            let addr = match addr.parse() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    return Err(format!("failed to parse listen: {}", e).into());
+                if let Some(k) = c.params.keys().next() {
+                    return Err(format!("failed to parse listen: invalid param: {}", k).into());
                 }
-            };
 
-            ListenSpec::Tcp {
-                addr,
-                tls,
-                default_cert,
+                (
+                    ListenSpec::Tcp {
+                        addr: c.addr,
+                        tls,
+                        default_cert,
+                    },
+                    stream,
+                )
+            }
+            NetListenConfig::Unix(mut c) => {
+                let stream =
+                    c.params.remove("req").is_none() || c.params.remove("stream").is_some();
+
+                if let Some(k) = c.params.keys().next() {
+                    return Err(format!("failed to parse listen: invalid param: {}", k).into());
+                }
+
+                (
+                    ListenSpec::Local {
+                        path: c.path,
+                        mode: c.mode,
+                        user: c.user,
+                        group: c.group,
+                    },
+                    stream,
+                )
             }
         };
 
@@ -197,42 +169,13 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
     }
 
     if let Some(v) = &args.debug_socket {
-        let mut parts = v.split(',');
-
-        // There's always a first part
-        let part1 = parts.next().unwrap();
-
-        let mut mode = None;
-        let mut user = None;
-        let mut group = None;
-
-        for part in parts {
-            let (k, v) = match part.find('=') {
-                Some(pos) => (&part[..pos], &part[(pos + 1)..]),
-                None => (part, ""),
-            };
-
-            match k {
-                "mode" => match u32::from_str_radix(v, 8) {
-                    Ok(x) => mode = Some(x),
-                    Err(e) => return Err(format!("failed to parse mode: {}", e).into()),
-                },
-                "user" => user = Some(String::from(v)),
-                "group" => group = Some(String::from(v)),
-                _ => {
-                    return Err(
-                        format!("failed to parse debug-socket: invalid param: {}", part).into(),
-                    )
-                }
-            }
+        let spec: UnixListenConfig = v
+            .parse()
+            .map_err(|e| format!("failed to parse debug-socket: {}", e))?;
+        if let Some(k) = spec.params.keys().next() {
+            return Err(format!("failed to parse debug-socket: invalid param: {}", k).into());
         }
-
-        config.debug_socket = Some(DebugSocketConfig {
-            path: PathBuf::from(part1),
-            mode,
-            user,
-            group,
-        });
+        config.debug_socket = Some(spec);
     }
 
     run(&config)

--- a/src/bin/pushpin-connmgr.rs
+++ b/src/bin/pushpin-connmgr.rs
@@ -115,14 +115,25 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
     };
 
     for v in args.listen.iter() {
-        let net: NetListenConfig = v
+        let mut net: NetListenConfig = v
             .parse()
             .map_err(|e| format!("failed to parse listen: {}", e))?;
 
-        let (spec, stream) = match net {
+        let stream = {
+            let params = match &mut net {
+                NetListenConfig::Tcp(c) => &mut c.params,
+                NetListenConfig::Unix(c) => &mut c.params,
+            };
+
+            let req = params.remove("req").is_some();
+            let stream = params.remove("stream").is_some();
+
+            // Stream mode indicated by presence of stream param or absence of req param
+            stream || !req
+        };
+
+        let spec = match net {
             NetListenConfig::Tcp(mut c) => {
-                let stream =
-                    c.params.remove("req").is_none() || c.params.remove("stream").is_some();
                 let tls = c.params.remove("tls").is_some();
                 let default_cert = c.params.remove("default-cert");
 
@@ -130,32 +141,23 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
                     return Err(format!("failed to parse listen: invalid param: {}", k).into());
                 }
 
-                (
-                    ListenSpec::Tcp {
-                        addr: c.addr,
-                        tls,
-                        default_cert,
-                    },
-                    stream,
-                )
+                ListenSpec::Tcp {
+                    addr: c.addr,
+                    tls,
+                    default_cert,
+                }
             }
-            NetListenConfig::Unix(mut c) => {
-                let stream =
-                    c.params.remove("req").is_none() || c.params.remove("stream").is_some();
-
+            NetListenConfig::Unix(c) => {
                 if let Some(k) = c.params.keys().next() {
                     return Err(format!("failed to parse listen: invalid param: {}", k).into());
                 }
 
-                (
-                    ListenSpec::Local {
-                        path: c.path,
-                        mode: c.mode,
-                        user: c.user,
-                        group: c.group,
-                    },
-                    stream,
-                )
+                ListenSpec::Local {
+                    path: c.path,
+                    mode: c.mode,
+                    user: c.user,
+                    group: c.group,
+                }
             }
         };
 

--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -31,20 +31,17 @@ pub mod websocket;
 
 use self::client::Client;
 use self::server::Server;
-use crate::core::fs::{set_group, set_user};
+use crate::core::config::UnixListenConfig;
 use crate::core::log::DebugLogger;
+use crate::core::net::bind_unix_config;
 use crate::core::zmq::SpecInfo;
 use ipnet::IpNet;
 use log::{debug, info};
-use mio::net::UnixListener;
 use signal_hook;
 use signal_hook::consts::TERM_SIGNALS;
 use signal_hook::iterator::Signals;
 use std::cmp;
 use std::error::Error;
-use std::fs;
-use std::io;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -103,13 +100,6 @@ pub struct ListenConfig {
     pub stream: bool,
 }
 
-pub struct DebugSocketConfig {
-    pub path: PathBuf,
-    pub mode: Option<u32>,
-    pub user: Option<String>,
-    pub group: Option<String>,
-}
-
 pub struct Config {
     pub instance_id: String,
     pub workers: usize,
@@ -133,7 +123,7 @@ pub struct Config {
     pub certs_dir: PathBuf,
     pub allow_compression: bool,
     pub deny: Vec<IpNet>,
-    pub debug_socket: Option<DebugSocketConfig>,
+    pub debug_socket: Option<UnixListenConfig>,
 }
 
 pub struct App {
@@ -154,50 +144,8 @@ impl App {
 
         let mut debug_logger = None;
 
-        if let Some(DebugSocketConfig {
-            path,
-            mode,
-            user,
-            group,
-        }) = &config.debug_socket
-        {
-            // Ensure pipe file doesn't exist
-            match fs::remove_file(path) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-                Err(e) => panic!("{}", e),
-            }
-
-            let l = match UnixListener::bind(path) {
-                Ok(l) => l,
-                Err(e) => return Err(format!("failed to bind {:?}: {}", path, e)),
-            };
-
-            if let Some(mode) = mode {
-                let perms = fs::Permissions::from_mode(*mode);
-
-                if let Err(e) = fs::set_permissions(path, perms) {
-                    return Err(format!("failed to set mode on {:?}: {}", path, e));
-                }
-            }
-
-            if let Some(user) = user {
-                if let Err(e) = set_user(path, user) {
-                    return Err(format!(
-                        "failed to set user {:?} on {:?}: {}",
-                        user, path, e
-                    ));
-                }
-            }
-
-            if let Some(group) = group {
-                if let Err(e) = set_group(path, group) {
-                    return Err(format!(
-                        "failed to set group {:?} on {:?}: {}",
-                        group, path, e
-                    ));
-                }
-            }
+        if let Some(spec) = &config.debug_socket {
+            let l = bind_unix_config(spec).map_err(|e| format!("debug socket: {}", e))?;
 
             // Scale the log queue with the number of workers
             let queue_max = (config.workers * 1000) + 1000;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -16,9 +16,12 @@
 
 use config::{Config, ConfigError};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::env;
 use std::error::Error;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 #[cfg(not(test))]
 use config::File;
@@ -527,12 +530,258 @@ mod ffi {
     }
 }
 
+/// Address specification for a TCP listener. Supports parsing from a comma-separated string: the
+/// first field is an address — a bare port number (e.g. `"9001"`) expands to `0.0.0.0:9001`, and
+/// a `host:port` pair is used as-is. Remaining fields are `key` or `key=value` pairs; unrecognized
+/// ones are collected into `params`.
+pub struct TcpListenConfig {
+    pub addr: std::net::SocketAddr,
+    pub params: HashMap<String, String>,
+}
+
+impl FromStr for TcpListenConfig {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(',');
+
+        // There is always a first part.
+        let first = parts.next().unwrap();
+
+        let addr: std::net::SocketAddr = if let Ok(addr) = first.parse() {
+            addr
+        } else if let Ok(port) = first.parse::<u16>() {
+            (IpAddr::V4(Ipv4Addr::UNSPECIFIED), port).into()
+        } else {
+            return Err(format!("invalid TCP address or port: {}", first));
+        };
+
+        let mut params = HashMap::new();
+
+        for part in parts {
+            let (k, v) = match part.find('=') {
+                Some(pos) => (&part[..pos], &part[(pos + 1)..]),
+                None => (part, ""),
+            };
+            params.insert(k.to_string(), v.to_string());
+        }
+
+        Ok(Self { addr, params })
+    }
+}
+
+/// Address specification for a Unix socket listener. Supports parsing from a comma-separated
+/// string: the first field is the socket path, and remaining fields are `key` or `key=value`
+/// pairs. Recognized keys are `mode` (octal permissions), `user`, and `group`. Unrecognized ones
+/// are collected into `params`.
+pub struct UnixListenConfig {
+    pub path: PathBuf,
+    pub mode: Option<u32>,
+    pub user: Option<String>,
+    pub group: Option<String>,
+    pub params: HashMap<String, String>,
+}
+
+impl FromStr for UnixListenConfig {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(',');
+
+        // There is always a first part.
+        let path = PathBuf::from(parts.next().unwrap());
+
+        let mut mode = None;
+        let mut user = None;
+        let mut group = None;
+        let mut params = HashMap::new();
+
+        for part in parts {
+            let (k, v) = match part.find('=') {
+                Some(pos) => (&part[..pos], &part[(pos + 1)..]),
+                None => (part, ""),
+            };
+
+            match k {
+                "mode" => match u32::from_str_radix(v, 8) {
+                    Ok(x) => mode = Some(x),
+                    Err(e) => return Err(format!("failed to parse mode: {}", e)),
+                },
+                "user" => user = Some(String::from(v)),
+                "group" => group = Some(String::from(v)),
+                _ => {
+                    params.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+
+        Ok(Self {
+            path,
+            mode,
+            user,
+            group,
+            params,
+        })
+    }
+}
+
+pub enum NetListenConfig {
+    Tcp(TcpListenConfig),
+    Unix(UnixListenConfig),
+}
+
+impl FromStr for NetListenConfig {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(',');
+
+        // There is always a first part.
+        let first = parts.next().unwrap();
+
+        let mut local = false;
+        let mut rest: Vec<&str> = Vec::new();
+
+        for part in parts {
+            let k = match part.find('=') {
+                Some(pos) => &part[..pos],
+                None => part,
+            };
+            if k == "local" {
+                local = true;
+            } else {
+                rest.push(part);
+            }
+        }
+
+        // Reconstruct a string for the inner parser: first field + remaining params.
+        let inner = if rest.is_empty() {
+            first.to_string()
+        } else {
+            format!("{},{}", first, rest.join(","))
+        };
+
+        if local {
+            Ok(Self::Unix(inner.parse()?))
+        } else {
+            Ok(Self::Tcp(inner.parse()?))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::{ensure_example_config, test_dir};
     use std::error::Error;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::path::PathBuf;
+
+    #[test]
+    fn tcp_listen_config_port_only() {
+        let c: TcpListenConfig = "9001".parse().unwrap();
+        assert_eq!(c.addr, SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 9001));
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn tcp_listen_config_host_port() {
+        let c: TcpListenConfig = "127.0.0.1:9001".parse().unwrap();
+        assert_eq!(c.addr, "127.0.0.1:9001".parse().unwrap());
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn tcp_listen_config_ipv6() {
+        let c: TcpListenConfig = "[::1]:9001".parse().unwrap();
+        assert_eq!(c.addr, SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 9001));
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn tcp_listen_config_params() {
+        let c: TcpListenConfig = "9001,tls,default-cert=mycert".parse().unwrap();
+        assert_eq!(c.addr, SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 9001));
+        assert_eq!(c.params["tls"], "");
+        assert_eq!(c.params["default-cert"], "mycert");
+    }
+
+    #[test]
+    fn tcp_listen_config_invalid() {
+        assert!("notanaddr".parse::<TcpListenConfig>().is_err());
+    }
+
+    #[test]
+    fn unix_listen_config_path_only() {
+        let c: UnixListenConfig = "/tmp/foo.sock".parse().unwrap();
+        assert_eq!(c.path, PathBuf::from("/tmp/foo.sock"));
+        assert_eq!(c.mode, None);
+        assert_eq!(c.user, None);
+        assert_eq!(c.group, None);
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn unix_listen_config_all_known_params() {
+        let c: UnixListenConfig = "/tmp/foo.sock,mode=0600,user=www,group=www"
+            .parse()
+            .unwrap();
+        assert_eq!(c.path, PathBuf::from("/tmp/foo.sock"));
+        assert_eq!(c.mode, Some(0o600));
+        assert_eq!(c.user.as_deref(), Some("www"));
+        assert_eq!(c.group.as_deref(), Some("www"));
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn unix_listen_config_unknown_params() {
+        let c: UnixListenConfig = "/tmp/foo.sock,req".parse().unwrap();
+        assert_eq!(c.params["req"], "");
+    }
+
+    #[test]
+    fn unix_listen_config_bad_mode() {
+        assert!("/tmp/foo.sock,mode=notoctal"
+            .parse::<UnixListenConfig>()
+            .is_err());
+    }
+
+    #[test]
+    fn net_listen_config_tcp_port_only() {
+        let NetListenConfig::Tcp(c) = "9001".parse().unwrap() else {
+            panic!("expected Tcp")
+        };
+        assert_eq!(c.addr, SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 9001));
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn net_listen_config_tcp_with_params() {
+        let NetListenConfig::Tcp(c) = "9001,tls,default-cert=mycert".parse().unwrap() else {
+            panic!("expected Tcp")
+        };
+        assert_eq!(c.addr, SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 9001));
+        assert_eq!(c.params["tls"], "");
+        assert_eq!(c.params["default-cert"], "mycert");
+    }
+
+    #[test]
+    fn net_listen_config_unix_via_local() {
+        let NetListenConfig::Unix(c) = "/tmp/foo.sock,local,mode=0600".parse().unwrap() else {
+            panic!("expected Unix")
+        };
+        assert_eq!(c.path, PathBuf::from("/tmp/foo.sock"));
+        assert_eq!(c.mode, Some(0o600));
+        assert!(c.params.is_empty());
+    }
+
+    #[test]
+    fn net_listen_config_unix_unknown_params() {
+        let NetListenConfig::Unix(c) = "/tmp/foo.sock,local,req".parse().unwrap() else {
+            panic!("expected Unix")
+        };
+        assert_eq!(c.params["req"], "");
+    }
 
     struct TestArgs {
         name: &'static str,

--- a/src/core/net.rs
+++ b/src/core/net.rs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+use crate::core::config::{NetListenConfig, UnixListenConfig};
 use crate::core::event::ReadinessExt;
+use crate::core::fs::{set_group, set_user};
 use crate::core::io::{AsyncRead, AsyncWrite};
 use crate::core::reactor::IoEvented;
 use crate::core::task::get_reactor;
@@ -24,6 +26,7 @@ use socket2::Socket;
 use std::fmt;
 use std::future::Future;
 use std::io::{self, Read, Write};
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::path::Path;
 use std::pin::Pin;
@@ -65,10 +68,51 @@ impl fmt::Display for SocketAddr {
     }
 }
 
+pub fn bind_unix_config(config: &UnixListenConfig) -> Result<UnixListener, String> {
+    // Remove any existing socket file before binding.
+    match std::fs::remove_file(&config.path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Err(format!("failed to remove {:?}: {}", config.path, e)),
+    }
+
+    let listener = UnixListener::bind(&config.path)
+        .map_err(|e| format!("failed to bind {:?}: {}", config.path, e))?;
+
+    if let Some(mode) = config.mode {
+        let perms = std::fs::Permissions::from_mode(mode);
+        std::fs::set_permissions(&config.path, perms)
+            .map_err(|e| format!("failed to set permissions on {:?}: {}", config.path, e))?;
+    }
+
+    if let Some(user) = &config.user {
+        set_user(&config.path, user)
+            .map_err(|e| format!("failed to set user on {:?}: {}", config.path, e))?;
+    }
+
+    if let Some(group) = &config.group {
+        set_group(&config.path, group)
+            .map_err(|e| format!("failed to set group on {:?}: {}", config.path, e))?;
+    }
+
+    Ok(listener)
+}
+
 #[derive(Debug)]
 pub enum NetListener {
     Tcp(TcpListener),
     Unix(UnixListener),
+}
+
+impl NetListener {
+    pub fn bind_config(config: &NetListenConfig) -> Result<Self, String> {
+        match config {
+            NetListenConfig::Tcp(c) => TcpListener::bind(c.addr)
+                .map(Self::Tcp)
+                .map_err(|e| format!("failed to bind {}: {}", c.addr, e)),
+            NetListenConfig::Unix(c) => bind_unix_config(c).map(Self::Unix),
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
While preparing to implement prometheus metrics in connmgr, I realized we need a way to specify a listener binding, and currently we have two existing code paths for this kind of thing (for accepting client connections and for the debug socket) that are not reusable. This PR consolidates both the input parsing and the socket binding to reduce code duplication as well as make it reusable.

Notably, we need to support two kinds of inputs: strings that can specify either a tcp or unix listening configuration (used for accepting client connections, where a `local` param indicates unix), and strings for specifying only unix listening configuration (used for the debug socket, no `'local` flag needed in that context).

Summary:

* Input string parsing is moved into the `config` module. It knows how to parse various string forms, such as a tcp port by itself (`9000`), tcp addr+port (`127.0.0.1:9000`), or unix path with params (`/path/to/foo.sock,mode=700`) into a `NetListenConfig` struct.
* Functions are added to the `net` module for binding TCP or Unix sockets based on a supplied config.
* Call sites updated to use the new APIs.