### PR TITLE
include process metrics in prometheus output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -187,7 +187,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.89",
  "tempfile",
  "toml 0.8.19",
 ]
@@ -269,7 +269,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -661,6 +661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,7 +787,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1167,7 +1173,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1256,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.50",
  "ucd-trie",
 ]
 
@@ -1280,7 +1286,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1344,17 +1350,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.4"
+name = "procfs"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.9.0",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.28",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.9.0",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
- "thiserror",
+ "procfs",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1390,7 +1420,7 @@ dependencies = [
  "socket2",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 1.0.50",
  "time",
  "url",
  "zmq",
@@ -1670,7 +1700,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1748,7 +1778,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.50",
  "time",
 ]
 
@@ -1804,6 +1834,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,7 +1852,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1845,7 +1886,7 @@ checksum = "f66edd6b6cd810743c0c71e1d085e92b01ce6a72782032e3f794c8284fe4bcdd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1854,7 +1895,16 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.50",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1865,7 +1915,18 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2087,7 +2148,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -2109,7 +2170,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2376,7 +2437,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -2397,7 +2458,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2417,7 +2478,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -2446,7 +2507,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ mio = { version = "1", features = ["os-poll", "os-ext", "net"] }
 notify = "7"
 openssl = "=0.10.72"
 paste = "1.0"
-prometheus = { version = "0.13", default-features = false }
+prometheus = { version = "0.14", default-features = false, features = ["process"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-native-certs = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/connmgr/metrics.rs
+++ b/src/connmgr/metrics.rs
@@ -21,15 +21,19 @@ static TOTAL_REQUESTS: OnceLock<Counter> = OnceLock::new();
 
 pub fn total_requests() -> &'static Counter {
     TOTAL_REQUESTS.get_or_init(|| {
-        prometheus::register_counter!(
-            "connmgr_requests_total",
-            "Total number of requests processed by connmgr"
+        prometheus::Counter::new(
+            "requests_total",
+            "Total number of requests processed by connmgr",
         )
-        .expect("failed to register total_requests counter")
+        .expect("failed to create total_requests counter")
     })
 }
 
-pub fn init() {
-    // Pre-initialize metrics so they appear even before any requests arrive.
-    let _ = total_requests();
+pub fn init(registry: &prometheus::Registry) {
+    // Pre-initialize metrics so they appear even before any requests arrive,
+    // and register them with the provided registry.
+    let counter = total_requests();
+    registry
+        .register(Box::new(counter.clone()))
+        .expect("failed to register total_requests counter");
 }

--- a/src/connmgr/mod.rs
+++ b/src/connmgr/mod.rs
@@ -35,7 +35,7 @@ use self::server::Server;
 use crate::core::config::{NetListenConfig, UnixListenConfig};
 use crate::core::log::DebugLogger;
 use crate::core::net::{bind_unix_config, NetListener};
-use crate::core::prometheus::PrometheusServer;
+use crate::core::prometheus::{try_register_process_collector, PrometheusServer};
 use crate::core::zmq::SpecInfo;
 use ipnet::IpNet;
 use log::{debug, info};
@@ -165,16 +165,20 @@ impl App {
         let mut prometheus = None;
 
         if let Some(config) = &config.prometheus {
-            metrics::init();
+            let combined_prefix = format!("{}connmgr", config.prefix);
+
+            let registry = prometheus::Registry::new_custom(Some(combined_prefix), None)
+                .expect("failed to create prometheus registry");
+
+            try_register_process_collector(&registry)
+                .expect("failed to register process collector");
+
+            metrics::init(&registry);
 
             let l = NetListener::bind_config(&config.listen_config)
                 .map_err(|e| format!("prometheus listener: {e}"))?;
 
-            prometheus = Some(PrometheusServer::new(
-                l,
-                &config.prefix,
-                prometheus::default_registry().clone(),
-            ));
+            prometheus = Some(PrometheusServer::new(l, registry));
         }
 
         let zmq_context = Arc::new(zmq::Context::new());

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -38,16 +38,32 @@ const CONNS_MAX: usize = 10;
 const REACTOR_BUDGET: u32 = 100;
 const BUFFER_SIZE: usize = 4096;
 
+#[cfg(target_os = "linux")]
+fn try_register_process_collector_inner(
+    registry: &prometheus::Registry,
+) -> Result<(), prometheus::Error> {
+    let pc = prometheus::process_collector::ProcessCollector::for_self();
+
+    registry.register(Box::new(pc))
+}
+
+pub fn try_register_process_collector(
+    _registry: &prometheus::Registry,
+) -> Result<(), prometheus::Error> {
+    #[cfg(target_os = "linux")]
+    try_register_process_collector_inner(_registry)?;
+
+    Ok(())
+}
+
 pub struct PrometheusServer {
     thread: Option<thread::JoinHandle<()>>,
     stop: Option<channel::Sender<()>>,
 }
 
 impl PrometheusServer {
-    pub fn new(listener: NetListener, prefix: &str, registry: prometheus::Registry) -> Self {
+    pub fn new(listener: NetListener, registry: prometheus::Registry) -> Self {
         let (stop_s, stop_r) = channel::channel(1);
-
-        let prefix = prefix.to_string();
 
         let thread = thread::Builder::new()
             .name("prometheus".to_string())
@@ -75,7 +91,7 @@ impl PrometheusServer {
                     .expect("failed to spawn prometheus stop watcher");
 
                 executor
-                    .spawn(run_server(listener, cancel_t, prefix, registry))
+                    .spawn(run_server(listener, cancel_t, registry))
                     .expect("failed to spawn prometheus server task");
 
                 executor
@@ -111,7 +127,6 @@ struct Client {
 async fn run_server(
     listener: NetListener,
     stop: CancellationToken,
-    prefix: String,
     registry: prometheus::Registry,
 ) {
     let listener = AsyncNetListener::new(listener);
@@ -154,7 +169,6 @@ async fn run_server(
                     AsyncTcpStream::new(s),
                     token,
                     s_done,
-                    prefix.clone(),
                     registry.clone(),
                 ))
                 .expect("failed to spawn prometheus connection task"),
@@ -163,7 +177,6 @@ async fn run_server(
                     AsyncUnixStream::new(s),
                     token,
                     s_done,
-                    prefix.clone(),
                     registry.clone(),
                 ))
                 .expect("failed to spawn prometheus connection task"),
@@ -180,11 +193,10 @@ async fn run_connection<S: AsyncRead + AsyncWrite + 'static>(
     stream: S,
     token: CancellationToken,
     _done: channel::LocalSender<()>, // dropped when function returns, indicating done
-    prefix: String,
     registry: prometheus::Registry,
 ) {
     let result = match select_2(
-        pin!(handle_connection(stream, &prefix, &registry)),
+        pin!(handle_connection(stream, &registry)),
         pin!(token.cancelled()),
     )
     .await
@@ -200,7 +212,6 @@ async fn run_connection<S: AsyncRead + AsyncWrite + 'static>(
 
 async fn handle_connection<S: AsyncRead + AsyncWrite>(
     stream: S,
-    prefix: &str,
     registry: &prometheus::Registry,
 ) -> Result<(), Box<dyn Error>> {
     let stream = RefCell::new(stream);
@@ -209,12 +220,7 @@ async fn handle_connection<S: AsyncRead + AsyncWrite>(
     let mut buf1 = VecRingBuffer::new(BUFFER_SIZE, &rb_tmp);
     let mut buf2 = VecRingBuffer::new(BUFFER_SIZE, &rb_tmp);
 
-    let mut metric_families = registry.gather();
-    if !prefix.is_empty() {
-        for mf in &mut metric_families {
-            mf.set_name(format!("{}{}", prefix, mf.get_name()));
-        }
-    }
+    let metric_families = registry.gather();
 
     let encoder = TextEncoder::new();
 
@@ -281,7 +287,8 @@ mod tests {
 
     #[test]
     fn request_metrics() {
-        let registry = prometheus::Registry::new();
+        let registry =
+            prometheus::Registry::new_custom(Some("myprefix".to_string()), None).unwrap();
         let counter = prometheus::Counter::new("test_counter", "a test counter").unwrap();
         registry.register(Box::new(counter.clone())).unwrap();
         counter.inc();
@@ -289,7 +296,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0".parse().unwrap()).unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let server = PrometheusServer::new(NetListener::Tcp(listener), "myprefix_", registry);
+        let server = PrometheusServer::new(NetListener::Tcp(listener), registry);
 
         let mut stream = std::net::TcpStream::connect(addr).unwrap();
         stream


### PR DESCRIPTION
The `prometheus` crate includes built-in support for process metrics on Linux. This PR enables them.

Also, prefixing metric names is now handled by the `Registry` type so that they are applied to the built-in metrics.

Tested manually on Linux:

```
# HELP connmgr_process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE connmgr_process_cpu_seconds_total counter
connmgr_process_cpu_seconds_total 0
# HELP connmgr_process_max_fds Maximum number of open file descriptors.
# TYPE connmgr_process_max_fds gauge
connmgr_process_max_fds 1024
# HELP connmgr_process_open_fds Number of open file descriptors.
# TYPE connmgr_process_open_fds gauge
connmgr_process_open_fds 36
# HELP connmgr_process_resident_memory_bytes Resident memory size in bytes.
# TYPE connmgr_process_resident_memory_bytes gauge
connmgr_process_resident_memory_bytes 23588864
# HELP connmgr_process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE connmgr_process_start_time_seconds gauge
connmgr_process_start_time_seconds 1788905358
# HELP connmgr_process_threads Number of OS threads in the process.
# TYPE connmgr_process_threads gauge
connmgr_process_threads 9
# HELP connmgr_process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE connmgr_process_virtual_memory_bytes gauge
connmgr_process_virtual_memory_bytes 723877888
# HELP connmgr_requests_total Total number of requests processed by connmgr
# TYPE connmgr_requests_total counter
connmgr_requests_total 0
```