### PR TITLE
add feature flag for including breaking changes regardless of app version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "pushpin"
-version = "2.0.0-dev"
+version = "1.41.0"
 dependencies = [
  "arrayvec",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pushpin"
-version = "2.0.0-dev"
+version = "1.41.0"
 authors = ["Fastly <oss@fastly.com>"]
 description = "Reverse proxy for realtime web services"
 repository = "https://github.com/fastly/pushpin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ license-file = ["packaging/debian/license-file", "0"]
 default = ["do-qmake", "do-cpp-build", "legacy-runner"]
 do-qmake = []
 do-cpp-build = []
+breaking-changes = []
 legacy-runner = []
 
 [profile.dev]

--- a/build.rs
+++ b/build.rs
@@ -28,12 +28,10 @@ fn get_version() -> String {
     version
 }
 
-fn get_version_int() -> Result<u32, Box<dyn Error>> {
-    let version = env!("CARGO_PKG_VERSION");
-
-    let version = match version.find('-') {
-        Some(pos) => &version[..pos],
-        None => version,
+fn get_compat_version_int() -> Result<u32, Box<dyn Error>> {
+    let version = match env::var("COMPAT_VERSION") {
+        Ok(s) => s,
+        Err(_) => return Ok(0xffffff), // all versions
     };
 
     let mut v = 0;
@@ -544,7 +542,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let version_ge_2 = get_version_int()? >= 0x020000;
+    let version_ge_2 = get_compat_version_int()? >= 0x020000;
 
     write_cpp_conf_pri(
         &cpp_build_dir.join("conf.pri"),
@@ -631,6 +629,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-env-changed=LOGDIR");
     println!("cargo:rerun-if-env-changed=RUNDIR");
     println!("cargo:rerun-if-env-changed=CPP_BUILD_DIR");
+    println!("cargo:rerun-if-env-changed=COMPAT_VERSION");
     println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=cbindgen.toml");
 

--- a/build.rs
+++ b/build.rs
@@ -28,10 +28,12 @@ fn get_version() -> String {
     version
 }
 
-fn get_compat_version_int() -> Result<u32, Box<dyn Error>> {
-    let version = match env::var("COMPAT_VERSION") {
-        Ok(s) => s,
-        Err(_) => return Ok(0xffffff), // all versions
+fn get_version_int() -> Result<u32, Box<dyn Error>> {
+    let version = env!("CARGO_PKG_VERSION");
+
+    let version = match version.find('-') {
+        Some(pos) => &version[..pos],
+        None => version,
     };
 
     let mut v = 0;
@@ -542,7 +544,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let version_ge_2 = get_compat_version_int()? >= 0x020000;
+    let version_ge_2 = get_version_int()? >= 0x020000 || cfg!(feature = "breaking-changes");
 
     write_cpp_conf_pri(
         &cpp_build_dir.join("conf.pri"),
@@ -629,9 +631,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-env-changed=LOGDIR");
     println!("cargo:rerun-if-env-changed=RUNDIR");
     println!("cargo:rerun-if-env-changed=CPP_BUILD_DIR");
-    println!("cargo:rerun-if-env-changed=COMPAT_VERSION");
     println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-changed=Cargo.toml");
 
     Ok(())
 }


### PR DESCRIPTION
Currently, the features to include in a build are determined by the version set in `Cargo.toml`. For example, setting it to 2.0.0 causes v2 features to be included. However, we want to move to a version management process whereby:

* The version in `Cargo.toml` in `main` is set to the most recently released version. Currently that's 1.41.0.
* Building from `main` can potentially include upcoming breaking changes. For example, if the current version is 1.41.0, and 2.0.0 is imminent, we want a way to include the v2 features by default on `main` without updating the version yet.

The latter behavior feels a little strange but it is expected with this style of process. Historically we've used a `-dev` suffix to disambiguate `main` builds vs release builds but this is not idiomatic.

This PR introduces a `breaking-changes` feature flag that includes everything, disabled by default. If disabled, only the features appropriate for the version set in `Cargo.toml` are included, so no change in behavior. However, when a major version change is imminent, we can choose to explicitly enable `breaking-changes` in `Cargo.toml` such that building `main` gets everything.

This PR also sets the version in `Cargo.toml` to that of the most recent release. This means v2 features will no longer be included by default when building `main`. Notably, there is no `-dev` suffix.