### PR TITLE
by default, don't build legacy runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ section = "net"
 license-file = ["packaging/debian/license-file", "0"]
 
 [features]
-default = ["do-qmake", "do-cpp-build", "legacy-runner"]
+default = ["do-qmake", "do-cpp-build"]
 do-qmake = []
 do-cpp-build = []
 breaking-changes = []


### PR DESCRIPTION
Disabling this feature by default so that `main` is release-ready by default. I thought about adding it as a dependency of `breaking-changes` but it's not something we plan to ship in v2 either. It's more of a development feature.