### PR TITLE
[release] Bump version to 1.42.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "pushpin"
-version = "1.41.0"
+version = "1.42.0"
 dependencies = [
  "arrayvec",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pushpin"
-version = "1.41.0"
+version = "1.42.0"
 authors = ["Fastly <oss@fastly.com>"]
 description = "Reverse proxy for realtime web services"
 repository = "https://github.com/fastly/pushpin"


### PR DESCRIPTION
A makeup PR for https://github.com/fastly/pushpin/pull/48405. I'm so used to just bumping the version currently in `Cargo.toml` that I forgot we're still at 1.41.

We're trying out a new(to this project) single trunk approach for releases and hoping to make them more frequent as we've made strides on fixing other parts of the release process.

This is the first step where we cut the release at a specific commit and bump the version.

Note: We're moving away from appending -dev since every version bump will essentially be a chronological marker for the exact commits within those versions.

Manually built binaries can be designated to have special suffixes by using specific build flags instead.

Since the last time, we've now gated v2 things behind feature flags that rely on the Cargo.toml version and/or explicit flags so hopefully should be able to single branch from here.