### PR TITLE
use json api wrapper everywhere

### DIFF
--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -25,6 +25,7 @@
 
 #include "defercall.h"
 #include "httpheaders.h"
+#include "json.h"
 #include "log.h"
 #include "simplehttpserver.h"
 #include "timer.h"
@@ -34,9 +35,6 @@
 #include "zmqsocket.h"
 #include "zutil.h"
 #include <QDateTime>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QVector>
 #include <assert.h>
 
 // Make this somewhat big since PUB is lossy
@@ -759,8 +757,7 @@ public:
         if (outputFormat == TnetStringFormat) {
             buf = prefix + " T" + TnetString::fromVariant(vpacket);
         } else if (outputFormat == JsonFormat) {
-            QJsonObject obj = QJsonObject::fromVariantHash(vpacket.toHash());
-            buf = prefix + " J" + QJsonDocument(obj).toJson(QJsonDocument::Compact);
+            buf = prefix + " J" + Json::toString(vpacket.toHash());
         }
 
         if (!buf.isEmpty()) {

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -25,12 +25,11 @@
 
 #include "format.h"
 #include "idformat.h"
+#include "json.h"
 #include "log.h"
 #include "variant.h"
 #include "zhttpmanager.h"
 #include "zhttprequest.h"
-#include <QJsonDocument>
-#include <QJsonObject>
 
 #define REQUEST_TIMEOUT_SECS 10
 
@@ -496,8 +495,7 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
             vmap[it.key()] = it.value();
         }
 
-        QJsonDocument doc = QJsonDocument(QJsonObject::fromVariantMap(vmap));
-        headers += HttpHeader("Sub-Meta", doc.toJson(QJsonDocument::Compact));
+        headers += HttpHeader("Sub-Meta", Json::toString(vmap));
     }
 
     {
@@ -508,8 +506,7 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
             vmap[it.key()] = it.value();
         }
 
-        QJsonDocument doc = QJsonDocument(QJsonObject::fromVariantMap(vmap));
-        headers += HttpHeader("Pub-Meta", doc.toJson(QJsonDocument::Compact));
+        headers += HttpHeader("Pub-Meta", Json::toString(vmap));
     }
 
     {

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -21,13 +21,12 @@
  */
 
 #include "filter.h"
+#include "json.h"
 #include "log.h"
 #include "ratelimiter.h"
 #include "test.h"
 #include "zhttpmanager.h"
 #include <QDir>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <boost/signals2.hpp>
 #include <unordered_map>
 
@@ -119,12 +118,12 @@ public:
                 return;
             }
 
-            QJsonDocument subMetaDoc =
-                QJsonDocument::fromJson(req->requestHeaders().get("Sub-Meta").asQByteArray());
-            QJsonObject subMeta = subMetaDoc.object();
-            QJsonDocument pubMetaDoc =
-                QJsonDocument::fromJson(req->requestHeaders().get("Pub-Meta").asQByteArray());
-            QJsonObject pubMeta = pubMetaDoc.object();
+            Variant subMetaDoc =
+                Json::fromString(req->requestHeaders().get("Sub-Meta").asQByteArray());
+            VariantMap subMeta = subMetaDoc.toMap();
+            Variant pubMetaDoc =
+                Json::fromString(req->requestHeaders().get("Pub-Meta").asQByteArray());
+            VariantMap pubMeta = pubMetaDoc.toMap();
 
             QString prepend = subMeta["prepend"].toString();
             QString append = pubMeta["append"].toString();

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -23,9 +23,7 @@
 
 #include "handlerengine.h"
 
-#include "cidset.h"
 #include "conncheckworker.h"
-#include "controlrequest.h"
 #include "defercall.h"
 #include "deferred.h"
 #include "detectrule.h"
@@ -34,6 +32,7 @@
 #include "httpsessionupdatemanager.h"
 #include "inspectdata.h"
 #include "instruct.h"
+#include "json.h"
 #include "jsonpointer.h"
 #include "lastids.h"
 #include "log.h"
@@ -69,9 +68,6 @@
 #include "zrpcmanager.h"
 #include "zrpcrequest.h"
 #include "zutil.h"
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <algorithm>
 #include <assert.h>
 
@@ -296,17 +292,8 @@ private:
                     jsonData = requestData.body;
                 }
 
-                QJsonParseError e;
-                QJsonDocument doc = QJsonDocument::fromJson(jsonData, &e);
-                if (e.error != QJsonParseError::NoError)
-                    continue;
-
-                Variant vdata;
-                if (doc.isObject())
-                    vdata = doc.object().toVariantMap();
-                else if (doc.isArray())
-                    vdata = doc.array().toVariantList();
-                else
+                Variant vdata = Json::fromString(jsonData);
+                if (!vdata.isValid())
                     continue;
 
                 JsonPointer ptr = JsonPointer::resolve(&vdata, rule.sidPtr);
@@ -2184,9 +2171,8 @@ private:
         Variant data;
         bool ok_;
         if (message.length() > 0 && message[0] == 'J') {
-            QJsonParseError e;
-            QJsonDocument doc = QJsonDocument::fromJson(message.mid(1).asQByteArray(), &e);
-            if (e.error != QJsonParseError::NoError) {
+            Variant doc = Json::fromString(message.mid(1).asQByteArray());
+            if (!doc.isValid()) {
                 if (errorMessage)
                     *errorMessage =
                         QString("received message with invalid format (json parse failed)");
@@ -2195,8 +2181,8 @@ private:
                 return data;
             }
 
-            if (doc.isObject()) {
-                data = doc.object().toVariantMap();
+            if (typeId(doc) == VariantType::Map) {
+                data = doc.toMap();
             } else {
                 if (errorMessage)
                     *errorMessage =
@@ -2389,17 +2375,12 @@ private:
                        item.type == WsControlPacket::Item::Cancel) {
                 removeWsSession(s);
             } else if (item.type == WsControlPacket::Item::Grip) {
-                QJsonParseError e;
-                QJsonDocument doc = QJsonDocument::fromJson(item.message, &e);
-                if (e.error != QJsonParseError::NoError || (!doc.isObject() && !doc.isArray())) {
+                Variant data = Json::fromString(item.message);
+                if (!data.isValid() ||
+                    (typeId(data) != VariantType::Map && typeId(data) != VariantType::List)) {
                     log_debug("grip control message is not valid json");
                     continue;
                 }
-
-                if (doc.isObject())
-                    data = doc.object().toVariantMap();
-                else // IsArray
-                    data = doc.array().toVariantList();
 
                 QString errorMessage;
                 WsControlMessage cm = WsControlMessage::fromVariant(data, &ok, &errorMessage);
@@ -2708,19 +2689,18 @@ private:
             httpControlRespond(req, 200, "OK", "Pushpin API\n");
         } else if (path == "/publish") {
             if (req->requestMethod() == "POST") {
-                QJsonParseError e;
-                QJsonDocument doc = QJsonDocument::fromJson(req->requestBody(), &e);
-                if (e.error != QJsonParseError::NoError) {
+                Variant doc = Json::fromString(req->requestBody());
+                if (!doc.isValid()) {
                     httpControlRespond(req, 400, "Bad Request", "Body is not valid JSON.\n");
                     return;
                 }
 
-                if (!doc.isObject()) {
+                if (typeId(doc) != VariantType::Map) {
                     httpControlRespond(req, 400, "Bad Request", "Invalid format.\n");
                     return;
                 }
 
-                VariantMap mdata = doc.object().toVariantMap();
+                VariantMap mdata = doc.toMap();
                 VariantList vitems;
 
                 if (!mdata.contains("items")) {
@@ -2750,8 +2730,7 @@ private:
                 if (responseContentType == "application/json") {
                     VariantMap obj;
                     obj["message"] = message;
-                    QString body = QJsonDocument(QJsonObject::fromVariantMap(obj))
-                                       .toJson(QJsonDocument::Compact);
+                    QString body = QString::fromUtf8(Json::toString(obj));
                     httpControlRespond(req, 200, "OK", body + "\n", responseContentType,
                                        HttpHeaders(), items.count());
                 } else // Text/plain
@@ -2775,8 +2754,7 @@ private:
                 if (responseContentType == "application/json") {
                     VariantMap obj;
                     obj["message"] = message;
-                    QString body = QJsonDocument(QJsonObject::fromVariantMap(obj))
-                                       .toJson(QJsonDocument::Compact);
+                    QString body = QString::fromUtf8(Json::toString(obj));
                     httpControlRespond(req, 200, "OK", body + "\n", responseContentType,
                                        HttpHeaders());
                 } else // Text/plain

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -28,6 +28,7 @@
 #include "defercall.h"
 #include "filterstack.h"
 #include "httpsessionupdatemanager.h"
+#include "json.h"
 #include "jsonpatch.h"
 #include "log.h"
 #include "logutil.h"
@@ -43,9 +44,6 @@
 #include "variantutil.h"
 #include "zhttpmanager.h"
 #include "zhttprequest.h"
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QRandomGenerator>
 #include <assert.h>
 
@@ -59,14 +57,9 @@
 static QByteArray applyBodyPatch(const QByteArray &in, const VariantList &bodyPatch) {
     QByteArray body;
 
-    QJsonParseError e;
-    QJsonDocument doc = QJsonDocument::fromJson(in, &e);
-    if (e.error == QJsonParseError::NoError && (doc.isObject() || doc.isArray())) {
-        Variant vbody;
-        if (doc.isObject())
-            vbody = doc.object().toVariantMap();
-        else // IsArray
-            vbody = doc.array().toVariantList();
+    Variant vdoc = Json::fromString(in);
+    if (vdoc.isValid() && (typeId(vdoc) == VariantType::Map || typeId(vdoc) == VariantType::List)) {
+        Variant vbody = vdoc;
 
         QString errorMessage;
         vbody = JsonPatch::patch(vbody, bodyPatch, &errorMessage);
@@ -74,13 +67,7 @@ static QByteArray applyBodyPatch(const QByteArray &in, const VariantList &bodyPa
             vbody = VariantUtil::convertToJsonStyle(vbody);
         if (vbody.isValid() &&
             (typeId(vbody) == VariantType::Map || typeId(vbody) == VariantType::List)) {
-            QJsonDocument doc;
-            if (typeId(vbody) == VariantType::Map)
-                doc = QJsonDocument(QJsonObject::fromVariantMap(vbody.toMap()));
-            else // List
-                doc = QJsonDocument(QJsonArray::fromVariantList(vbody.toList()));
-
-            body = doc.toJson(QJsonDocument::Compact);
+            body = Json::toString(vbody);
 
             if (in.endsWith("\r\n"))
                 body += "\r\n";
@@ -847,8 +834,7 @@ private:
 
                     result["body"] = QString::fromUtf8(body);
 
-                    QByteArray resultJson = QJsonDocument(QJsonObject::fromVariantMap(result))
-                                                .toJson(QJsonDocument::Compact);
+                    QByteArray resultJson = Json::toString(result);
 
                     body = "/**/" + adata.jsonpCallback + '(' + resultJson + ");\n";
                 } else {

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -24,12 +24,11 @@
 #include "instruct.h"
 
 #include "filter.h"
+#include "json.h"
 #include "qtcompat.h"
 #include "statusreasons.h"
 #include "variant.h"
 #include "variantutil.h"
-#include <QJsonDocument>
-#include <QJsonObject>
 
 #define DEFAULT_RESPONSE_TIMEOUT 55
 #define MINIMUM_RESPONSE_TIMEOUT 5
@@ -323,19 +322,18 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
             return Instruct();
         }
 
-        QJsonParseError e;
-        QJsonDocument doc = QJsonDocument::fromJson(response.body, &e);
-        if (e.error != QJsonParseError::NoError) {
+        Variant doc = Json::fromString(response.body);
+        if (!doc.isValid()) {
             setError(ok, errorMessage, "failed to parse application/grip-instruct content as JSON");
             return Instruct();
         }
 
-        if (!doc.isObject()) {
+        if (typeId(doc) != VariantType::Map) {
             setError(ok, errorMessage, "instruct must be an object");
             return Instruct();
         }
 
-        VariantMap minstruct = doc.object().toVariantMap();
+        VariantMap minstruct = doc.toMap();
 
         bool ok_;
 

--- a/src/m2adapter/m2requestpacket.cpp
+++ b/src/m2adapter/m2requestpacket.cpp
@@ -23,11 +23,10 @@
 
 #include "m2requestpacket.h"
 
+#include "json.h"
 #include "qtcompat.h"
 #include "tnetstring.h"
 #include "variant.h"
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QSet>
 
 static bool isAllCaps(const QString &s) {
@@ -141,12 +140,11 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in) {
         }
     } else // ByteArray
     {
-        QJsonParseError error;
-        QJsonDocument doc = QJsonDocument::fromJson(vheaders.toByteArray(), &error);
-        if (error.error != QJsonParseError::NoError || !doc.isObject())
+        Variant doc = Json::fromString(vheaders.toByteArray());
+        if (!doc.isValid() || typeId(doc) != VariantType::Map)
             return false;
 
-        VariantMap headersMap = doc.object().toVariantMap();
+        VariantMap headersMap = doc.toMap();
         for (auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit) {
             const QString &key = vit.key();
             const Variant &val = vit.value();
@@ -204,12 +202,11 @@ bool M2RequestPacket::fromByteArray(const QByteArray &in) {
         downloadCredits = m2headers.value("DOWNLOAD_CREDITS").toInt();
 
     if (m2method == "JSON") {
-        QJsonParseError error;
-        QJsonDocument doc = QJsonDocument::fromJson(body, &error);
-        if (error.error != QJsonParseError::NoError || !doc.isObject())
+        Variant doc = Json::fromString(body);
+        if (!doc.isValid() || typeId(doc) != VariantType::Map)
             return false;
 
-        VariantMap data = doc.object().toVariantMap();
+        VariantMap data = doc.toMap();
         if (!data.contains("type") || typeId(data["type"]) != VariantType::String)
             return false;
 

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -25,6 +25,7 @@
 #include "cowstring.h"
 #include "domainmap.h"
 #include "eventloop.h"
+#include "json.h"
 #include "log.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
@@ -41,8 +42,6 @@
 #include "zmqsocket.h"
 #include "zmqvalve.h"
 #include <QDir>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <boost/signals2.hpp>
 #include <chrono>
 #include <thread>
@@ -480,12 +479,11 @@ private:
         QByteArray hold;
 
         if (acceptHeaders.get("Content-Type") == "application/grip-instruct") {
-            QJsonParseError e;
-            QJsonDocument doc = QJsonDocument::fromJson(acceptIn, &e);
-            TEST_ASSERT(e.error == QJsonParseError::NoError);
-            TEST_ASSERT(doc.isObject());
+            Variant doc = Json::fromString(acceptIn);
+            TEST_ASSERT(doc.isValid());
+            TEST_ASSERT(typeId(doc) == VariantType::Map);
 
-            jsonInstruct = doc.object().toVariantMap();
+            jsonInstruct = doc.toMap();
 
             if (jsonInstruct.contains("hold"))
                 hold = jsonInstruct["hold"].toMap().value("mode").toString().toUtf8();
@@ -719,12 +717,11 @@ static void passthroughJsonp(TestState &state, std::function<void(int)> loop_wai
     TEST_ASSERT(wrapper->in.endsWith("});\n"));
     QByteArray dataRaw = wrapper->in.mid(9, wrapper->in.size() - 9 - 3);
 
-    QJsonParseError e;
-    QJsonDocument doc = QJsonDocument::fromJson(dataRaw, &e);
-    TEST_ASSERT(e.error == QJsonParseError::NoError);
-    TEST_ASSERT(doc.isObject());
+    Variant doc = Json::fromString(dataRaw);
+    TEST_ASSERT(doc.isValid());
+    TEST_ASSERT(typeId(doc) == VariantType::Map);
 
-    VariantMap data = doc.object().toVariantMap();
+    VariantMap data = doc.toMap();
 
     TEST_ASSERT_EQ(data["code"].toInt(), 200);
     TEST_ASSERT_EQ(data["body"].toByteArray(), QByteArray("{\"hello\": \"world\"}"));

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -29,8 +29,6 @@
 #include "qtcompat.h"
 #include "variant.h"
 #include <QDateTime>
-#include <QJsonDocument>
-#include <QJsonObject>
 
 static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key) {
     VariantMap claim;

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -31,6 +31,7 @@
 #include "defercall.h"
 #include "inspectdata.h"
 #include "inspectrequest.h"
+#include "json.h"
 #include "layertracker.h"
 #include "log.h"
 #include "packet/httprequestdata.h"
@@ -46,9 +47,6 @@
 #include "zrpcchecker.h"
 #include "zrpcmanager.h"
 #include <QHostAddress>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <assert.h>
 
 #define MAX_SHARED_REQUEST_BODY 100000
@@ -107,8 +105,7 @@ static bool validMethod(const QString &in) {
 }
 
 static QByteArray serializeJsonString(const QString &s) {
-    QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s))
-                         .toJson(QJsonDocument::Compact);
+    QByteArray tmp = Json::toString(VariantList() << s);
 
     assert(tmp.length() >= 4);
     assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
@@ -527,8 +524,7 @@ public:
                     vheaders[h.first.asQByteArray()] = h.second.asQByteArray();
             }
 
-            QByteArray headersJson =
-                QJsonDocument(QJsonObject::fromVariantMap(vheaders)).toJson(QJsonDocument::Compact);
+            QByteArray headersJson = Json::toString(vheaders);
             if (headersJson.isNull())
                 return QByteArray();
 
@@ -621,12 +617,9 @@ public:
 
         HttpHeaders headers;
         if (query.hasQueryItem("_headers")) {
-            QJsonParseError e;
-            QJsonDocument doc = QJsonDocument::fromJson(
-                parsePercentEncoding(
-                    query.queryItemValue("_headers", CowUrl::FullyEncoded).toUtf8()),
-                &e);
-            if (e.error != QJsonParseError::NoError || !doc.isObject()) {
+            Variant doc = Json::fromString(parsePercentEncoding(
+                query.queryItemValue("_headers", CowUrl::FullyEncoded).toUtf8()));
+            if (!doc.isValid() || typeId(doc) != VariantType::Map) {
                 log_debug("requestsession: id=%s invalid _headers parameter, rejecting",
                           rid.second.data());
                 *ok = false;
@@ -634,7 +627,7 @@ public:
                 return false;
             }
 
-            VariantMap headersMap = doc.object().toVariantMap();
+            VariantMap headersMap = doc.toMap();
 
             for (auto vit = headersMap.constBegin(); vit != headersMap.constEnd(); ++vit) {
                 if (typeId(vit.value()) != VariantType::String) {

--- a/src/proxy/sockjsmanager.cpp
+++ b/src/proxy/sockjsmanager.cpp
@@ -24,6 +24,7 @@
 #include "sockjsmanager.h"
 
 #include "bufferlist.h"
+#include "json.h"
 #include "log.h"
 #include "qtcompat.h"
 #include "sockjssession.h"
@@ -33,9 +34,6 @@
 #include "zhttprequest.h"
 #include "zwebsocket.h"
 #include <QCryptographicHash>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QRandomGenerator>
 #include <QtGlobal>
 #include <assert.h>
@@ -65,8 +63,7 @@ const char *iframeHtmlTemplate =
     "</html>\n";
 
 static QByteArray serializeJsonString(const QString &s) {
-    QByteArray tmp = QJsonDocument(QJsonArray::fromVariantList(VariantList() << s))
-                         .toJson(QJsonDocument::Compact);
+    QByteArray tmp = Json::toString(VariantList() << s);
 
     assert(tmp.length() >= 4);
     assert(tmp[0] == '[' && tmp[tmp.length() - 1] == ']');
@@ -303,15 +300,10 @@ public:
             headers += HttpHeader("Content-Type", "text/plain");
 
         QByteArray body;
-        if (data.isValid()) {
-            QJsonDocument doc;
-            if (typeId(data) == VariantType::Map)
-                doc = QJsonDocument(QJsonObject::fromVariantMap(data.toMap()));
-            else // List
-                doc = QJsonDocument(QJsonArray::fromVariantList(data.toList()));
 
-            body = doc.toJson(QJsonDocument::Compact);
-        }
+        if (data.isValid())
+            body = Json::toString(data);
+
         if (!prefix.isEmpty())
             body.prepend(prefix);
 

--- a/src/proxy/sockjssession.cpp
+++ b/src/proxy/sockjssession.cpp
@@ -25,6 +25,7 @@
 
 #include "bufferlist.h"
 #include "defercall.h"
+#include "json.h"
 #include "log.h"
 #include "packet/httprequestdata.h"
 #include "qtcompat.h"
@@ -34,9 +35,6 @@
 #include "variant.h"
 #include "zhttprequest.h"
 #include "zwebsocket.h"
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <assert.h>
 
 using std::map;
@@ -349,16 +347,15 @@ public:
                 param = query.queryItemValue("d").toUtf8();
             }
 
-            QJsonParseError error;
-            QJsonDocument doc = QJsonDocument::fromJson(param, &error);
-            if (error.error != QJsonParseError::NoError || !doc.isArray()) {
+            Variant doc = Json::fromString(param);
+            if (!doc.isValid() || typeId(doc) != VariantType::List) {
                 requests.insert(
                     _req, new RequestItem(_req, jsonpCallback, RequestItem::Background, true));
                 respondError(_req, 400, "Bad Request", "Payload expected");
                 return;
             }
 
-            VariantList messages = doc.array().toVariantList();
+            VariantList messages = doc.toList();
 
             QList<Frame> frames;
             int bytes = 0;
@@ -486,8 +483,7 @@ public:
                 VariantList messages;
                 messages += QString::fromUtf8(frame.data);
 
-                QByteArray arrayJson = QJsonDocument(QJsonArray::fromVariantList(messages))
-                                           .toJson(QJsonDocument::Compact);
+                QByteArray arrayJson = Json::toString(messages);
                 Frame f(Frame::Text, "a" + arrayJson, false);
 
                 pendingWrites += WriteItem(WriteItem::User, frame.data.size());
@@ -687,14 +683,13 @@ public:
 
                 QByteArray data = bufs.toByteArray();
 
-                QJsonParseError e;
-                QJsonDocument doc = QJsonDocument::fromJson(data, &e);
-                if (e.error != QJsonParseError::NoError || !doc.isArray()) {
+                Variant doc = Json::fromString(data);
+                if (!doc.isValid() || typeId(doc) != VariantType::List) {
                     error = true;
                     break;
                 }
 
-                VariantList messages = doc.array().toVariantList();
+                VariantList messages = doc.toList();
 
                 QList<Frame> frames;
                 int bytes = 0;

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -24,12 +24,11 @@
 #include "testwebsocket.h"
 
 #include "defercall.h"
+#include "json.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
 #include "statusreasons.h"
 #include "urlquery.h"
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <assert.h>
 
 #define BUFFER_SIZE 200000
@@ -87,11 +86,10 @@ public:
                 response.headers += HttpHeader("Sec-WebSocket-Extensions", "grip");
 
                 foreach (const QString &channel, channels) {
-                    QJsonObject obj;
+                    VariantMap obj;
                     obj["type"] = QString("subscribe");
                     obj["channel"] = channel;
-                    inFrames +=
-                        Frame(Frame::Text, QByteArray("c:") + QJsonDocument(obj).toJson(), false);
+                    inFrames += Frame(Frame::Text, QByteArray("c:") + Json::toString(obj), false);
                 }
             }
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -44,8 +44,6 @@
 #include "zwebsocket.h"
 #include <QDateTime>
 #include <QHostAddress>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QRandomGenerator>
 #include <assert.h>
 


### PR DESCRIPTION
Following #48397, this updates all `QJson*` call sites to use the wrapper.