### PR TITLE
runner: correct use of cowurl when determining listen arg

### DIFF
--- a/src/runner/connmgrservice.cpp
+++ b/src/runner/connmgrservice.cpp
@@ -69,8 +69,7 @@ ConnmgrService::ConnmgrService(const QString &name, const QString &binFile, cons
 
                 args_ += arg;
             } else {
-                CowUrl url;
-                url.setHost(!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0"));
+                CowUrl url("http://" + (!p.addr.isNull() ? p.addr.toString() : QString("0.0.0.0")));
                 url.setPort(p.port);
 
                 QString arg = "--listen=" + url.authority() + ",stream";


### PR DESCRIPTION
`QUrl` supports manipulation when null, which this code was relying on. `CowUrl` does not support this, and I'm thinking we keep it that way and just update the call site.

I also checked a bunch of other call sites to see if we are doing this anywhere else and didn't find anything.