### PR TITLE
add json api wrapper around qjson

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -68,6 +68,7 @@ HEADERS += \
 	$$PWD/timerwheel.h \
 	$$PWD/reactor.h \
 	$$PWD/executor.h \
+	$$PWD/json.h \
 	$$PWD/jwt.h \
 	$$PWD/timer.h \
 	$$PWD/defercall.h \
@@ -103,6 +104,7 @@ SOURCES += \
 	$$PWD/timerwheel.cpp \
 	$$PWD/reactor.cpp \
 	$$PWD/executor.cpp \
+	$$PWD/json.cpp \
 	$$PWD/jwt.cpp \
 	$$PWD/timer.cpp \
 	$$PWD/defercall.cpp \

--- a/src/core/json.cpp
+++ b/src/core/json.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "json.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+static QJsonValue variantToJsonValue(const Variant &v) {
+    switch (typeId(v)) {
+    case VariantType::Invalid:
+    case VariantType::Nullptr:
+        return QJsonValue::Null;
+    case VariantType::Bool:
+        return QJsonValue(v.toBool());
+    case VariantType::Int:
+    case VariantType::UInt:
+    case VariantType::LongLong:
+    case VariantType::ULongLong:
+    case VariantType::Float:
+    case VariantType::Double:
+        return QJsonValue(v.toDouble());
+    case VariantType::String:
+        return QJsonValue(v.toString());
+    case VariantType::ByteArray:
+        return QJsonValue(QString::fromUtf8(v.toByteArray()));
+    case VariantType::List:
+        return QJsonArray::fromVariantList(v.toList());
+    case VariantType::Map:
+        return QJsonObject::fromVariantMap(v.toMap());
+    case VariantType::Hash:
+        return QJsonObject::fromVariantHash(v.toHash());
+    default:
+        return QJsonValue::Null;
+    }
+}
+
+static Variant jsonValueToVariant(const QJsonValue &v) {
+    switch (v.type()) {
+    case QJsonValue::Null:
+    case QJsonValue::Undefined:
+        return Variant();
+    case QJsonValue::Bool:
+        return Variant(v.toBool());
+    case QJsonValue::Double:
+        return Variant(v.toDouble());
+    case QJsonValue::String:
+        return Variant(v.toString());
+    case QJsonValue::Array:
+        return v.toArray().toVariantList();
+    case QJsonValue::Object:
+        return v.toObject().toVariantMap();
+    }
+    return Variant();
+}
+
+namespace Json {
+
+QByteArray toString(const Variant &variant) {
+    QJsonValue jv = variantToJsonValue(variant);
+
+    if (jv.isObject())
+        return QJsonDocument(jv.toObject()).toJson(QJsonDocument::Compact);
+    if (jv.isArray())
+        return QJsonDocument(jv.toArray()).toJson(QJsonDocument::Compact);
+
+    // For scalars (null, bool, number, string), use the array trick to get proper encoding
+    QByteArray arr = QJsonDocument(QJsonArray{jv}).toJson(QJsonDocument::Compact);
+    return arr.mid(1, arr.size() - 2); // strip surrounding [ and ]
+}
+
+Variant fromString(const QByteArray &json) {
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &err);
+    if (err.error != QJsonParseError::NoError)
+        return Variant();
+
+    if (doc.isObject())
+        return jsonValueToVariant(doc.object());
+    else if (doc.isArray())
+        return jsonValueToVariant(doc.array());
+
+    return Variant();
+}
+
+} // namespace Json

--- a/src/core/json.h
+++ b/src/core/json.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JSON_H
+#define JSON_H
+
+#include "variant.h"
+#include <QByteArray>
+
+namespace Json {
+
+QByteArray toString(const Variant &variant);
+
+Variant fromString(const QByteArray &json);
+
+} // namespace Json
+
+#endif // JSON_H

--- a/src/core/jsontest.cpp
+++ b/src/core/jsontest.cpp
@@ -113,7 +113,6 @@ static void roundtrip() {
     original["test"] = "roundtrip";
     original["number"] = 42;
 
-    // Serialize with Rust serde_json
     QByteArray json = Json::toString(original);
 
     // Deserialize back
@@ -132,27 +131,25 @@ static void compatibilityWithQtJson() {
     testData["number"] = 42;
     testData["bool"] = true;
 
-    // Serialize with Qt JSON
     QByteArray qtJson =
         QJsonDocument(QJsonObject::fromVariantMap(testData)).toJson(QJsonDocument::Compact);
 
-    // Serialize with Rust serde_json
-    QByteArray rustJson = Json::toString(testData);
+    QByteArray json = Json::toString(testData);
 
     // Both should parse to equivalent structures
     QJsonDocument qtDoc = QJsonDocument::fromJson(qtJson);
-    QJsonDocument rustDoc = QJsonDocument::fromJson(rustJson);
+    QJsonDocument doc = QJsonDocument::fromJson(json);
 
     TEST_ASSERT_EQ(qtDoc.isObject(), true);
-    TEST_ASSERT_EQ(rustDoc.isObject(), true);
+    TEST_ASSERT_EQ(doc.isObject(), true);
 
     // The objects should be equivalent (though order might differ)
     QJsonObject qtObj = qtDoc.object();
-    QJsonObject rustObj = rustDoc.object();
+    QJsonObject obj = doc.object();
 
-    TEST_ASSERT_EQ(rustObj["string"], qtObj["string"]);
-    TEST_ASSERT_EQ(rustObj["number"], qtObj["number"]);
-    TEST_ASSERT_EQ(rustObj["bool"], qtObj["bool"]);
+    TEST_ASSERT_EQ(obj["string"], qtObj["string"]);
+    TEST_ASSERT_EQ(obj["number"], qtObj["number"]);
+    TEST_ASSERT_EQ(obj["bool"], qtObj["bool"]);
 }
 
 static void scalarValues() {

--- a/src/core/jsontest.cpp
+++ b/src/core/jsontest.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "json.h"
+#include "qtcompat.h"
+#include "test.h"
+#include "variant.h"
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+static void variantMapSerialization() {
+    VariantMap vmap;
+    vmap["string"] = "test value";
+    vmap["number"] = 42;
+    vmap["boolean"] = true;
+    vmap["null"] = Variant();
+
+    QByteArray json = Json::toString(vmap);
+    TEST_ASSERT(!json.isEmpty());
+
+    // Should be valid JSON
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &error);
+    TEST_ASSERT_EQ(error.error, QJsonParseError::NoError);
+    TEST_ASSERT_EQ(doc.isObject(), true);
+
+    QJsonObject obj = doc.object();
+    TEST_ASSERT_EQ(obj["string"].toString(), QString("test value"));
+    TEST_ASSERT_EQ(obj["number"].toInt(), 42);
+    TEST_ASSERT_EQ(obj["boolean"].toBool(), true);
+    TEST_ASSERT_EQ(obj["null"].isNull(), true);
+}
+
+static void variantListSerialization() {
+    VariantList vlist;
+    vlist << "item1" << 123 << false << Variant();
+
+    QByteArray json = Json::toString(vlist);
+    TEST_ASSERT(!json.isEmpty());
+
+    // Should be valid JSON array
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &error);
+    TEST_ASSERT_EQ(error.error, QJsonParseError::NoError);
+    TEST_ASSERT_EQ(doc.isArray(), true);
+
+    QJsonArray arr = doc.array();
+    TEST_ASSERT_EQ(arr.size(), 4);
+    TEST_ASSERT_EQ(arr[0].toString(), QString("item1"));
+    TEST_ASSERT_EQ(arr[1].toInt(), 123);
+    TEST_ASSERT_EQ(arr[2].toBool(), false);
+    TEST_ASSERT_EQ(arr[3].isNull(), true);
+}
+
+static void variantHashSerialization() {
+    VariantHash vhash;
+    vhash["key1"] = "value1";
+    vhash["key2"] = 999;
+
+    QByteArray json = Json::toString(vhash);
+    TEST_ASSERT(!json.isEmpty());
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &error);
+    TEST_ASSERT_EQ(error.error, QJsonParseError::NoError);
+    TEST_ASSERT_EQ(doc.isObject(), true);
+}
+
+static void nestedStructure() {
+    VariantList innerList;
+    innerList << 1 << 2 << 3;
+
+    VariantMap innerMap;
+    innerMap["nested_key"] = "nested_value";
+    innerMap["nested_list"] = innerList;
+
+    VariantMap outerMap;
+    outerMap["inner"] = innerMap;
+    outerMap["simple"] = "value";
+
+    QByteArray json = Json::toString(outerMap);
+    TEST_ASSERT(!json.isEmpty());
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &error);
+    TEST_ASSERT_EQ(error.error, QJsonParseError::NoError);
+
+    QJsonObject obj = doc.object();
+    TEST_ASSERT_EQ(obj.contains("inner"), true);
+    TEST_ASSERT_EQ(obj["inner"].isObject(), true);
+
+    QJsonObject inner = obj["inner"].toObject();
+    TEST_ASSERT_EQ(inner["nested_key"].toString(), QString("nested_value"));
+    TEST_ASSERT_EQ(inner["nested_list"].isArray(), true);
+}
+
+static void roundtrip() {
+    VariantMap original;
+    original["test"] = "roundtrip";
+    original["number"] = 42;
+
+    // Serialize with Rust serde_json
+    QByteArray json = Json::toString(original);
+
+    // Deserialize back
+    Variant restored = Json::fromString(json);
+    TEST_ASSERT_EQ(restored.isValid(), true);
+    TEST_ASSERT(typeId(restored) == VariantType::Map);
+
+    VariantMap restoredMap = restored.toMap();
+    TEST_ASSERT_EQ(restoredMap["test"].toString(), original["test"].toString());
+    TEST_ASSERT_EQ(restoredMap["number"].toInt(), original["number"].toInt());
+}
+
+static void compatibilityWithQtJson() {
+    VariantMap testData;
+    testData["string"] = "test";
+    testData["number"] = 42;
+    testData["bool"] = true;
+
+    // Serialize with Qt JSON
+    QByteArray qtJson =
+        QJsonDocument(QJsonObject::fromVariantMap(testData)).toJson(QJsonDocument::Compact);
+
+    // Serialize with Rust serde_json
+    QByteArray rustJson = Json::toString(testData);
+
+    // Both should parse to equivalent structures
+    QJsonDocument qtDoc = QJsonDocument::fromJson(qtJson);
+    QJsonDocument rustDoc = QJsonDocument::fromJson(rustJson);
+
+    TEST_ASSERT_EQ(qtDoc.isObject(), true);
+    TEST_ASSERT_EQ(rustDoc.isObject(), true);
+
+    // The objects should be equivalent (though order might differ)
+    QJsonObject qtObj = qtDoc.object();
+    QJsonObject rustObj = rustDoc.object();
+
+    TEST_ASSERT_EQ(rustObj["string"], qtObj["string"]);
+    TEST_ASSERT_EQ(rustObj["number"], qtObj["number"]);
+    TEST_ASSERT_EQ(rustObj["bool"], qtObj["bool"]);
+}
+
+static void scalarValues() {
+    // Test individual scalar values
+    Variant stringVar("test string");
+    QByteArray stringJson = Json::toString(stringVar);
+    TEST_ASSERT(!stringJson.isEmpty());
+    // Should produce clean scalar: "test string"
+    TEST_ASSERT_EQ(stringJson, QByteArray("\"test string\""));
+
+    Variant intVar(123);
+    QByteArray intJson = Json::toString(intVar);
+    TEST_ASSERT(!intJson.isEmpty());
+    // Should produce clean scalar: 123
+    TEST_ASSERT_EQ(intJson, QByteArray("123"));
+
+    Variant boolVar(true);
+    QByteArray boolJson = Json::toString(boolVar);
+    TEST_ASSERT(!boolJson.isEmpty());
+    // Should produce clean scalar: true
+    TEST_ASSERT_EQ(boolJson, QByteArray("true"));
+
+    // For Qt compatibility testing, wrap scalars in objects since Qt JSON only handles
+    // objects/arrays
+    QByteArray wrappedStringJson = "{\"value\":" + stringJson + "}";
+    QByteArray wrappedIntJson = "{\"value\":" + intJson + "}";
+    QByteArray wrappedBoolJson = "{\"value\":" + boolJson + "}";
+
+    // Wrapped versions should be parseable by Qt JSON
+    QJsonParseError error1, error2, error3;
+    QJsonDocument doc1 = QJsonDocument::fromJson(wrappedStringJson, &error1);
+    QJsonDocument doc2 = QJsonDocument::fromJson(wrappedIntJson, &error2);
+    QJsonDocument doc3 = QJsonDocument::fromJson(wrappedBoolJson, &error3);
+
+    TEST_ASSERT_EQ(error1.error, QJsonParseError::NoError);
+    TEST_ASSERT_EQ(error2.error, QJsonParseError::NoError);
+    TEST_ASSERT_EQ(error3.error, QJsonParseError::NoError);
+}
+
+extern "C" int json_test(ffi::TestException *out_ex) {
+    TEST_CATCH(variantMapSerialization());
+    TEST_CATCH(variantListSerialization());
+    TEST_CATCH(variantHashSerialization());
+    TEST_CATCH(nestedStructure());
+    TEST_CATCH(roundtrip());
+    TEST_CATCH(compatibilityWithQtJson());
+    TEST_CATCH(scalarValues());
+
+    return 0;
+}

--- a/src/core/jwt.cpp
+++ b/src/core/jwt.cpp
@@ -23,12 +23,11 @@
 
 #include "jwt.h"
 
+#include "json.h"
+#include "qtcompat.h"
 #include "variant.h"
 #include <QFile>
 #include <QFileInfo>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QString>
 
 namespace Jwt {
 
@@ -184,8 +183,7 @@ QByteArray encode(const Variant &claim, const EncodingKey &key) {
         return QByteArray();
     }
 
-    QByteArray claimJson =
-        QJsonDocument(QJsonObject::fromVariantMap(claim.toMap())).toJson(QJsonDocument::Compact);
+    QByteArray claimJson = Json::toString(claim.toMap());
     if (claimJson.isNull())
         return QByteArray();
 
@@ -212,12 +210,11 @@ Variant decode(const QByteArray &token, const DecodingKey &key) {
     if (claimJson.isEmpty())
         return Variant();
 
-    QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(claimJson, &error);
-    if (error.error != QJsonParseError::NoError || !doc.isObject())
+    Variant result = Json::fromString(claimJson);
+    if (!result.isValid() || typeId(result) != VariantType::Map)
         return Variant();
 
-    return doc.object().toVariantMap();
+    return result;
 }
 
 } // namespace Jwt

--- a/src/core/jwttest.cpp
+++ b/src/core/jwttest.cpp
@@ -22,11 +22,10 @@
  */
 
 #include "jwt.h"
+#include "json.h"
 #include "qtcompat.h"
 #include "test.h"
 #include "variant.h"
-#include <QJsonDocument>
-#include <QJsonObject>
 
 static const char *test_ec_private_key_pem =
     "-----BEGIN PRIVATE KEY-----\n"
@@ -148,8 +147,7 @@ static void es256EncodeDecode() {
     VariantMap claim;
     claim["iss"] = "nobody";
 
-    QByteArray claimJson =
-        QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
+    QByteArray claimJson = Json::toString(claim);
     TEST_ASSERT(!claimJson.isNull());
 
     QByteArray token = Jwt::encodeWithAlgorithm(Jwt::ES256, claimJson, privateKey);
@@ -158,12 +156,11 @@ static void es256EncodeDecode() {
     QByteArray resultJson = Jwt::decodeWithAlgorithm(Jwt::ES256, token, publicKey);
     TEST_ASSERT(!resultJson.isNull());
 
-    QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(resultJson, &error);
-    TEST_ASSERT(error.error == QJsonParseError::NoError);
-    TEST_ASSERT(doc.isObject());
+    Variant result_variant = Json::fromString(resultJson);
+    TEST_ASSERT(result_variant.isValid());
+    TEST_ASSERT(typeId(result_variant) == VariantType::Map);
 
-    VariantMap result = doc.object().toVariantMap();
+    VariantMap result = result_variant.toMap();
     TEST_ASSERT_EQ(result["iss"], "nobody");
 }
 
@@ -179,8 +176,7 @@ static void rs256EncodeDecode() {
     VariantMap claim;
     claim["iss"] = "nobody";
 
-    QByteArray claimJson =
-        QJsonDocument(QJsonObject::fromVariantMap(claim)).toJson(QJsonDocument::Compact);
+    QByteArray claimJson = Json::toString(claim);
     TEST_ASSERT(!claimJson.isNull());
 
     QByteArray token = Jwt::encodeWithAlgorithm(Jwt::RS256, claimJson, privateKey);
@@ -189,12 +185,11 @@ static void rs256EncodeDecode() {
     QByteArray resultJson = Jwt::decodeWithAlgorithm(Jwt::RS256, token, publicKey);
     TEST_ASSERT(!resultJson.isNull());
 
-    QJsonParseError error;
-    QJsonDocument doc = QJsonDocument::fromJson(resultJson, &error);
-    TEST_ASSERT(error.error == QJsonParseError::NoError);
-    TEST_ASSERT(doc.isObject());
+    Variant result_variant = Json::fromString(resultJson);
+    TEST_ASSERT(result_variant.isValid());
+    TEST_ASSERT(typeId(result_variant) == VariantType::Map);
 
-    VariantMap result = doc.object().toVariantMap();
+    VariantMap result = result_variant.toMap();
     TEST_ASSERT_EQ(result["iss"], "nobody");
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -144,6 +144,11 @@ mod tests {
         unsafe { ffi::httpheaders_test(out_ex) == 0 }
     }
 
+    fn json_test(out_ex: &mut TestException) -> bool {
+        // SAFETY: safe to call
+        unsafe { ffi::json_test(out_ex) == 0 }
+    }
+
     fn jwt_test(out_ex: &mut TestException) -> bool {
         // SAFETY: safe to call
         unsafe { ffi::jwt_test(out_ex) == 0 }
@@ -192,6 +197,11 @@ mod tests {
     #[test]
     fn httpheaders() {
         run_cpp(httpheaders_test);
+    }
+
+    #[test]
+    fn json() {
+        run_cpp(json_test);
     }
 
     #[test]

--- a/src/core/qtcompat.h
+++ b/src/core/qtcompat.h
@@ -29,10 +29,14 @@
 namespace VariantType {
 enum Type {
     Invalid = QMetaType::UnknownType,
+    Nullptr = QMetaType::Nullptr,
     Bool = QMetaType::Bool,
     Int = QMetaType::Int,
-    Double = QMetaType::Double,
+    UInt = QMetaType::UInt,
     LongLong = QMetaType::LongLong,
+    ULongLong = QMetaType::ULongLong,
+    Float = QMetaType::Float,
+    Double = QMetaType::Double,
     String = QMetaType::QString,
     ByteArray = QMetaType::QByteArray,
     Hash = QMetaType::QVariantHash,

--- a/src/core/tests.pri
+++ b/src/core/tests.pri
@@ -3,6 +3,7 @@ SOURCES += \
 	$$PWD/cowstringtest.cpp \
 	$$PWD/cowurltest.cpp \
 	$$PWD/httpheaderstest.cpp \
+	$$PWD/jsontest.cpp \
 	$$PWD/jwttest.cpp \
 	$$PWD/timertest.cpp \
 	$$PWD/defercalltest.cpp \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ pub mod ffi {
         pub fn cowstring_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn cowurl_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn httpheaders_test(out_ex: *mut TestException) -> libc::c_int;
+        pub fn json_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn jwt_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn timer_test(out_ex: *mut TestException) -> libc::c_int;
         pub fn defercall_test(out_ex: *mut TestException) -> libc::c_int;


### PR DESCRIPTION
As part of migrating away from Qt's JSON API (`QJson*` types), this PR introduces a wrapper API that the project can use instead, so that we can later substitute its implementation with Rust's serde.

Only a few call sites are updated. Will do the rest after it lands.