### PR TITLE
use cow types in packet classes

### DIFF
--- a/src/core/cowbytearray.h
+++ b/src/core/cowbytearray.h
@@ -121,10 +121,16 @@ public:
     friend CowByteArray operator+(const CowByteArray &lhs, const CowByteArray &rhs);
     friend CowByteArray operator+(const CowByteArray &lhs, const char *rhs);
     friend CowByteArray operator+(const char *lhs, const CowByteArray &rhs);
+    friend CowByteArray operator+(const CowByteArray &lhs, char rhs);
+    friend CowByteArray operator+(char lhs, const CowByteArray &rhs);
+    friend CowByteArray operator+(const CowByteArray &lhs, const QByteArray &rhs);
+    friend CowByteArray operator+(const QByteArray &lhs, const CowByteArray &rhs);
 
     friend bool operator==(const CowByteArray &lhs, const CowByteArray &rhs);
     friend bool operator==(const CowByteArray &lhs, const char *const &rhs);
     friend bool operator==(const char *const &lhs, const CowByteArray &rhs);
+    friend bool operator==(const CowByteArray &lhs, const QByteArray &rhs);
+    friend bool operator==(const QByteArray &lhs, const CowByteArray &rhs);
 
 private:
     friend class CowByteArrayRef;
@@ -137,6 +143,14 @@ inline CowByteArray operator+(const CowByteArray &lhs, const CowByteArray &rhs) 
 }
 inline CowByteArray operator+(const CowByteArray &lhs, const char *rhs) { return lhs.inner_ + rhs; }
 inline CowByteArray operator+(const char *lhs, const CowByteArray &rhs) { return lhs + rhs.inner_; }
+inline CowByteArray operator+(const CowByteArray &lhs, char rhs) { return lhs.inner_ + rhs; }
+inline CowByteArray operator+(char lhs, const CowByteArray &rhs) { return lhs + rhs.inner_; }
+inline CowByteArray operator+(const CowByteArray &lhs, const QByteArray &rhs) {
+    return lhs.inner_ + rhs;
+}
+inline CowByteArray operator+(const QByteArray &lhs, const CowByteArray &rhs) {
+    return lhs + rhs.inner_;
+}
 
 inline bool operator==(const CowByteArray &lhs, const CowByteArray &rhs) {
     return lhs.inner_ == rhs.inner_;
@@ -147,9 +161,17 @@ inline bool operator==(const CowByteArray &lhs, const char *const &rhs) {
 inline bool operator==(const char *const &lhs, const CowByteArray &rhs) {
     return lhs == rhs.inner_;
 }
+inline bool operator==(const CowByteArray &lhs, const QByteArray &rhs) { return lhs.inner_ == rhs; }
+inline bool operator==(const QByteArray &lhs, const CowByteArray &rhs) { return lhs == rhs.inner_; }
 inline bool operator!=(const CowByteArray &lhs, const CowByteArray &rhs) { return !(lhs == rhs); }
 inline bool operator!=(const CowByteArray &lhs, const char *const &rhs) { return !(lhs == rhs); }
 inline bool operator!=(const char *const &lhs, const CowByteArray &rhs) { return !(lhs == rhs); }
+inline bool operator!=(const CowByteArray &lhs, const QByteArray &rhs) { return !(lhs == rhs); }
+inline bool operator!=(const QByteArray &lhs, const CowByteArray &rhs) { return !(lhs == rhs); }
+
+inline size_t qHash(const CowByteArray &key, size_t seed = 0) noexcept {
+    return qHash(key.asQByteArray(), seed);
+}
 
 inline CowByteArray CowByteArrayConstRef::mid(ssize_t pos, ssize_t len) const {
     return inner_.mid(pos, len);

--- a/src/core/inspectdata.h
+++ b/src/core/inspectdata.h
@@ -23,15 +23,15 @@
 #ifndef INSPECTDATA_H
 #define INSPECTDATA_H
 
+#include "cowbytearray.h"
 #include "variant.h"
-#include <QByteArray>
 
 class InspectData {
 public:
     bool doProxy;
-    QByteArray sharingKey;
-    QByteArray sid;
-    QHash<QByteArray, QByteArray> lastIds;
+    CowByteArray sharingKey;
+    CowByteArray sid;
+    QHash<CowByteArray, CowByteArray> lastIds;
     Variant userData;
 
     InspectData() : doProxy(false) {}

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -141,7 +141,7 @@ void logVariantWithContent(int level, const Variant &data, const QString &conten
 }
 
 void logRequest(int level, const RequestData &data, const Config &config) {
-    QString msg = QString("%1 %2").arg(data.requestData.method,
+    QString msg = QString("%1 %2").arg(data.requestData.method.asQString(),
                                        data.requestData.uri.toString(CowUrl::FullyEncoded));
 
     if (!data.targetStr.isEmpty())

--- a/src/core/packet/httprequestdata.h
+++ b/src/core/packet/httprequestdata.h
@@ -24,14 +24,15 @@
 #define HTTPREQUESTDATA_H
 
 #include "../httpheaders.h"
+#include "cowstring.h"
 #include "cowurl.h"
 
 class HttpRequestData {
 public:
-    QString method;
+    CowString method;
     CowUrl uri;
     HttpHeaders headers;
-    QByteArray body;
+    CowByteArray body;
 };
 
 #endif

--- a/src/core/packet/httpresponsedata.h
+++ b/src/core/packet/httpresponsedata.h
@@ -28,9 +28,9 @@
 class HttpResponseData {
 public:
     int code;
-    QByteArray reason;
+    CowByteArray reason;
     HttpHeaders headers;
-    QByteArray body;
+    CowByteArray body;
 
     HttpResponseData() : code(-1) {}
 };

--- a/src/core/packet/retryrequestpacket.cpp
+++ b/src/core/packet/retryrequestpacket.cpp
@@ -36,8 +36,8 @@ Variant RetryRequestPacket::toVariant() const {
         VariantHash vrequest;
 
         VariantHash vrid;
-        vrid["sender"] = r.rid.first;
-        vrid["id"] = r.rid.second;
+        vrid["sender"] = r.rid.first.asQByteArray();
+        vrid["id"] = r.rid.second.asQByteArray();
 
         vrequest["rid"] = vrid;
 
@@ -54,7 +54,7 @@ Variant RetryRequestPacket::toVariant() const {
             vrequest["auto-cross-origin"] = true;
 
         if (!r.jsonpCallback.isEmpty())
-            vrequest["jsonp-callback"] = r.jsonpCallback;
+            vrequest["jsonp-callback"] = r.jsonpCallback.asQByteArray();
 
         if (r.jsonpExtendedResponse)
             vrequest["jsonp-extended-response"] = true;
@@ -79,7 +79,7 @@ Variant RetryRequestPacket::toVariant() const {
 
     VariantHash vrequestData;
 
-    vrequestData["method"] = requestData.method.toLatin1();
+    vrequestData["method"] = requestData.method.toUtf8().asQByteArray();
     vrequestData["uri"] = requestData.uri.toEncoded();
 
     VariantList vheaders;
@@ -91,7 +91,7 @@ Variant RetryRequestPacket::toVariant() const {
     }
     vrequestData["headers"] = vheaders;
 
-    vrequestData["body"] = requestData.body;
+    vrequestData["body"] = requestData.body.asQByteArray();
 
     obj["request-data"] = vrequestData;
 
@@ -101,19 +101,19 @@ Variant RetryRequestPacket::toVariant() const {
         vinspect["no-proxy"] = !inspectInfo.doProxy;
 
         if (!inspectInfo.sharingKey.isEmpty())
-            vinspect["sharing-key"] = inspectInfo.sharingKey;
+            vinspect["sharing-key"] = inspectInfo.sharingKey.asQByteArray();
 
         if (!inspectInfo.sid.isEmpty())
-            vinspect["sid"] = inspectInfo.sid;
+            vinspect["sid"] = inspectInfo.sid.asQByteArray();
 
         if (!inspectInfo.lastIds.isEmpty()) {
             VariantHash vlastIds;
 
-            QHashIterator<QByteArray, QByteArray> it(inspectInfo.lastIds);
+            QHashIterator<CowByteArray, CowByteArray> it(inspectInfo.lastIds);
             while (it.hasNext()) {
                 it.next();
 
-                vlastIds[QString::fromUtf8(it.key())] = it.value();
+                vlastIds[QString::fromUtf8(it.key().asQByteArray())] = it.value().asQByteArray();
             }
 
             vinspect["last-ids"] = vlastIds;
@@ -126,7 +126,7 @@ Variant RetryRequestPacket::toVariant() const {
     }
 
     if (!route.isEmpty())
-        obj["route"] = route;
+        obj["route"] = route.asQByteArray();
 
     if (retrySeq >= 0)
         obj["retry-seq"] = retrySeq;

--- a/src/core/packet/retryrequestpacket.h
+++ b/src/core/packet/retryrequestpacket.h
@@ -30,7 +30,7 @@
 
 class RetryRequestPacket {
 public:
-    typedef QPair<QByteArray, QByteArray> Rid;
+    typedef QPair<CowByteArray, CowByteArray> Rid;
 
     class Request {
     public:
@@ -39,7 +39,7 @@ public:
         QHostAddress peerAddress;
         bool debug;
         bool autoCrossOrigin;
-        QByteArray jsonpCallback;
+        CowByteArray jsonpCallback;
         bool jsonpExtendedResponse;
         int unreportedTime;
 
@@ -65,9 +65,9 @@ public:
     class InspectInfo {
     public:
         bool doProxy;
-        QByteArray sharingKey;
-        QByteArray sid;
-        QHash<QByteArray, QByteArray> lastIds;
+        CowByteArray sharingKey;
+        CowByteArray sid;
+        QHash<CowByteArray, CowByteArray> lastIds;
         Variant userData;
 
         InspectInfo() : doProxy(false) {}
@@ -79,7 +79,7 @@ public:
     bool haveInspectInfo;
     InspectInfo inspectInfo;
 
-    QByteArray route;
+    CowByteArray route;
     int retrySeq;
 
     RetryRequestPacket();

--- a/src/core/packet/statspacket.cpp
+++ b/src/core/packet/statspacket.cpp
@@ -41,10 +41,10 @@ Variant StatsPacket::toVariant() const {
     VariantHash obj;
 
     if (!from.isEmpty())
-        obj["from"] = from;
+        obj["from"] = from.asQByteArray();
 
     if (!route.isEmpty())
-        obj["route"] = route;
+        obj["route"] = route.asQByteArray();
 
     if (type == Activity) {
         int x = count;
@@ -52,10 +52,10 @@ Variant StatsPacket::toVariant() const {
             x = 0;
         obj["count"] = x;
     } else if (type == Message) {
-        obj["channel"] = channel;
+        obj["channel"] = channel.asQByteArray();
 
         if (!itemId.isNull())
-            obj["item-id"] = itemId;
+            obj["item-id"] = itemId.asQByteArray();
 
         int x = count;
         if (x < 0)
@@ -65,9 +65,9 @@ Variant StatsPacket::toVariant() const {
         if (blocks >= 0)
             obj["blocks"] = blocks;
 
-        obj["transport"] = transport;
+        obj["transport"] = transport.asQByteArray();
     } else if (type == Connected || type == Disconnected) {
-        obj["id"] = connectionId;
+        obj["id"] = connectionId.asQByteArray();
 
         if (type == Connected) {
             if (connectionType == WebSocket)
@@ -87,8 +87,8 @@ Variant StatsPacket::toVariant() const {
             obj["unavailable"] = true;
         }
     } else if (type == Subscribed || type == Unsubscribed) {
-        obj["mode"] = mode;
-        obj["channel"] = channel;
+        obj["mode"] = mode.asQByteArray();
+        obj["channel"] = channel.asQByteArray();
 
         if (type == Subscribed) {
             obj["ttl"] = ttl;
@@ -156,7 +156,7 @@ Variant StatsPacket::toVariant() const {
     return obj;
 }
 
-bool StatsPacket::fromVariant(const QByteArray &_type, const Variant &in) {
+bool StatsPacket::fromVariant(const CowByteArray &_type, const Variant &in) {
     if (typeId(in) != VariantType::Hash)
         return false;
 

--- a/src/core/packet/statspacket.h
+++ b/src/core/packet/statspacket.h
@@ -24,8 +24,8 @@
 #ifndef STATSPACKET_H
 #define STATSPACKET_H
 
+#include "cowbytearray.h"
 #include "variant.h"
-#include <QByteArray>
 #include <QHostAddress>
 
 class StatsPacket {
@@ -45,19 +45,19 @@ public:
     enum ConnectionType { Http, WebSocket };
 
     Type type;
-    QByteArray from;
-    QByteArray route;
+    CowByteArray from;
+    CowByteArray route;
     int64_t retrySeq;               // Connections max
     int count;                      // Activity, message
-    QByteArray connectionId;        // Connected, disconnected
+    CowByteArray connectionId;      // Connected, disconnected
     ConnectionType connectionType;  // Connected
     QHostAddress peerAddress;       // Connected
     bool ssl;                       // Connected
     int ttl;                        // Connected, subscribed, connections max
-    QByteArray mode;                // Subscribed, unsubscribed
-    QByteArray channel;             // Message, subscribed, unsubscribed
-    QByteArray itemId;              // Message
-    QByteArray transport;           // Message
+    CowByteArray mode;              // Subscribed, unsubscribed
+    CowByteArray channel;           // Message, subscribed, unsubscribed
+    CowByteArray itemId;            // Message
+    CowByteArray transport;         // Message
     int blocks;                     // Message
     int subscribers;                // Subscribed
     int connectionsMax;             // Report, connections max
@@ -114,7 +114,7 @@ public:
           serverMessagesSent(-1) {}
 
     Variant toVariant() const;
-    bool fromVariant(const QByteArray &type, const Variant &in);
+    bool fromVariant(const CowByteArray &type, const Variant &in);
 };
 
 #endif

--- a/src/core/packet/wscontrolpacket.cpp
+++ b/src/core/packet/wscontrolpacket.cpp
@@ -156,13 +156,13 @@ contains 'message' with wrong type").arg(pn)); return WsControlPacket();
 Variant WsControlPacket::toVariant() const {
     VariantHash obj;
 
-    obj["from"] = from;
+    obj["from"] = from.asQByteArray();
 
     VariantList vitems;
     foreach (const Item &item, items) {
         VariantHash vitem;
 
-        vitem["cid"] = item.cid;
+        vitem["cid"] = item.cid.asQByteArray();
 
         QByteArray typeStr;
         switch (item.type) {
@@ -211,16 +211,16 @@ Variant WsControlPacket::toVariant() const {
         vitem["type"] = typeStr;
 
         if (!item.requestId.isEmpty())
-            vitem["req-id"] = item.requestId;
+            vitem["req-id"] = item.requestId.asQByteArray();
 
         if (!item.uri.isEmpty())
             vitem["uri"] = item.uri.toEncoded();
 
         if (!item.contentType.isEmpty())
-            vitem["content-type"] = item.contentType;
+            vitem["content-type"] = item.contentType.asQByteArray();
 
         if (!item.message.isNull())
-            vitem["message"] = item.message;
+            vitem["message"] = item.message.asQByteArray();
 
         if (item.queue)
             vitem["queue"] = true;
@@ -229,19 +229,19 @@ Variant WsControlPacket::toVariant() const {
             vitem["code"] = item.code;
 
         if (!item.reason.isEmpty())
-            vitem["reason"] = item.reason;
+            vitem["reason"] = item.reason.asQByteArray();
 
         if (item.debug)
             vitem["debug"] = true;
 
         if (!item.route.isEmpty())
-            vitem["route"] = item.route;
+            vitem["route"] = item.route.asQByteArray();
 
         if (item.separateStats)
             vitem["separate-stats"] = true;
 
         if (!item.channelPrefix.isEmpty())
-            vitem["channel-prefix"] = item.channelPrefix;
+            vitem["channel-prefix"] = item.channelPrefix.asQByteArray();
 
         if (item.logLevel >= 0)
             vitem["log-level"] = item.logLevel;
@@ -250,7 +250,7 @@ Variant WsControlPacket::toVariant() const {
             vitem["trusted"] = true;
 
         if (!item.channel.isEmpty())
-            vitem["channel"] = item.channel;
+            vitem["channel"] = item.channel.asQByteArray();
 
         if (item.ttl >= 0)
             vitem["ttl"] = item.ttl;
@@ -259,7 +259,7 @@ Variant WsControlPacket::toVariant() const {
             vitem["timeout"] = item.timeout;
 
         if (!item.keepAliveMode.isEmpty())
-            vitem["keep-alive-mode"] = item.keepAliveMode;
+            vitem["keep-alive-mode"] = item.keepAliveMode.asQByteArray();
 
         vitems += vitem;
     }

--- a/src/core/packet/wscontrolpacket.h
+++ b/src/core/packet/wscontrolpacket.h
@@ -24,9 +24,9 @@
 #ifndef WSCONTROLPACKET_H
 #define WSCONTROLPACKET_H
 
+#include "cowbytearray.h"
 #include "cowurl.h"
 #include "variant.h"
-#include <QByteArray>
 #include <QList>
 
 class WsControlPacket {
@@ -49,25 +49,25 @@ public:
             Ack
         };
 
-        QByteArray cid;
+        CowByteArray cid;
         Type type;
-        QByteArray requestId;
+        CowByteArray requestId;
         CowUrl uri;
-        QByteArray contentType;
-        QByteArray message;
+        CowByteArray contentType;
+        CowByteArray message;
         bool queue;
         int code;
-        QByteArray reason;
+        CowByteArray reason;
         bool debug;
-        QByteArray route;
+        CowByteArray route;
         bool separateStats;
-        QByteArray channelPrefix;
+        CowByteArray channelPrefix;
         int logLevel;
         bool trusted;
-        QByteArray channel;
+        CowByteArray channel;
         int ttl;
         int timeout;
-        QByteArray keepAliveMode;
+        CowByteArray keepAliveMode;
 
         Item()
             : type((Type)-1),
@@ -81,7 +81,7 @@ public:
               timeout(-1) {}
     };
 
-    QByteArray from;
+    CowByteArray from;
     QList<Item> items;
 
     Variant toVariant() const;

--- a/src/core/packet/zrpcrequestpacket.cpp
+++ b/src/core/packet/zrpcrequestpacket.cpp
@@ -30,12 +30,12 @@ Variant ZrpcRequestPacket::toVariant() const {
     VariantHash obj;
 
     if (!from.isEmpty())
-        obj["from"] = from;
+        obj["from"] = from.asQByteArray();
 
     if (!id.isEmpty())
-        obj["id"] = id;
+        obj["id"] = id.asQByteArray();
 
-    obj["method"] = method.toUtf8();
+    obj["method"] = method.toUtf8().asQByteArray();
 
     if (!args.isEmpty())
         obj["args"] = args;

--- a/src/core/packet/zrpcrequestpacket.h
+++ b/src/core/packet/zrpcrequestpacket.h
@@ -24,14 +24,15 @@
 #ifndef ZRPCREQUESTPACKET_H
 #define ZRPCREQUESTPACKET_H
 
+#include "cowbytearray.h"
+#include "cowstring.h"
 #include "variant.h"
-#include <QByteArray>
 
 class ZrpcRequestPacket {
 public:
-    QByteArray from;
-    QByteArray id;
-    QString method;
+    CowByteArray from;
+    CowByteArray id;
+    CowString method;
     VariantHash args;
 
     Variant toVariant() const;

--- a/src/core/packet/zrpcresponsepacket.cpp
+++ b/src/core/packet/zrpcresponsepacket.cpp
@@ -30,7 +30,7 @@ Variant ZrpcResponsePacket::toVariant() const {
     VariantHash obj;
 
     if (!id.isEmpty())
-        obj["id"] = id;
+        obj["id"] = id.asQByteArray();
 
     obj["success"] = success;
 
@@ -40,7 +40,7 @@ Variant ZrpcResponsePacket::toVariant() const {
         else
             obj["value"] = value;
     } else {
-        obj["condition"] = condition;
+        obj["condition"] = condition.asQByteArray();
 
         if (value.isValid()) {
             if (typeId(value) == VariantType::String)

--- a/src/core/packet/zrpcresponsepacket.h
+++ b/src/core/packet/zrpcresponsepacket.h
@@ -23,15 +23,15 @@
 #ifndef ZRPCRESPONSEPACKET_H
 #define ZRPCRESPONSEPACKET_H
 
+#include "cowbytearray.h"
 #include "variant.h"
-#include <QByteArray>
 
 class ZrpcResponsePacket {
 public:
-    QByteArray id;
+    CowByteArray id;
     bool success;
     Variant value;
-    QByteArray condition;
+    CowByteArray condition;
 
     ZrpcResponsePacket() : success(false) {}
 

--- a/src/core/statsmanager.cpp
+++ b/src/core/statsmanager.cpp
@@ -1121,27 +1121,27 @@ public:
 
     void mergeExternalConnectionsMax(const StatsPacket &packet, int64_t now) {
         if (packet.retrySeq >= 0)
-            removeLingeringConnections(packet.from, (uint64_t)packet.retrySeq);
+            removeLingeringConnections(packet.from.asQByteArray(), (uint64_t)packet.retrySeq);
 
         QHash<QByteArray, ExternalConnectionsMax> &maxes =
-            externalConnectionsMaxes[packet.route].maxes;
+            externalConnectionsMaxes[packet.route.asQByteArray()].maxes;
 
-        if (!maxes.contains(packet.from))
-            maxes.insert(packet.from, ExternalConnectionsMax());
+        if (!maxes.contains(packet.from.asQByteArray()))
+            maxes.insert(packet.from.asQByteArray(), ExternalConnectionsMax());
 
-        ExternalConnectionsMax &cm = maxes[packet.from];
+        ExternalConnectionsMax &cm = maxes[packet.from.asQByteArray()];
 
         cm.value = (uint32_t)qMax(packet.connectionsMax, 0);
         cm.expires = now + (qMax(packet.ttl, 0) * 1000);
 
-        updateConnectionsMax(packet.route, now);
+        updateConnectionsMax(packet.route.asQByteArray(), now);
     }
 
     void mergeExternalReport(const StatsPacket &packet, bool includeConnections) {
         if (reportInterval <= 0)
             return;
 
-        Report *report = getOrCreateReport(packet.route);
+        Report *report = getOrCreateReport(packet.route.asQByteArray());
 
         Stats::Counters counters;
 
@@ -1164,10 +1164,10 @@ public:
         combinedReport.addCounters(counters, now);
 
         if (includeConnections) {
-            if (!report->externalReports.contains(packet.from))
-                report->externalReports[packet.from] = Report();
+            if (!report->externalReports.contains(packet.from.asQByteArray()))
+                report->externalReports[packet.from.asQByteArray()] = Report();
 
-            Report &r = report->externalReports[packet.from];
+            Report &r = report->externalReports[packet.from.asQByteArray()];
 
             int mins = qMax(packet.connectionsMinutes, 0);
 
@@ -1721,7 +1721,8 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
 
         if (packet.type == StatsPacket::Connected) {
             // Is there a local connection with the same ID?
-            Private::ConnectionInfo *c = d->connectionInfoById.value(packet.connectionId);
+            Private::ConnectionInfo *c =
+                d->connectionInfoById.value(packet.connectionId.asQByteArray());
             if (c) {
                 // If there is a non-lingering local connection, ignore the packet
                 if (!c->linger) {
@@ -1748,12 +1749,13 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
             it.next();
             const QByteArray &from = it.key();
 
-            if (from == packet.from)
+            if (from == packet.from.asQByteArray())
                 continue;
 
             const QHash<QByteArray, Private::ConnectionInfo *> &extConnectionInfoById = it.value();
 
-            Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
+            Private::ConnectionInfo *c =
+                extConnectionInfoById.value(packet.connectionId.asQByteArray());
             if (c)
                 toDelete += c;
         }
@@ -1763,21 +1765,22 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
         }
 
         QHash<QByteArray, Private::ConnectionInfo *> &extConnectionInfoById =
-            d->externalConnectionInfoByFrom[packet.from];
+            d->externalConnectionInfoByFrom[packet.from.asQByteArray()];
 
         if (packet.type == StatsPacket::Connected) {
             // Add/update
-            Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
+            Private::ConnectionInfo *c =
+                extConnectionInfoById.value(packet.connectionId.asQByteArray());
             if (!c) {
                 c = new Private::ConnectionInfo;
                 c->timerType = Private::TimerBase::Type::ExternalConnection;
-                c->id = packet.connectionId;
-                c->routeId = packet.route;
+                c->id = packet.connectionId.asQByteArray();
+                c->routeId = packet.route.asQByteArray();
                 c->type = packet.connectionType == StatsPacket::Http ? Http : WebSocket;
                 c->peerAddress = packet.peerAddress;
                 c->ssl = packet.ssl;
                 c->lastReport = lastReport;
-                c->from = packet.from;
+                c->from = packet.from.asQByteArray();
                 c->lastActive = now;
                 d->insertExternalConnection(c);
 
@@ -1801,7 +1804,8 @@ bool StatsManager::processExternalPacket(const StatsPacket &packet, bool mergeCo
             d->updateConnectionsMinutes(c, now);
         } else // Disconnected
         {
-            Private::ConnectionInfo *c = extConnectionInfoById.value(packet.connectionId);
+            Private::ConnectionInfo *c =
+                extConnectionInfoById.value(packet.connectionId.asQByteArray());
             if (c) {
                 QByteArray routeId = c->routeId;
 

--- a/src/core/zrpcmanager.cpp
+++ b/src/core/zrpcmanager.cpp
@@ -184,7 +184,7 @@ public:
             return;
         }
 
-        ZrpcRequest *req = clientReqsById.value(p.id);
+        ZrpcRequest *req = clientReqsById.value(p.id.asQByteArray());
         if (!req) {
             log_debug("zrpc client: received message for unknown request id, skipping");
             return;

--- a/src/core/zrpcrequest.cpp
+++ b/src/core/zrpcrequest.cpp
@@ -88,9 +88,9 @@ public:
 
     void handle(const QList<QByteArray> &headers, const ZrpcRequestPacket &packet) {
         reqHeaders = headers;
-        from = packet.from;
-        id = packet.id;
-        method = packet.method;
+        from = packet.from.asQByteArray();
+        id = packet.id.asQByteArray();
+        method = packet.method.asQString();
         args = packet.args;
     }
 
@@ -107,7 +107,7 @@ public:
             else
                 condition = ErrorGeneric;
 
-            conditionString = packet.condition;
+            conditionString = packet.condition.asQByteArray();
 
             result = packet.value;
             q->onError();

--- a/src/handler/handlerengine.cpp
+++ b/src/handler/handlerengine.cpp
@@ -254,7 +254,7 @@ private:
             result["sharing-key"] = key;
         } else if (shareAll)
             result["sharing-key"] =
-                requestData.method.toLatin1() + '|' + requestData.uri.toEncoded();
+                (requestData.method.toUtf8() + '|' + requestData.uri.toEncoded()).asQByteArray();
 
         if (!sid.isEmpty()) {
             result["sid"] = sid.toUtf8();
@@ -286,10 +286,10 @@ private:
                 QByteArray jsonData;
 
                 if (!rule.jsonParam.isEmpty()) {
-                    UrlQuery tmp(QString::fromUtf8(requestData.body));
+                    UrlQuery tmp(QString::fromUtf8(requestData.body.asQByteArray()));
                     jsonData = tmp.queryItemValue(rule.jsonParam, CowUrl::FullyDecoded).toUtf8();
                 } else {
-                    jsonData = requestData.body;
+                    jsonData = requestData.body.asQByteArray();
                 }
 
                 Variant vdata = Json::fromString(jsonData);
@@ -830,7 +830,7 @@ private:
                 fc.subscriptionMeta = instruct.meta;
 
                 FilterStack fs(fc, allFilters);
-                QByteArray body = fs.process(instruct.response.body);
+                QByteArray body = fs.process(instruct.response.body.asQByteArray());
                 if (body.isNull()) {
                     req->respondError("bad-format",
                                       QString("filter error: %1").arg(fs.errorMessage()).toUtf8());
@@ -843,7 +843,7 @@ private:
 
                 VariantHash vresponse;
                 vresponse["code"] = instruct.response.code;
-                vresponse["reason"] = instruct.response.reason;
+                vresponse["reason"] = instruct.response.reason.asQByteArray();
                 VariantList vheaders;
                 foreach (const HttpHeader &h, instruct.response.headers) {
                     VariantList vheader;
@@ -926,7 +926,9 @@ private:
                     rp.inspectInfo.doProxy = inspectInfo.doProxy;
                     rp.inspectInfo.sharingKey = inspectInfo.sharingKey;
                     rp.inspectInfo.sid = inspectInfo.sid;
-                    rp.inspectInfo.lastIds = inspectInfo.lastIds;
+                    for (auto it = inspectInfo.lastIds.constBegin();
+                         it != inspectInfo.lastIds.constEnd(); ++it)
+                        rp.inspectInfo.lastIds.insert(it.key(), it.value());
                     rp.inspectInfo.userData = inspectInfo.userData;
                 }
 
@@ -966,11 +968,11 @@ private:
             ZhttpRequest::ServerState ss;
             ss.rid = ZhttpRequest::Rid(rs.rid.first, rs.rid.second);
             ss.peerAddress = rs.peerAddress;
-            ss.requestMethod = requestData.method;
+            ss.requestMethod = requestData.method.asQString();
             ss.requestUri = requestData.uri;
             ss.requestUri.setScheme(rs.isHttps ? "https" : "http");
             ss.requestHeaders = requestData.headers;
-            ss.requestBody = requestData.body;
+            ss.requestBody = requestData.body.asQByteArray();
             ss.responseCode = rs.responseCode;
             ss.inSeq = rs.inSeq;
             ss.outSeq = rs.outSeq;
@@ -2323,7 +2325,8 @@ private:
             }
 
             if (item.type == WsControlPacket::Item::Here) {
-                std::shared_ptr<WsSession> s = cs.wsSessions.value(item.cid);
+                std::shared_ptr<WsSession> s =
+                    cs.wsSessions.value(QString::fromUtf8(item.cid.asQByteArray()));
                 if (!s) {
                     s = std::make_shared<WsSession>();
                     wsSessionConnectionMap[s.get()] = {
@@ -2331,8 +2334,8 @@ private:
                                                     boost::placeholders::_1, s.get())),
                         s->expired.connect(boost::bind(&Private::wssession_expired, this, s.get())),
                         s->error.connect(boost::bind(&Private::wssession_error, this, s.get()))};
-                    s->peer = packet.from;
-                    s->cid = QString::fromUtf8(item.cid);
+                    s->peer = packet.from.asQByteArray();
+                    s->cid = QString::fromUtf8(item.cid.asQByteArray());
                     s->ttl = item.ttl;
                     s->requestData.uri = item.uri;
                     s->zhttpOut = zhttpOut.get();
@@ -2343,10 +2346,11 @@ private:
                 }
 
                 s->debug = item.debug;
-                s->route = item.route;
-                s->statsRoute = item.separateStats ? item.route : QString();
+                s->route = QString::fromUtf8(item.route.asQByteArray());
+                s->statsRoute =
+                    item.separateStats ? QString::fromUtf8(item.route.asQByteArray()) : QString();
                 s->targetTrusted = item.trusted;
-                s->channelPrefix = QString::fromUtf8(item.channelPrefix);
+                s->channelPrefix = QString::fromUtf8(item.channelPrefix.asQByteArray());
                 if (item.logLevel >= 0)
                     s->logLevel = item.logLevel;
 
@@ -2357,7 +2361,7 @@ private:
             }
 
             // Any other type must be for a known cid
-            WsSession *s = cs.wsSessions.value(QString::fromUtf8(item.cid)).get();
+            WsSession *s = cs.wsSessions.value(QString::fromUtf8(item.cid.asQByteArray())).get();
             if (!s) {
                 // Send cancel, causing the proxy to close the connection. Client will need to retry
                 // to repair
@@ -2375,7 +2379,7 @@ private:
                        item.type == WsControlPacket::Item::Cancel) {
                 removeWsSession(s);
             } else if (item.type == WsControlPacket::Item::Grip) {
-                Variant data = Json::fromString(item.message);
+                Variant data = Json::fromString(item.message.asQByteArray());
                 if (!data.isValid() ||
                     (typeId(data) != VariantType::Map && typeId(data) != VariantType::List)) {
                     log_debug("grip control message is not valid json");
@@ -2527,7 +2531,7 @@ private:
                     stats->addActivity(s->statsRoute.toUtf8(), 1);
                 }
             } else if (item.type == WsControlPacket::Item::Subscribe) {
-                QString channel = QString::fromUtf8(item.channel);
+                QString channel = QString::fromUtf8(item.channel.asQByteArray());
 
                 s->implicitChannels += channel;
 
@@ -2551,13 +2555,13 @@ private:
                          qPrintable(s->requestData.uri.toString(CowUrl::FullyEncoded)),
                          qPrintable(channel));
             } else if (item.type == WsControlPacket::Item::Ack) {
-                int reqId = item.requestId.toInt();
+                int reqId = item.requestId.asQByteArray().toInt();
                 s->ack(reqId);
             }
         }
 
         if (!outItems.isEmpty())
-            writeWsControlItems(packet.from, outItems);
+            writeWsControlItems(packet.from.asQByteArray(), outItems);
 
         if (stateClient) {
             foreach (const QString &sid, createOrUpdateSids) {
@@ -2624,7 +2628,7 @@ private:
         if (p.type == StatsPacket::Activity) {
             if (p.count > 0) {
                 // Merge with our own stats
-                stats->addActivity(p.route, p.count);
+                stats->addActivity(p.route.asQByteArray(), p.count);
             }
         } else if (p.type == StatsPacket::Counts) {
             if (p.requestsReceived > 0) {

--- a/src/handler/handlerenginetest.cpp
+++ b/src/handler/handlerenginetest.cpp
@@ -168,12 +168,12 @@ public:
             if (!responses.contains(zresp.ids.first().id.asQByteArray())) {
                 HttpResponseData rd;
                 rd.code = zresp.code;
-                rd.reason = zresp.reason.asQByteArray();
+                rd.reason = zresp.reason;
                 rd.headers = zresp.headers;
                 responses[zresp.ids.first().id.asQByteArray()] = rd;
             }
 
-            responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
+            responses[zresp.ids.first().id.asQByteArray()].body += zresp.body;
 
             if (!zresp.more)
                 finished = true;

--- a/src/handler/httpsession.cpp
+++ b/src/handler/httpsession.cpp
@@ -270,11 +270,13 @@ public:
             if (adata.autoCrossOrigin)
                 Cors::applyCorsHeaders(req->requestHeaders(), &headers);
 
-            incCounter(Stats::ClientHeaderBytesSent,
-                       ZhttpManager::estimateResponseHeaderBytes(
-                           instruct.response.code, instruct.response.reason, headers));
+            incCounter(
+                Stats::ClientHeaderBytesSent,
+                ZhttpManager::estimateResponseHeaderBytes(
+                    instruct.response.code, instruct.response.reason.asQByteArray(), headers));
 
-            req->beginResponse(instruct.response.code, instruct.response.reason, headers);
+            req->beginResponse(instruct.response.code, instruct.response.reason.asQByteArray(),
+                               headers);
 
             if (!instruct.response.body.isEmpty()) {
                 // Apply ResponseContent filters of all channels
@@ -291,7 +293,7 @@ public:
                 fc.subscriptionMeta = instruct.meta;
 
                 FilterStack fs(fc, allFilters);
-                instruct.response.body = fs.process(instruct.response.body);
+                instruct.response.body = fs.process(instruct.response.body.asQByteArray());
                 if (instruct.response.body.isNull()) {
                     errorMessage = QString("filter error: %1").arg(fs.errorMessage());
                     doError();
@@ -300,7 +302,7 @@ public:
 
                 state = SendingFirstInstructResponse;
 
-                firstInstructResponse += instruct.response.body;
+                firstInstructResponse += instruct.response.body.asQByteArray();
                 tryWriteFirstInstructResponse();
                 return;
             }
@@ -705,7 +707,7 @@ private:
 
             QByteArray body;
             if (f.type == PublishFormat::HttpResponse && f.haveBodyPatch)
-                body = applyBodyPatch(instruct.response.body, f.bodyPatch);
+                body = applyBodyPatch(instruct.response.body.asQByteArray(), f.bodyPatch);
             else
                 body = f.body;
 
@@ -1453,8 +1455,8 @@ private:
     void timer_timeout() {
         if (instruct.holdMode == Instruct::ResponseHold) {
             // Send timeout response
-            respond(instruct.response.code, instruct.response.reason, instruct.response.headers,
-                    instruct.response.body);
+            respond(instruct.response.code, instruct.response.reason.asQByteArray(),
+                    instruct.response.headers, instruct.response.body.asQByteArray());
         } else if (instruct.holdMode == Instruct::StreamHold) {
             writeBody(instruct.keepAliveData);
 

--- a/src/handler/instruct.cpp
+++ b/src/handler/instruct.cpp
@@ -322,7 +322,7 @@ Instruct Instruct::fromResponse(const HttpResponseData &response, bool *ok, QStr
             return Instruct();
         }
 
-        Variant doc = Json::fromString(response.body);
+        Variant doc = Json::fromString(response.body.asQByteArray());
         if (!doc.isValid()) {
             setError(ok, errorMessage, "failed to parse application/grip-instruct content as JSON");
             return Instruct();

--- a/src/handler/instructtest.cpp
+++ b/src/handler/instructtest.cpp
@@ -40,17 +40,17 @@ static void noHold() {
     TEST_ASSERT(ok);
     TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
     TEST_ASSERT_EQ(i.response.code, 200);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("OK"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
     TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 
     data.headers += HttpHeader("Grip-Status", "404");
     i = Instruct::fromResponse(data, &ok);
     TEST_ASSERT(ok);
     TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
     TEST_ASSERT_EQ(i.response.code, 404);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("Not Found"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("Not Found"));
 
     data.headers.removeAll("Grip-Status");
     data.headers += HttpHeader("Grip-Status", "404 Nothing To See Here");
@@ -58,7 +58,7 @@ static void noHold() {
     TEST_ASSERT(ok);
     TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
     TEST_ASSERT_EQ(i.response.code, 404);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("Nothing To See Here"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("Nothing To See Here"));
 
     data.headers.clear();
     data.headers += HttpHeader("Content-Type", "application/grip-instruct");
@@ -70,9 +70,9 @@ static void noHold() {
     TEST_ASSERT(ok);
     TEST_ASSERT_EQ(i.holdMode, Instruct::NoHold);
     TEST_ASSERT_EQ(i.response.code, 200);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("OK"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 }
 
 static void responseHold() {
@@ -102,7 +102,7 @@ static void responseHold() {
     TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
     TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 
     data.headers.clear();
     data.headers += HttpHeader("Content-Type", "application/grip-instruct");
@@ -122,9 +122,9 @@ static void responseHold() {
     TEST_ASSERT_EQ(i.meta.value("foo"), QString("bar"));
     TEST_ASSERT_EQ(i.meta.value("bar"), QString("baz"));
     TEST_ASSERT_EQ(i.response.code, 200);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("OK"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 }
 
 static void responseHoldChannelParams() {
@@ -158,7 +158,7 @@ static void responseHoldChannelParams() {
     TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
     TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 
     data.headers.clear();
     data.headers += HttpHeader("Content-Type", "application/grip-instruct");
@@ -187,9 +187,9 @@ static void responseHoldChannelParams() {
     TEST_ASSERT_EQ(i.channels[2].filters[0], QString("f1"));
     TEST_ASSERT_EQ(i.channels[2].filters[1], QString("f2"));
     TEST_ASSERT_EQ(i.response.code, 200);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("OK"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 }
 
 static void streamHold() {
@@ -213,7 +213,7 @@ static void streamHold() {
     TEST_ASSERT_EQ(i.channels[2].name, QString("cherry"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
     TEST_ASSERT(!i.response.headers.contains("Grip-Channel"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 
     data.headers.clear();
     data.headers += HttpHeader("Content-Type", "application/grip-instruct");
@@ -228,9 +228,9 @@ static void streamHold() {
     TEST_ASSERT_EQ(i.channels.count(), 1);
     TEST_ASSERT_EQ(i.channels[0].name, QString("test"));
     TEST_ASSERT_EQ(i.response.code, 200);
-    TEST_ASSERT_EQ(i.response.reason, QByteArray("OK"));
+    TEST_ASSERT_EQ(i.response.reason, CowByteArray("OK"));
     TEST_ASSERT_EQ(i.response.headers.get("Content-Type"), CowByteArray("text/plain"));
-    TEST_ASSERT_EQ(i.response.body, QByteArray("hello world"));
+    TEST_ASSERT_EQ(i.response.body, CowByteArray("hello world"));
 }
 
 static void streamHoldKeepAlive() {

--- a/src/proxy/acceptrequest.cpp
+++ b/src/proxy/acceptrequest.cpp
@@ -92,7 +92,7 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
         const HttpRequestData &requestData = adata.requestData;
         VariantHash vrequestData;
 
-        vrequestData["method"] = requestData.method.toLatin1();
+        vrequestData["method"] = requestData.method.toUtf8().asQByteArray();
         vrequestData["uri"] = requestData.uri.toEncoded();
 
         VariantList vheaders;
@@ -105,7 +105,7 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
 
         vrequestData["headers"] = vheaders;
 
-        vrequestData["body"] = requestData.body;
+        vrequestData["body"] = requestData.body.asQByteArray();
 
         obj["request-data"] = vrequestData;
     }
@@ -114,7 +114,7 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
         const HttpRequestData &requestData = adata.origRequestData;
         VariantHash vrequestData;
 
-        vrequestData["method"] = requestData.method.toLatin1();
+        vrequestData["method"] = requestData.method.toUtf8().asQByteArray();
         vrequestData["uri"] = requestData.uri.toEncoded();
 
         VariantList vheaders;
@@ -127,7 +127,7 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
 
         vrequestData["headers"] = vheaders;
 
-        vrequestData["body"] = requestData.body;
+        vrequestData["body"] = requestData.body.asQByteArray();
 
         obj["orig-request-data"] = vrequestData;
     }
@@ -138,17 +138,17 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
         vinspect["no-proxy"] = !adata.inspectData.doProxy;
 
         if (!adata.inspectData.sharingKey.isEmpty())
-            vinspect["sharing-key"] = adata.inspectData.sharingKey;
+            vinspect["sharing-key"] = adata.inspectData.sharingKey.asQByteArray();
 
         if (!adata.inspectData.sid.isEmpty())
-            vinspect["sid"] = adata.inspectData.sid;
+            vinspect["sid"] = adata.inspectData.sid.asQByteArray();
 
         if (!adata.inspectData.lastIds.isEmpty()) {
             VariantHash vlastIds;
-            QHashIterator<QByteArray, QByteArray> it(adata.inspectData.lastIds);
+            QHashIterator<CowByteArray, CowByteArray> it(adata.inspectData.lastIds);
             while (it.hasNext()) {
                 it.next();
-                vlastIds[QString::fromUtf8(it.key())] = it.value();
+                vlastIds[QString::fromUtf8(it.key().asQByteArray())] = it.value().asQByteArray();
             }
 
             vinspect["last-ids"] = vlastIds;
@@ -164,7 +164,7 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
         VariantHash vresponse;
 
         vresponse["code"] = adata.response.code;
-        vresponse["reason"] = adata.response.reason;
+        vresponse["reason"] = adata.response.reason.asQByteArray();
 
         VariantList vheaders;
         foreach (const HttpHeader &h, adata.response.headers) {
@@ -175,7 +175,7 @@ static Variant acceptDataToVariant(const AcceptData &adata) {
         }
         vresponse["headers"] = vheaders;
 
-        vresponse["body"] = adata.response.body;
+        vresponse["body"] = adata.response.body.asQByteArray();
 
         obj["response"] = vresponse;
     }

--- a/src/proxy/inspectrequest.cpp
+++ b/src/proxy/inspectrequest.cpp
@@ -110,7 +110,7 @@ void InspectRequest::start(const HttpRequestData &hdata, bool truncated, bool ge
                            bool autoShare) {
     VariantHash args;
 
-    args["method"] = hdata.method.toLatin1();
+    args["method"] = hdata.method.toUtf8().asQByteArray();
     args["uri"] = hdata.uri.toEncoded();
 
     VariantList vheaders;
@@ -122,7 +122,7 @@ void InspectRequest::start(const HttpRequestData &hdata, bool truncated, bool ge
     }
 
     args["headers"] = vheaders;
-    args["body"] = hdata.body;
+    args["body"] = hdata.body.asQByteArray();
 
     if (truncated)
         args["truncated"] = true;

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -355,7 +355,7 @@ public:
         if (sharable) {
             log_debug("need to proxy with sharing key: %s", idata->sharingKey.data());
 
-            ProxyItem *i = proxyItemsByKey.value(idata->sharingKey);
+            ProxyItem *i = proxyItemsByKey.value(idata->sharingKey.asQByteArray());
             if (i)
                 ps = i->ps;
         }
@@ -391,7 +391,7 @@ public:
 
             if (sharable) {
                 i->shared = true;
-                i->key = idata->sharingKey;
+                i->key = idata->sharingKey.asQByteArray();
                 proxyItemsByKey.insert(i->key, i);
             }
         } else
@@ -806,7 +806,7 @@ private:
             return;
         }
 
-        log_debug("IN (retry) %s %s", qPrintable(p.requestData.method),
+        log_debug("IN (retry) %s %s", qPrintable(p.requestData.method.asQString()),
                   p.requestData.uri.toEncoded().data());
 
         InspectData idata;
@@ -820,14 +820,14 @@ private:
 
         foreach (const RetryRequestPacket::Request &req, p.requests) {
             ZhttpRequest::ServerState ss;
-            ss.rid = ZhttpRequest::Rid(req.rid.first, req.rid.second);
+            ss.rid = ZhttpRequest::Rid(req.rid.first.asQByteArray(), req.rid.second.asQByteArray());
             ss.peerAddress = req.peerAddress;
-            ss.requestMethod = p.requestData.method;
+            ss.requestMethod = p.requestData.method.asQString();
             ss.requestUri = p.requestData.uri;
             if (req.https)
                 ss.requestUri.setScheme("https");
             ss.requestHeaders = p.requestData.headers;
-            ss.requestBody = p.requestData.body;
+            ss.requestBody = p.requestData.body.asQByteArray();
             ss.inSeq = req.inSeq;
             ss.outSeq = req.outSeq;
             ss.outCredits = req.outCredits;
@@ -849,7 +849,7 @@ private:
             QString host = p.requestData.uri.host();
             QByteArray encPath = p.requestData.uri.path(CowUrl::FullyEncoded).toUtf8();
 
-            QString routeId = QString::fromUtf8(p.route);
+            QString routeId = QString::fromUtf8(p.route.asQByteArray());
 
             // Look up the route
             DomainMap::Entry route;
@@ -863,8 +863,9 @@ private:
             // Note: if the routing table was changed, there's a chance the request might get a
             // different route id this time around. This could confuse stats processors tracking
             // route+connection mappings.
-            rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin, req.jsonpCallback,
-                           req.jsonpExtendedResponse, req.unreportedTime, p.retrySeq);
+            rs->startRetry(zhttpRequest, req.debug, req.autoCrossOrigin,
+                           req.jsonpCallback.asQByteArray(), req.jsonpExtendedResponse,
+                           req.unreportedTime, p.retrySeq);
 
             doProxy(rs, p.haveInspectInfo ? &idata : 0);
         }

--- a/src/proxy/proxyenginetest.cpp
+++ b/src/proxy/proxyenginetest.cpp
@@ -209,12 +209,12 @@ private:
             if (!responses.contains(zresp.ids.first().id.asQByteArray())) {
                 HttpResponseData rd;
                 rd.code = zresp.code;
-                rd.reason = zresp.reason.asQByteArray();
+                rd.reason = zresp.reason;
                 rd.headers = zresp.headers;
                 responses[zresp.ids.first().id.asQByteArray()] = rd;
             }
 
-            responses[zresp.ids.first().id.asQByteArray()].body += zresp.body.asQByteArray();
+            responses[zresp.ids.first().id.asQByteArray()].body += zresp.body;
             in += zresp.body.asQByteArray();
 
             if (!isWs && !zresp.more) {
@@ -261,7 +261,7 @@ private:
         zreq.fromVariant(v);
 
         HttpRequestData rd;
-        rd.method = zreq.method.asQString();
+        rd.method = zreq.method;
         rd.uri = zreq.uri;
         rd.headers = zreq.headers;
         serverReqs[zreq.ids[0].id.asQByteArray()] = rd;
@@ -288,7 +288,7 @@ private:
             return;
         }
 
-        serverReqs[zreq.ids[0].id.asQByteArray()].body += zreq.body.asQByteArray();
+        serverReqs[zreq.ids[0].id.asQByteArray()].body += zreq.body;
 
         if (zreq.type == ZhttpRequestPacket::Data)
             requestBody += zreq.body.asQByteArray();
@@ -663,8 +663,9 @@ static void passthrough(TestState &state, std::function<void(int)> loop_wait) {
                    43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
                                                   // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    43); // "200" + "OK" + "Content-Type" + "text/plain" +
@@ -806,8 +807,9 @@ static void passthroughPostStream(TestState &state, std::function<void(int)> loo
                    43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
                                                   // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 11);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    43); // "200" + "OK" + "Content-Type" + "text/plain" +
@@ -868,8 +870,9 @@ static void passthroughPostStreamFail(TestState &state, std::function<void(int)>
     TEST_ASSERT_EQ(p.clientContentBytesReceived, 5); // "hello"
     TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
     TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 5); // "hello"
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived, 0);
     TEST_ASSERT_EQ(p.serverContentBytesReceived, 0);
@@ -911,8 +914,9 @@ static void acceptResponse(TestState &state, std::function<void(int)> loop_wait)
     TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
     TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
     TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    61); // "200" + "OK" + "Grip-Hold" + "response" + "Grip-Channel" +
@@ -957,8 +961,9 @@ static void acceptStream(TestState &state, std::function<void(int)> loop_wait) {
     TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
     TEST_ASSERT_EQ(p.clientHeaderBytesSent, 0);
     TEST_ASSERT_EQ(p.clientContentBytesSent, 0);
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    60); // "200" + "OK" + "Grip-Hold" + "stream" + "Grip-Channel"
@@ -1024,8 +1029,9 @@ static void acceptNoHold(TestState &state, std::function<void(int)> loop_wait) {
                    43);                           // "200" + "OK" + "Content-Type" + "text/plain" +
                                                   // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 11); // "hello world"
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    54); // "200" + "OK" + "Content-Type" + "text/plain" +
@@ -1093,8 +1099,9 @@ static void passthroughThenAcceptStream(TestState &state, std::function<void(int
     TEST_ASSERT_EQ(p.clientContentBytesReceived, 0);
     TEST_ASSERT_EQ(p.clientHeaderBytesSent, 5); // "200" + "OK"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 110001);
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    64); // "200" + "OK" + "Grip-Hold" + "stream" + "Grip-Channel"
@@ -1140,8 +1147,9 @@ static void passthroughThenAcceptNext(TestState &state, std::function<void(int)>
     TEST_ASSERT_EQ(p.clientHeaderBytesSent,
                    27); // "200" + "OK" + "Content-Type" + "text/plain"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 110001);
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    74); // "200" + "OK" + "Content-Type" + "text/plain" + "Grip-Link" +
@@ -1181,12 +1189,12 @@ static void acceptWithRetry(TestState &state, std::function<void(int)> loop_wait
     int headerBytes = 0;
     int contentBytes = 0;
 
-    headerBytes +=
-        ZhttpManager::estimateRequestHeaderBytes(req1Data.method, req1Data.uri, req1Data.headers);
+    headerBytes += ZhttpManager::estimateRequestHeaderBytes(req1Data.method.asQString(),
+                                                            req1Data.uri, req1Data.headers);
     contentBytes += req1Data.body.size();
 
-    headerBytes +=
-        ZhttpManager::estimateRequestHeaderBytes(req2Data.method, req2Data.uri, req2Data.headers);
+    headerBytes += ZhttpManager::estimateRequestHeaderBytes(req2Data.method.asQString(),
+                                                            req2Data.uri, req2Data.headers);
     contentBytes += req2Data.body.size();
 
     TEST_ASSERT_EQ(state.trackedPackets.size(), 1);
@@ -1268,8 +1276,9 @@ static void passthroughShared(TestState &state, std::function<void(int)> loop_wa
                         // "Content-Length" + "11" + "200" + "OK" + "Content-Type" + "text/plain" +
                         // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 0);
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    43); // "200" + "OK" + "Content-Type" + "text/plain" +
@@ -1366,8 +1375,9 @@ static void passthroughSharedPost(TestState &state, std::function<void(int)> loo
                         // "Content-Length" + "11" + "200" + "OK" + "Content-Type" + "text/plain" +
                         // "Content-Length" + "11"
     TEST_ASSERT_EQ(p.clientContentBytesSent, 22); // "hello world" + "hello world"
-    TEST_ASSERT_EQ(p.serverHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                reqData.method, reqData.uri, reqData.headers));
+    TEST_ASSERT_EQ(p.serverHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(reqData.method.asQString(), reqData.uri,
+                                                            reqData.headers));
     TEST_ASSERT_EQ(p.serverContentBytesSent, 11); // "hello world"
     TEST_ASSERT_EQ(p.serverHeaderBytesReceived,
                    43); // "200" + "OK" + "Content-Type" + "text/plain" +

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -238,8 +238,9 @@ public:
 
         if (si->countClientReceivedBytes) {
             incCounter(Stats::ClientHeaderBytesReceived,
-                       ZhttpManager::estimateRequestHeaderBytes(
-                           rsRequestData.method, rsRequestData.uri, rsRequestData.headers));
+                       ZhttpManager::estimateRequestHeaderBytes(rsRequestData.method.asQString(),
+                                                                rsRequestData.uri,
+                                                                rsRequestData.headers));
             incCounter(Stats::ClientContentBytesReceived, rsRequestData.body.size());
         }
 
@@ -247,7 +248,7 @@ public:
             isHttps = rs->isHttps();
 
             requestData = rsRequestData;
-            requestBody += requestData.body;
+            requestBody += requestData.body.asQByteArray();
             requestData.body.clear();
 
             origRequestData = requestData;
@@ -327,7 +328,8 @@ public:
 
             si->state = SessionItem::Responding;
             si->startedResponse = true;
-            rs->startResponse(responseData.code, responseData.reason, responseData.headers);
+            rs->startResponse(responseData.code, responseData.reason.asQByteArray(),
+                              responseData.headers);
 
             if (!responseBody.isEmpty()) {
                 si->bytesToWrite += responseBody.size();
@@ -444,10 +446,11 @@ public:
 
         ProxyUtil::applyHostHeader(&requestData.headers, uri);
 
-        incCounter(Stats::ServerHeaderBytesSent, ZhttpManager::estimateRequestHeaderBytes(
-                                                     requestData.method, uri, requestData.headers));
+        incCounter(Stats::ServerHeaderBytesSent,
+                   ZhttpManager::estimateRequestHeaderBytes(requestData.method.asQString(), uri,
+                                                            requestData.headers));
 
-        zhttpRequest->start(requestData.method, uri, requestData.headers);
+        zhttpRequest->start(requestData.method.asQString(), uri, requestData.headers);
 
         requestBodySent = false;
 
@@ -888,7 +891,8 @@ public:
         foreach (SessionItem *si, sessionItems) {
             si->state = SessionItem::Responding;
             si->startedResponse = true;
-            si->rs->startResponse(responseData.code, responseData.reason, responseData.headers);
+            si->rs->startResponse(responseData.code, responseData.reason.asQByteArray(),
+                                  responseData.headers);
 
             if (!responseBody.isEmpty()) {
                 si->bytesToWrite += responseBody.size();
@@ -959,8 +963,9 @@ public:
             QByteArray buf = zhttpRequest->readBody(MAX_INITIAL_BUFFER);
 
             incCounter(Stats::ServerHeaderBytesReceived,
-                       ZhttpManager::estimateResponseHeaderBytes(
-                           responseData.code, responseData.reason, responseData.headers));
+                       ZhttpManager::estimateResponseHeaderBytes(responseData.code,
+                                                                 responseData.reason.asQByteArray(),
+                                                                 responseData.headers));
             incCounter(Stats::ServerContentBytesReceived, buf.size());
 
             responseBody += buf;
@@ -1281,7 +1286,7 @@ public:
                         si->rs->resume();
 
                         if (rdata.response.code != -1)
-                            si->rs->writeResponseBody(rdata.response.body);
+                            si->rs->writeResponseBody(rdata.response.body.asQByteArray());
 
                         si->bytesToWrite = -1;
                         si->rs->endResponseBody();
@@ -1294,8 +1299,8 @@ public:
                             si->rs->resume();
                         }
 
-                        respondAll(rdata.response.code, rdata.response.reason,
-                                   rdata.response.headers, rdata.response.body);
+                        respondAll(rdata.response.code, rdata.response.reason.asQByteArray(),
+                                   rdata.response.headers, rdata.response.body.asQByteArray());
                     } else {
                         cannotAcceptAll();
                     }

--- a/src/proxy/proxyutil.cpp
+++ b/src/proxy/proxyutil.cpp
@@ -184,7 +184,7 @@ void manipulateRequestHeaders(const char *logprefix, void *object, HttpRequestDa
         }
 
         if (!idata.lastIds.isEmpty()) {
-            QHashIterator<QByteArray, QByteArray> it(idata.lastIds);
+            QHashIterator<CowByteArray, CowByteArray> it(idata.lastIds);
             while (it.hasNext()) {
                 it.next();
                 requestData->headers +=
@@ -246,7 +246,7 @@ void applyHostHeader(HttpHeaders *headers, const CowUrl &uri) {
     if (uri.port() != -1)
         hostHeader += ':' + QByteArray::number(uri.port());
 
-    if (headers->get("Host").asQByteArray() != hostHeader) {
+    if (headers->get("Host") != hostHeader) {
         headers->removeAll("Host");
         headers->append(HttpHeader("Host", hostHeader));
     }

--- a/src/proxy/requestsession.cpp
+++ b/src/proxy/requestsession.cpp
@@ -264,7 +264,7 @@ public:
             requestData.headers, trusted ? xffTrustedRule : xffRule, peerAddress);
 
         log_debug("worker %d: IN id=%s, %s %s", workerId, rid.second.data(),
-                  qPrintable(requestData.method), requestData.uri.toEncoded().data());
+                  qPrintable(requestData.method.asQString()), requestData.uri.toEncoded().data());
 
         bool isHttps = (requestData.uri.scheme() == "https");
         QString host = requestData.uri.host();
@@ -855,8 +855,8 @@ public:
             } else {
                 if (rdata.response.code != -1) {
                     zhttpRequest->resume();
-                    respond(rdata.response.code, rdata.response.reason, rdata.response.headers,
-                            rdata.response.body);
+                    respond(rdata.response.code, rdata.response.reason.asQByteArray(),
+                            rdata.response.headers, rdata.response.body.asQByteArray());
                 } else {
                     zhttpRequest->resume();
                     respondCannotAccept();
@@ -891,8 +891,9 @@ public:
                             bodyRawBuf.truncate(bodyRawBuf.size() - 1);
                     }
 
-                    QByteArray startBuf = makeJsonpStart(responseData.code, responseData.reason,
-                                                         responseData.headers);
+                    QByteArray startBuf =
+                        makeJsonpStart(responseData.code, responseData.reason.asQByteArray(),
+                                       responseData.headers);
                     QByteArray bodyBuf;
                     QByteArray endBuf = makeJsonpEnd();
                     if (!startBuf.isNull())
@@ -942,8 +943,8 @@ public:
                     return;
                 }
 
-                QByteArray buf =
-                    makeJsonpStart(responseData.code, responseData.reason, responseData.headers);
+                QByteArray buf = makeJsonpStart(
+                    responseData.code, responseData.reason.asQByteArray(), responseData.headers);
                 if (buf.isNull()) {
                     state = RespondingInternal;
 
@@ -979,7 +980,7 @@ public:
                     zhttpRequest->bytesWritten.connect(boost::bind(
                         &Private::zhttpRequest_bytesWritten, this, boost::placeholders::_1));
 
-                zhttpRequest->beginResponse(responseData.code, responseData.reason,
+                zhttpRequest->beginResponse(responseData.code, responseData.reason.asQByteArray(),
                                             responseData.headers);
             }
         }

--- a/src/proxy/testhttprequest.cpp
+++ b/src/proxy/testhttprequest.cpp
@@ -205,7 +205,7 @@ bool TestHttpRequest::isErrored() const {
 
 HttpRequest::ErrorCondition TestHttpRequest::errorCondition() const { return d->errorCondition; }
 
-QString TestHttpRequest::requestMethod() const { return d->request.method; }
+QString TestHttpRequest::requestMethod() const { return d->request.method.asQString(); }
 
 CowUrl TestHttpRequest::requestUri() const { return d->request.uri; }
 
@@ -213,7 +213,7 @@ HttpHeaders TestHttpRequest::requestHeaders() const { return d->request.headers;
 
 int TestHttpRequest::responseCode() const { return d->response.code; }
 
-QByteArray TestHttpRequest::responseReason() const { return d->response.reason; }
+QByteArray TestHttpRequest::responseReason() const { return d->response.reason.asQByteArray(); }
 
 HttpHeaders TestHttpRequest::responseHeaders() const { return d->response.headers; }
 

--- a/src/proxy/testwebsocket.cpp
+++ b/src/proxy/testwebsocket.cpp
@@ -101,7 +101,7 @@ public:
             response.code = 404;
             response.reason = StatusReasons::getReason(response.code);
             response.headers += HttpHeader("Content-Type", "text/plain");
-            response.body += QByteArray("no such test resource\n");
+            response.body += "no such test resource\n";
 
             errorCondition = ErrorRejected;
             q->error();
@@ -182,11 +182,11 @@ HttpHeaders TestWebSocket::requestHeaders() const { return d->request.headers; }
 
 int TestWebSocket::responseCode() const { return d->response.code; }
 
-QByteArray TestWebSocket::responseReason() const { return d->response.reason; }
+QByteArray TestWebSocket::responseReason() const { return d->response.reason.asQByteArray(); }
 
 HttpHeaders TestWebSocket::responseHeaders() const { return d->response.headers; }
 
-QByteArray TestWebSocket::responseBody() const { return d->response.body; }
+QByteArray TestWebSocket::responseBody() const { return d->response.body.asQByteArray(); }
 
 int TestWebSocket::framesAvailable() const { return d->inFrames.count(); }
 

--- a/src/proxy/websocketoverhttp.cpp
+++ b/src/proxy/websocketoverhttp.cpp
@@ -659,7 +659,7 @@ private:
 
         foreach (const HttpHeader &h, responseHeaders) {
             if (h.first.size() >= 10 && qstrnicmp(h.first.data(), "Set-Meta-", 9) == 0) {
-                QByteArray name = h.first.mid(9).asQByteArray();
+                CowByteArray name = h.first.mid(9);
                 if (meta.contains(name))
                     meta.removeAll(name);
                 if (!h.second.isEmpty())
@@ -987,11 +987,13 @@ HttpHeaders WebSocketOverHttp::requestHeaders() const { return d->requestData.he
 
 int WebSocketOverHttp::responseCode() const { return d->responseData.code; }
 
-QByteArray WebSocketOverHttp::responseReason() const { return d->responseData.reason; }
+QByteArray WebSocketOverHttp::responseReason() const {
+    return d->responseData.reason.asQByteArray();
+}
 
 HttpHeaders WebSocketOverHttp::responseHeaders() const { return d->responseData.headers; }
 
-QByteArray WebSocketOverHttp::responseBody() const { return d->responseData.body; }
+QByteArray WebSocketOverHttp::responseBody() const { return d->responseData.body.asQByteArray(); }
 
 int WebSocketOverHttp::framesAvailable() const { return d->inFrames.count(); }
 

--- a/src/proxy/wscontrolmanager.cpp
+++ b/src/proxy/wscontrolmanager.cpp
@@ -264,7 +264,7 @@ private:
         std::weak_ptr<Private> self = q->d;
 
         foreach (const WsControlPacket::Item &i, p.items) {
-            WsControlSession *s = sessionsByCid.value(i.cid);
+            WsControlSession *s = sessionsByCid.value(i.cid.asQByteArray());
             if (!s) {
                 log_debug("wscontrol: received item for unknown connection id, canceling");
 
@@ -273,13 +273,13 @@ private:
                     WsControlPacket::Item out;
                     out.cid = i.cid;
                     out.type = WsControlPacket::Item::Cancel;
-                    writeStream(out, p.from);
+                    writeStream(out, p.from.asQByteArray());
                 }
 
                 continue;
             }
 
-            s->handle(p.from, i);
+            s->handle(p.from.asQByteArray(), i);
 
             if (self.expired())
                 return;

--- a/src/proxy/wscontrolsession.cpp
+++ b/src/proxy/wscontrolsession.cpp
@@ -213,11 +213,11 @@ public:
             // For sends, don't ack until written
 
             if (!item.requestId.isEmpty())
-                pendingSendEventWrites += item.requestId;
+                pendingSendEventWrites += item.requestId.asQByteArray();
             else
                 pendingSendEventWrites += QByteArray(); // Placeholder
 
-            q->sendEventReceived(type, item.message, item.queue);
+            q->sendEventReceived(type, item.message.asQByteArray(), item.queue);
         } else if (item.type == WsControlPacket::Item::KeepAliveSetup) {
             if (item.timeout > 0) {
                 WsControl::KeepAliveMode mode;
@@ -231,13 +231,13 @@ public:
         } else if (item.type == WsControlPacket::Item::Refresh) {
             q->refreshEventReceived();
         } else if (item.type == WsControlPacket::Item::Close) {
-            q->closeEventReceived(item.code, item.reason);
+            q->closeEventReceived(item.code, item.reason.asQByteArray());
         } else if (item.type == WsControlPacket::Item::Detach) {
             q->detachEventReceived();
         } else if (item.type == WsControlPacket::Item::Cancel) {
             q->cancelEventReceived();
         } else if (item.type == WsControlPacket::Item::Ack) {
-            int reqId = item.requestId.toInt();
+            int reqId = item.requestId.asQByteArray().toInt();
             if (pendingRequests.contains(reqId)) {
                 pendingRequests.remove(reqId);
                 setupRequestTimer();


### PR DESCRIPTION
Needed to add a few more methods to `CowByteArray` for this. The bulk of the changes are updating call sites.

Calls to `toLatin1` are replaced with `toUtf8`. The former was used for strings expected to be in the ASCII range, which is the same as UTF-8.