### PR TITLE
connmgr: add prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +988,15 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1178,6 +1199,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1344,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
 name = "pushpin"
 version = "1.42.0-dev"
 dependencies = [
@@ -1321,6 +1379,7 @@ dependencies = [
  "openssl",
  "paste",
  "pkg-config",
+ "prometheus",
  "rustls",
  "rustls-native-certs",
  "serde",
@@ -1564,6 +1623,12 @@ checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2095,6 +2160,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ mio = { version = "1", features = ["os-poll", "os-ext", "net"] }
 notify = "7"
 openssl = "=0.10.72"
 paste = "1.0"
+prometheus = { version = "0.13", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-native-certs = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/bin/pushpin-connmgr.rs
+++ b/src/bin/pushpin-connmgr.rs
@@ -17,7 +17,7 @@
 
 use clap::{Arg, ArgAction, Command};
 use log::{error, LevelFilter};
-use pushpin::connmgr::{run, App, Config, ListenConfig, ListenSpec};
+use pushpin::connmgr::{run, App, Config, ListenConfig, ListenSpec, PrometheusConfig};
 use pushpin::core::config::{NetListenConfig, UnixListenConfig};
 use pushpin::core::log::{get_simple_logger, local_offset_check};
 use pushpin::core::version;
@@ -65,6 +65,7 @@ struct Args {
     allow_compression: bool,
     deny_out_internal: bool,
     debug_socket: Option<String>,
+    prometheus: Option<String>,
 }
 
 fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
@@ -112,6 +113,7 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
         allow_compression: args.allow_compression,
         deny: Vec::new(),
         debug_socket: None,
+        prometheus: None,
     };
 
     for v in args.listen.iter() {
@@ -174,10 +176,37 @@ fn process_args_and_run(args: Args) -> Result<(), Box<dyn Error>> {
         let spec: UnixListenConfig = v
             .parse()
             .map_err(|e| format!("failed to parse debug-socket: {}", e))?;
+
         if let Some(k) = spec.params.keys().next() {
             return Err(format!("failed to parse debug-socket: invalid param: {}", k).into());
         }
+
         config.debug_socket = Some(spec);
+    }
+
+    if let Some(v) = &args.prometheus {
+        let mut spec: NetListenConfig = match v.parse() {
+            Ok(s) => s,
+            Err(e) => {
+                return Err(format!("failed to parse prometheus: {}", e).into());
+            }
+        };
+
+        let params = match &mut spec {
+            NetListenConfig::Tcp(c) => &mut c.params,
+            NetListenConfig::Unix(c) => &mut c.params,
+        };
+
+        let prefix = params.remove("prefix").unwrap_or_default();
+
+        if let Some(k) = params.keys().next() {
+            return Err(format!("failed to parse prometheus: invalid param: {}", k).into());
+        }
+
+        config.prometheus = Some(PrometheusConfig {
+            listen_config: spec,
+            prefix,
+        });
     }
 
     run(&config)
@@ -369,6 +398,13 @@ fn main() {
                 .num_args(1)
                 .value_name("path")
                 .help("Unix socket for serving debug logs"),
+        )
+        .arg(
+            Arg::new("prometheus")
+                .long("prometheus")
+                .num_args(1)
+                .value_name("[addr:]port[,params...]")
+                .help("Address/port to serve Prometheus metrics on"),
         )
         .arg(
             Arg::new("sizes")
@@ -573,6 +609,8 @@ fn main() {
 
     let debug_socket = matches.get_one::<String>("debug-socket").cloned();
 
+    let prometheus = matches.get_one::<String>("prometheus").cloned();
+
     // If no zmq server specs are set (needed by client mode), specify
     // default listen configuration in order to enable server mode. This
     // means if zmq server specs are set, then server mode won't be enabled
@@ -605,6 +643,7 @@ fn main() {
         allow_compression,
         deny_out_internal,
         debug_socket,
+        prometheus,
     };
 
     if let Err(e) = process_args_and_run(args) {

--- a/src/connmgr/connection.rs
+++ b/src/connmgr/connection.rs
@@ -34,6 +34,7 @@
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::collapsible_else_if)]
 
+use crate::connmgr::metrics;
 use crate::connmgr::pool::Pool;
 use crate::connmgr::resolver;
 use crate::connmgr::tls::{AsyncTlsStream, TlsConfigCache, TlsStream, TlsWaker, VerifyMode};
@@ -1533,6 +1534,8 @@ async fn server_req_read_header_and_body<R: AsyncRead, W: AsyncWrite>(
             Err(e) => return Err(e),
         }
     };
+
+    metrics::total_requests().inc();
 
     let req_ref = req_header.get();
 
@@ -3408,6 +3411,8 @@ async fn server_stream_read_header<'a: 'b, 'b, R: AsyncRead, W: AsyncWrite>(
             Err(e) => return Err(e),
         }
     };
+
+    metrics::total_requests().inc();
 
     let req_ref = req_header.get();
 

--- a/src/connmgr/metrics.rs
+++ b/src/connmgr/metrics.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use prometheus::Counter;
+use std::sync::OnceLock;
+
+static TOTAL_REQUESTS: OnceLock<Counter> = OnceLock::new();
+
+pub fn total_requests() -> &'static Counter {
+    TOTAL_REQUESTS.get_or_init(|| {
+        prometheus::register_counter!(
+            "connmgr_requests_total",
+            "Total number of requests processed by connmgr"
+        )
+        .expect("failed to register total_requests counter")
+    })
+}
+
+pub fn init() {
+    // Pre-initialize metrics so they appear even before any requests arrive.
+    let _ = total_requests();
+}

--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -17,6 +17,7 @@
 
 mod batch;
 mod listener;
+mod metrics;
 mod pool;
 mod track;
 mod zhttppacket;
@@ -31,9 +32,10 @@ pub mod websocket;
 
 use self::client::Client;
 use self::server::Server;
-use crate::core::config::UnixListenConfig;
+use crate::core::config::{NetListenConfig, UnixListenConfig};
 use crate::core::log::DebugLogger;
-use crate::core::net::bind_unix_config;
+use crate::core::net::{bind_unix_config, NetListener};
+use crate::core::prometheus::PrometheusServer;
 use crate::core::zmq::SpecInfo;
 use ipnet::IpNet;
 use log::{debug, info};
@@ -100,6 +102,11 @@ pub struct ListenConfig {
     pub stream: bool,
 }
 
+pub struct PrometheusConfig {
+    pub listen_config: NetListenConfig,
+    pub prefix: String,
+}
+
 pub struct Config {
     pub instance_id: String,
     pub workers: usize,
@@ -124,12 +131,14 @@ pub struct Config {
     pub allow_compression: bool,
     pub deny: Vec<IpNet>,
     pub debug_socket: Option<UnixListenConfig>,
+    pub prometheus: Option<PrometheusConfig>,
 }
 
 pub struct App {
     _server: Option<Server>,
     _client: Option<Client>,
     _debug_logger: Option<DebugLogger>,
+    _prometheus: Option<PrometheusServer>,
 }
 
 impl App {
@@ -151,6 +160,21 @@ impl App {
             let queue_max = (config.workers * 1000) + 1000;
 
             debug_logger = Some(DebugLogger::new(l, queue_max));
+        }
+
+        let mut prometheus = None;
+
+        if let Some(config) = &config.prometheus {
+            metrics::init();
+
+            let l = NetListener::bind_config(&config.listen_config)
+                .map_err(|e| format!("prometheus listener: {e}"))?;
+
+            prometheus = Some(PrometheusServer::new(
+                l,
+                &config.prefix,
+                prometheus::default_registry().clone(),
+            ));
         }
 
         let zmq_context = Arc::new(zmq::Context::new());
@@ -378,6 +402,7 @@ impl App {
             _server: server,
             _client: client,
             _debug_logger: debug_logger,
+            _prometheus: prometheus,
         })
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod list;
 pub mod log;
 pub mod memorypool;
 pub mod net;
+pub mod prometheus;
 pub mod reactor;
 pub mod select;
 pub mod shuffle;

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -1,0 +1,334 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::core::buffer::{Buffer, ContiguousBuffer, TmpBuffer, VecRingBuffer};
+use crate::core::channel;
+use crate::core::executor::Executor;
+use crate::core::http1::{self, server};
+use crate::core::io::io_split;
+use crate::core::io::{AsyncRead, AsyncWrite};
+use crate::core::net::{AsyncNetListener, AsyncTcpStream, AsyncUnixStream, NetListener, NetStream};
+use crate::core::reactor::Reactor;
+use crate::core::select::{select_2, Select2};
+use crate::core::task::{CancellationSender, CancellationToken};
+use log::{debug, error, warn};
+use prometheus::{Encoder, TextEncoder};
+use std::cell::RefCell;
+use std::error::Error;
+use std::io::Write;
+use std::pin::pin;
+use std::rc::Rc;
+use std::sync::mpsc;
+use std::thread;
+
+const CONNS_MAX: usize = 10;
+const REACTOR_BUDGET: u32 = 100;
+const BUFFER_SIZE: usize = 4096;
+
+pub struct PrometheusServer {
+    thread: Option<thread::JoinHandle<()>>,
+    stop: Option<channel::Sender<()>>,
+}
+
+impl PrometheusServer {
+    pub fn new(listener: NetListener, prefix: &str, registry: prometheus::Registry) -> Self {
+        let (stop_s, stop_r) = channel::channel(1);
+
+        let prefix = prefix.to_string();
+
+        let thread = thread::Builder::new()
+            .name("prometheus".to_string())
+            .spawn(move || {
+                let reactor = Reactor::new(CONNS_MAX * 4 + 10); // 4 per client plus extra
+                let executor = Executor::new(CONNS_MAX + 2); // clients plus stop and server tasks
+
+                {
+                    let reactor = reactor.clone();
+                    executor.set_pre_poll(move || {
+                        reactor.set_budget(Some(REACTOR_BUDGET));
+                    });
+                }
+
+                let (cancel_s, cancel_t) =
+                    CancellationToken::new(&reactor.local_registration_memory());
+
+                // Watch for stop signal and cancel the token when triggered.
+                executor
+                    .spawn(async move {
+                        let stop_r = channel::AsyncReceiver::new(stop_r);
+                        let _ = stop_r.recv().await;
+                        drop(cancel_s);
+                    })
+                    .expect("failed to spawn prometheus stop watcher");
+
+                executor
+                    .spawn(run_server(listener, cancel_t, prefix, registry))
+                    .expect("failed to spawn prometheus server task");
+
+                executor
+                    .run(|timeout| reactor.poll(timeout))
+                    .expect("prometheus server error");
+            })
+            .expect("failed to spawn prometheus thread");
+
+        Self {
+            thread: Some(thread),
+            stop: Some(stop_s),
+        }
+    }
+}
+
+impl Drop for PrometheusServer {
+    fn drop(&mut self) {
+        // Signal the thread to stop.
+        self.stop = None;
+
+        // Wait for the thread to exit.
+        self.thread.take().unwrap().join().unwrap();
+
+        debug!("prometheus server stopped");
+    }
+}
+
+struct Client {
+    done: channel::LocalReceiver<()>,
+    _cancel: CancellationSender,
+}
+
+async fn run_server(
+    listener: NetListener,
+    stop: CancellationToken,
+    prefix: String,
+    registry: prometheus::Registry,
+) {
+    let listener = AsyncNetListener::new(listener);
+
+    let reactor = Reactor::current().unwrap();
+    let executor = Executor::current().unwrap();
+    let mut clients: Vec<Client> = Vec::new();
+
+    debug!("prometheus server started");
+
+    // Loop to serve connections. When the loop ends, the `clients` Vec is dropped, which causes
+    // causes all the client tasks to end as well.
+
+    loop {
+        let stream = match select_2(pin!(listener.accept()), pin!(stop.cancelled())).await {
+            Select2::R1(Ok((stream, _peer_addr))) => stream,
+            Select2::R1(Err(e)) => {
+                error!("prometheus: accept error: {}", e);
+                continue;
+            }
+            Select2::R2(_) => break,
+        };
+
+        // Clear finished clients. With a low CONNS_MAX this should be relatively cheap.
+        clients.retain(|c| !matches!(c.done.try_recv(), Err(mpsc::TryRecvError::Disconnected)));
+
+        if clients.len() >= CONNS_MAX {
+            // Drop the stream to close the connection immediately.
+            warn!("too many prometheus connections, rejecting");
+            continue;
+        }
+
+        let (s_done, r_done) = channel::local_channel(1, 1, &reactor.local_registration_memory());
+
+        let (cancel, token) = CancellationToken::new(&reactor.local_registration_memory());
+
+        match stream {
+            NetStream::Tcp(s) => executor
+                .spawn(run_connection(
+                    AsyncTcpStream::new(s),
+                    token,
+                    s_done,
+                    prefix.clone(),
+                    registry.clone(),
+                ))
+                .expect("failed to spawn prometheus connection task"),
+            NetStream::Unix(s) => executor
+                .spawn(run_connection(
+                    AsyncUnixStream::new(s),
+                    token,
+                    s_done,
+                    prefix.clone(),
+                    registry.clone(),
+                ))
+                .expect("failed to spawn prometheus connection task"),
+        };
+
+        clients.push(Client {
+            done: r_done,
+            _cancel: cancel,
+        })
+    }
+}
+
+async fn run_connection<S: AsyncRead + AsyncWrite + 'static>(
+    stream: S,
+    token: CancellationToken,
+    _done: channel::LocalSender<()>, // dropped when function returns, indicating done
+    prefix: String,
+    registry: prometheus::Registry,
+) {
+    let result = match select_2(
+        pin!(handle_connection(stream, &prefix, &registry)),
+        pin!(token.cancelled()),
+    )
+    .await
+    {
+        Select2::R1(r) => r,
+        Select2::R2(()) => return,
+    };
+
+    if let Err(e) = result {
+        debug!("prometheus connection error: {e}");
+    }
+}
+
+async fn handle_connection<S: AsyncRead + AsyncWrite>(
+    stream: S,
+    prefix: &str,
+    registry: &prometheus::Registry,
+) -> Result<(), Box<dyn Error>> {
+    let stream = RefCell::new(stream);
+
+    let rb_tmp = Rc::new(TmpBuffer::new(BUFFER_SIZE));
+    let mut buf1 = VecRingBuffer::new(BUFFER_SIZE, &rb_tmp);
+    let mut buf2 = VecRingBuffer::new(BUFFER_SIZE, &rb_tmp);
+
+    let mut metric_families = registry.gather();
+    if !prefix.is_empty() {
+        for mf in &mut metric_families {
+            mf.set_name(format!("{}{}", prefix, mf.get_name()));
+        }
+    }
+
+    let encoder = TextEncoder::new();
+
+    let mut output = {
+        let mut output = Vec::new();
+        encoder.encode(&metric_families, &mut output)?;
+
+        let mut output_buffer = ContiguousBuffer::new(output.len());
+        output_buffer
+            .write_all(&output)
+            .expect("output didn't fit in appropriately-sized buffer");
+
+        output_buffer
+    };
+
+    let content_type = encoder.format_type();
+
+    let mut resp_state = server::ResponseState::default();
+
+    let resp_body = {
+        let (req, mut resp) = server::Request::new(io_split(&stream), &mut buf1, &mut buf2);
+
+        let mut scratch = http1::ParseScratch::<64>::new();
+        let (owned_req, req_body) = req.recv_header(&mut resp).recv(&mut scratch, None).await?;
+        let _ = req_body.discard_header(owned_req);
+
+        let headers = [http1::Header {
+            name: "Content-Type",
+            value: content_type.as_bytes(),
+        }];
+
+        let (resp_header, prepare_body) = resp.prepare_header(
+            200,
+            "OK",
+            &headers,
+            http1::BodySize::Known(output.len()),
+            &mut resp_state,
+        )?;
+
+        resp_header.send().await?.start_body(prepare_body)
+    };
+
+    loop {
+        // Fill the buffer as much as possible
+        let size = resp_body.prepare(Buffer::read_buf(&output), true)?;
+        output.read_commit(size);
+
+        match resp_body.send().await {
+            http1::SendStatus::Complete(_) => break,
+            http1::SendStatus::EarlyResponse(_) => unreachable!(), // For requests only
+            http1::SendStatus::Partial((), _) => {}
+            http1::SendStatus::Error((), e) => return Err(e.into()),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mio::net::TcpListener;
+    use std::io::{Read, Write};
+
+    #[test]
+    fn request_metrics() {
+        let registry = prometheus::Registry::new();
+        let counter = prometheus::Counter::new("test_counter", "a test counter").unwrap();
+        registry.register(Box::new(counter.clone())).unwrap();
+        counter.inc();
+
+        let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = PrometheusServer::new(NetListener::Tcp(listener), "myprefix_", registry);
+
+        let mut stream = std::net::TcpStream::connect(addr).unwrap();
+        stream
+            .write_all(b"GET /metrics HTTP/1.0\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+
+        drop(server);
+
+        assert!(
+            response.starts_with("HTTP/1.0 200 OK\r\n"),
+            "unexpected response: {}",
+            response
+        );
+
+        let (headers, body) = response.split_once("\r\n\r\n").unwrap();
+        assert!(
+            headers.contains("Content-Type: text/plain"),
+            "missing Content-Type header"
+        );
+
+        // Every non-comment, non-empty line must carry the prefix.
+        let unprefixed: Vec<&str> = body
+            .lines()
+            .filter(|l| !l.is_empty() && !l.starts_with('#') && !l.starts_with("myprefix_"))
+            .collect();
+        assert!(
+            unprefixed.is_empty(),
+            "body contains unprefixed metric names: {:?}",
+            unprefixed
+        );
+
+        // The prefixed counter must appear in the output.
+        assert!(
+            body.contains("myprefix_test_counter"),
+            "expected metric not found in body:\n{}",
+            body
+        );
+    }
+}

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -123,7 +123,7 @@ async fn run_server(
     debug!("prometheus server started");
 
     // Loop to serve connections. When the loop ends, the `clients` Vec is dropped, which causes
-    // causes all the client tasks to end as well.
+    // all the client tasks to end as well.
 
     loop {
         let stream = match select_2(pin!(listener.accept()), pin!(stop.cancelled())).await {


### PR DESCRIPTION
This adds Prometheus metrics to connmgr entirely in Rust and using the `prometheus` crate. It implements a Prometheus server using the `http1` module, and adds one metric to start out with (`total_requests`). Metrics are declared per-component, in this case within `connmgr::metrics`, whereas the Prometheus server itself lives in `core`. This way each component can reuse the server but register distinct metrics.

Notably, these metrics are not implemented using the `StatsManager` C++ class which supports Prometheus. It also doesn't implement cross-component aggregation like `StatsManager` does. This is intentional and part of a plan of phasing out the use of `StatsManager` for operational metrics, in favor of having each component serve their own metrics without any internal aggregation. After this lands, we can consider porting other components to use it as well, and removing Prometheus support from `StatsManager`.