### PR TITLE
[release] Update cargo deb settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,11 @@ assets = [
     { source = "dist/usr/share/doc/pushpin/README.md.gz", dest = "usr/share/doc/pushpin/", mode = "644" },
     { source = "dist/usr/share/doc/pushpin/NEWS.Debian.gz", dest = "usr/share/doc/pushpin/", mode = "644" },
     { source = "dist/usr/share/doc/pushpin/changelog.Debian.gz", dest = "usr/share/doc/pushpin/", mode = "644" },
-    { source = "source/tools/*.py", dest = "usr/share/doc/pushpin/examples/tools/", mode = "644" },
-    { source = "source/tools/*.php", dest = "usr/share/doc/pushpin/examples/tools/", mode = "644" },
-    { source = "source/tools/*.js", dest = "usr/share/doc/pushpin/examples/tools/", mode = "644" },
-    { source = "source/tools/*.sh", dest = "usr/share/doc/pushpin/examples/tools/", mode = "755" },
-    { source = "source/tools/zhttp/*.py", dest = "usr/share/doc/pushpin/examples/tools/zhttp/", mode = "644" },
-    { source = "source/tools/echo/*", dest = "usr/share/doc/pushpin/examples/tools/echo/", mode = "644" },
+    { source = "tools/*.py", dest = "usr/share/doc/pushpin/examples/tools/", mode = "644" },
+    { source = "tools/*.php", dest = "usr/share/doc/pushpin/examples/tools/", mode = "644" },
+    { source = "tools/*.js", dest = "usr/share/doc/pushpin/examples/tools/", mode = "644" },
+    { source = "tools/*.sh", dest = "usr/share/doc/pushpin/examples/tools/", mode = "755" },
+    { source = "tools/zhttp/*.py", dest = "usr/share/doc/pushpin/examples/tools/zhttp/", mode = "644" },
 ]
 preserve-symlinks = true
 maintainer-scripts = "packaging/debian/debian"


### PR DESCRIPTION
A while back we consolidated the pushpin repo debian deployment process into this main repo. The problem with this is that I forgot to update some of the directory references and it caused a failure when trying to cut a new release from this repo.

This should fix those directory settings to reflect the new locations.