### PR TITLE
add DateTime alias, as preparation to migrate away from QDateTime

### DIFF
--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -3,6 +3,7 @@ HEADERS += \
 	$$PWD/cowstring.h \
 	$$PWD/cowurl.h \
 	$$PWD/urlquery.h \
+	$$PWD/datetime.h \
 	$$PWD/variant.h
 
 SOURCES += \

--- a/src/core/datetime.h
+++ b/src/core/datetime.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Fastly, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DATETIME_H
+#define DATETIME_H
+
+#include <QDateTime>
+
+// QDateTime-like type that currently aliases QDateTime, to assist with reducing direct dependency
+// on Qt. The API is designed to allow cheap conversion to/from QDateTime.
+using DateTime = QDateTime;
+
+#endif

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -23,6 +23,7 @@
 
 #include "statsmanager.h"
 
+#include "datetime.h"
 #include "defercall.h"
 #include "httpheaders.h"
 #include "json.h"
@@ -34,7 +35,6 @@
 #include "variant.h"
 #include "zmqsocket.h"
 #include "zutil.h"
-#include "datetime.h"
 #include <assert.h>
 
 // Make this somewhat big since PUB is lossy

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -34,7 +34,7 @@
 #include "variant.h"
 #include "zmqsocket.h"
 #include "zutil.h"
-#include <QDateTime>
+#include "datetime.h"
 #include <assert.h>
 
 // Make this somewhat big since PUB is lossy
@@ -406,7 +406,7 @@ public:
         prometheusMetrics += PrometheusMetric(PrometheusMetric::MessageSent, "message_sent",
                                               "counter", "Number of messages sent to clients");
 
-        startTime = QDateTime::currentMSecsSinceEpoch();
+        startTime = DateTime::currentMSecsSinceEpoch();
 
         connectionsMaxes.lastRefresh = startTime;
     }
@@ -711,7 +711,7 @@ public:
         if (!report) {
             report = new Report;
             report->routeId = routeId;
-            report->startTime = QDateTime::currentMSecsSinceEpoch();
+            report->startTime = DateTime::currentMSecsSinceEpoch();
             reports[routeId] = report;
         }
 
@@ -1158,7 +1158,7 @@ public:
         counters.inc(Stats::ServerMessagesReceived, qMax(packet.serverMessagesReceived, 0));
         counters.inc(Stats::ServerMessagesSent, qMax(packet.serverMessagesSent, 0));
 
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         report->addCounters(counters, now);
         combinedReport.addCounters(counters, now);
@@ -1224,7 +1224,7 @@ public:
     void flushReport(const QByteArray &routeId) {
         Report *report = getOrCreateReport(routeId);
 
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         StatsPacket p = reportToPacket(report, routeId, now);
 
@@ -1273,7 +1273,7 @@ private:
             combinedCounts = Counts();
         }
 
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         QSet<QByteArray> needSendNext;
 
@@ -1296,7 +1296,7 @@ private:
     }
 
     void report_timeout() {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         QList<StatsPacket> reportPackets;
         QList<Report *> toDelete;
@@ -1333,7 +1333,7 @@ private:
     }
 
     void refresh_timeout() {
-        int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+        int64_t currentTime = DateTime::currentMSecsSinceEpoch();
 
         // Time must go forward
         if (currentTime > startTime) {
@@ -1350,7 +1350,7 @@ private:
     }
 
     void externalConnectionsMax_timeout() {
-        int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+        int64_t currentTime = DateTime::currentMSecsSinceEpoch();
 
         expireExternalConnectionsMaxes(currentTime);
     }
@@ -1463,7 +1463,7 @@ void StatsManager::addMessage(const QString &channel, const QString &itemId,
 void StatsManager::addConnection(const QByteArray &id, const QByteArray &routeId,
                                  ConnectionType type, const QHostAddress &peerAddress, bool ssl,
                                  bool quiet, int reportOffset) {
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
 
     bool replacing = false;
     int64_t lastReport = now;
@@ -1539,7 +1539,7 @@ int StatsManager::removeConnection(const QByteArray &id, bool linger, const QByt
     if (!c)
         return 0;
 
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
     QByteArray routeId = c->routeId;
     int unreportedTime = 0;
 
@@ -1594,7 +1594,7 @@ void StatsManager::addSubscription(const QString &mode, const QString &channel,
     Private::SubscriptionKey subKey(mode, channel);
     Private::Subscription *s = d->subscriptionsByKey.value(subKey);
     if (!s) {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         // Add the subscription if we didn't have it
         s = new Private::Subscription;
@@ -1612,7 +1612,7 @@ void StatsManager::addSubscription(const QString &mode, const QString &channel,
         s->subscriberCount = subscriberCount;
 
         if (s->linger) {
-            int64_t now = QDateTime::currentMSecsSinceEpoch();
+            int64_t now = DateTime::currentMSecsSinceEpoch();
 
             // If this was a lingering subscription, return it to normal
             s->linger = false;
@@ -1622,7 +1622,7 @@ void StatsManager::addSubscription(const QString &mode, const QString &channel,
 
             d->sendSubscribed(s);
         } else if (s->subscriberCount != oldSubscriberCount) {
-            int64_t now = QDateTime::currentMSecsSinceEpoch();
+            int64_t now = DateTime::currentMSecsSinceEpoch();
 
             // Process soon
             s->lastRefresh = now - SHOULD_PROCESS_TIME(d->subscriptionTtl);
@@ -1639,7 +1639,7 @@ void StatsManager::removeSubscription(const QString &mode, const QString &channe
 
     if (linger) {
         if (!s->linger) {
-            int64_t now = QDateTime::currentMSecsSinceEpoch();
+            int64_t now = DateTime::currentMSecsSinceEpoch();
 
             s->linger = true;
 
@@ -1665,7 +1665,7 @@ void StatsManager::addMessageReceived(const QByteArray &routeId, int blocks) {
 
     Private::Report *report = d->getOrCreateReport(routeId);
 
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
 
     report->addMessageReceived(blocks, now);
     d->combinedReport.addMessageReceived(blocks, now);
@@ -1677,7 +1677,7 @@ void StatsManager::addMessageSent(const QByteArray &routeId, const QString &tran
 
     Private::Report *report = d->getOrCreateReport(routeId);
 
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
 
     report->addMessageSent(transport, blocks, now);
     d->combinedReport.addMessageSent(transport, blocks, now);
@@ -1689,14 +1689,14 @@ void StatsManager::incCounter(const QByteArray &routeId, Stats::Counter c, uint3
 
     Private::Report *report = d->getOrCreateReport(routeId);
 
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
 
     report->incCounter(c, count, now);
     d->combinedReport.incCounter(c, count, now);
 }
 
 void StatsManager::addRequestsReceived(uint32_t count) {
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
 
     d->combinedCounts.requestsReceived += count;
     d->combinedReport.addRequestsReceived(count, now);
@@ -1714,7 +1714,7 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
         return false;
 
     if (packet.type == StatsPacket::Connected || packet.type == StatsPacket::Disconnected) {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         bool replacing = false;
         int64_t lastReport = now;
@@ -1815,7 +1815,7 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
 
         return replacing;
     } else if (packet.type == StatsPacket::ConnectionsMax) {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         d->mergeExternalConnectionsMax(packet, now);
 
@@ -1852,7 +1852,7 @@ int64_t StatsManager::lastRetrySeq(const QByteArray &source) const {
 StatsPacket StatsManager::getConnMaxPacket(const QByteArray &routeId) {
     Private::ConnectionsMax &cm = d->getOrCreateConnectionsMax(routeId);
 
-    int64_t now = QDateTime::currentMSecsSinceEpoch();
+    int64_t now = DateTime::currentMSecsSinceEpoch();
 
     return d->getConnMaxPacket(routeId, &cm, now);
 }

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -25,7 +25,7 @@
 
 #include "eventloop.h"
 #include "timerwheel.h"
-#include <QDateTime>
+#include "datetime.h"
 #include <QTimer>
 #include <assert.h>
 
@@ -59,7 +59,7 @@ private:
 };
 
 TimerManager::TimerManager(int capacity) : wheel_(TimerWheel(capacity)) {
-    startTime_ = QDateTime::currentMSecsSinceEpoch();
+    startTime_ = DateTime::currentMSecsSinceEpoch();
     currentTicks_ = 0;
 
     t_ = std::make_unique<QTimer>();
@@ -71,7 +71,7 @@ TimerManager::TimerManager(int capacity) : wheel_(TimerWheel(capacity)) {
 }
 
 int TimerManager::add(int msec, Timer *r) {
-    int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+    int64_t currentTime = DateTime::currentMSecsSinceEpoch();
 
     int64_t expiresTicks;
     if (msec <= 0) {
@@ -96,13 +96,13 @@ int TimerManager::add(int msec, Timer *r) {
 void TimerManager::remove(int key) {
     wheel_.remove(key);
 
-    int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+    int64_t currentTime = DateTime::currentMSecsSinceEpoch();
 
     updateTimeout(currentTime);
 }
 
 void TimerManager::t_timeout() {
-    int64_t currentTime = QDateTime::currentMSecsSinceEpoch();
+    int64_t currentTime = DateTime::currentMSecsSinceEpoch();
 
     // Time must go forward
     if (currentTime > startTime_) {

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -23,9 +23,9 @@
 
 #include "timer.h"
 
+#include "datetime.h"
 #include "eventloop.h"
 #include "timerwheel.h"
-#include "datetime.h"
 #include <QTimer>
 #include <assert.h>
 

--- a/src/handler/publishlastids.cpp
+++ b/src/handler/publishlastids.cpp
@@ -27,7 +27,7 @@
 PublishLastIds::PublishLastIds(int maxCapacity) : maxCapacity_(maxCapacity) {}
 
 void PublishLastIds::set(const QString &channel, const QString &id) {
-    QDateTime now = QDateTime::currentDateTimeUtc();
+    DateTime now = DateTime::currentDateTimeUtc();
 
     if (table_.contains(channel)) {
         Item &i = table_[channel];

--- a/src/handler/publishlastids.h
+++ b/src/handler/publishlastids.h
@@ -23,7 +23,7 @@
 #ifndef PUBLISHLASTIDS_H
 #define PUBLISHLASTIDS_H
 
-#include <QDateTime>
+#include "datetime.h"
 #include <QHash>
 #include <QMap>
 #include <QString>
@@ -38,13 +38,13 @@ public:
     QString value(const QString &channel);
 
 private:
-    typedef QPair<QDateTime, QString> TimeStringPair;
+    typedef QPair<DateTime, QString> TimeStringPair;
 
     class Item {
     public:
         QString channel;
         QString id;
-        QDateTime time;
+        DateTime time;
     };
 
     QHash<QString, Item> table_;

--- a/src/handler/sequencer.cpp
+++ b/src/handler/sequencer.cpp
@@ -23,12 +23,12 @@
 
 #include "sequencer.h"
 
+#include "datetime.h"
 #include "defercall.h"
 #include "log.h"
 #include "publishitem.h"
 #include "publishlastids.h"
 #include "timer.h"
-#include "datetime.h"
 
 #define CHANNEL_PENDING_MAX 100
 #define DEFAULT_PENDING_EXPIRE 5000

--- a/src/handler/sequencer.cpp
+++ b/src/handler/sequencer.cpp
@@ -28,7 +28,7 @@
 #include "publishitem.h"
 #include "publishlastids.h"
 #include "timer.h"
-#include <QDateTime>
+#include "datetime.h"
 
 #define CHANNEL_PENDING_MAX 100
 #define DEFAULT_PENDING_EXPIRE 5000
@@ -78,7 +78,7 @@ public:
     ~Private() { qDeleteAll(idCacheById); }
 
     void addItem(const PublishItem &item, bool seq) {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         while (!idCacheByExpireTime.isEmpty()) {
             QMap<QPair<int64_t, CachedId *>, CachedId *>::iterator it = idCacheByExpireTime.begin();
@@ -203,7 +203,7 @@ public:
     }
 
     void expireTimer_timeout() {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
         int64_t threshold = now - pendingExpireMSecs;
 
         while (!pendingItemsByTime.isEmpty()) {

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -29,7 +29,7 @@
 #include "publishformat.h"
 #include "publishitem.h"
 #include "timer.h"
-#include <QDateTime>
+#include "datetime.h"
 
 #define WSCONTROL_REQUEST_TIMEOUT 8000
 
@@ -253,7 +253,7 @@ void WsSession::setupRequestTimer() {
                 lowestTime = time;
         }
 
-        int until = int(lowestTime - QDateTime::currentMSecsSinceEpoch());
+        int until = int(lowestTime - DateTime::currentMSecsSinceEpoch());
 
         requestTimer->start(qMax(until, 0));
     } else {
@@ -273,7 +273,7 @@ void WsSession::delayedTimer_timeout() {
     QByteArray message = delayedMessage;
     delayedMessage.clear();
 
-    pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + WSCONTROL_REQUEST_TIMEOUT;
+    pendingRequests[reqId] = DateTime::currentMSecsSinceEpoch() + WSCONTROL_REQUEST_TIMEOUT;
     setupRequestTimer();
 
     WsControlPacket::Item i;

--- a/src/handler/wssession.cpp
+++ b/src/handler/wssession.cpp
@@ -23,13 +23,13 @@
 
 #include "wssession.h"
 
+#include "datetime.h"
 #include "defercall.h"
 #include "filter.h"
 #include "log.h"
 #include "publishformat.h"
 #include "publishitem.h"
 #include "timer.h"
-#include "datetime.h"
 
 #define WSCONTROL_REQUEST_TIMEOUT 8000
 

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "cowbytearray.h"
 #include "cowstring.h"
+#include "datetime.h"
 #include "layertracker.h"
 #include "log.h"
 #include "logutil.h"
@@ -42,7 +43,6 @@
 #include "zmqvalve.h"
 #include <QCommandLineParser>
 #include <QCoreApplication>
-#include "datetime.h"
 #include <QDir>
 #include <QElapsedTimer>
 #include <QHash>

--- a/src/m2adapter/m2adapterapp.cpp
+++ b/src/m2adapter/m2adapterapp.cpp
@@ -42,7 +42,7 @@
 #include "zmqvalve.h"
 #include <QCommandLineParser>
 #include <QCoreApplication>
-#include <QDateTime>
+#include "datetime.h"
 #include <QDir>
 #include <QElapsedTimer>
 #include <QHash>
@@ -1215,7 +1215,7 @@ public:
             Session *s = conn->session;
 
             // Update lastActive
-            qint64 now = QDateTime::currentMSecsSinceEpoch();
+            qint64 now = DateTime::currentMSecsSinceEpoch();
             sessionsByLastActive.remove(QPair<qint64, Session *>(s->lastActive, s));
             s->lastActive = now;
             sessionsByLastActive.insert(QPair<qint64, Session *>(s->lastActive, s), s);
@@ -1408,7 +1408,7 @@ public:
         if (seq != -1)
             ++(s->inSeq);
 
-        qint64 now = QDateTime::currentMSecsSinceEpoch();
+        qint64 now = DateTime::currentMSecsSinceEpoch();
 
         if (s->lastRefresh < 0 && !s->zhttpAddress.isEmpty()) {
             // Once we have the peer's address, set up refresh
@@ -2103,7 +2103,7 @@ public:
             return;
         }
 
-        qint64 now = QDateTime::currentMSecsSinceEpoch();
+        qint64 now = DateTime::currentMSecsSinceEpoch();
 
         Rid m2Rid(mreq.sender, mreq.id);
 
@@ -2297,7 +2297,7 @@ public:
 
             sessionsByM2Rid.insert(m2Rid, s);
 
-            qint64 now = QDateTime::currentMSecsSinceEpoch();
+            qint64 now = DateTime::currentMSecsSinceEpoch();
 
             s->lastActive = now;
             sessionsByLastActive.insert(QPair<qint64, Session *>(s->lastActive, s), s);
@@ -2536,7 +2536,7 @@ private slots:
     }
 
     void refresh_timeout() {
-        qint64 now = QDateTime::currentMSecsSinceEpoch();
+        qint64 now = DateTime::currentMSecsSinceEpoch();
 
         refreshM2Connections(now);
         refreshSessions(now);

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -23,12 +23,12 @@
 
 #include "proxyutil.h"
 
+#include "datetime.h"
 #include "inspectdata.h"
 #include "jwt.h"
 #include "log.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include "datetime.h"
 
 static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key) {
     VariantMap claim;

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -28,12 +28,12 @@
 #include "log.h"
 #include "qtcompat.h"
 #include "variant.h"
-#include <QDateTime>
+#include "datetime.h"
 
 static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key) {
     VariantMap claim;
     claim["iss"] = QString::fromUtf8(iss);
-    claim["exp"] = QDateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600;
+    claim["exp"] = DateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600;
     return Jwt::encode(claim, key);
 }
 
@@ -45,7 +45,7 @@ static bool validate_token(const QByteArray &token, const Jwt::DecodingKey &key)
     VariantMap claim = claimObj.toMap();
 
     int exp = claim.value("exp").toInt();
-    if (exp <= 0 || (int)QDateTime::currentDateTimeUtc().toSecsSinceEpoch() >= exp)
+    if (exp <= 0 || (int)DateTime::currentDateTimeUtc().toSecsSinceEpoch() >= exp)
         return false;
 
     return true;

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -33,7 +33,7 @@
 #include "zmqsocket.h"
 #include "zmqvalve.h"
 #include "zutil.h"
-#include <QDateTime>
+#include "datetime.h"
 #include <assert.h>
 #include <boost/signals2.hpp>
 
@@ -194,7 +194,7 @@ public:
         if (keepAliveRegistrations.contains(s))
             return;
 
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         KeepAliveRegistration *r = new KeepAliveRegistration;
         r->s = s;
@@ -287,7 +287,7 @@ private:
     }
 
     void refresh_timeout() {
-        int64_t now = QDateTime::currentMSecsSinceEpoch();
+        int64_t now = DateTime::currentMSecsSinceEpoch();
 
         QHash<QByteArray, WsControlPacket> packets;
 

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -23,6 +23,7 @@
 
 #include "wscontrolmanager.h"
 
+#include "datetime.h"
 #include "log.h"
 #include "logutil.h"
 #include "timer.h"
@@ -33,7 +34,6 @@
 #include "zmqsocket.h"
 #include "zmqvalve.h"
 #include "zutil.h"
-#include "datetime.h"
 #include <assert.h>
 #include <boost/signals2.hpp>
 

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -24,9 +24,9 @@
 #include "wscontrolsession.h"
 
 #include "cowurl.h"
+#include "datetime.h"
 #include "timer.h"
 #include "wscontrolmanager.h"
-#include "datetime.h"
 #include <assert.h>
 #include <boost/signals2.hpp>
 

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -26,7 +26,7 @@
 #include "cowurl.h"
 #include "timer.h"
 #include "wscontrolmanager.h"
-#include <QDateTime>
+#include "datetime.h"
 #include <assert.h>
 #include <boost/signals2.hpp>
 
@@ -116,7 +116,7 @@ public:
                     lowestTime = time;
             }
 
-            int until = int(lowestTime - QDateTime::currentMSecsSinceEpoch());
+            int until = int(lowestTime - DateTime::currentMSecsSinceEpoch());
 
             requestTimer->start(qMax(until, 0));
         } else {
@@ -132,7 +132,7 @@ public:
         i.requestId = QByteArray::number(reqId);
         i.message = message;
 
-        pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
+        pendingRequests[reqId] = DateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
         setupRequestTimer();
 
         write(i);
@@ -152,7 +152,7 @@ public:
         i.requestId = QByteArray::number(reqId);
         i.channel = channel;
 
-        pendingRequests[reqId] = QDateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
+        pendingRequests[reqId] = DateTime::currentMSecsSinceEpoch() + REQUEST_TIMEOUT;
         setupRequestTimer();
 
         write(i);

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -42,7 +42,7 @@
 #include "zhttpmanager.h"
 #include "zroutes.h"
 #include "zwebsocket.h"
-#include <QDateTime>
+#include "datetime.h"
 #include <QHostAddress>
 #include <QRandomGenerator>
 #include <assert.h>
@@ -258,7 +258,7 @@ public:
     bool acceptGripMessages;
     QByteArray messagePrefix;
     bool detached;
-    QDateTime activityTime;
+    DateTime activityTime;
     QByteArray publicCid;
     std::unique_ptr<Timer> keepAliveTimer;
     WsControl::KeepAliveMode keepAliveMode;
@@ -343,7 +343,7 @@ public:
         publicCid = _publicCid;
 
         if (statsManager)
-            activityTime = QDateTime::currentDateTimeUtc();
+            activityTime = DateTime::currentDateTimeUtc();
 
         inSock = std::unique_ptr<WebSocket>(sock);
         inWSConnection = InWSConnections{
@@ -679,7 +679,7 @@ public:
 
     void tryLogActivity() {
         if (statsManager && !activityTime.isNull()) {
-            QDateTime now = QDateTime::currentDateTimeUtc();
+            DateTime now = DateTime::currentDateTimeUtc();
             if (now >= activityTime.addMSecs(ACTIVITY_TIMEOUT)) {
                 statsManager->addActivity(route.id);
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -25,6 +25,7 @@
 
 #include "connectionmanager.h"
 #include "cowurl.h"
+#include "datetime.h"
 #include "defercall.h"
 #include "inspectdata.h"
 #include "jwt.h"
@@ -42,7 +43,6 @@
 #include "zhttpmanager.h"
 #include "zroutes.h"
 #include "zwebsocket.h"
-#include "datetime.h"
 #include <QHostAddress>
 #include <QRandomGenerator>
 #include <assert.h>

--- a/src/runner/mongrel2service.cpp
+++ b/src/runner/mongrel2service.cpp
@@ -26,7 +26,7 @@
 #include "log.h"
 #include "template.h"
 #include "variant.h"
-#include <QDateTime>
+#include "datetime.h"
 #include <QDir>
 #include <QProcess>
 
@@ -117,7 +117,7 @@ QString Mongrel2Service::filterLogLine(const int level, const QString &line) con
     if (level > logLevel_) {
         return QString();
     }
-    QString tstr = QDateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
+    QString tstr = DateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
     switch (level) {
     case LOG_LEVEL_DEBUG:
         return "[DEBUG] " + tstr + " " + line;

--- a/src/runner/mongrel2service.cpp
+++ b/src/runner/mongrel2service.cpp
@@ -23,10 +23,10 @@
 #include "mongrel2service.h"
 #include "tnetstring.h"
 
+#include "datetime.h"
 #include "log.h"
 #include "template.h"
 #include "variant.h"
-#include "datetime.h"
 #include <QDir>
 #include <QProcess>
 


### PR DESCRIPTION
As part of our ongoing process of migrating away from Qt types, this PR is the first in a series for addressing `QDateTime`. It adds a type alias and changes all call sites to use it. Since it's technically still the same type, the code should compile to the same thing with no change in behavior. Later, we can replace the alias with an alternative implementation, likely based on C++ `std::chrono`.

Notably, the type is not named `CowDateTime`, because I'm planning for the alternative implementation to not implement implicit sharing. A "date time" object is small enough (often just an integer) to not need it. `QDateTime` is likely implicitly shared due to being able to carry attached time zone data, and thus allowing cheap copies in that case, but we don't use this feature.