### PR TITLE
[ci] Run codeql only on files that require it

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,12 +4,31 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '21 13 * * 6'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            src:
+              - '**'
+              - '!docker/**'
+              - '!.github/Dockerfile'
+              - '!**/*.md'
+              - '!.github/workflows/**'
+              - '!packaging/**'
   analyze:
+    needs: [changes]
     name: Analyze (${{ matrix.language }})
     runs-on: 'ubuntu-latest'
     container: fanout/build-base:latest
@@ -35,28 +54,32 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
+      if: needs.changes.outputs.src != 'false'
       uses: actions/checkout@v4
     - name: Cache
+      if: needs.changes.outputs.src != 'false'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "codeql"
-    - if: matrix.build-mode == 'manual'
+    - if: needs.changes.outputs.src != 'false' && matrix.build-mode == 'manual'
       shell: bash
       env:
         CPP_BUILD_DIR: ${{ github.workspace }}/cppbuild
       run: cargo check --no-default-features --features do-qmake
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
+      if: needs.changes.outputs.src != 'false'
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-    - if: matrix.build-mode == 'manual'
+    - if: needs.changes.outputs.src != 'false' && matrix.build-mode == 'manual'
       shell: bash
       env:
         CPP_BUILD_DIR: ${{ github.workspace }}/cppbuild
       run: cargo build --no-default-features --features do-cpp-build
     - name: Perform CodeQL Analysis
+      if: needs.changes.outputs.src != 'false'
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -1,18 +1,29 @@
 name: CI
 on:
   pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'docker/**'
-      - '**/*.md'
-      - '.github/workflows/docker-publish.yml'
-      - 'packaging/**'
 defaults:
   run:
      shell: bash -leo pipefail {0}
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          predicate-quantifier: 'some-with-excludes'
+          filters: |
+            src:
+              - '**'
+              - '!docker/**'
+              - '!**/*.md'
+              - '!.github/workflows/**'
+              - '!packaging/**'
   check:
+    needs: [changes]
     strategy:
       fail-fast: true
       matrix:
@@ -21,14 +32,17 @@ jobs:
     container: fanout/build-base:latest
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: check
+      if: needs.changes.outputs.src == 'true'
       run:  RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} c
   clippy:
     strategy:
@@ -37,17 +51,20 @@ jobs:
         rust-version: [stable, 1.75.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: check
+    needs: [changes, check]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: clippy
+      if: needs.changes.outputs.src == 'true'
       run:  RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} clippy -- -D warnings
   lint:
     strategy:
@@ -56,21 +73,26 @@ jobs:
         rust-version: [stable, 1.75.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: check
+    needs: [changes, check]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: format rust
+      if: needs.changes.outputs.src == 'true'
       run:  RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} fmt --check
     - name: format c++
+      if: needs.changes.outputs.src == 'true'
       run:  find src -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror -style=file
     - name: format python
+      if: needs.changes.outputs.src == 'true'
       run:  black --check .
   build:
     strategy:
@@ -79,17 +101,20 @@ jobs:
         rust-version: [stable, 1.75.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: check
+    needs: [changes, check]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: build
+      if: needs.changes.outputs.src == 'true'
       run: RUSTFLAGS="-D warnings" TOOLCHAIN=${{ matrix.rust-version }} make build
   audit:
     strategy:
@@ -98,17 +123,20 @@ jobs:
         rust-version: [stable]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: build
+    needs: [changes, build]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: audit
+      if: needs.changes.outputs.src == 'true'
       run:  RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} audit
   test:
     strategy:
@@ -117,17 +145,20 @@ jobs:
         rust-version: [stable, 1.75.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: build
+    needs: [changes, build]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: test
+      if: needs.changes.outputs.src == 'true'
       run: TOOLCHAIN=${{ matrix.rust-version }} make cargo-test
   benchmark:
     strategy:
@@ -136,17 +167,20 @@ jobs:
         rust-version: [stable, 1.75.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: build
+    needs: [changes, build]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: bench
+      if: needs.changes.outputs.src == 'true'
       run: RUSTFLAGS="-D warnings" cargo +${{ matrix.rust-version }} bench --no-run
   build-full:
     strategy:
@@ -155,17 +189,21 @@ jobs:
         rust-version: [stable, 1.75.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
-    needs: [audit, test]
+    needs: [changes, audit, test]
     steps:
     - name: Checkout code
+      if: needs.changes.outputs.src == 'true'
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Cache
+      if: needs.changes.outputs.src == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "CI-Suite"
     - name: cargo fetch
+      if: needs.changes.outputs.src == 'true'
       run: cargo +${{ matrix.rust-version }} fetch
     - name: build release
+      if: needs.changes.outputs.src == 'true'
       run: TOOLCHAIN=${{ matrix.rust-version }} RELEASE=1 RUSTFLAGS="-D warnings" make build


### PR DESCRIPTION
This change is to fix an earlier change which occurred for the same reasons.

We previously tried to make it so files like `.md` or `Dockerfile` wouldn't
trigger the full suite of tests that builds pushpin and tests it, purely
for quality of life reasons.

Unfortunately, this conflicts with the expected Github status checks settings
where Github expects certain checks to return before a PR can be merged.

To keep the status checks requirements intact but also allow us to skip
checks which don't make sense for the PR we have to move away from the
`paths-ignore` way of filtering to running a small pre-check workflow to
list the files being changed and return a value that the rest of the
workflow can read to determine if we should run or skip the rest of the
jobs.