### PR TITLE
update msrv to 1.81

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -25,7 +25,7 @@ ENV RUSTUP_HOME="/root/.rustup" \
     PATH=/root/.cargo/bin:$PATH
 
 # Keep in sync with minimum support Rust Version for Pushpin 
-RUN rustup install 1.75.0-x86_64-unknown-linux-gnu
+RUN rustup install 1.81.0-x86_64-unknown-linux-gnu
 
 RUN rustup component add rustfmt
 

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     steps:
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [changes, check]
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [changes, check]
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [changes, check]
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [changes, build]
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [changes, build]
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust-version: [stable, 1.75.0]
+        rust-version: [stable, 1.81.0]
     runs-on: ubuntu-latest
     container: fanout/build-base:latest
     needs: [changes, audit, test]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/fastly/pushpin"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2018"
-rust-version = "1.75"
+rust-version = "1.81"
 default-run = "pushpin"
 
 [package.metadata.deb]


### PR DESCRIPTION
(Please approve this despite failed checks. After that I'll push a new base image and they'll pass.)

While doing some work with the prometheus crate and updating it to the latest version I ran into its MSRV of 1.81 (vs our 1.75). We could easily avoid updating the crate, but since the last compatible version is over two years old, and since the official Rust packages for the latest Ubuntu LTS meet this MSRV (our usual rule for MSRV bumps), I'm thinking we just bump.