### PR TITLE
log: use cow types in api

### DIFF
--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -33,7 +33,7 @@ static void logWithOutputLevel(int outputLevel, int level, const char *fmt, va_l
     ffi::log_log_with_max_level(outputLevel, level, str.toUtf8().data());
 }
 
-bool log_init(const QString &outputFile) {
+bool log_init(const CowString &outputFile) {
     int ret;
 
     if (!outputFile.isEmpty())
@@ -48,7 +48,7 @@ int log_outputLevel() { return ffi::log_get_level(); }
 
 void log_setOutputLevel(int level) { ffi::log_set_level(level); }
 
-bool log_rotate(const QString &outputFile) {
+bool log_rotate(const CowString &outputFile) {
     return (ffi::log_rotate(outputFile.toUtf8().data()) == 0);
 }
 

--- a/src/core/log.h
+++ b/src/core/log.h
@@ -22,8 +22,8 @@
 #ifndef LOG_H
 #define LOG_H
 
+#include "cowstring.h"
 #include "rust/bindings.h"
-#include <QString>
 
 enum LogLevel {
     LOG_LEVEL_ERROR = ffi::LOG_LEVEL_ERROR,
@@ -33,11 +33,11 @@ enum LogLevel {
     LOG_LEVEL_TRACE = ffi::LOG_LEVEL_TRACE,
 };
 
-bool log_init(const QString &outputFile = QString());
+bool log_init(const CowString &outputFile = CowString());
 
 int log_outputLevel();
 void log_setOutputLevel(int level);
-bool log_rotate(const QString &outputFile);
+bool log_rotate(const CowString &outputFile);
 
 void log(int level, const char *fmt, ...);
 void log_error(const char *fmt, ...);

--- a/src/core/logutil.cpp
+++ b/src/core/logutil.cpp
@@ -125,18 +125,18 @@ void logVariant(int level, const Variant &data, const char *fmt, ...) {
     va_end(ap);
 }
 
-void logByteArray(int level, const QByteArray &content, const char *fmt, ...) {
+void logByteArray(int level, const CowByteArray &content, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    logPacket(level, content, fmt, ap);
+    logPacket(level, content.asQByteArray(), fmt, ap);
     va_end(ap);
 }
 
-void logVariantWithContent(int level, const Variant &data, const QString &contentField,
+void logVariantWithContent(int level, const Variant &data, const CowString &contentField,
                            const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    logPacket(level, data, contentField, fmt, ap);
+    logPacket(level, data, contentField.asQString(), fmt, ap);
     va_end(ap);
 }
 
@@ -145,7 +145,7 @@ void logRequest(int level, const RequestData &data, const Config &config) {
                                        data.requestData.uri.toString(CowUrl::FullyEncoded));
 
     if (!data.targetStr.isEmpty())
-        msg += QString(" -> %1").arg(data.targetStr);
+        msg += QString(" -> %1").arg(data.targetStr.asQString());
 
     if (data.requestData.uri.scheme() != "http" && data.requestData.uri.scheme() != "https" &&
         data.targetOverHttp)
@@ -159,7 +159,7 @@ void logRequest(int level, const RequestData &data, const Config &config) {
         msg += QString(" ref=%1").arg(ref.toString(CowUrl::FullyEncoded));
 
     if (!data.routeId.isEmpty())
-        msg += QString(" route=%1").arg(data.routeId);
+        msg += QString(" route=%1").arg(data.routeId.asQString());
 
     if (data.status == LogUtil::Response) {
         msg += QString(" code=%1 %2")
@@ -195,7 +195,7 @@ void logForRoute(int level, const RouteInfo &routeInfo, const char *fmt, ...) {
     va_start(ap, fmt);
     QString msg = QString::vasprintf(fmt, ap);
     if (!routeInfo.id.isEmpty())
-        msg += QString(" route=%1").arg(routeInfo.id);
+        msg += QString(" route=%1").arg(routeInfo.id.asQString());
     logPacketWithOutputLevel(routeInfo.logLevel, level, msg);
     va_end(ap);
 }

--- a/src/core/logutil.h
+++ b/src/core/logutil.h
@@ -24,6 +24,8 @@
 #ifndef LOGUTIL_H
 #define LOGUTIL_H
 
+#include "cowbytearray.h"
+#include "cowstring.h"
 #include "log.h"
 #include "packet/httprequestdata.h"
 #include "packet/httpresponsedata.h"
@@ -36,13 +38,13 @@ enum RequestStatus { Response, Accept, Error };
 
 class RequestData {
 public:
-    QString routeId;
+    CowString routeId;
     int logLevel;
     RequestStatus status;
     HttpRequestData requestData;
     HttpResponseData responseData;
     int responseBodySize;
-    QString targetStr;
+    CowString targetStr;
     bool targetOverHttp;
     bool retry;
     void *sharedBy;
@@ -67,16 +69,16 @@ public:
 
 class RouteInfo {
 public:
-    QString id;
+    CowString id;
     int logLevel;
 
-    RouteInfo(const QString &initId = QString(), int initLogLevel = LOG_LEVEL_DEBUG)
+    RouteInfo(const CowString &initId = CowString(), int initLogLevel = LOG_LEVEL_DEBUG)
         : id(initId), logLevel(initLogLevel) {}
 };
 
 void logVariant(int level, const Variant &data, const char *fmt, ...);
-void logByteArray(int level, const QByteArray &content, const char *fmt, ...);
-void logVariantWithContent(int level, const Variant &data, const QString &contentField,
+void logByteArray(int level, const CowByteArray &content, const char *fmt, ...);
+void logVariantWithContent(int level, const Variant &data, const CowString &contentField,
                            const char *fmt, ...);
 void logRequest(int level, const RequestData &data, const Config &config = Config());
 void logForRoute(int level, const RouteInfo &routeInfo, const char *fmt, ...);

--- a/src/proxy/proxyengine.cpp
+++ b/src/proxy/proxyengine.cpp
@@ -659,7 +659,7 @@ public:
 
         // Only log route id if explicitly set
         if (route.separateStats)
-            rd.routeId = route.id;
+            rd.routeId = QString::fromUtf8(route.id);
 
         rd.logLevel = route.logLevel;
 

--- a/src/proxy/proxysession.cpp
+++ b/src/proxy/proxysession.cpp
@@ -910,7 +910,7 @@ public:
 
         // Only log route id if explicitly set
         if (route.separateStats)
-            rd.routeId = route.id;
+            rd.routeId = QString::fromUtf8(route.id);
 
         rd.logLevel = route.logLevel;
 

--- a/src/proxy/wsproxysession.cpp
+++ b/src/proxy/wsproxysession.cpp
@@ -695,7 +695,7 @@ public:
 
         // Only log route id if explicitly set
         if (route.separateStats)
-            rd.routeId = route.id;
+            rd.routeId = QString::fromUtf8(route.id);
 
         rd.logLevel = route.logLevel;
 


### PR DESCRIPTION
Note: the `rd.routeId = QString::fromUtf8(route.id)` lines are needed because the Cow types don't perform implicit conversion, which I think is not a bad thing.