### PR TITLE
set app version to 2.0.0 and include v2 features in that case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "pushpin"
-version = "1.42.0-dev"
+version = "2.0.0-dev"
 dependencies = [
  "arrayvec",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pushpin"
-version = "1.42.0-dev"
+version = "2.0.0-dev"
 authors = ["Fastly <oss@fastly.com>"]
 description = "Reverse proxy for realtime web services"
 repository = "https://github.com/fastly/pushpin"
@@ -54,9 +54,10 @@ section = "net"
 license-file = ["packaging/debian/license-file", "0"]
 
 [features]
-default = ["do-qmake", "do-cpp-build"]
+default = ["do-qmake", "do-cpp-build", "legacy-runner"]
 do-qmake = []
 do-cpp-build = []
+legacy-runner = []
 
 [profile.dev]
 panic = "abort"
@@ -147,6 +148,7 @@ bench = false
 name = "pushpin-legacy"
 test = false
 bench = false
+required-features = ["legacy-runner"]
 
 [[bin]]
 name = "pushpin"
@@ -159,7 +161,7 @@ test = false
 bench = false
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(qt_lib_prefix, values("Qt", "Qt6", "Qt5"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(qt_lib_prefix, values("Qt", "Qt6", "Qt5"))', 'cfg(version_ge_2)'] }
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@
 nullstring :=
 space := $(nullstring) # end of the line
 
+cargo_flags := $(CARGO_FLAGS)
+
 ifdef RELEASE
-cargo_flags = $(space)--offline --locked --release
+cargo_flags += --offline --locked --release
+endif
+
+ifneq ($(strip $(cargo_flags)),)
+cargo_flags := $(space)$(strip $(cargo_flags))
 endif
 
 ifdef TOOLCHAIN

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,29 @@ fn get_version() -> String {
     version
 }
 
+fn get_version_int() -> Result<u32, Box<dyn Error>> {
+    let version = env!("CARGO_PKG_VERSION");
+
+    let version = match version.find('-') {
+        Some(pos) => &version[..pos],
+        None => version,
+    };
+
+    let mut v = 0;
+
+    for x in version.split('.') {
+        let x: u8 = match x.parse() {
+            Ok(x) => x,
+            Err(e) => return Err(format!("cannot parse numeric version component {x}: {e}").into()),
+        };
+
+        v <<= 8;
+        v |= x as u32;
+    }
+
+    Ok(v)
+}
+
 #[derive(Clone)]
 struct LibVersion {
     maj: u16,
@@ -124,6 +147,7 @@ fn write_cpp_conf_pri(
     release: bool,
     include_paths: &[&Path],
     deny_warnings: bool,
+    version_ge_2: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut out = Vec::new();
 
@@ -133,6 +157,11 @@ fn write_cpp_conf_pri(
         writeln!(&mut out, "CONFIG += release")?;
     } else {
         writeln!(&mut out, "CONFIG += debug")?;
+    }
+
+    if version_ge_2 {
+        writeln!(&mut out)?;
+        writeln!(&mut out, "DEFINES += VERSION_GE_2")?;
     }
 
     writeln!(&mut out)?;
@@ -157,6 +186,7 @@ fn write_postbuild_conf_pri(
     config_dir: &str,
     run_dir: &str,
     log_dir: &str,
+    include_legacy_runner: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut out = Vec::new();
 
@@ -165,6 +195,11 @@ fn write_postbuild_conf_pri(
     writeln!(&mut out, "CONFIGDIR = {}/pushpin", config_dir)?;
     writeln!(&mut out, "RUNDIR = {}/pushpin", run_dir)?;
     writeln!(&mut out, "LOGDIR = {}/pushpin", log_dir)?;
+
+    if include_legacy_runner {
+        writeln!(&mut out)?;
+        writeln!(&mut out, "CONFIG += include_legacy_runner")?;
+    }
 
     write_if_different(dest, &out)
 }
@@ -509,12 +544,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
+    let version_ge_2 = get_version_int()? >= 0x020000;
+
     write_cpp_conf_pri(
         &cpp_build_dir.join("conf.pri"),
         profile == "release",
         &include_paths,
         deny_warnings,
+        version_ge_2,
     )?;
+
+    let include_legacy_runner = cfg!(feature = "legacy-runner");
 
     write_postbuild_conf_pri(
         &Path::new("postbuild").join("conf.pri"),
@@ -523,6 +563,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         &config_dir,
         &run_dir,
         &log_dir,
+        include_legacy_runner,
     )?;
 
     if cfg!(feature = "do-qmake") {
@@ -564,6 +605,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-env=APP_VERSION={}", get_version());
     println!("cargo:rustc-env=CONFIG_DIR={}/pushpin", config_dir);
     println!("cargo:rustc-env=LIB_DIR={}/pushpin", lib_dir);
+
+    if version_ge_2 {
+        println!("cargo:rustc-cfg=version_ge_2");
+    }
 
     println!("cargo:rustc-cfg=qt_lib_prefix=\"{}\"", qt_lib_prefix);
 

--- a/postbuild/postbuild.pro
+++ b/postbuild/postbuild.pro
@@ -31,9 +31,11 @@ handler_bin.target = $$bin_dir/pushpin-handler
 handler_bin.depends = $$target_dir/pushpin-handler
 handler_bin.commands = mkdir -p $$bin_dir && cp -a $$target_dir/pushpin-handler $$bin_dir/pushpin-handler
 
-runner_legacy_bin.target = $$root_dir/pushpin-legacy
-runner_legacy_bin.depends = $$target_dir/pushpin-legacy
-runner_legacy_bin.commands = cp -a $$target_dir/pushpin-legacy $$root_dir/pushpin-legacy
+include_legacy_runner {
+    runner_legacy_bin.target = $$root_dir/pushpin-legacy
+    runner_legacy_bin.depends = $$target_dir/pushpin-legacy
+    runner_legacy_bin.commands = cp -a $$target_dir/pushpin-legacy $$root_dir/pushpin-legacy
+}
 
 runner_bin.target = $$root_dir/pushpin
 runner_bin.depends = $$target_dir/pushpin
@@ -47,8 +49,11 @@ QMAKE_EXTRA_TARGETS += \
 	connmgr_bin \
 	m2adapter_bin \
 	proxy_bin \
-	handler_bin \
-	runner_legacy_bin \
+	handler_bin
+
+include_legacy_runner:QMAKE_EXTRA_TARGETS += runner_legacy_bin
+
+QMAKE_EXTRA_TARGETS += \
 	runner_bin \
 	publish_bin
 
@@ -56,8 +61,11 @@ PRE_TARGETDEPS += \
 	$$bin_dir/pushpin-connmgr \
 	$$bin_dir/m2adapter \
 	$$bin_dir/pushpin-proxy \
-	$$bin_dir/pushpin-handler \
-	$$root_dir/pushpin-legacy \
+	$$bin_dir/pushpin-handler
+
+include_legacy_runner:PRE_TARGETDEPS += $$root_dir/pushpin-legacy
+
+PRE_TARGETDEPS += \
 	$$root_dir/pushpin \
 	$$bin_dir/pushpin-publish
 
@@ -74,14 +82,19 @@ PRE_TARGETDEPS += pushpin.conf.inst
 
 unix:!isEmpty(BINDIR) {
 	binfiles.path = $$BINDIR
+
 	binfiles.files = \
 		$$bin_dir/pushpin-connmgr \
 		$$bin_dir/m2adapter \
 		$$bin_dir/pushpin-proxy \
-		$$bin_dir/pushpin-handler \
-		$$root_dir/pushpin-legacy \
+		$$bin_dir/pushpin-handler
+
+	include_legacy_runner:binfiles.files += $$root_dir/pushpin-legacy
+
+	binfiles.files += \
 		$$root_dir/pushpin \
 		$$bin_dir/pushpin-publish
+
 	binfiles.CONFIG += no_check_exist executable
 
 	symlinks.path = $$BINDIR

--- a/src/bin/pushpin.rs
+++ b/src/bin/pushpin.rs
@@ -14,59 +14,86 @@
  * limitations under the License.
  */
 
-use clap::Parser;
-use log::{error, info, LevelFilter};
-use pushpin::core::log::{ensure_init_simple_logger, get_simple_logger, local_offset_check};
-use pushpin::runner::service::start_services;
-use pushpin::runner::{open_log_file, ArgsData, CliArgs, Settings};
-use std::env;
-use std::error::Error;
-use std::process;
+#[cfg(version_ge_2)]
+mod inner {
+    use clap::Parser;
+    use log::{error, info, LevelFilter};
+    use pushpin::core::log::{ensure_init_simple_logger, get_simple_logger, local_offset_check};
+    use pushpin::runner::service::start_services;
+    use pushpin::runner::{open_log_file, ArgsData, CliArgs, Settings};
+    use std::env;
+    use std::error::Error;
+    use std::process::{self, ExitCode};
 
-/// Main entry point for the Pushpin application
-fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
-    let args_data = ArgsData::new(args)?;
-    let settings = Settings::new(&env::current_dir()?, args_data)?;
+    /// Main entry point for the Pushpin application
+    fn process_args_and_run(args: CliArgs) -> Result<(), Box<dyn Error>> {
+        let args_data = ArgsData::new(args)?;
+        let settings = Settings::new(&env::current_dir()?, args_data)?;
 
-    let log_file = match settings.log_file.clone() {
-        Some(x) => match open_log_file(x) {
-            Ok(x) => Some(x),
-            Err(_) => {
-                error!("unable to open log file. logging to standard out.");
-                None
-            }
-        },
-        None => None,
-    };
-    ensure_init_simple_logger(log_file, true);
-    log::set_logger(get_simple_logger()).unwrap();
-    let ll = settings
-        .log_levels
-        .get("")
-        .unwrap_or_else(|| settings.log_levels.get("default").unwrap());
-    let level = match ll {
-        0 => LevelFilter::Error,
-        1 => LevelFilter::Warn,
-        2 => LevelFilter::Info,
-        3 => LevelFilter::Debug,
-        4..=u8::MAX => LevelFilter::Trace,
-    };
-    log::set_max_level(level);
+        let log_file = match settings.log_file.clone() {
+            Some(x) => match open_log_file(x) {
+                Ok(x) => Some(x),
+                Err(_) => {
+                    error!("unable to open log file. logging to standard out.");
+                    None
+                }
+            },
+            None => None,
+        };
+        ensure_init_simple_logger(log_file, true);
+        log::set_logger(get_simple_logger()).unwrap();
+        let ll = settings
+            .log_levels
+            .get("")
+            .unwrap_or_else(|| settings.log_levels.get("default").unwrap());
+        let level = match ll {
+            0 => LevelFilter::Error,
+            1 => LevelFilter::Warn,
+            2 => LevelFilter::Info,
+            3 => LevelFilter::Debug,
+            4..=u8::MAX => LevelFilter::Trace,
+        };
+        log::set_max_level(level);
 
-    local_offset_check();
+        local_offset_check();
 
-    info!("using config: {:?}", settings.config_file.display());
-    start_services(settings);
+        info!("using config: {:?}", settings.config_file.display());
+        start_services(settings);
 
-    Ok(())
+        Ok(())
+    }
+
+    pub fn main() -> ExitCode {
+        let args = CliArgs::parse();
+        info!("starting...");
+
+        if let Err(e) = process_args_and_run(args) {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+
+        ExitCode::SUCCESS
+    }
 }
 
-fn main() {
-    let args = CliArgs::parse();
-    info!("starting...");
+#[cfg(not(version_ge_2))]
+mod inner {
+    use pushpin::core::call_c_main;
+    use pushpin::import_cpp;
+    use std::env;
+    use std::process::ExitCode;
 
-    if let Err(e) = process_args_and_run(args) {
-        eprintln!("Error: {}", e);
-        process::exit(1);
+    import_cpp! {
+        fn runner_main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int;
     }
+
+    pub fn main() -> ExitCode {
+        unsafe { ExitCode::from(call_c_main(runner_main, env::args_os())) }
+    }
+}
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    inner::main()
 }

--- a/src/handler/filter.cpp
+++ b/src/handler/filter.cpp
@@ -253,6 +253,8 @@ public:
     virtual QByteArray finalize() { return QByteArray(""); }
 };
 
+#ifdef VERSION_GE_2
+
 class HttpFilterInner;
 
 class HttpFilter : public Filter::MessageFilter {
@@ -541,6 +543,8 @@ void HttpFilter::start(const Filter::Context &context, const QByteArray &content
 
 void HttpFilter::inner_finished(const Result &r) { finished(r); }
 
+#endif // VERSION_GE_2
+
 } // namespace
 
 Filter::MessageFilter::~MessageFilter() = default;
@@ -593,10 +597,12 @@ Filter::MessageFilter *Filter::createMessageFilter(const QString &name) {
         return new BuildIdFilter;
     else if (name == "var-subst")
         return new VarSubstFilter;
+#ifdef VERSION_GE_2
     else if (name == "http-check")
         return new HttpFilter(HttpFilter::Check);
     else if (name == "http-modify")
         return new HttpFilter(HttpFilter::Modify);
+#endif
     else
         return 0;
 }
@@ -607,8 +613,11 @@ QStringList Filter::names() {
                           << "require-sub"
                           << "build-id"
                           << "var-subst"
+#ifdef VERSION_GE_2
                           << "http-check"
-                          << "http-modify");
+                          << "http-modify"
+#endif
+    );
 }
 
 Filter::Targets Filter::targets(const QString &name) {
@@ -622,10 +631,12 @@ Filter::Targets Filter::targets(const QString &name) {
         return Filter::Targets(Filter::MessageContent | Filter::ResponseContent);
     else if (name == "var-subst")
         return Filter::MessageContent;
+#ifdef VERSION_GE_2
     else if (name == "http-check")
         return Filter::MessageDelivery;
     else if (name == "http-modify")
         return Filter::Targets(Filter::MessageDelivery | Filter::MessageContent);
+#endif
     else
         return Filter::Targets(0);
 }

--- a/src/handler/filtertest.cpp
+++ b/src/handler/filtertest.cpp
@@ -235,6 +235,8 @@ static void messageFilters(std::function<void(int)> loop_wait) {
     }
 }
 
+#ifdef VERSION_GE_2
+
 static void httpCheck(std::function<void(int)> loop_wait) {
     TestState state(loop_wait);
 
@@ -358,11 +360,16 @@ static void httpModifyExternal(std::function<void(int)> loop_wait) {
     }
 }
 
+#endif
+
 extern "C" int filter_test(ffi::TestException *out_ex) {
     TEST_CATCH(test_with_event_loop(messageFilters));
+
+#ifdef VERSION_GE_2
     TEST_CATCH(test_with_event_loop(httpCheck));
     TEST_CATCH(test_with_event_loop(httpModify));
     TEST_CATCH(test_with_event_loop(httpModifyExternal));
+#endif
 
     return 0;
 }

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -160,11 +160,23 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
     if (!trustedClient && gripEnabled) {
         applyGripSig(logprefix, object, &requestData->headers, sigIss, sigKey);
 
+        QStringList features = QStringList() << "status"
+                                             << "session"
+                                             << "link:next"
+                                             << "link:gone"
+                                             << "filter:skip-self"
+                                             << "filter:skip-users"
+                                             << "filter:require-sub"
+                                             << "filter:build-id"
+                                             << "filter:var-subst"
+#ifdef VERSION_GE_2
+                                             << "filter:http-check"
+                                             << "filter:http-modify"
+#endif
+            ;
+
         requestData->headers.removeAll("Grip-Feature");
-        requestData->headers +=
-            HttpHeader("Grip-Feature", "status, session, link:next, link:gone, filter:skip-self, "
-                                       "filter:skip-users, filter:require-sub, filter:build-id, "
-                                       "filter:var-subst, filter:http-check, filter:http-modify");
+        requestData->headers += HttpHeader("Grip-Feature", features.join(", ").toUtf8());
 
         if (!idata.sid.isEmpty()) {
             requestData->headers.removeAll("Grip-Session-Id");


### PR DESCRIPTION
This excludes v2 features when the app's version in `Cargo.toml` is < 2.0.0. It also sets the version to 2.0.0 so inclusion of v2 features remains the default when building on `main`. With this behavior in place, we can conditionally produce releases of either v1 or v2 from `main` and we shouldn't need a separate `v1` branch.

There is also a `legacy-runner` feature flag that controls whether to build a `pushpin-legacy` binary, which is default enabled as well. This is a separate flag since it's not possible to conditionally build binaries based on the app version. Note that the app version determines the implementation of the main runner; if you set the app version to 1.x but leave the `legacy-runner` feature enabled, you get two runners that are both the legacy implementation.

To build v1 and avoid producing a redundant `pushpin-legacy` binary (as a standard v1 release would do), change the version number in `Cargo.toml` to 1.x and set cargo features explicitly:

```
CARGO_FLAGS="--no-default-features --features do-qmake,do-cpp-build" make
```

The way it works under the hood is if the app version is >= 2.0.0, `build.rs` sets a `version_ge_2` Rust cfg attribute as well as a `VERSION_GE_2` C++ define, to mean "version greater than or equal to 2". Features are then guarded like:

```c++
#ifdef VERSION_GE_2
upcoming_v2_feature();
#endif
```

Flags are provided instead of actual version numbers since, unlike C++, Rust doesn't have a way to do conditional compilation based on version math, and this keeps things consistent in both languages. However, it should be possible to stack such version flags to do version range checks, which is why they indicate "greater than or equal" rather than exact versions. For example, a hypothetical major version 3 could set a `version_ge_3` flag along with a `version_ge_2` as well.