### PR TITLE
remove legacy-runner feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ default = ["do-qmake", "do-cpp-build"]
 do-qmake = []
 do-cpp-build = []
 breaking-changes = []
-legacy-runner = []
 
 [profile.dev]
 panic = "abort"
@@ -144,12 +143,6 @@ bench = false
 name = "pushpin-handler"
 test = false
 bench = false
-
-[[bin]]
-name = "pushpin-legacy"
-test = false
-bench = false
-required-features = ["legacy-runner"]
 
 [[bin]]
 name = "pushpin"

--- a/build.rs
+++ b/build.rs
@@ -186,7 +186,6 @@ fn write_postbuild_conf_pri(
     config_dir: &str,
     run_dir: &str,
     log_dir: &str,
-    include_legacy_runner: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut out = Vec::new();
 
@@ -195,11 +194,6 @@ fn write_postbuild_conf_pri(
     writeln!(&mut out, "CONFIGDIR = {}/pushpin", config_dir)?;
     writeln!(&mut out, "RUNDIR = {}/pushpin", run_dir)?;
     writeln!(&mut out, "LOGDIR = {}/pushpin", log_dir)?;
-
-    if include_legacy_runner {
-        writeln!(&mut out)?;
-        writeln!(&mut out, "CONFIG += include_legacy_runner")?;
-    }
 
     write_if_different(dest, &out)
 }
@@ -554,8 +548,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         version_ge_2,
     )?;
 
-    let include_legacy_runner = cfg!(feature = "legacy-runner");
-
     write_postbuild_conf_pri(
         &Path::new("postbuild").join("conf.pri"),
         &bin_dir,
@@ -563,7 +555,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         &config_dir,
         &run_dir,
         &log_dir,
-        include_legacy_runner,
     )?;
 
     if cfg!(feature = "do-qmake") {

--- a/postbuild/postbuild.pro
+++ b/postbuild/postbuild.pro
@@ -31,12 +31,6 @@ handler_bin.target = $$bin_dir/pushpin-handler
 handler_bin.depends = $$target_dir/pushpin-handler
 handler_bin.commands = mkdir -p $$bin_dir && cp -a $$target_dir/pushpin-handler $$bin_dir/pushpin-handler
 
-include_legacy_runner {
-    runner_legacy_bin.target = $$root_dir/pushpin-legacy
-    runner_legacy_bin.depends = $$target_dir/pushpin-legacy
-    runner_legacy_bin.commands = cp -a $$target_dir/pushpin-legacy $$root_dir/pushpin-legacy
-}
-
 runner_bin.target = $$root_dir/pushpin
 runner_bin.depends = $$target_dir/pushpin
 runner_bin.commands = cp -a $$target_dir/pushpin $$root_dir/pushpin
@@ -49,11 +43,7 @@ QMAKE_EXTRA_TARGETS += \
 	connmgr_bin \
 	m2adapter_bin \
 	proxy_bin \
-	handler_bin
-
-include_legacy_runner:QMAKE_EXTRA_TARGETS += runner_legacy_bin
-
-QMAKE_EXTRA_TARGETS += \
+	handler_bin \
 	runner_bin \
 	publish_bin
 
@@ -61,11 +51,7 @@ PRE_TARGETDEPS += \
 	$$bin_dir/pushpin-connmgr \
 	$$bin_dir/m2adapter \
 	$$bin_dir/pushpin-proxy \
-	$$bin_dir/pushpin-handler
-
-include_legacy_runner:PRE_TARGETDEPS += $$root_dir/pushpin-legacy
-
-PRE_TARGETDEPS += \
+	$$bin_dir/pushpin-handler \
 	$$root_dir/pushpin \
 	$$bin_dir/pushpin-publish
 
@@ -87,11 +73,7 @@ unix:!isEmpty(BINDIR) {
 		$$bin_dir/pushpin-connmgr \
 		$$bin_dir/m2adapter \
 		$$bin_dir/pushpin-proxy \
-		$$bin_dir/pushpin-handler
-
-	include_legacy_runner:binfiles.files += $$root_dir/pushpin-legacy
-
-	binfiles.files += \
+		$$bin_dir/pushpin-handler \
 		$$root_dir/pushpin \
 		$$bin_dir/pushpin-publish
 


### PR DESCRIPTION
This flag is redundant now that the primary runner uses the C++ impl by default. Let's remove it.

Removing it means it won't be possible to build both the C++ runner and Rust runner _at the same time_, but the ability to do this is a holdover from before we had proper versioning flags and in practice it is more confusing than useful.