### PR TITLE
update build image to install cargo-audit with --locked

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -27,8 +27,9 @@ ENV RUSTUP_HOME="/root/.rustup" \
 # Keep in sync with minimum support Rust Version for Pushpin 
 RUN rustup install 1.75.0-x86_64-unknown-linux-gnu
 
-RUN cargo install cargo-audit
-
 RUN rustup component add rustfmt
 
 RUN rustup component add clippy
+
+# Use --locked to ensure dependency changes can't break the build
+RUN cargo install --locked cargo-audit


### PR DESCRIPTION
The base image has been updated to Rust 1.98.1, but I had to add `--locked` to cargo-audit to get it to build due to breakage in a dependency (tinyvec). This PR is that fix.