### PR TITLE
datetime: switch from qdatetime impl to time_point impl

### DIFF
--- a/src/core/datetime.h
+++ b/src/core/datetime.h
@@ -17,10 +17,51 @@
 #ifndef DATETIME_H
 #define DATETIME_H
 
-#include <QDateTime>
+#include <chrono>
+#include <cstdint>
 
-// QDateTime-like type that currently aliases QDateTime, to assist with reducing direct dependency
-// on Qt. The API is designed to allow cheap conversion to/from QDateTime.
-using DateTime = QDateTime;
+// Date/time type wrapping std::chrono::system_clock::time_point.
+class DateTime {
+public:
+    using time_point = std::chrono::system_clock::time_point;
+
+    DateTime() = default;
+
+    static DateTime currentDateTimeUtc() {
+        DateTime dt;
+        dt.inner_ = std::chrono::system_clock::now();
+        return dt;
+    }
+
+    static int64_t currentMSecsSinceEpoch() {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    }
+
+    int64_t toSecsSinceEpoch() const {
+        return std::chrono::duration_cast<std::chrono::seconds>(inner_.time_since_epoch()).count();
+    }
+
+    DateTime addMSecs(int64_t msecs) const {
+        DateTime dt;
+        dt.inner_ = inner_ + std::chrono::milliseconds(msecs);
+        return dt;
+    }
+
+    int64_t msecsTo(const DateTime &other) const {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(other.inner_ - inner_).count();
+    }
+
+    friend bool operator==(const DateTime &a, const DateTime &b) { return a.inner_ == b.inner_; }
+    friend bool operator!=(const DateTime &a, const DateTime &b) { return a.inner_ != b.inner_; }
+    friend bool operator<(const DateTime &a, const DateTime &b) { return a.inner_ < b.inner_; }
+    friend bool operator<=(const DateTime &a, const DateTime &b) { return a.inner_ <= b.inner_; }
+    friend bool operator>(const DateTime &a, const DateTime &b) { return a.inner_ > b.inner_; }
+    friend bool operator>=(const DateTime &a, const DateTime &b) { return a.inner_ >= b.inner_; }
+
+private:
+    time_point inner_;
+};
 
 #endif

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -33,7 +33,7 @@
 static QByteArray make_token(const QByteArray &iss, const Jwt::EncodingKey &key) {
     VariantMap claim;
     claim["iss"] = QString::fromUtf8(iss);
-    claim["exp"] = DateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600;
+    claim["exp"] = (qint64)(DateTime::currentDateTimeUtc().toSecsSinceEpoch() + 3600);
     return Jwt::encode(claim, key);
 }
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -46,6 +46,7 @@
 #include <QHostAddress>
 #include <QRandomGenerator>
 #include <assert.h>
+#include <optional>
 
 #define ACTIVITY_TIMEOUT 60000
 #define KEEPALIVE_RAND_MAX 1000
@@ -258,7 +259,7 @@ public:
     bool acceptGripMessages;
     QByteArray messagePrefix;
     bool detached;
-    DateTime activityTime;
+    std::optional<DateTime> activityTime;
     QByteArray publicCid;
     std::unique_ptr<Timer> keepAliveTimer;
     WsControl::KeepAliveMode keepAliveMode;
@@ -678,13 +679,13 @@ public:
     }
 
     void tryLogActivity() {
-        if (statsManager && !activityTime.isNull()) {
+        if (statsManager && activityTime.has_value()) {
             DateTime now = DateTime::currentDateTimeUtc();
-            if (now >= activityTime.addMSecs(ACTIVITY_TIMEOUT)) {
+            if (now >= activityTime->addMSecs(ACTIVITY_TIMEOUT)) {
                 statsManager->addActivity(route.id);
 
-                activityTime = activityTime.addMSecs(
-                    (activityTime.msecsTo(now) / ACTIVITY_TIMEOUT) * ACTIVITY_TIMEOUT);
+                activityTime = activityTime->addMSecs(
+                    (activityTime->msecsTo(now) / ACTIVITY_TIMEOUT) * ACTIVITY_TIMEOUT);
             }
         }
     }

--- a/src/runner/mongrel2service.cpp
+++ b/src/runner/mongrel2service.cpp
@@ -23,12 +23,13 @@
 #include "mongrel2service.h"
 #include "tnetstring.h"
 
-#include "datetime.h"
 #include "log.h"
 #include "template.h"
 #include "variant.h"
 #include <QDir>
 #include <QProcess>
+#include <chrono>
+#include <ctime>
 
 Mongrel2Service::Mongrel2Service(const QString &binFile, const QString &configFile,
                                  const QString &serverName, const QString &runDir,
@@ -117,7 +118,14 @@ QString Mongrel2Service::filterLogLine(const int level, const QString &line) con
     if (level > logLevel_) {
         return QString();
     }
-    QString tstr = DateTime::currentDateTime().toString("yyyy-MM-dd HH:mm:ss.zzz");
+    auto tp = std::chrono::system_clock::now();
+    int ms =
+        (int)(std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count() %
+              1000);
+    std::time_t t = std::chrono::system_clock::to_time_t(tp);
+    char tbuf[20];
+    std::strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
+    QString tstr = QString::asprintf("%s.%03d", tbuf, ms);
     switch (level) {
     case LOG_LEVEL_DEBUG:
         return "[DEBUG] " + tstr + " " + line;


### PR DESCRIPTION
This replaces the `DateTime` alias with a class providing an API nearly identical to `QDateTime` but wrapping `std::chrono::system_clock::time_point`.

Deviations from `QDateTime`'s API:

* No concept of null. Only one call site was relying on this. Changed to wrap with `optional` instead.
* No `toString()`. Only called once, in a deprecated module. Changed to perform stringification on its own.

Also, the class does not provide implicit sharing since `time_point` is just an int and therefore cheap to copy around.